### PR TITLE
Remove unknown bundle identifier constraint

### DIFF
--- a/apple/bundling/bundling_support.bzl
+++ b/apple/bundling/bundling_support.bzl
@@ -284,8 +284,6 @@ def _validate_bundle_id(bundle_id):
       for ch in part:
         if ch != "-" and not ch.isalnum():
           fail("Invalid character(s) in bundle_id: \"%s\"" % bundle_id)
-  if len(bundle_id_parts) < 2:
-    fail("bundle_id isn't at least 2 segments: \"%s\"" % bundle_id)
 
 
 # Define the loadable module that lists the exported symbols in this file.

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -816,24 +816,6 @@ EOF
   expect_log "Invalid character(s) in bundle_id: \"my#bundle\""
 }
 
-function test_build_fails_if_bundle_id_too_short() {
-  create_common_files
-
-  cat >> app/BUILD <<EOF
-ios_application(
-    name = "app",
-    bundle_id = "one-segment",
-    families = ["iphone"],
-    infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
-    deps = [":lib"],
-)
-EOF
-
-  ! do_build ios //app:app || fail "Should fail"
-  expect_log "bundle_id isn't at least 2 segments: \"one-segment\""
-}
-
 # Tests that the IPA contains bitcode symbols when bitcode is embedded.
 function disabled_test_bitcode_symbol_maps_packaging() {  # Blocked on b/73546952
   # Bitcode is only availabe on device. Ignore the test for simulator builds.


### PR DESCRIPTION
Apple recommends a reverse-domain style string, so apps that use other
formats will no longer work with this release of rules apple.

Since it is not feasible to change bundle IDs to work with
`rules_apple`, this patch removes the constraint altogether since it is
not enforced by Apple.