### PR TITLE
Add trap to clean up simulator in ios_sample_test_runner

### DIFF
--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -40,8 +40,8 @@ NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SDK_VERSION")
 
 # Clean up our simulator and temp directory if we fail along the way
 function cleanup {
-	rm -rf "${TEST_TMP_DIR}"
-    xcrun simctl delete $"$NEW_SIM_ID"
+  rm -rf "${TEST_TMP_DIR}"
+  xcrun simctl delete $"$NEW_SIM_ID"
 }
 trap cleanup ERR EXIT
 

--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -28,7 +28,7 @@ basename_without_extension() {
   echo "${filename%.*}"
 }
 
-# Unpack the output IPA into a tmp folder
+# Create tmp folder to contain the extracted .xctest bundle
 TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tests.XXXXXX")"
 
 # Create a simulator with a random name and the iOS SDK provided by the
@@ -49,6 +49,7 @@ trap cleanup ERR EXIT
 # state to the Shutdown state.
 sleep 2
 
+# Extract the bundle into the tmp folder we created earlier
 TEST_BUNDLE_PATH="%(test_bundle_path)s"
 TEST_BUNDLE_NAME=$(basename_without_extension "$TEST_BUNDLE_PATH")
 
@@ -61,8 +62,3 @@ XCTEST_PATH="$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Library/Xc
 
 # Spawn xctest with the test bundle which runs the tests.
 xcrun simctl spawn "$NEW_SIM_ID" "$XCTEST_PATH" "$TEST_BUNDLE"
-EXIT_CODE=$?
-
-# Bazel detects the exit code from this script as the status of whether the
-# tests succeeded or failed. Any exit code other than 0 means tests failed.
-exit $EXIT_CODE

--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -45,6 +45,12 @@ SDK_VERSION="$(xcrun --sdk iphonesimulator --show-sdk-version)"
 
 NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SDK_VERSION")
 
+# Clean our simulator up even if we fail along the way
+function cleanup {
+    xcrun simctl delete $"$NEW_SIM_ID"
+}
+trap cleanup EXIT
+
 # Wait a bit so that the newly created simulator can pass from the Creating
 # state to the Shutdown state.
 sleep 2
@@ -56,8 +62,6 @@ XCTEST_PATH="$XCODE_PATH/Platforms/iPhoneSimulator.platform/Developer/Library/Xc
 # Spawn xctest with the test bundle which runs the tests.
 xcrun simctl spawn "$NEW_SIM_ID" "$XCTEST_PATH" "$TEST_BUNDLE"
 EXIT_CODE=$?
-
-xcrun simctl delete $"$NEW_SIM_ID"
 
 # Bazel detects the exit code from this script as the status of whether the
 # tests succeeded or failed. Any exit code other than 0 means tests failed.


### PR DESCRIPTION
Hi Bazel team,

I’m working on changing over our `ios_test` rules to the new `ios_unit_test` rules, and I’ve run into a few issues. The first is that I’m unable to call `bazel test` on the rule unless I disable the sandbox (using the `--strategy=TestRunner=standalone` flag). While debugging this, I found that the simulator that the default testrunner script creates isn’t cleaned up if anything fails along the way. To address this, could we add a trap that deletes the created simulator?

Also, should I open an issue around the sandboxing issue? The error I get is:
```
SandboxViolation: simctl(41704) deny file-write-create /Users/hshamansky/Library/Developer/CoreSimulator/Devices/26D97441-A139-45F7-A75F-2FA3A0C564DD/data/Library/Logs
Violation:       deny file-write-create /Users/hshamansky/Library/Developer/CoreSimulator/Devices/26D97441-A139-45F7-A75F-2FA3A0C564DD/data/Library/Logs 
Process:         simctl [41704]
Path:            /Applications/Xcode.app/Contents/Developer/usr/bin/simctl
Load Address:    0x104ed4000
Identifier:      simctl
Version:         ??? (???)
Code Type:       x86_64 (Native)
Parent Process:  bash [41689]
Responsible:     /Applications/Utilities/Terminal.app/Contents/MacOS/Terminal [33314]
User ID:         501
```