### PR TITLE
Remove a no-longer-needed flag from the macOS docs.

### DIFF
--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -9,7 +9,6 @@ compilation/linking to work correctly for macOS targets. Those flags are:
 
 ```shell
 --apple_crosstool_transition
---experimental_enable_objc_cc_deps
 --experimental_objc_crosstool=all
 ```
 


### PR DESCRIPTION
PiperOrigin-RevId: 158158859