### PR TITLE
Return to using security tool for extracting provisioning plist from profile.

### DIFF
--- a/apple/bundling/plist_support.bzl
+++ b/apple/bundling/plist_support.bzl
@@ -33,14 +33,7 @@ def _extract_provisioning_plist_command(ctx, provisioning_profile):
     # plist without a signature.
     return "cat " + bash_quote(provisioning_profile.path)
   else:
-    # The `security cms -D -i` command previously used here spits out a message
-    # that seems to indicate an internal error on Sierra (even though the
-    # command succeeds). The `openssl smime` command below also emits to stderr,
-    # but the message is a "Verification successful" message, which we deem to
-    # be somewhat preferable to one that implies failure. Regardless, we capture
-    # the stderr output and only emit it if the command *actually* terminated
-    # with a failing exit code so that we reduce noise in the build log.
-    extract_plist_cmd = ("openssl smime -inform der -verify -noverify -in " +
+    extract_plist_cmd = ("security cms -D -i " +
             bash_quote(provisioning_profile.path))
     return ("( " +
             "STDERR=$(mktemp -t openssl.stderr) && " +


### PR DESCRIPTION
In High Sierra there are encoding issues when reading profiles using the
openssl tool but the security tool works correctly. Builds that
previously worked in Sierra are failing in High Sierra due to this
depending on the decrypted value of your profile.

This, strangely, only happens for some of our provisioning profiles. The security tool version works for all of them.