### PR TITLE
Fixes for swift_library.

### DIFF
--- a/apple/utils.bzl
+++ b/apple/utils.bzl
@@ -15,7 +15,7 @@
 """Utility functions for working with strings, lists, and files in Skylark."""
 
 
-XCRUNWRAPPER_LABEL = "//external:xcrunwrapper"
+XCRUNWRAPPER_LABEL = "@bazel_tools//tools/objc:xcrunwrapper"
 """The label for xcrunwrapper tool."""
 
 

--- a/test/apple_shell_testrunner.sh
+++ b/test/apple_shell_testrunner.sh
@@ -66,14 +66,14 @@ function setup_clean_workspace() {
   [ "${new_workspace_dir}" = "${WORKSPACE_DIR}" ] || \
     { echo "Failed to create workspace" >&2; exit 1; }
   export BAZEL_INSTALL_BASE=$(bazel info install_base)
-  export BAZEL_GENFILES=$(bazel info bazel-genfiles "${EXTRA_BUILD_OPTIONS[@]}")
-  export BAZEL_BIN=$(bazel info bazel-bin "${EXTRA_BUILD_OPTIONS[@]}")
+  export BAZEL_GENFILES=$(bazel info bazel-genfiles "${EXTRA_BUILD_OPTIONS[@]:-}")
+  export BAZEL_BIN=$(bazel info bazel-bin "${EXTRA_BUILD_OPTIONS[@]:-}")
 }
 
 # Any remaining arguments are passed to every `bazel build` invocation in the
 # subsequent tests (see `do_build` in apple_shell_testutils.sh).
 export EXTRA_BUILD_OPTIONS=( "$@" ); shift $#
-echo "Applying extra options to each build: ${EXTRA_BUILD_OPTIONS[*]}" > "$TEST_log"
+echo "Applying extra options to each build: ${EXTRA_BUILD_OPTIONS[*]:-}" > "$TEST_log"
 
 setup_clean_workspace
 

--- a/test/swift_library_test.sh
+++ b/test/swift_library_test.sh
@@ -111,7 +111,7 @@ EOF
 
   do_build ios 8.0 --objccopt=-DCOPTS_FOO=1 --subcommands \
       //ios:swift_lib || fail "should build"
-  expect_log "-module-cache-path blaze-out/darwin_x86_64-fastbuild/genfiles/_objc_module_cache"
+  expect_log "-module-cache-path [^/]*-out/[^/]*/genfiles/_objc_module_cache"
 }
 
 function test_swift_imports_swift() {
@@ -380,8 +380,8 @@ objc_binary(name = "bin",
 EOF
 
   do_build ios 8.0 --subcommands //ios:bin || fail "should build"
-  expect_log "-Xlinker -add_ast_path -Xlinker blaze-out/ios_x86_64-fastbuild/genfiles/ios/dep/_objs/ios_dep\.swiftmodule"
-  expect_log "-Xlinker -add_ast_path -Xlinker blaze-out/ios_x86_64-fastbuild/genfiles/ios/swift_lib/_objs/ios_swift_lib\.swiftmodule"
+  expect_log "-Xlinker -add_ast_path -Xlinker [^/]*-out/[^/]*/genfiles/ios/dep/_objs/ios_dep\.swiftmodule"
+  expect_log "-Xlinker -add_ast_path -Xlinker [^/]*-out/[^/]*/genfiles/ios/swift_lib/_objs/ios_swift_lib\.swiftmodule"
 }
 
 function test_swiftc_script_mode() {


### PR DESCRIPTION
The rule was still referring to `//external:xcrunwrapper`, which we don't bind in our `WORKSPACE`, instead of `//tools/objc:xcrunwrapper`.

The changes in the test runner are to handle the fact that `swift_library_test`'s configuration has no options.

PiperOrigin-RevId: 153169142