### PR TITLE
Copy swift.bzl into rules_apple.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])

--- a/apple/swift.bzl
+++ b/apple/swift.bzl
@@ -1,0 +1,494 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylark rules for Swift."""
+
+load("//apple:utils.bzl",
+     "xcrun_action",
+     "XCRUNWRAPPER_LABEL",
+     "module_cache_path",
+     "label_scoped_path")
+
+def _parent_dirs(dirs):
+  """Returns a set of parent directories for each directory in dirs."""
+  return set([f.rpartition("/")[0] for f in dirs])
+
+
+def _framework_names(dirs):
+  """Returns the framework name for each directory in dir."""
+  return set([f.rpartition("/")[2].partition(".")[0] for f in dirs])
+
+
+def _intersperse(separator, iterable):
+  """Inserts separator before each item in iterable."""
+  result = []
+  for x in iterable:
+    result.append(separator)
+    result.append(x)
+
+  return result
+
+
+def _swift_target(cpu, platform, sdk_version):
+  """Returns a target triplet for Swift compiler."""
+  platform_string = str(platform.platform_type)
+  if platform_string not in ["ios", "watchos", "tvos"]:
+    fail("Platform '%s' is not supported" % platform_string)
+
+  return "%s-apple-%s%s" % (cpu, platform_string, sdk_version)
+
+
+def _swift_compilation_mode_flags(ctx):
+  """Returns additional swiftc flags for the current compilation mode."""
+  mode = ctx.var["COMPILATION_MODE"]
+
+  flags = []
+  if mode == "dbg" or mode == "fastbuild":
+    # TODO(dmishe): Find a way to test -serialize-debugging-options
+    flags += [
+        "-Onone", "-DDEBUG", "-enable-testing", "-Xfrontend",
+        "-serialize-debugging-options"
+    ]
+  elif mode == "opt":
+    flags += ["-O", "-DNDEBUG"]
+
+  if mode == "dbg" or ctx.fragments.objc.generate_dsym:
+    flags.append("-g")
+
+  return flags
+
+
+def _clang_compilation_mode_flags(ctx):
+  """Returns additional clang flags for the current compilation mode."""
+
+  # In general, every compilation mode flag from native objc_ rules should be
+  # passed, but -g seems to break Clang module compilation. Since this flag does
+  # not make much sense for module compilation and only touches headers,
+  # it's ok to omit.
+  native_clang_flags = ctx.fragments.objc.copts_for_current_compilation_mode
+
+  return [x for x in native_clang_flags if x != "-g"]
+
+
+def _swift_bitcode_flags(ctx):
+  """Returns bitcode flags based on selected mode."""
+  mode = str(ctx.fragments.apple.bitcode_mode)
+  if mode == "embedded":
+    return ["-embed-bitcode"]
+  elif mode == "embedded_markers":
+    return ["-embed-bitcode-marker"]
+
+  return []
+
+
+def swift_module_name(label):
+  """Returns a module name for the given label."""
+  return label.package.lstrip("//").replace("/", "_") + "_" + label.name
+
+
+def _swift_lib_dir(ctx):
+  """Returns the location of swift runtime directory to link against."""
+  platform_str = ctx.fragments.apple.single_arch_platform.name_in_plist.lower()
+
+  toolchain_name = "XcodeDefault"
+  if hasattr(ctx.fragments.apple, "xcode_toolchain"):
+    toolchain = ctx.fragments.apple.xcode_toolchain
+
+    # We cannot use non Xcode-packaged toolchains, and the only one non-default
+    # toolchain known to exist (as of Xcode 8.1) is this one.
+    # TODO(b/29338444): Write an integration test when Xcode 8 is available.
+    if toolchain == "com.apple.dt.toolchain.Swift_2_3":
+      toolchain_name = "Swift_2.3"
+
+  return "{0}/Toolchains/{1}.xctoolchain/usr/lib/swift/{2}".format(
+      apple_common.apple_toolchain().developer_dir(), toolchain_name, platform_str)
+
+
+def _swift_linkopts(ctx):
+  """Returns additional linker arguments for the given rule context."""
+  return set(["-L" + _swift_lib_dir(ctx)])
+
+
+def _swift_xcrun_args(ctx):
+  """Returns additional arguments that should be passed to xcrun."""
+  if ctx.fragments.apple.xcode_toolchain:
+    return ["--toolchain", ctx.fragments.apple.xcode_toolchain]
+
+  return []
+
+
+def _swift_parsing_flags(ctx):
+  """Returns additional parsing flags for swiftc."""
+  srcs = ctx.files.srcs
+
+  # swiftc has two different parsing modes: script and library.
+  # The difference is that in script mode top-level expressions are allowed.
+  # This mode is triggered when the file compiled is called main.swift.
+  # Additionally, script mode is used when there's just one file in the
+  # compilation. we would like to avoid that and therefore force library mode
+  # when there's only one source and it's not called main.
+  if len(srcs) == 1 and srcs[0].basename != "main.swift":
+    return ["-parse-as-library"]
+  return []
+
+
+def _is_valid_swift_module_name(string):
+  """Returns True if the string is a valid Swift module name."""
+  if not string:
+    return False
+
+  for char in string:
+    # Check that the character is in [a-zA-Z0-9_]
+    if not (char.isalnum() or char == "_"):
+      return False
+
+  return True
+
+
+def _validate_rule_and_deps(ctx):
+  """Validates the target and its dependencies."""
+
+  name_error_str = ("Error in target '%s', Swift target and its dependencies' "+
+                    "names can only contain characters in [a-zA-Z0-9_].")
+
+  # Validate the name of the target
+  if not _is_valid_swift_module_name(ctx.label.name):
+    fail(name_error_str % ctx.label)
+
+  # Validate names of the dependencies
+  for dep in ctx.attr.deps:
+    if not _is_valid_swift_module_name(dep.label.name):
+      fail(name_error_str % dep.label)
+
+
+def swiftc_inputs(ctx):
+  """Determine the list of inputs required for the compile action.
+
+  Args:
+    ctx: rule context.
+
+  Returns:
+    A list of files needed by swiftc.
+  """
+  swift_providers = [x.swift for x in ctx.attr.deps if hasattr(x, "swift")]
+  objc_providers = [x.objc for x in ctx.attr.deps if hasattr(x, "objc")]
+
+  dep_modules = []
+  for swift in swift_providers:
+    dep_modules += swift.transitive_modules
+
+  objc_files = set()
+  for objc in objc_providers:
+    objc_files += objc.header
+    objc_files += objc.module_map
+    objc_files += set(objc.static_framework_file)
+    objc_files += set(objc.dynamic_framework_file)
+
+  return ctx.files.srcs + dep_modules + list(objc_files)
+
+
+def swiftc_args(ctx):
+  """Returns an almost compelete array of arguments to be passed to swiftc.
+
+  This macro is intended to be used by the swift_library rule implementation
+  below but it also may be used by other rules outside this file. It has no
+  side effects and does not modify ctx. It expects ctx to contain the same
+  fragments and attributes as swift_library (you're encouraged to depend on
+  SWIFT_LIBRARY_ATTRS in your rule definition).
+
+  Args:
+    ctx: rule context
+
+  Returns:
+    A list of command line arguments for swiftc. The returned arguments
+    include everything except the arguments generation of which would require
+    adding new files or actions.
+  """
+
+  apple_fragment = ctx.fragments.apple
+
+  cpu = apple_fragment.single_arch_cpu
+  platform = apple_fragment.single_arch_platform
+
+  target_os = apple_fragment.minimum_os_for_platform_type(
+      platform.platform_type)
+  target = _swift_target(cpu, platform, target_os)
+  apple_toolchain = apple_common.apple_toolchain()
+
+  module_name = ctx.attr.module_name or swift_module_name(ctx.label)
+
+  # A list of paths to pass with -F flag.
+  framework_dirs = set([
+      apple_toolchain.platform_developer_framework_dir(apple_fragment)])
+
+  # Collect transitive dependecies.
+  dep_modules = []
+  swiftc_defines = ctx.attr.defines
+
+  swift_providers = [x.swift for x in ctx.attr.deps if hasattr(x, "swift")]
+  objc_providers = [x.objc for x in ctx.attr.deps if hasattr(x, "objc")]
+
+  for swift in swift_providers:
+    dep_modules += swift.transitive_modules
+    swiftc_defines += swift.transitive_defines
+
+  objc_includes = set()     # Everything that needs to be included with -I
+  objc_module_maps = set()  # Module maps for dependent targets
+  objc_defines = set()
+  static_frameworks = set()
+  for objc in objc_providers:
+    objc_includes += objc.include
+    objc_module_maps += objc.module_map
+
+    static_frameworks += _framework_names(objc.framework_dir)
+    framework_dirs += _parent_dirs(objc.framework_dir)
+    framework_dirs += _parent_dirs(objc.dynamic_framework_dir)
+
+    # objc_library#copts is not propagated to its dependencies and so it is not
+    # collected here. In theory this may lead to un-importable targets (since
+    # their module cannot be compiled by clang), but did not occur in practice.
+    objc_defines += objc.define
+
+  srcs_args = [f.path for f in ctx.files.srcs]
+
+  # Include each swift module's parent directory for imports to work.
+  include_dirs = set([x.dirname for x in dep_modules])
+
+  # Include the genfiles root so full-path imports can work for generated protos.
+  include_dirs += set([ctx.genfiles_dir.path])
+
+  include_args = ["-I%s" % d for d in include_dirs + objc_includes]
+  framework_args = ["-F%s" % x for x in framework_dirs]
+  define_args = ["-D%s" % x for x in swiftc_defines]
+
+  # Disable the LC_LINKER_OPTION load commands for static frameworks automatic
+  # linking. This is needed to correctly deduplicate static frameworks from also
+  # being linked into test binaries where it is also linked into the app binary.
+  autolink_args =_intersperse(
+      "-Xfrontend",
+      _intersperse("-disable-autolink-framework", static_frameworks))
+
+  clang_args = _intersperse(
+      "-Xcc",
+
+      # Add the current directory to clang's search path.
+      # This instance of clang is spawned by swiftc to compile module maps and
+      # is not passed the current directory as a search path by default.
+      ["-iquote", "."]
+
+      # Pass DEFINE or copt values from objc configuration and rules to clang
+      + ["-D" + x for x in objc_defines] + ctx.fragments.objc.copts
+      + _clang_compilation_mode_flags(ctx)
+
+      # Load module maps explicitly instead of letting Clang discover them on
+      # search paths. This is needed to avoid a case where Clang may load the
+      # same header both in modular and non-modular contexts, leading to
+      # duplicate definitions in the same file.
+      # https://llvm.org/bugs/show_bug.cgi?id=19501
+      + ["-fmodule-map-file=%s" % x.path for x in objc_module_maps])
+
+  args = [
+      "-emit-object",
+      "-module-name",
+      module_name,
+      "-target",
+      target,
+      "-sdk",
+      apple_toolchain.sdk_dir(),
+      "-module-cache-path",
+      module_cache_path(ctx),
+  ]
+
+  if ctx.configuration.coverage_enabled:
+    args.extend(["-profile-generate", "-profile-coverage-mapping"])
+
+  args.extend(_swift_compilation_mode_flags(ctx))
+  args.extend(_swift_bitcode_flags(ctx))
+  args.extend(_swift_parsing_flags(ctx))
+  args.extend(srcs_args)
+  args.extend(include_args)
+  args.extend(framework_args)
+  args.extend(clang_args)
+  args.extend(define_args)
+  args.extend(autolink_args)
+  args.extend(ctx.fragments.swift.copts())
+  args.extend(ctx.attr.copts)
+
+  return args
+
+
+def _swift_library_impl(ctx):
+  """Implementation for swift_library Skylark rule."""
+
+  _validate_rule_and_deps(ctx)
+
+  # Collect transitive dependecies.
+  dep_modules = []
+  dep_libs = []
+  swiftc_defines = ctx.attr.defines
+
+  swift_providers = [x.swift for x in ctx.attr.deps if hasattr(x, "swift")]
+  objc_providers = [x.objc for x in ctx.attr.deps if hasattr(x, "objc")]
+
+  for swift in swift_providers:
+    dep_libs += swift.transitive_libs
+    dep_modules += swift.transitive_modules
+    swiftc_defines += swift.transitive_defines
+
+  # A unique path for rule's outputs.
+  objs_outputs_path = label_scoped_path(ctx, "_objs/")
+
+  module_name = ctx.attr.module_name or swift_module_name(ctx.label)
+  output_lib = ctx.new_file(objs_outputs_path + module_name + ".a")
+  output_module = ctx.new_file(objs_outputs_path + module_name + ".swiftmodule")
+
+  # These filenames are guaranteed to be unique, no need to scope.
+  output_header = ctx.new_file(ctx.label.name + "-Swift.h")
+  swiftc_output_map_file = ctx.new_file(ctx.label.name + ".output_file_map.json")
+
+  swiftc_output_map = struct()  # Maps output types to paths.
+  output_objs = []  # Object file outputs, used in archive action.
+  swiftc_outputs = []  # Other swiftc outputs that aren't processed further.
+
+  # Check if the user enabled Whole Module Optimization (WMO)
+  # This is highly experimental and tracked in b/29465250
+  has_wmo = ("-wmo" in ctx.attr.copts) or ("-whole-module-optimization" in ctx.attr.copts)
+
+  for source in ctx.files.srcs:
+    basename = source.basename
+    output_map_entry = {}
+
+    # Output an object file
+    obj = ctx.new_file(objs_outputs_path + basename + ".o")
+    output_objs.append(obj)
+    output_map_entry["object"] = obj.path
+
+    # Output a partial module file, unless WMO is enabled in which case only
+    # the final, complete module will be generated.
+    if not has_wmo:
+      partial_module = ctx.new_file(objs_outputs_path + basename +
+                                    ".partial_swiftmodule")
+      swiftc_outputs.append(partial_module)
+      output_map_entry["swiftmodule"] = partial_module.path
+
+    swiftc_output_map += struct(**{source.path: struct(**output_map_entry)})
+
+  # Write down the intermediate outputs map for this compilation, to be used
+  # with -output-file-map flag.
+  # It's a JSON file that maps each source input (.swift) to its outputs
+  # (.o, .bc, .d, ...)
+  # Example:
+  #   {'foo.swift':
+  #       {'object': 'foo.o', 'bitcode': 'foo.bc', 'dependencies': 'foo.d'}}
+  # There's currently no documentation on this option, however all of the keys
+  # are listed here https://github.com/apple/swift/blob/swift-2.2.1-RELEASE/include/swift/Driver/Types.def
+  ctx.file_action(output=swiftc_output_map_file, content=swiftc_output_map.to_json())
+
+  args = _swift_xcrun_args(ctx) + ["swiftc"] + swiftc_args(ctx)
+  args += [
+      "-I" + output_module.dirname,
+      "-emit-module-path",
+      output_module.path,
+      "-emit-objc-header-path",
+      output_header.path,
+      "-output-file-map",
+      swiftc_output_map_file.path,
+  ]
+
+  if has_wmo:
+    # WMO has two modes: threaded and not. We want the threaded mode because it
+    # will use the output map we generate. This leads to a better debug
+    # experience in lldb and Xcode.
+    # TODO(b/32571265): 12 has been chosen as the best option for a Mac Pro,
+    # we should get an interface in Bazel to get core count.
+    args.extend(["-num-threads", "12"])
+
+  xcrun_action(
+      ctx,
+      inputs=swiftc_inputs(ctx) + [swiftc_output_map_file],
+      outputs=[output_module, output_header] + output_objs + swiftc_outputs,
+      mnemonic="SwiftCompile",
+      arguments=args,
+      use_default_shell_env=False,
+      progress_message=("Compiling Swift module %s (%d files)" %
+                        (ctx.label.name, len(ctx.files.srcs))))
+
+  xcrun_action(ctx,
+               inputs=output_objs,
+               outputs=(output_lib,),
+               mnemonic="SwiftArchive",
+               arguments=[
+                   "libtool", "-static", "-o", output_lib.path
+               ] + [x.path for x in output_objs],
+               progress_message=("Archiving Swift objects %s" % ctx.label.name))
+
+  # This tells the linker to write a reference to .swiftmodule as an AST symbol
+  # in the final binary.
+  # With dSYM enabled, this results in a __DWARF,__swift_ast section added to
+  # the dSYM binary, from where LLDB is able deserialize module information.
+  # Without dSYM, LLDB will follow the AST references, however there is a bug
+  # where it follows only the first one https://bugs.swift.org/browse/SR-2637
+  # This means that dSYM is required for debugging until that is resolved.
+  extra_linker_args = ["-Xlinker -add_ast_path -Xlinker " + output_module.path]
+
+  objc_provider = apple_common.new_objc_provider(
+      library=set([output_lib] + dep_libs),
+      header=set([output_header]),
+      providers=objc_providers,
+      linkopt=_swift_linkopts(ctx) + extra_linker_args,
+      link_inputs=set([output_module]),
+      uses_swift=True,)
+
+  return struct(
+      swift=struct(
+          transitive_libs=[output_lib] + dep_libs,
+          transitive_modules=[output_module] + dep_modules,
+          transitive_defines=swiftc_defines),
+      objc=objc_provider,
+      files=set([output_lib, output_module, output_header]))
+
+SWIFT_LIBRARY_ATTRS = {
+    "srcs": attr.label_list(allow_files = [".swift"], allow_empty=False),
+    "deps": attr.label_list(providers=[["swift"], ["objc"]]),
+    "module_name": attr.string(mandatory=False),
+    "defines": attr.string_list(mandatory=False, allow_empty=True),
+    "copts": attr.string_list(mandatory=False, allow_empty=True),
+    "_xcrunwrapper": attr.label(
+        executable=True,
+        cfg="host",
+        default=Label(XCRUNWRAPPER_LABEL))
+}
+
+swift_library = rule(
+    _swift_library_impl,
+    attrs = SWIFT_LIBRARY_ATTRS,
+    fragments = ["apple", "objc", "swift"],
+    output_to_genfiles=True,
+)
+"""
+Builds a Swift module.
+
+A module is a pair of static library (.a) + module header (.swiftmodule).
+Dependant targets can import this module as "import RuleName".
+
+Args:
+  srcs: Swift sources that comprise this module.
+  deps: Other Swift modules.
+  module_name: Optional. Sets the Swift module name for this target. By default
+      the module name is the target path with all special symbols replaced
+      by "_", e.g. //foo:bar can be imported as "foo_bar".
+  copts: A list of flags passed to swiftc command line.
+  defines: Each VALUE in this attribute is passed as -DVALUE to the compiler for
+      this and dependent targets.
+"""

--- a/apple/utils.bzl
+++ b/apple/utils.bzl
@@ -15,6 +15,10 @@
 """Utility functions for working with strings, lists, and files in Skylark."""
 
 
+XCRUNWRAPPER_LABEL = "//external:xcrunwrapper"
+"""The label for xcrunwrapper tool."""
+
+
 def apple_action(ctx, **kw):
   """Creates an action that only runs on MacOS/Darwin.
 
@@ -223,6 +227,11 @@ def join_commands(cmds):
   return ' && '.join(cmds)
 
 
+def label_scoped_path(ctx, path):
+  """Return the path scoped to target's label."""
+  return ctx.label.name + "/" + path.lstrip("/")
+
+
 def merge_dictionaries(*dictionaries):
   """Merges at least two dictionaries.
 
@@ -239,6 +248,11 @@ def merge_dictionaries(*dictionaries):
     for name, value in d.items():
       result[name] = value
   return result
+
+
+def module_cache_path(ctx):
+  """Returns the Clang module cache path to use for this rule."""
+  return ctx.genfiles_dir.path + "/_objc_module_cache"
 
 
 def optionally_prefixed_path(path, prefix):

--- a/test/BUILD
+++ b/test/BUILD
@@ -38,6 +38,13 @@ apple_shell_test(
 )
 
 apple_shell_test(
+    name = "ios_application_swift_test",
+    size = "medium",
+    src = "ios_application_swift_test.sh",
+    configurations = IOS_CONFIGURATIONS,
+)
+
+apple_shell_test(
     name = "ios_extension_test",
     size = "medium",
     src = "ios_extension_test.sh",
@@ -50,9 +57,32 @@ apple_shell_test(
 )
 
 apple_shell_test(
+    name = "ios_extension_swift_test",
+    size = "medium",
+    src = "ios_extension_swift_test.sh",
+    configurations = IOS_CONFIGURATIONS,
+)
+
+# The swift_library test does not use any canned configurations; it controls
+# options manually for various tests.
+apple_shell_test(
+    name = "swift_library_test",
+    size = "medium",
+    src = "swift_library_test.sh",
+    configurations = {"default": []},
+)
+
+apple_shell_test(
     name = "tvos_application_test",
     size = "medium",
     src = "tvos_application_test.sh",
+    configurations = TVOS_CONFIGURATIONS,
+)
+
+apple_shell_test(
+    name = "tvos_application_swift_test",
+    size = "medium",
+    src = "tvos_application_swift_test.sh",
     configurations = TVOS_CONFIGURATIONS,
 )
 
@@ -64,8 +94,22 @@ apple_shell_test(
 )
 
 apple_shell_test(
+    name = "tvos_extension_swift_test",
+    size = "medium",
+    src = "tvos_extension_swift_test.sh",
+    configurations = TVOS_CONFIGURATIONS,
+)
+
+apple_shell_test(
     name = "watchos_application_test",
     size = "medium",
     src = "watchos_application_test.sh",
+    configurations = WATCHOS_CONFIGURATIONS,
+)
+
+apple_shell_test(
+    name = "watchos_application_swift_test",
+    size = "medium",
+    src = "watchos_application_swift_test.sh",
     configurations = WATCHOS_CONFIGURATIONS,
 )

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -248,7 +248,7 @@ function current_archs() {
     platform=ios_multi
   fi
 
-  for option in "${EXTRA_BUILD_OPTIONS[@]}"; do
+  for option in "${EXTRA_BUILD_OPTIONS[@]-}"; do
     case "$option" in
       --"${platform}"_cpus=*)
         value="$(echo "$option" | cut -d= -f2)"
@@ -291,8 +291,11 @@ function do_build() {
     bazel_options+=("--ios_signing_cert_name=-")
   fi
 
+  if [[ -n "${EXTRA_BUILD_OPTIONS[@]-}" ]]; then
+    bazel_options+=( "${EXTRA_BUILD_OPTIONS[@]}" )
+  fi
+
   bazel_options+=( \
-      "${EXTRA_BUILD_OPTIONS[@]}" \
       --define=bazel_rules_apple.mock_provisioning=true \
       "$@" \
   )
@@ -307,7 +310,7 @@ function do_build() {
 # Returns a success code if the --ios_signing_cert_name flag is set to "-";
 # otherwise, it returns a failure exit code.
 function is_ad_hoc_signed_build() {
-  for option in "${EXTRA_BUILD_OPTIONS[@]}"; do
+  for option in "${EXTRA_BUILD_OPTIONS[@]-}"; do
     if [[ "$option" == "--ios_signing_cert_name=-" ]]; then
       return 0
     fi
@@ -322,7 +325,7 @@ function is_ad_hoc_signed_build() {
 # Returns a success code if the --apple_bitcode flag is set to either
 # "embedded" or "embedded_markers"; otherwise, it returns a failure exit code.
 function is_bitcode_build() {
-  for option in "${EXTRA_BUILD_OPTIONS[@]}"; do
+  for option in "${EXTRA_BUILD_OPTIONS[@]-}"; do
     case "$option" in
       --apple-bitcode=none)
         return 1

--- a/test/ios_application_swift_test.sh
+++ b/test/ios_application_swift_test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for bundling iOS applications that use Swift.
+
+function set_up() {
+  rm -rf app
+  mkdir -p app
+}
+
+# Creates common source, targets, and basic plist for iOS applications.
+#
+# This creates everything but the "lib" target, which must be created by the
+# individual tests (so that they can exercise different dependency structures).
+function create_minimal_ios_application() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+     "ios_application")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":lib"],
+)
+EOF
+
+  cat > app/AppDelegate.swift <<EOF
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+}
+EOF
+
+  cat > app/Info.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleSignature = "????";
+}
+EOF
+}
+
+# Asserts that app.ipa contains the Swift dylibs in both the application
+# bundle and in the top-level support directory.
+#
+# We look for three dylibs based on what is used in the scratch AppDelegate
+# class above: Core, Foundation, and UIKit.
+function assert_ipa_contains_swift_dylibs() {
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
+
+  # Ignore the following checks for simulator builds.
+  # Support bundles are only present on device builds, since those are
+  # configured for opt compilation model.
+  is_device_build ios || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftUIKit.dylib"
+}
+
+# Tests that the bundler includes the Swift dylibs both in the application
+# bundle and in the top-level support directory of the IPA.
+function test_swift_dylibs_present() {
+  create_minimal_ios_application
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "lib",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  do_build ios 9.0 //app:app || fail "Should build"
+  assert_ipa_contains_swift_dylibs
+}
+
+# Tests that the bundler includes the Swift dylibs even when Swift is an
+# indirect dependency (that is, none of the direct deps of the application
+# are swift_libraries, but a transitive dependency is). This verifies that
+# the `uses_swift` property is propagated correctly.
+function test_swift_dylibs_present_with_only_indirect_swift_deps() {
+  create_minimal_ios_application
+
+  cat >> app/dummy.m <<EOF
+static void dummy() {}
+EOF
+
+  cat >> app/BUILD <<EOF
+objc_library(
+    name = "lib",
+    srcs = ["dummy.m"],
+    deps = [":lib2"],
+)
+
+swift_library(
+    name = "lib2",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  do_build ios 9.0 //app:app || fail "Should build"
+  assert_ipa_contains_swift_dylibs
+}
+
+# For device builds, tests that the Swift dylibs and the app are signed with
+# the same certificate.
+#
+# This test does not work for ad hoc signed builds. To test it, make sure you
+# specify a real certificate using the --ios_signing_cert_name command line
+# flag.
+function test_swift_dylibs_are_signed_with_same_certificate_as_app() {
+  is_device_build ios || return 0
+  ! is_ad_hoc_signed_build || return 0
+
+  create_minimal_ios_application
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "lib",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  create_dump_codesign_count "//app:app.ipa" \
+      "Payload/app.app/app" \
+      "Payload/app.app/Frameworks/libswiftCore.dylib"
+  do_build ios 9.0 //app:dump_codesign_count || fail "Should build"
+
+  # We checked two files, but there should be exactly one unique certificate.
+  assert_equals "1" "$(cat "test-genfiles/app/codesign_count_output")"
+}
+
+run_suite "ios_application with Swift bundling tests"

--- a/test/ios_extension_swift_test.sh
+++ b/test/ios_extension_swift_test.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for bundling iOS extensions that use Swift.
+
+function set_up() {
+  rm -rf app
+  mkdir -p app
+}
+
+# Creates the targets for a minimal iOS application written in Objective-C that
+# uses Swift in an app extension.
+function create_minimal_ios_application_with_swift_extension() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+     "ios_application",
+     "ios_extension")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(
+    name = "swiftlib",
+    srcs = ["ExtensionClass.swift"],
+)
+
+objc_library(
+    name = "objclib",
+    srcs = ["main.m"],
+)
+
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = ["Info-App.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":objclib"],
+)
+
+ios_extension(
+    name = "ext",
+    bundle_id = "my.bundle.id.extension",
+    families = ["iphone"],
+    infoplists = ["Info-Ext.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":swiftlib"],
+)
+EOF
+
+  cat > app/main.m <<EOF
+int main(int argc, char **argv) {
+  return 0;
+}
+EOF
+
+  # The extension shouldn't use UIApplicationMain, but something seems to be
+  # stripping the class (and thus the import it needs) out if I don't use
+  # something like this to force it to be exported.
+  cat > app/ExtensionClass.swift <<EOF
+import UIKit
+
+@UIApplicationMain
+class ExtensionClass: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+}
+EOF
+
+  cat > app/Info-App.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+}
+EOF
+
+  cat > app/Info-Ext.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  NSExtension = {
+    NSExtensionPrincipalClass = "DummyValue";
+    NSExtensionPointIdentifier = "com.apple.widget-extension";
+  };
+}
+EOF
+}
+
+# Creates the targets for a minimal iOS application written in Swift that also
+# uses Swift in an app extension, but where the extension.
+function create_minimal_swift_ios_application_with_swift_extension() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+     "ios_application",
+     "ios_extension")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(
+    name = "app_swiftlib",
+    srcs = ["AppDelegate.swift"],
+)
+
+swift_library(
+    name = "ext_swiftlib",
+    srcs = ["ExtensionClass.swift"],
+)
+
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = ["Info-App.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":app_swiftlib"],
+)
+
+ios_extension(
+    name = "ext",
+    bundle_id = "my.bundle.id.extension",
+    families = ["iphone"],
+    infoplists = ["Info-Ext.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":ext_swiftlib"],
+)
+EOF
+
+  cat > app/AppDelegate.swift <<EOF
+import AVFoundation
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  var asset: AVAsset?
+}
+EOF
+
+  # The extension shouldn't use UIApplicationMain, but something seems to be
+  # stripping the class (and thus the import it needs) out if I don't use
+  # something like this to force it to be exported.
+  cat > app/ExtensionClass.swift <<EOF
+import CoreLocation
+import UIKit
+
+@UIApplicationMain
+class ExtensionClass: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  var locationManager: CLLocationManager?
+}
+EOF
+
+  cat > app/Info-App.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+}
+EOF
+
+  cat > app/Info-Ext.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  NSExtension = {
+    NSExtensionPrincipalClass = "DummyValue";
+    NSExtensionPointIdentifier = "com.apple.widget-extension";
+  };
+}
+EOF
+}
+
+# Tests that the bundler includes the Swift dylibs when only an extension uses
+# Swift.
+#
+# We look for three dylibs based on what is used in the scratch AppDelegate
+# class above: Core, Foundation, and UIKit.
+function test_swift_dylibs_present() {
+  create_minimal_ios_application_with_swift_extension
+  do_build ios 9.0 //app:app || fail "Should build"
+
+  # Verify that the Swift dylibs are packaged with the *application*, not with
+  # the extension, as Xcode would do.
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
+
+  # And to be safe, verify that they *aren't* packaged with the extension.
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftFoundation.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftUIKit.dylib"
+
+  # Ignore the following checks for simulator builds.
+  is_device_build ios || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftUIKit.dylib"
+}
+
+# Tests that the bundler includes the union of Swift libraries used by the
+# application and the extension. Only the application created by this test
+# uses AVFoundation and only the extension uses CoreLocation; both should be
+# present in the Frameworks folder and, for release builds, the SwiftSupport
+# folder.
+function test_union_of_swift_dylibs_present_for_app_and_extension() {
+  create_minimal_swift_ios_application_with_swift_extension
+  do_build ios 9.0 //app:app || fail "Should build"
+
+  # Verify that the Swift dylibs are packaged with the *application*, not with
+  # the extension, as Xcode would do.
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftAVFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCoreLocation.dylib"
+
+  # And to be safe, verify that they *aren't* packaged with the extension.
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftAVFoundation.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCoreLocation.dylib"
+
+  # Ignore the following checks for simulator builds.
+  is_device_build ios || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftAVFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/iphoneos/libswiftCoreLocation.dylib"
+}
+
+run_suite "ios_extension with Swift bundling tests"

--- a/test/swift_library_test.sh
+++ b/test/swift_library_test.sh
@@ -1,0 +1,522 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for Swift libraries.
+
+function set_up() {
+  rm -rf ios
+  mkdir -p ios
+}
+
+function test_objc_depends_on_swift() {
+  cat >ios/main.swift <<EOF
+import Foundation
+
+@objc public class Foo: NSObject {
+  public func bar() -> Int { return 42; }
+}
+EOF
+
+  cat >ios/app.m <<EOF
+#import <UIKit/UIKit.h>
+#import "ios/SwiftMain-Swift.h"
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    NSLog(@"%d", [[[Foo alloc] init] bar]);
+    return UIApplicationMain(argc, argv, nil, nil);
+  }
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "SwiftMain",
+              srcs = ["main.swift"])
+
+objc_binary(name = "bin",
+            srcs = ['app.m',],
+            deps = [":SwiftMain"])
+EOF
+
+  do_build ios 8.0 //ios:bin || fail "should build"
+}
+
+function test_swift_imports_objc() {
+  cat >ios/main.swift <<EOF
+import Foundation
+import ios_ObjcLib
+
+public class SwiftClass {
+  public func bar() -> String {
+    return ObjcClass().foo()
+  }
+}
+EOF
+
+  cat >ios/ObjcClass.h <<EOF
+#import <Foundation/Foundation.h>
+
+#if !DEFINE_FOO
+#error "Define is not passed in"
+#endif
+
+#if !COPTS_FOO
+#error "Copt is not passed in
+#endif
+
+@interface ObjcClass : NSObject
+- (NSString *)foo;
+@end
+EOF
+
+  cat >ios/ObjcClass.m <<EOF
+#import "ObjcClass.h"
+@implementation ObjcClass
+- (NSString *)foo { return @"Hello ObjcClass"; }
+@end
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              deps = [":ObjcLib"])
+
+objc_library(name = "ObjcLib",
+             hdrs = ['ObjcClass.h'],
+             srcs = ['ObjcClass.m'],
+             defines = ["DEFINE_FOO=1"])
+EOF
+
+  do_build ios 8.0 --objccopt=-DCOPTS_FOO=1 --subcommands \
+      //ios:swift_lib || fail "should build"
+  expect_log "-module-cache-path blaze-out/darwin_x86_64-fastbuild/genfiles/_objc_module_cache"
+}
+
+function test_swift_imports_swift() {
+  cat >ios/main.swift <<EOF
+import Foundation
+import ios_util
+
+public class SwiftClass {
+  public func bar() -> String {
+    return Utility().foo()
+  }
+}
+EOF
+
+  cat >ios/Utility.swift <<EOF
+public class Utility {
+  public init() {}
+  public func foo() -> String { return "foo" }
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              deps = [":util"])
+
+swift_library(name = "util",
+              srcs = ['Utility.swift'])
+EOF
+
+  do_build ios 8.0 //ios:swift_lib || fail "should build"
+}
+
+function test_swift_compilation_mode_flags() {
+  cat >ios/debug.swift <<EOF
+// A trick to break compilation when DEBUG is not set.
+func foo() {
+  #if DEBUG
+  var x: Int
+  #endif
+  x = 3
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["debug.swift"])
+EOF
+
+  ! do_build ios 8.0 -c opt //ios:swift_lib || fail "should not build"
+  expect_log "error: use of unresolved identifier 'x'"
+
+  do_build ios 8.0 -c dbg //ios:swift_lib || fail "should build"
+}
+
+function test_swift_defines() {
+  touch ios/dummy.swift
+
+  cat >ios/main.swift <<EOF
+import Foundation
+
+public class SwiftClass {
+  public func bar() {
+    #if !FLAG
+    let x: String = 1 // Invalid statement, should throw compiler error when FLAG is not set
+    #endif
+
+    #if !DEP_FLAG
+    let x: String = 2 // Invalid statement, should throw compiler error when DEP_FLAG is not set
+    #endif
+  }
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "dep_lib",
+              srcs = ["dummy.swift"],
+              defines = ["DEP_FLAG"])
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              defines = ["FLAG"],
+              deps = [":dep_lib"])
+EOF
+
+  do_build ios 8.0 //ios:swift_lib || fail "should build"
+}
+
+function test_swift_no_object_file_collisions() {
+  touch ios/foo.swift
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "Foo",
+              srcs = ["foo.swift"])
+swift_library(name = "Bar",
+              srcs = ["foo.swift"])
+EOF
+
+  do_build ios 8.0 //ios:{Foo,Bar} || fail "should build"
+}
+
+function test_minimum_os_passed_to_swiftc() {
+  touch ios/foo.swift
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "foo",
+              srcs = ["foo.swift"])
+EOF
+
+  do_build ios 8.0 --ios_minimum_os=9.0 --announce_rc \
+      //ios:foo || fail "should build"
+
+  # Get the min OS version encoded as "version" argument of
+  # LC_VERSION_MIN_IPHONEOS load command in Mach-O
+  MIN_OS=$(otool -l test-genfiles/ios/foo/_objs/ios_foo.a | \
+      grep -A 3 LC_VERSION_MIN_IPHONEOS | grep version | cut -d " " -f4)
+  assert_equals $MIN_OS "9.0"
+}
+
+function test_swift_copts() {
+  cat >ios/main.swift <<EOF
+import Foundation
+
+public class SwiftClass {
+  public func bar() {
+    #if !FLAG
+    let x: String = 1 // Invalid statement, should throw compiler error when FLAG is not set
+    #endif
+
+    #if !CMD_FLAG
+    let y: String = 1 // Invalid statement, should throw compiler error when CMD_FLAG is not set
+    #endif
+  }
+}
+EOF
+
+cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              copts = ["-DFLAG"])
+EOF
+
+  do_build ios 8.0 --swiftcopt=-DCMD_FLAG \
+      //ios:swift_lib || fail "should build"
+}
+
+function test_swift_bitcode() {
+  cat >ios/main.swift <<EOF
+func f() {}
+EOF
+
+cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"])
+EOF
+
+  ARCHIVE=test-genfiles/ios/swift_lib/_objs/ios_swift_lib.a
+
+  # No bitcode
+  do_build ios --ios_multi_cpus=arm64 \
+      //ios:swift_lib >$TEST_log 2>&1 || fail "should build"
+  ! otool -l $ARCHIVE | grep __bitcode -sq \
+      || fail "expected a.o to not contain bitcode"
+
+  # Bitcode marker
+  do_build ios 8.0 --apple_bitcode=embedded_markers --ios_multi_cpus=arm64 \
+      //ios:swift_lib || fail "should build"
+  # Bitcode marker has a length of 1.
+  assert_equals $(size -m $ARCHIVE | grep __bitcode | cut -d: -f2 | tr -d ' ') "1"
+
+  # Full bitcode
+  do_build ios 8.0 --apple_bitcode=embedded --ios_multi_cpus=arm64 \
+      //ios:swift_lib || fail "should build"
+  otool -l $ARCHIVE | grep __bitcode -sq \
+      || fail "expected a.o to contain bitcode"
+
+  # Bitcode disabled because of simulator architecture
+  do_build ios 8.0 --apple_bitcode=embedded --ios_multi_cpus=x86_64 \
+      //ios:swift_lib || fail "should build"
+  ! otool -l $ARCHIVE | grep __bitcode -sq \
+      || fail "expected a.o to not contain bitcode"
+}
+
+function test_swift_name_validation() {
+  touch ios/main.swift
+  touch ios/main.m
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift-lib",
+              srcs = ["main.swift"])
+EOF
+
+  ! do_build ios 8.0 //ios:swift-lib || fail "should fail"
+  expect_log "Error in target '//ios:swift-lib'"
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+objc_library(name = "bad-dep", srcs = ["main.m"])
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"], deps=[":bad-dep"])
+EOF
+
+  ! do_build ios 8.0 //ios:swift_lib || fail "should fail"
+  expect_log "Error in target '//ios:bad-dep'"
+}
+
+function test_swift_ast_is_recorded() {
+  touch ios/main.swift
+  cat >ios/dep.swift <<EOF
+import UIKit
+// Add dummy code so that Swift symbols are exported into final binary, which
+// will cause runtime libraries to be packaged into the IPA
+class X: UIViewController {}
+EOF
+
+  cat >ios/main.m <<EOF
+#import <UIKit/UIKit.h>
+
+int main(int argc, char *argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, nil);
+  }
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "dep",
+              srcs = ["dep.swift"])
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              deps = [":dep"])
+objc_binary(name = "bin",
+            srcs = ["main.m"],
+            deps = [":swift_lib"])
+EOF
+
+  do_build ios 8.0 --subcommands //ios:bin || fail "should build"
+  expect_log "-Xlinker -add_ast_path -Xlinker blaze-out/ios_x86_64-fastbuild/genfiles/ios/dep/_objs/ios_dep\.swiftmodule"
+  expect_log "-Xlinker -add_ast_path -Xlinker blaze-out/ios_x86_64-fastbuild/genfiles/ios/swift_lib/_objs/ios_swift_lib\.swiftmodule"
+}
+
+function test_swiftc_script_mode() {
+  touch ios/foo.swift
+
+  cat >ios/top.swift <<EOF
+print() // Top level expression outside of main.swift, should fail.
+EOF
+
+  cat >ios/main.swift <<EOF
+import UIKit
+
+class AppDelegate: UIResponder, UIApplicationDelegate {}
+
+#if swift(>=3)
+UIApplicationMain(
+  CommandLine.argc,
+  UnsafeMutableRawPointer(CommandLine.unsafeArgv)
+    .bindMemory(
+      to: UnsafeMutablePointer<Int8>.self,
+      capacity: Int(CommandLine.argc)),
+  nil,
+  NSStringFromClass(AppDelegate.self)
+)
+#else
+UIApplicationMain(
+  Process.argc, UnsafeMutablePointer<UnsafeMutablePointer<CChar>>(Process.unsafeArgv),
+  nil, NSStringFromClass(AppDelegate)
+)
+#endif
+EOF
+
+cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "main_should_compile_as_script",
+              srcs = ["main.swift", "foo.swift"])
+swift_library(name = "top_should_not_compile_as_script",
+              srcs = ["top.swift"])
+swift_library(name = "single_source_should_compile_as_library",
+              srcs = ["foo.swift"])
+EOF
+
+  do_build ios 8.0 \
+      //ios:single_source_should_compile_as_library \
+      //ios:main_should_compile_as_script || fail "should build"
+
+  ! do_build ios 8.0 \
+      //ios:top_should_not_compile_as_script || fail "should not build"
+  expect_log "ios/top.swift:1:1: error: expressions are not allowed at the top level"
+}
+
+# Test that it's possible to import Clang module of a target that contains private headers.
+function test_import_module_with_private_hdrs() {
+  touch ios/Foo.h ios/Foo_Private.h
+
+  cat >ios/main.swift <<EOF
+import ios_lib
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+objc_library(name = "lib",
+             srcs = ["Foo_Private.h"],
+             hdrs = ["Foo.h"])
+
+swift_library(name = "swiftmodule",
+              srcs = ["main.swift"],
+              deps = [":lib"])
+EOF
+  do_build ios 8.0 //ios:swiftmodule || fail "should build"
+}
+
+function test_swift_whole_module_optimization() {
+  cat >ios/main.swift <<EOF
+import Foundation
+import ios_util
+
+public class SwiftClass {
+  public func bar() -> String {
+    return Utility().foo()
+  }
+}
+EOF
+
+  cat >ios/Utility.swift <<EOF
+public class Utility {
+  public init() {}
+  public func foo() -> String { return "foo" }
+}
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"],
+              deps = [":util"],
+              copts = ["-wmo"])
+
+swift_library(name = "util",
+              srcs = ['Utility.swift'],
+              copts = ["-whole-module-optimization"])
+EOF
+
+  do_build ios 8.0 //ios:swift_lib || fail "should build"
+}
+
+function test_swift_dsym() {
+  cat >ios/main.swift <<EOF
+import Foundation
+
+public class SwiftClass {
+  public func bar() -> String { return "foo" } }
+EOF
+
+  cat >ios/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_lib",
+              srcs = ["main.swift"])
+EOF
+
+  do_build ios 8.0 -c opt --apple_generate_dsym \
+      //ios:swift_lib || fail "should build"
+
+  # Verify that debug info is present.
+  dwarfdump -R test-genfiles/ios/swift_lib/_objs/ios_swift_lib.a \
+      | grep -sq "__DWARF" \
+      || fail "should contain DWARF data"
+}
+
+run_suite "swift_library tests"

--- a/test/testdata/provisioning/integration_testing.mobileprovision
+++ b/test/testdata/provisioning/integration_testing.mobileprovision
@@ -33,7 +33,7 @@
         </array>
         <key>keychain-access-groups</key>
         <array>
-            <string>FOOBARBAZ1.*</string>       
+            <string>FOOBARBAZ1.*</string>
         </array>
         <key>get-task-allow</key>
         <true/>

--- a/test/tvos_application_swift_test.sh
+++ b/test/tvos_application_swift_test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for bundling tvOS applications that use Swift.
+
+function set_up() {
+  rm -rf app
+  mkdir -p app
+}
+
+# Creates common source, targets, and basic plist for tvOS applications.
+#
+# This creates everything but the "lib" target, which must be created by the
+# individual tests (so that they can exercise different dependency structures).
+function create_minimal_tvos_application() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:tvos.bzl",
+     "tvos_application")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+tvos_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    infoplists = ["Info.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":lib"],
+)
+EOF
+
+  cat > app/AppDelegate.swift <<EOF
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+}
+EOF
+
+  cat > app/Info.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleSignature = "????";
+}
+EOF
+}
+
+# Asserts that app.ipa contains the Swift dylibs in both the application
+# bundle and in the top-level support directory.
+#
+# We look for three dylibs based on what is used in the scratch AppDelegate
+# class above: Core, Foundation, and UIKit.
+function assert_ipa_contains_swift_dylibs() {
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
+
+  # Ignore the following checks for simulator builds.
+  # Support bundles are only present on device builds, since those are
+  # configured for opt compilation model.
+  is_device_build tvos || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftUIKit.dylib"
+}
+
+# Tests that the bundler includes the Swift dylibs both in the application
+# bundle and in the top-level support directory of the IPA.
+function test_swift_dylibs_present() {
+  create_minimal_tvos_application
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "lib",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  do_build tvos 10.0 //app:app || fail "Should build"
+  assert_ipa_contains_swift_dylibs
+}
+
+# Tests that the bundler includes the Swift dylibs even when Swift is an
+# indirect dependency (that is, none of the direct deps of the application
+# are swift_libraries, but a transitive dependency is). This verifies that
+# the `uses_swift` property is propagated correctly.
+function test_swift_dylibs_present_with_only_indirect_swift_deps() {
+  create_minimal_tvos_application
+
+  cat >> app/dummy.m <<EOF
+static void dummy() {}
+EOF
+
+  cat >> app/BUILD <<EOF
+objc_library(
+    name = "lib",
+    srcs = ["dummy.m"],
+    deps = [":lib2"],
+)
+
+swift_library(
+    name = "lib2",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  do_build tvos 10.0 //app:app || fail "Should build"
+  assert_ipa_contains_swift_dylibs
+}
+
+run_suite "tvos_application with Swift bundling tests"

--- a/test/tvos_extension_swift_test.sh
+++ b/test/tvos_extension_swift_test.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for bundling tvOS extensions that use Swift.
+
+function set_up() {
+  rm -rf app
+  mkdir -p app
+}
+
+# Creates the targets for a minimal tvOS application written in Objective-C
+# that uses Swift in an app extension.
+function create_minimal_tvos_application_with_swift_extension() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:tvos.bzl",
+     "tvos_application",
+     "tvos_extension")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(
+    name = "swiftlib",
+    srcs = ["ExtensionClass.swift"],
+)
+
+objc_library(
+    name = "objclib",
+    srcs = ["main.m"],
+)
+
+tvos_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    infoplists = ["Info-App.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":objclib"],
+)
+
+tvos_extension(
+    name = "ext",
+    bundle_id = "my.bundle.id.extension",
+    infoplists = ["Info-Ext.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":swiftlib"],
+)
+EOF
+
+  cat > app/main.m <<EOF
+int main(int argc, char **argv) {
+  return 0;
+}
+EOF
+
+  # The extension shouldn't use UIApplicationMain, but something seems to be
+  # stripping the class (and thus the import it needs) out if I don't use
+  # something like this to force it to be exported.
+  cat > app/ExtensionClass.swift <<EOF
+import UIKit
+
+@UIApplicationMain
+class ExtensionClass: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+}
+EOF
+
+  cat > app/Info-App.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+}
+EOF
+
+  cat > app/Info-Ext.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  NSExtension = {
+    NSExtensionPrincipalClass = "DummyValue";
+    NSExtensionPointIdentifier = "com.apple.widget-extension";
+  };
+}
+EOF
+}
+
+# Creates the targets for a minimal tvOS application written in Swift that also
+# uses Swift in an app extension, but where the extension.
+function create_minimal_swift_tvos_application_with_swift_extension() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:tvos.bzl",
+     "tvos_application",
+     "tvos_extension")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(
+    name = "app_swiftlib",
+    srcs = ["AppDelegate.swift"],
+)
+
+swift_library(
+    name = "ext_swiftlib",
+    srcs = ["ExtensionClass.swift"],
+)
+
+tvos_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    infoplists = ["Info-App.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":app_swiftlib"],
+)
+
+tvos_extension(
+    name = "ext",
+    bundle_id = "my.bundle.id.extension",
+    infoplists = ["Info-Ext.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":ext_swiftlib"],
+)
+EOF
+
+  cat > app/AppDelegate.swift <<EOF
+import AVFoundation
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  var asset: AVAsset?
+}
+EOF
+
+  # The extension shouldn't use UIApplicationMain, but something seems to be
+  # stripping the class (and thus the import it needs) out if I don't use
+  # something like this to force it to be exported.
+  cat > app/ExtensionClass.swift <<EOF
+import CoreLocation
+import UIKit
+
+@UIApplicationMain
+class ExtensionClass: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+  var locationManager: CLLocationManager?
+}
+EOF
+
+  cat > app/Info-App.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+}
+EOF
+
+  cat > app/Info-Ext.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  NSExtension = {
+    NSExtensionPrincipalClass = "DummyValue";
+    NSExtensionPointIdentifier = "com.apple.widget-extension";
+  };
+}
+EOF
+}
+
+# Tests that the bundler includes the Swift dylibs when only an extension uses
+# Swift.
+#
+# We look for three dylibs based on what is used in the scratch AppDelegate
+# class above: Core, Foundation, and UIKit.
+function test_swift_dylibs_present() {
+  create_minimal_tvos_application_with_swift_extension
+  do_build tvos 10.0 //app:app || fail "Should build"
+
+  # Verify that the Swift dylibs are packaged with the *application*, not with
+  # the extension, as Xcode would do.
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
+
+  # And to be safe, verify that they *aren't* packaged with the extension.
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftFoundation.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftUIKit.dylib"
+
+  # Ignore the following checks for simulator builds.
+  is_device_build tvos || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftUIKit.dylib"
+}
+
+# Tests that the bundler includes the union of Swift libraries used by the
+# application and the extension. Only the application created by this test
+# uses AVFoundation and only the extension uses CoreLocation; both should be
+# present in the Frameworks folder and, for release builds, the SwiftSupport
+# folder.
+function test_union_of_swift_dylibs_present_for_app_and_extension() {
+  create_minimal_swift_tvos_application_with_swift_extension
+  do_build tvos 10.0 //app:app || fail "Should build"
+
+  # Verify that the Swift dylibs are packaged with the *application*, not with
+  # the extension, as Xcode would do.
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftAVFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/Frameworks/libswiftCoreLocation.dylib"
+
+  # And to be safe, verify that they *aren't* packaged with the extension.
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftAVFoundation.dylib"
+  assert_zip_not_contains "test-bin/app/app.ipa" \
+      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCoreLocation.dylib"
+
+  # Ignore the following checks for simulator builds.
+  is_device_build tvos || return 0
+
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftAVFoundation.dylib"
+  assert_zip_contains "test-bin/app/app.ipa" \
+      "SwiftSupport/appletvos/libswiftCoreLocation.dylib"
+}
+
+run_suite "tvos_extension with Swift bundling tests"

--- a/test/watchos_application_swift_test.sh
+++ b/test/watchos_application_swift_test.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Integration tests for bundling simple watchOS applications that use Swift.
+
+function set_up() {
+  rm -rf app
+  mkdir -p app
+}
+
+# Creates watchOS application and extension targets along with a
+# companion iOS app. The iOS application depends on a library named
+# ":phone_lib" and the watchOS extension depends on a library named
+# ":watch_lib". These targets must be created by the individual test cases
+# (so that they can test Obj-C vs. Swift as needed).
+function create_app_and_extension_targets() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+     "ios_application")
+load("@build_bazel_rules_apple//apple:watchos.bzl",
+     "watchos_application",
+     "watchos_extension")
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+ios_application(
+    name = "phone_app",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info-PhoneApp.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    watch_application = ":watch_app",
+    deps = [":phone_lib"],
+)
+
+watchos_application(
+    name = "watch_app",
+    bundle_id = "my.bundle.id.watch_app",
+    extension = ":watch_ext",
+    infoplists = ["Info-WatchApp.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+)
+
+watchos_extension(
+    name = "watch_ext",
+    bundle_id = "my.bundle.id.watch_app.watch_ext",
+    infoplists = ["Info-WatchExt.plist"],
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":watch_lib"],
+)
+EOF
+
+  cat > app/main.swift <<EOF
+import Foundation
+
+class SomeObject: NSObject {}
+EOF
+
+  cat > app/main.m <<EOF
+int main(int argc, char **argv) {
+  return 0;
+}
+EOF
+
+  cat > app/Info-PhoneApp.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+}
+EOF
+
+  cat > app/Info-WatchApp.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  WKCompanionAppBundleIdentifier = "my.bundle.id";
+  WKWatchKitApp = true;
+}
+EOF
+
+  cat > app/Info-WatchExt.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1";
+  CFBundleSignature = "????";
+  NSExtension = {
+    NSExtensionAttributes = {
+      WKAppBundleIdentifier = "my.bundle.id.watch_app";
+    };
+    NSExtensionPointIdentifier = "com.apple.watchkit";
+  };
+}
+EOF
+}
+
+# Tests that if the iOS app uses Swift and the watchOS extension does not, then
+# Swift libraries are only bundled in the iOS app and only iOS Swift libraries
+# are in the SwiftSupport folder for release builds.
+function test_only_ios_swift_libs_present() {
+  create_app_and_extension_targets
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "phone_lib",
+    srcs = ["main.swift"],
+)
+
+objc_library(
+    name = "watch_lib",
+    srcs = ["main.m"],
+)
+EOF
+
+  do_build watchos 2.0 //app:phone_app || fail "Should build"
+
+  # Make sure we do have Swift dylibs in the iOS application.
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Frameworks/libswiftFoundation.dylib"
+
+  # Make sure we don't have a Swift dylib in the watchOS extension.
+  assert_zip_not_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Watch/watch_app.app/PlugIns/watch_ext.appex/Frameworks/libswiftCore.dylib"
+
+  # Ignore the following checks for simulator builds.
+  # Support bundles are only present on device builds, since those are
+  # configured for opt compilation model.
+  is_device_build watchos || return 0
+
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/iphoneos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
+}
+
+# Tests that if the watchOS extension uses Swift and the iOS app does not, then
+# Swift libraries are only bundled in the watchOS app (not the extension) and
+# only watchOS Swift libraries are in the SwiftSupport folder for release
+# builds.
+function test_only_watchos_swift_libs_present() {
+  create_app_and_extension_targets
+
+  cat >> app/BUILD <<EOF
+objc_library(
+    name = "phone_lib",
+    srcs = ["main.m"],
+)
+
+swift_library(
+    name = "watch_lib",
+    srcs = ["main.swift"],
+)
+EOF
+
+  do_build watchos 2.0 //app:phone_app || fail "Should build"
+
+  # Make sure we don't have a Swift dylib in the iOS application.
+  assert_zip_not_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Frameworks/libswiftCore.dylib"
+
+  # Make sure we do have Swift dylibs in the watchOS extension.
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftFoundation.dylib"
+
+  # Ignore the following checks for simulator builds.
+  # Support bundles are only present on device builds, since those are
+  # configured for opt compilation model.
+  is_device_build watchos || return 0
+
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/watchos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/watchos/libswiftFoundation.dylib"
+}
+
+# Tests that if both the iOS app and the watchOS extension use Swift, then the
+# iOS app and watchOS app (not the extension) have Swift libraries bundled, and
+# that Swift libraries for both platforms are in the SwiftSupport folder for
+# release builds.
+function test_both_ios_and_watchos_swift_libs_present() {
+  create_app_and_extension_targets
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "phone_lib",
+    srcs = ["main.swift"],
+)
+
+swift_library(
+    name = "watch_lib",
+    srcs = ["main.swift"],
+)
+EOF
+
+  do_build watchos 2.0 //app:phone_app || fail "Should build"
+
+  # Make sure we do have Swift dylibs in the iOS application.
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Frameworks/libswiftFoundation.dylib"
+
+  # Make sure we do have Swift dylibs in the watchOS extension.
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftFoundation.dylib"
+
+  # Ignore the following checks for simulator builds.
+  # Support bundles are only present on device builds, since those are
+  # configured for opt compilation model.
+  is_device_build watchos || return 0
+
+  # Make sure iOS and watchOS Swift libraries are in SwiftSupport.
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/iphoneos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/watchos/libswiftCore.dylib"
+  assert_zip_contains "test-bin/app/phone_app.ipa" \
+      "SwiftSupport/watchos/libswiftFoundation.dylib"
+}
+
+run_suite "watchos_application with Swift bundling tests"


### PR DESCRIPTION
As of this change, the copy of `swift.bzl` in [bazelbuild/bazel](https://github.com/bazelbuild/bazel) should be considered frozen and deprecated, and it will be removed soon. All future Swift rule development will occur in this repository.

(This PR also contains some other various cleanup.)

Fixes #13.

PiperOrigin-RevId: 152729637