### PR TITLE
Use latest simulator runtime instead of latest iOS SDK

### DIFF
--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -31,12 +31,11 @@ basename_without_extension() {
 # Create tmp folder to contain the extracted .xctest bundle
 TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tests.XXXXXX")"
 
-# Create a simulator with a random name and the iOS SDK provided by the
-# Xcode currently selected with xcode-select.
+# Create a simulator with a random name and the latest iOS SDK
 RANDOM_NAME="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-SDK_VERSION="$(xcrun --sdk iphonesimulator --show-sdk-version)"
+SIM_VERSION="$(xcrun simctl list runtimes | grep "SimRuntime\.iOS" | perl -pe 's|^iOS.*?\((.*?) -.*|\1|' | tail -n 1)"
 
-NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SDK_VERSION")
+NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SIM_VERSION")
 
 # Clean up our simulator and temp directory if we fail along the way
 function cleanup {

--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -33,7 +33,7 @@ TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tests.XXXXXX")"
 
 # Create a simulator with a random name and the latest iOS SDK
 RANDOM_NAME="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-SIM_VERSION="$(xcrun simctl list runtimes | grep "SimRuntime\.iOS" | perl -pe 's|^iOS.*?\((.*?) -.*|\1|' | tail -n 1)"
+SIM_VERSION="$(xcrun simctl list runtimes | grep "SimRuntime\.iOS" | sed 's/^iOS [0-9\\.]* (\([0-9\.]*\).*/\1/' | tail -n 1)"
 
 NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SIM_VERSION")
 


### PR DESCRIPTION
The default test runner currently uses `xcrun --sdk iphonesimulator --show-sdk-version` to get the simulator version. This works fine in Xcode 8.3.2 where the SDK is `10.3` and so is the simulator version:

```
== Runtimes ==
...
iOS 10.3 (10.3 - 14E269) (com.apple.CoreSimulator.SimRuntime.iOS-10-3)
```

Xcode 8.3.3 still uses the `10.3` SDK, but the simulator runtime is now `10.3.1`:

```
== Runtimes ==
...
iOS 10.3 (10.3.1 - 14E8301) (com.apple.CoreSimulator.SimRuntime.iOS-10-3)
```

I've modified the default test runner script to account for this. It now lists out the runtimes (`xcrun simctl list runtimes`), filters the output down to the iOS runtimes (`grep "SimRuntime\.iOS"`), gets the real simulator version number (`sed 's/^iOS [0-9\\.]* (\([0-9\.]*\).*/\1/'`), then takes the last line as the versions are sorted in order (`tail -n 1`).

If you can come up with a more terse way to write that, please feel free to make a suggestion. My command-line-fu is good, not great :wink: There may also be a better way to write this overall. Internally, we've rewritten the test runner as a python script. This lets us use `simctl`'s JSON API instead, which is a lot less hairy to work with.

This same issue may crop up in other areas where simulators are involved (`bazel run ...` comes to mind).