### PR TITLE
Add support for the minimum_os_version attribute for the iOS test rules.

### DIFF
--- a/apple/testing/ios.bzl
+++ b/apple/testing/ios.bzl
@@ -112,6 +112,7 @@ def _ios_test(name,
               runner=None,
               deps=[],
               bundle_id=None,
+              minimum_os_version=None,
               infoplists=[
                   "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
               ],
@@ -141,6 +142,7 @@ def _ios_test(name,
       sdk_frameworks = ["XCTest"],
       binary_type = "loadable_bundle",
       bundle_loader = bundle_loader_binary,
+      minimum_os_version = minimum_os_version,
       visibility = ["//visibility:private"],
       testonly = 1,
   )
@@ -151,6 +153,7 @@ def _ios_test(name,
       bundle_name = name,
       bundle_id = bundle_id,
       infoplists = infoplists,
+      minimum_os_version = minimum_os_version,
       test_host = test_host,
       testonly = 1,
       visibility = ["//visibility:private"],
@@ -184,6 +187,8 @@ def ios_unit_test(
         "Tests".
     infoplists: A list of plist files that will be merged to form the
         Info.plist that represents the test bundle.
+    minimum_os_version: The minimum OS version that this target and its
+        dependencies should be built for. Optional.
     runner: The runner target that contains the logic of how the tests should
         be executed. This target needs to provide an AppleTestRunner provider.
         Optional.
@@ -217,6 +222,8 @@ def ios_ui_test(
         "Tests".
     infoplists: A list of plist files that will be merged to form the
         Info.plist that represents the test bundle.
+    minimum_os_version: The minimum OS version that this target and its
+        dependencies should be built for. Optional.
     runner: The runner target that contains the logic of how the tests should
         be executed. This target needs to provide an AppleTestRunner provider.
         Optional.

--- a/test/ios_ui_test_test.sh
+++ b/test/ios_ui_test_test.sh
@@ -88,6 +88,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
     deps = [":lib"],
 )
@@ -95,6 +96,7 @@ ios_application(
 ios_ui_test(
     name = "ui_tests",
     deps = [":ui_test_lib"],
+    minimum_os_version = "9.0",
     test_host = ":app",
 EOF
 
@@ -135,6 +137,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
     deps = [":lib"],
 )
@@ -151,6 +154,7 @@ dummy_test_runner(
 ios_ui_test(
     name = "ui_tests",
     deps = [":ui_test_lib"],
+    minimum_os_version = "9.0",
     test_host = ":app",
     runner = ":DummyTestRunner",
 )

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -88,6 +88,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
     deps = [":lib"],
 )
@@ -95,6 +96,7 @@ ios_application(
 ios_unit_test(
     name = "unit_tests",
     deps = [":unit_test_lib"],
+    minimum_os_version = "9.0",
     test_host = ":app",
 EOF
 
@@ -118,6 +120,7 @@ function create_minimal_ios_unit_test() {
   cat >> app/BUILD <<EOF
 ios_unit_test(
     name = "unit_tests",
+    minimum_os_version = "9.0",
     deps = [":unit_test_lib"],
 )
 EOF
@@ -135,6 +138,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
     deps = [":lib"],
 )
@@ -151,6 +155,7 @@ dummy_test_runner(
 ios_unit_test(
     name = "unit_tests",
     deps = [":unit_test_lib"],
+    minimum_os_version = "9.0",
     test_host = ":app",
     runner = ":DummyTestRunner",
 )


### PR DESCRIPTION
PiperOrigin-RevId: 155418253