### PR TITLE
iOS bundling rules use declared providers to restrict dependencies.

### DIFF
--- a/apple/bundling/ios_rules.bzl
+++ b/apple/bundling/ios_rules.bzl
@@ -255,10 +255,9 @@ def _ios_framework_impl(ctx):
 # All attributes available to the _ios_framework rule.
 _IOS_FRAMEWORK_ATTRIBUTES = merge_dictionaries(common_rule_attributes(), {
     "binary": attr.label(
-        # TODO(b/36513471): Restrict to apple dylib provider.
-        allow_rules=["apple_binary"],
         aspects=[apple_bundling_aspect],
         mandatory=True,
+        providers=[apple_common.AppleDylibBinary],
         single_file=True,
     ),
     "hdrs": attr.label_list(

--- a/apple/bundling/rule_attributes.bzl
+++ b/apple/bundling/rule_attributes.bzl
@@ -219,8 +219,8 @@ def common_rule_attributes():
       simple_path_format_attributes(),
       {
           "binary": attr.label(
-              allow_rules=["apple_binary"],
               aspects=[apple_bundling_aspect],
+              providers=[apple_common.AppleExecutableBinary],
               single_file=True,
           ),
           "bundle_id": attr.string(


### PR DESCRIPTION
In practice, this is a no-op, but it's slightly cleaner with regards to targeting rules by function instead of by name.

RELNOTES: None.
PiperOrigin-RevId: 154465261