### PR TITLE
Fix iOS simulator unit tests

### DIFF
--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -40,7 +40,7 @@ NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SIM_VERSION")
 # Clean up our simulator and temp directory if we fail along the way
 function cleanup {
   rm -rf "${TEST_TMP_DIR}"
-  xcrun simctl delete $"$NEW_SIM_ID"
+  xcrun simctl delete "$RANDOM_NAME"
 }
 trap cleanup ERR EXIT
 

--- a/apple/testing/default_runner/ios_sample_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_sample_test_runner.template.sh
@@ -33,20 +33,33 @@ TEST_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tests.XXXXXX")"
 
 # Create a simulator with a random name and the latest iOS SDK
 RANDOM_NAME="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
-SIM_VERSION="$(xcrun simctl list runtimes | grep "SimRuntime\.iOS" | sed 's/^iOS [0-9\\.]* (\([0-9\.]*\).*/\1/' | tail -n 1)"
+SDK_VERSION="$(xcrun --sdk iphonesimulator --show-sdk-version | tr "." "-")"
+SIMULATOR_RUNTIME="com.apple.CoreSimulator.SimRuntime.iOS-$SDK_VERSION"
+NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SIMULATOR_RUNTIME")
 
-NEW_SIM_ID=$(xcrun simctl create "$RANDOM_NAME" "iPhone 6" "$SIM_VERSION")
+# Shut down and clean up our simulator and temp directory even if we fail along the way.
+did_cleanup=0
 
-# Clean up our simulator and temp directory if we fail along the way
 function cleanup {
-  rm -rf "${TEST_TMP_DIR}"
-  xcrun simctl delete "$RANDOM_NAME"
+  if [[ "$did_cleanup" == "0" ]]; then
+    did_cleanup=1
+    rm -rf "${TEST_TMP_DIR}"
+    xcrun simctl shutdown "$RANDOM_NAME"
+    xcrun simctl delete "$RANDOM_NAME"
+  fi
 }
+
 trap cleanup ERR EXIT
 
 # Wait a bit so that the newly created simulator can pass from the Creating
 # state to the Shutdown state.
 sleep 2
+
+# Ensure simulator is booted.
+xcrun simctl boot "$NEW_SIM_ID"
+
+# Ensure log directory exists.
+mkdir -p "/Users/$(whoami)/Library/Developer/CoreSimulator/Devices/$NEW_SIM_ID/data/Library/logs"
 
 # Extract the bundle into the tmp folder we created earlier
 TEST_BUNDLE_PATH="%(test_bundle_path)s"

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -253,7 +253,7 @@ function test_builds_with_default_host() {
     create_common_files
     create_minimal_ios_unit_test
 
-    do_build ios --ios_minimum_os=9.0 //app:unit_tests || fail "Should build"
+    do_test ios --ios_minimum_os=9.0 //app:unit_tests || fail "Should build"
   fi
 }
 

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -36,4 +36,7 @@ else
   readonly tests="$@"
 fi
 
-bazel test "$tests" --test_strategy=standalone --strategy=TestRunner=standalone
+bazel test "$tests" \
+    --test_strategy=standalone \
+    --strategy=TestRunner=standalone \
+    --test_output=errors


### PR DESCRIPTION
I started working on this before @dflems fixed the sim runtime, but there were a few more issues in the runner script. The test `//test:ios_unit_test_test.simulator` now passes for me against Xcode 9.0 beta 1. 

Unfortunately, when I run this against Xcode 8.3.3, I get the following error. Does anyone maybe know more about the toolchain to know what's wrong here? 

>2017-06-20 21:46:03.261 simctl[99457:8822718] CoreSimulatorService connection became invalid.  Simulator services will no longer be available.
Unable to locate device set: Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort" UserInfo={NSLocalizedFailureReason=Failed to subscribe to notifications from CoreSimulatorService., NSLocalizedDescription=Failed to initialize simulator device set., NSUnderlyingError=0x7fef3660f0b0 {Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort" UserInfo={NSLocalizedDescription=Error returned in reply to notification request: Connection invalid}}}
Use --strategy=TestRunner=standalone to disable sandboxing for the failing actions.

`bazel version` == `0.5.1-homebrew`