### PR TITLE
Add "manual" tag to implicit apple_binary targets.

### DIFF
--- a/apple/bundling/binary_support.bzl
+++ b/apple/bundling/binary_support.bzl
@@ -99,14 +99,14 @@ def _create_binary(
   native.apple_binary(
       name = apple_binary_name,
       srcs = entitlements_srcs,
+      dylibs = kwargs.get("frameworks"),
       features = kwargs.get("features"),
       linkopts = linkopts,
       minimum_os_version = minimum_os_version,
       platform_type = platform_type,
       sdk_frameworks = sdk_frameworks,
       deps = deps + entitlements_deps,
-      dylibs = kwargs.get("frameworks"),
-      tags = kwargs.get("tags"),
+      tags = ["manual"] + kwargs.get("tags", []),
       testonly = kwargs.get("testonly"),
       visibility = kwargs.get("visibility"),
   )


### PR DESCRIPTION
This will prevent builds of :all or /... from trying to build the binary as an isolated target. In some cases doing so would cause failures (e.g., watchOS applications) because the linked binary will error out since it has no srcs but the target must still act as a choke point to correctly pass the platform down to its dependencies.

RELNOTES: None.
PiperOrigin-RevId: 155880519