### PR TITLE
Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ git_repository(
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.3.0",
+    tag = "0.4.0",
 )
 ```
 

--- a/apple/bundling/codesigning_support.bzl
+++ b/apple/bundling/codesigning_support.bzl
@@ -176,11 +176,12 @@ def _codesign_command(ctx, path_to_sign, entitlements_file):
       entitlements_flag = (
           "--entitlements %s" % shell.quote(entitlements_file.path))
 
-    return (cmd_prefix + "/usr/bin/codesign --force " +
-            "--sign $VERIFIED_ID %s %s" % (entitlements_flag, path))
+    return ((cmd_prefix + "/usr/bin/codesign --force " +
+             "--sign $VERIFIED_ID %s %s") % (entitlements_flag, path))
   else:
     # Use ad hoc signing for simulator builds.
-    return cmd_prefix + '/usr/bin/codesign --force --sign "-" %s' % path
+    return ((cmd_prefix + "/usr/bin/codesign --force " +
+             "--timestamp=none --sign \"-\" %s") % path)
 
 
 def _path_to_sign(path, optional=False):

--- a/doc/rules-swift.md
+++ b/doc/rules-swift.md
@@ -57,7 +57,7 @@ swift_library(
 ```
 
 It can also be enabled for all targets in the build using the Bazel flag
-`--swift_whole_module_optimization`.
+`--swiftcopt=-whole-module-optimization`.
 
 ### Toolchains
 

--- a/test/swift_library_test.sh
+++ b/test/swift_library_test.sh
@@ -505,23 +505,6 @@ EOF
   expect_log "-whole-module-optimization"
 }
 
-function test_swift_wmo_flag() {
-  echo 'class SwiftClass { func bar() -> Int { return 1 } }' > ios/main.swift
-
-  cat >ios/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:swift.bzl",
-     "swift_library")
-
-swift_library(name = "swift_lib_copt_wmo_flag",
-              srcs = ["main.swift"])
-EOF
-
-  do_build ios //ios:swift_lib_copt_wmo_flag -s \
-      --swift_whole_module_optimization || fail "should build"
-  expect_log "-num-threads"
-  expect_log "-whole-module-optimization"
-}
-
 function test_swift_dsym() {
   cat >ios/main.swift <<EOF
 import Foundation

--- a/tools/environment_plist/environment_plist.sh
+++ b/tools/environment_plist/environment_plist.sh
@@ -77,11 +77,14 @@ xcode_version_string=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f
 # Converts '7.1' -> 0710, and '7.1.1' -> 0711.
 xcode_version=$(/usr/bin/printf '%02d%d%d\n' $(echo "${xcode_version_string//./ }"))
 
-/usr/bin/defaults write "${PLIST}" DTPlatformBuild -string ${platform_build:-""}
-/usr/bin/defaults write "${PLIST}" DTSDKBuild -string ${sdk_build:-""}
-/usr/bin/defaults write "${PLIST}" DTPlatformVersion -string ${platform_version:-""}
-/usr/bin/defaults write "${PLIST}" DTXcode -string ${xcode_version:-""}
-/usr/bin/defaults write "${PLIST}" DTXcodeBuild -string ${xcode_build:-""}
-/usr/bin/defaults write "${PLIST}" DTCompiler -string ${compiler:-""}
-/usr/bin/defaults write "${PLIST}" BuildMachineOSBuild -string ${os_build:-""}
-cat "${PLIST}" > "${OUTPUT}"
+/usr/libexec/PlistBuddy \
+    -c "Add :DTPlatformBuild string ${platform_build:-""}" \
+    -c "Add :DTSDKBuild string ${sdk_build:-""}" \
+    -c "Add :DTPlatformVersion string ${platform_version:-""}" \
+    -c "Add :DTXcode string ${xcode_version:-""}" \
+    -c "Add :DTXcodeBuild string ${xcode_build:-""}" \
+    -c "Add :DTCompiler string ${compiler:-""}" \
+    -c "Add :BuildMachineOSBuild string ${os_build:-""}" \
+    "$PLIST"
+
+plutil -convert binary1 -o "${OUTPUT}" -s  -- "${PLIST}"

--- a/tools/environment_plist/environment_plist.sh
+++ b/tools/environment_plist/environment_plist.sh
@@ -85,6 +85,6 @@ xcode_version=$(/usr/bin/printf '%02d%d%d\n' $(echo "${xcode_version_string//./ 
     -c "Add :DTXcodeBuild string ${xcode_build:-""}" \
     -c "Add :DTCompiler string ${compiler:-""}" \
     -c "Add :BuildMachineOSBuild string ${os_build:-""}" \
-    "$PLIST"
+    "$PLIST" > /dev/null
 
 plutil -convert binary1 -o "${OUTPUT}" -s  -- "${PLIST}"


### PR DESCRIPTION
* Codesigning now passes `--timestamp=none`
* `--swift_whole_module_optimization` is no longer supported by `swift_library`, you'll need to pass `--swiftcopt=-whole-module-optimization` instead.
* Documentation version update