### PR TITLE
Add a dump test so something is enabled in the file.

### DIFF
--- a/test/ios_application_clang_rt_test.sh
+++ b/test/ios_application_clang_rt_test.sh
@@ -123,4 +123,10 @@ function disabled_test_ubsan_bundle() {  # Blocked on b/73547309
   fi
 }
 
+function test_empty() {
+  # Empty test so there is still an enabled test in here.
+  # Remove after b/73547309 is fixed.
+  assert_equals "abc" "abc"
+}
+
 run_suite "ios_application clang support tests"


### PR DESCRIPTION
Looks like the unittesting support chokes if there are no test methods
enabled, so provide one until the other things are fixed.

PiperOrigin-RevId: 190476974