### PR TITLE
Fix bug affecting module name at root of workspace

### DIFF
--- a/apple/swift.bzl
+++ b/apple/swift.bzl
@@ -132,8 +132,12 @@ def _swift_version_flags(apple_fragment, swift_version):
 
 def swift_module_name(label):
   """Returns a module name for the given label."""
-  return (label.package.lstrip("//").replace("/", "_").replace("-", "_") + "_" +
-          label.name.replace("-", "_"))
+  prefix = label.package.lstrip("//").replace("/", "_").replace("-", "_")
+  suffix = label.name.replace("-", "_")
+  if prefix:
+     return (prefix + "_" + suffix)
+  else:
+     return suffix
 
 
 def _swift_lib_dir(apple_fragment, config_vars, is_static=False):

--- a/test/swift_library_test.sh
+++ b/test/swift_library_test.sh
@@ -534,4 +534,28 @@ EOF
       || fail "should contain DWARF data"
 }
 
+# Verifies that a swift module's name has no prefixes when it is defined at the root of
+# the workspace.
+function test_swift_module_name_at_root() {
+  echo 'public class SwiftClass { func bar() -> Int { return 1 } }' > dep.swift
+  echo 'import swift_module_name_at_root_dep' > main.swift
+
+  cat >BUILD <<EOF
+load("@build_bazel_rules_apple//apple:swift.bzl",
+     "swift_library")
+
+swift_library(name = "swift_module_name_at_root_dep",
+              srcs = ["dep.swift"])
+swift_library(name = "swift_module_name_at_root",
+              srcs = ["main.swift"],
+              deps = [":swift_module_name_at_root_dep"])
+EOF
+
+  do_build ios //:swift_module_name_at_root -s || fail "should build"
+
+  rm dep.swift
+  rm main.swift
+  rm BUILD
+}
+
 run_suite "swift_library tests"


### PR DESCRIPTION
If an Objective-C or Swift target is defined at the root of a workspace, swift_module_name was creating a module name with a `_` prefix. For example, a target named "MyComponent" would be given the name "_MyComponent". This meant that targets depending on that module would have to import the component as _MyComponent rather than the expected MyComponent.

This change fixes that bug by checking whether there is a non-empty package prefix string when generating the module name. If there is no prefix then we simply return the target name.

Closes #109