### PR TITLE
More codesigning fixes.

### DIFF
--- a/apple/bundling/codesigning_support.bzl
+++ b/apple/bundling/codesigning_support.bzl
@@ -67,7 +67,7 @@ def _verify_signing_id_commands(ctx, identity, provisioning_profile):
   verified_id = ("VERIFIED_ID=" +
                  "$( " +
                  "security find-identity -v -p codesigning | " +
-                 "grep -F " + bash_quote(identity) + " | " +
+                 "grep -F \"" + identity + "\" | " +
                  "xargs | " +
                  "cut -d' ' -f2 " +
                  ")\n")
@@ -85,10 +85,9 @@ def _verify_signing_id_commands(ctx, identity, provisioning_profile):
   error_handling = ("if [[ -z \"$VERIFIED_ID\" ]]; then\n" +
                     "  " +
                     "echo " +
-                    bash_quote("error: Could not find a valid identity in " +
-                               "the keychain matching " +
-                               '"' + identity + '"' +
-                               found_in_prov_profile_msg + ".") +
+                    "error: Could not find a valid identity in the " +
+                    "keychain matching \"" + identity + "\"" +
+                    found_in_prov_profile_msg + "." +
                     "\n" +
                     "  " +
                     "exit 1\n" +

--- a/apple/bundling/entitlements.bzl
+++ b/apple/bundling/entitlements.bzl
@@ -67,6 +67,7 @@ def _extract_team_prefix_action(ctx):
            "${PLIST} > " + bash_quote(team_prefix_file.path)),
       ],
       mnemonic = "ExtractAppleTeamPrefix",
+      no_sandbox = True,  # "security" tool requires this
   )
 
   return team_prefix_file
@@ -101,7 +102,7 @@ def _extract_entitlements_action(ctx):
            "${PLIST} > " + bash_quote(extracted_entitlements_file.path)),
       ],
       mnemonic = "ExtractAppleEntitlements",
-      no_sandbox = True,
+      no_sandbox = True,  # "security" tool requires this
   )
 
   return extracted_entitlements_file


### PR DESCRIPTION
- Disable sandboxing for another "security" action.
- Remove some overly aggressive shell quoting that was breaking provisioning profile certificate extraction.

PiperOrigin-RevId: 154079591