### PR TITLE
Allow files, not just labels, in app_icons/launch_images.

### DIFF
--- a/apple/bundling/ios_rules.bzl
+++ b/apple/bundling/ios_rules.bzl
@@ -107,7 +107,7 @@ def _ios_application_impl(ctx):
 # All attributes available to the _ios_application rule. (Note that this does
 # not include linkopts, which is consumed entirely by the wrapping macro.)
 _IOS_APPLICATION_ATTRIBUTES = merge_dictionaries(common_rule_attributes(), {
-    "app_icons": attr.label_list(),
+    "app_icons": attr.label_list(allow_files=True),
     "entitlements": attr.label(
         allow_files=[".entitlements"],
         single_file=True,
@@ -121,7 +121,7 @@ _IOS_APPLICATION_ATTRIBUTES = merge_dictionaries(common_rule_attributes(), {
     "frameworks": attr.label_list(
         allow_rules=["ios_framework"],
     ),
-    "launch_images": attr.label_list(),
+    "launch_images": attr.label_list(allow_files=True),
     "launch_storyboard": attr.label(
         allow_files=[".storyboard", ".xib"],
         single_file=True,
@@ -187,7 +187,7 @@ def _ios_extension_impl(ctx):
 # All attributes available to the _ios_extension rule. (Note that this does
 # not include linkopts, which is consumed entirely by the wrapping macro.)
 _IOS_EXTENSION_ATTRIBUTES = merge_dictionaries(common_rule_attributes(), {
-    "app_icons": attr.label_list(),
+    "app_icons": attr.label_list(allow_files=True),
     "asset_catalogs": attr.label_list(
         allow_files=True,
     ),
@@ -254,7 +254,6 @@ def _ios_framework_impl(ctx):
 
 # All attributes available to the _ios_framework rule.
 _IOS_FRAMEWORK_ATTRIBUTES = merge_dictionaries(common_rule_without_binary_attributes(), {
-    "app_icons": attr.label_list(),
     "binary": attr.label(
         # TODO(b/36513471): Restrict to apple dylib provider.
         allow_rules=["apple_binary"],

--- a/apple/bundling/tvos_rules.bzl
+++ b/apple/bundling/tvos_rules.bzl
@@ -88,7 +88,7 @@ def _tvos_application_impl(ctx):
 tvos_application = rule(
     _tvos_application_impl,
     attrs = merge_dictionaries(common_rule_attributes(), {
-        "app_icons": attr.label_list(),
+        "app_icons": attr.label_list(allow_files=True),
         "entitlements": attr.label(
             allow_files=[".entitlements"],
             single_file=True,
@@ -96,7 +96,7 @@ tvos_application = rule(
         "extensions": attr.label_list(
             providers=[["apple_bundle", "tvos_extension"]],
         ),
-        "launch_images": attr.label_list(),
+        "launch_images": attr.label_list(allow_files=True),
         "launch_storyboard": attr.label(
             allow_files=[".storyboard", ".xib"],
             single_file=True,

--- a/apple/bundling/watchos_rules.bzl
+++ b/apple/bundling/watchos_rules.bzl
@@ -76,7 +76,7 @@ def _watchos_application_impl(ctx):
 watchos_application = rule(
     _watchos_application_impl,
     attrs = merge_dictionaries(common_rule_without_binary_attributes(), {
-        "app_icons": attr.label_list(),
+        "app_icons": attr.label_list(allow_files=True),
         "entitlements": attr.label(
             allow_files=[".entitlements"],
             single_file=True,
@@ -146,7 +146,7 @@ def _watchos_extension_impl(ctx):
 watchos_extension = rule(
     _watchos_extension_impl,
     attrs = merge_dictionaries(common_rule_attributes(), {
-        "app_icons": attr.label_list(),
+        "app_icons": attr.label_list(allow_files=True),
         "entitlements": attr.label(
             allow_files=[".entitlements"],
             single_file=True,


### PR DESCRIPTION
Fixes #25.

PiperOrigin-RevId: 153720427