### PR TITLE
Add "resources", "structured_resources" attrs to swift_library.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -42,6 +42,10 @@ apple_shell_test(
     size = "medium",
     src = "ios_application_swift_test.sh",
     configurations = IOS_CONFIGURATIONS,
+    data = [
+        "//test/testdata/resources:resource_data_deps_ios",
+        "//test/testdata/resources:resource_data_deps_platform_independent",
+    ],
 )
 
 apple_shell_test(

--- a/test/testdata/resources/storyboard_ios.storyboard
+++ b/test/testdata/resources/storyboard_ios.storyboard
@@ -4,10 +4,10 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--My View Controller-->
         <scene sceneID="hTu-93-i48">
             <objects>
-                <viewController id="mdN-da-fi0" sceneMemberID="viewController">
+                <viewController id="mdN-da-fi0" customClass="MyViewController" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="9yG-FV-4rp"/>
                         <viewControllerLayoutGuide type="bottom" id="Yh6-Np-8xF"/>

--- a/test/testdata/resources/unversioned_datamodel.xcdatamodel/contents
+++ b/test/testdata/resources/unversioned_datamodel.xcdatamodel/contents
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15G31" minimumToolsVersion="Xcode 7.0">
-    <elements/>
+    <entity name="Entity" representedClassName=".Entity" syncable="YES" codeGenerationType="class"/>
+    <elements>
+        <element name="Entity" positionX="-63" positionY="-18" width="128" height="45"/>
+    </elements>
 </model>

--- a/test/testdata/resources/versioned_datamodel.xcdatamodeld/v1.xcdatamodel/contents
+++ b/test/testdata/resources/versioned_datamodel.xcdatamodeld/v1.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16D32" minimumToolsVersion="Xcode 7.0" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="1">
-    <entity name="Entity" syncable="YES">
+    <entity name="Entity" representedClassName=".Entity" syncable="YES" codeGenerationType="class">
         <attribute name="attribute" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
     </entity>
     <elements>

--- a/test/testdata/resources/versioned_datamodel.xcdatamodeld/v2.xcdatamodel/contents
+++ b/test/testdata/resources/versioned_datamodel.xcdatamodeld/v2.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="12141" systemVersion="16D32" minimumToolsVersion="Xcode 7.0" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="2">
-    <entity name="Entity" syncable="YES">
+    <entity name="Entity" representedClassName=".Entity" syncable="YES" codeGenerationType="class">
         <attribute name="attribute" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
     </entity>
     <elements>

--- a/test/testdata/resources/view_ios.xib
+++ b/test/testdata/resources/view_ios.xib
@@ -6,7 +6,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="YWX-9B-fWw">
+        <view contentMode="scaleToFill" id="YWX-9B-fWw" customClass="MyView" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
This *only* works with the Skylark-based bundling rules; the attributes are ignored if a native bundlng rule depends on them.

The "resources" attribute takes the place of "asset_catalogs", "datamodels", "resources", "storyboards", "strings", and "xibs" that are on similar rules like "objc_library". All the specific resource types can be included in "resources" instead and they are processed according to their names.

"structured_resources" has the same meaning as before.

"bundles" are not yet supported; they will be in the near future.

Partially addresses #34.

RELNOTES: None.
PiperOrigin-RevId: 154857955