### PR TITLE
Add bundle_name attribute so it can differ from the target name.

### DIFF
--- a/apple/bundling/bundling_support.bzl
+++ b/apple/bundling/bundling_support.bzl
@@ -70,16 +70,18 @@ def _bundlable_file_sources(bundlable_files):
 def _bundle_name(ctx):
   """Returns the name of the bundle.
 
+  The name of the bundle is the value of the `bundle_name` attribute if it was
+  given; if not, then the name of the target will be used instead.
+
   Args:
     ctx: The Skylark context.
   Returns:
     The bundle name.
   """
-  if hasattr(ctx.attr, "_bundle_name_attr"):
-    bundle_name_attr = ctx.attr._bundle_name_attr
-    return getattr(ctx.attr, bundle_name_attr)
-  else:
-    return ctx.label.name
+  bundle_name = ctx.attr.bundle_name
+  if not bundle_name:
+    bundle_name = ctx.label.name
+  return bundle_name
 
 
 def _bundle_name_with_extension(ctx):

--- a/apple/bundling/rule_factory.bzl
+++ b/apple/bundling/rule_factory.bzl
@@ -359,6 +359,7 @@ def _make_bundling_rule(implementation,
               single_file=True,
           ),
           "bundle_id": attr.string(mandatory=True),
+          "bundle_name": attr.string(mandatory=False),
           "infoplists": attr.label_list(
               allow_files=[".plist"],
               mandatory=True,

--- a/apple/testing/ios_rules.bzl
+++ b/apple/testing/ios_rules.bzl
@@ -70,15 +70,9 @@ _ios_test_bundle = rule_factory.make_bundling_rule(
         # order to make it optional. Bundle identifier for the
         # _ios_test_bundle output.
         "bundle_id": attr.string(),
-        # Internal name for the bundle. Used so that the output .xctest bundle
-        # has the same name as the test target and avoid Tulsi the confusion
-        # of the internal paths.
-        "bundle_name": attr.string(mandatory=True),
         # The test host that will run these tests. This is required in order to
         # obtain a sensible default for the tests bundle identifier.
         "test_host": attr.label(mandatory=True, providers=[AppleBundleInfo]),
-        # Name of the attribute that contains the internal bundle name.
-        "_bundle_name_attr": attr.string(default="bundle_name"),
     },
     # TODO(b/34774324): Rename to zip.
     archive_extension=".ipa",

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -4,10 +4,10 @@
 ## ios_application
 
 ```python
-ios_application(name, app_icons, bundle_id, entitlements, extensions, families,
-frameworks, infoplists, ipa_post_processor, launch_images, launch_storyboard,
-minimum_os_version, linkopts, product_type, provisioning_profile, settings_bundle,
-strings, deps)
+ios_application(name, app_icons, bundle_id, bundle_name, entitlements,
+extensions, families, frameworks, infoplists, ipa_post_processor, launch_images,
+launch_storyboard, minimum_os_version, linkopts, product_type,
+provisioning_profile, settings_bundle, strings, deps)
 ```
 
 Builds and bundles an iOS application.
@@ -49,6 +49,15 @@ inside the application bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         application.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.app</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>
@@ -218,9 +227,9 @@ inside the application bundle.
 ## ios_extension
 
 ```python
-ios_extension(name, app_icons, bundle_id, entitlements, families, frameworks,
-infoplists, ipa_post_processor, linkopts, minimum_os_version, product_type,
-provisioning_profile, strings, deps)
+ios_extension(name, app_icons, bundle_id, bundle_name, entitlements,
+families, frameworks, infoplists, ipa_post_processor, linkopts,
+minimum_os_version, product_type, provisioning_profile, strings, deps)
 ```
 
 Builds and bundles an iOS application extension.
@@ -262,6 +271,15 @@ executable inside the extension bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         extension.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.appex</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>
@@ -382,8 +400,8 @@ executable inside the extension bundle.
 ## ios_framework
 
 ```python
-ios_framework(name, bundle_id, families, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, extension_safe, strings, deps)
+ios_framework(name, bundle_id, bundle_name, extension_safe, families,
+infoplists, ipa_post_processor, linkopts, minimum_os_version, strings, deps)
 ```
 
 Builds and bundles an iOS dynamic framework.
@@ -416,6 +434,15 @@ inside the framework bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         framework.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.framework</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -19,8 +19,8 @@ compilation/linking to work correctly for macOS targets. Those flags are:
 ## macos_application
 
 ```python
-macos_application(name, app_icons, bundle_id, entitlements, extensions,
-infoplists, ipa_post_processor, linkopts, minimum_os_version,
+macos_application(name, app_icons, bundle_id, bundle_name, entitlements,
+extensions, infoplists, ipa_post_processor, linkopts, minimum_os_version,
 provisioning_profile, strings, deps)
 ```
 
@@ -63,6 +63,15 @@ inside the application bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         application.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.app</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>
@@ -165,8 +174,8 @@ inside the application bundle.
 ## macos_extension
 
 ```python
-macos_extension(name, bundle_id, entitlements, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, strings, deps)
+macos_extension(name, bundle_id, bundle_name, entitlements, infoplists,
+ipa_post_processor, linkopts, minimum_os_version, strings, deps)
 ```
 
 Builds and bundles a macOS extension.
@@ -199,6 +208,15 @@ executable inside the extension bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         extension.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.appex</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -4,9 +4,10 @@
 ## tvos_application
 
 ```python
-tvos_application(name, app_icons, bundle_id, entitlements, extensions,
-infoplists, ipa_post_processor, launch_images, launch_storyboard, linkopts,
-minimum_os_version, provisioning_profile, settings_bundle, strings, deps)
+tvos_application(name, app_icons, bundle_id, bundle_name, entitlements,
+extensions, infoplists, ipa_post_processor, launch_images, launch_storyboard,
+linkopts, minimum_os_version, provisioning_profile, settings_bundle, strings,
+deps)
 ```
 
 Builds and bundles a tvOS application.
@@ -48,6 +49,15 @@ inside the application bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         application.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.app</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>
@@ -184,8 +194,8 @@ inside the application bundle.
 ## tvos_extension
 
 ```python
-tvos_extension(name, bundle_id, entitlements, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, strings, deps)
+tvos_extension(name, bundle_id, bundle_name, entitlements, infoplists,
+ipa_post_processor, linkopts, minimum_os_version, strings, deps)
 ```
 
 Builds and bundles a tvOS extension.
@@ -218,6 +228,15 @@ executable inside the extension bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         extension.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.appex</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -4,9 +4,9 @@
 ## watchos_application
 
 ```python
-watchos_application(name, app_icons, bundle_id, entitlements, extension,
-infoplists, ipa_post_processor, minimum_os_version, provisioning_profile,
-storyboards, strings, deps)
+watchos_application(name, app_icons, bundle_id, bundle_name,
+entitlements, extension, infoplists, ipa_post_processor, minimum_os_version,
+provisioning_profile, storyboards, strings, deps)
 ```
 
 Builds and bundles a watchOS application.
@@ -53,6 +53,15 @@ rule.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         application.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.app</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>
@@ -157,9 +166,9 @@ rule.
 ## watchos_extension
 
 ```python
-watchos_extension(name, app_icons, bundle_id, entitlements, infoplists,
-ipa_post_processor, linkopts, minimum_os_version, provisioning_profile,
-strings, deps)
+watchos_extension(name, app_icons, bundle_id, bundle_name, entitlements,
+infoplists, ipa_post_processor, linkopts, minimum_os_version,
+provisioning_profile, strings, deps)
 ```
 
 Builds and bundles a watchOS extension.
@@ -205,6 +214,15 @@ executable inside the extension bundle.
         <p><code>String; required</code></p>
         <p>The bundle ID (reverse-DNS path followed by app name) of the
         extension.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.appex</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
       </td>
     </tr>
     <tr>

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -605,4 +605,29 @@ function test_bitcode_symbol_maps_packaging() {
       "Payload/app.app/app"
 }
 
+# Tests that the bundle name can be overridden to differ from the target name.
+function test_bundle_name_can_differ_from_target() {
+  create_common_files
+
+  cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    bundle_name = "different",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing.mobileprovision",
+    deps = [":lib"],
+)
+EOF
+
+  do_build ios 10.0 //app:app || fail "Should build"
+
+  # Both the bundle name and the executable name should correspond to
+  # bundle_name.
+  assert_zip_contains "test-bin/app/app.ipa" "Payload/different.app/"
+  assert_zip_contains "test-bin/app/app.ipa" "Payload/different.app/different"
+}
+
 run_suite "ios_application bundling tests"


### PR DESCRIPTION
Fixes #70.

RELNOTES: None.
PiperOrigin-RevId: 156862341