### PR TITLE
Add codesigntool to handle signing identity

### DIFF
--- a/apple/bundling/bundler.bzl
+++ b/apple/bundling/bundler.bzl
@@ -579,6 +579,8 @@ def _process_and_sign_archive(
             progress_description,
             bundle_name,
         ),
+        no_sandbox=True,
+        no_cache=True,
         tools = [
             ctx.executable._codesigningtool,
         ]

--- a/apple/bundling/bundler.bzl
+++ b/apple/bundling/bundler.bzl
@@ -579,6 +579,9 @@ def _process_and_sign_archive(
             progress_description,
             bundle_name,
         ),
+        tools = [
+            ctx.executable._codesigningtool,
+        ]
     )
     return (work_dir, entitlements)
 

--- a/apple/bundling/codesigning_support.bzl
+++ b/apple/bundling/codesigning_support.bzl
@@ -31,113 +31,6 @@ load(
     "define_utils",
 )
 
-def _extract_provisioning_plist_command(ctx, provisioning_profile):
-    """Returns the shell command to extract a plist from a provisioning profile.
-
-    Args:
-      ctx: The Skylark context.
-      provisioning_profile: The `File` representing the provisioning profile.
-
-    Returns:
-      The shell command used to extract the plist.
-    """
-    if mock_support.is_provisioning_mocked(ctx):
-        # If provisioning is mocked, treat the provisioning profile as a plain XML
-        # plist without a signature.
-        return "cat " + shell.quote(provisioning_profile.path)
-    else:
-        # NOTE: Until the bundling rules are updated to merge entitlements support
-        # and signing, this extraction command should be kept in sync with what
-        # exists in provisioning_profile_tool.
-        #
-        # Use a fallback mechanism to call first the security command and if that
-        # fails (e.g. when running in El Capitan) call the openssl command.
-        # The whole output for that fallback command group is then rerouted to
-        # STDERR which is only printed if the command actually failed (security and
-        # openssl print information into stderr even if the command succeeded).
-        profile_path = shell.quote(provisioning_profile.path)
-        extract_plist_cmd = (
-            "(security cms -D -i %s || " % profile_path +
-            "openssl smime -inform der -verify -noverify -in %s)" % profile_path
-        )
-        return ("( " +
-                "STDERR=$(mktemp -t openssl.stderr) && " +
-                "trap \"rm -f ${STDERR}\" EXIT && " +
-                extract_plist_cmd + " 2> ${STDERR} || " +
-                "( >&2 echo 'Could not extract plist from provisioning profile' " +
-                " && >&2 cat ${STDERR} && exit 1 ) " +
-                ")")
-
-def _extracted_provisioning_profile_identity(ctx, provisioning_profile):
-    """Extracts the first signing certificate hex ID from a provisioning profile.
-
-    Args:
-      ctx: The Skylark context.
-      provisioning_profile: The provisioning profile from which to extract the
-          signing identity.
-
-    Returns:
-      A Bash output-capturing subshell expression (`$( ... )`) that executes
-      commands needed to extract the hex ID of a signing certificate from a
-      provisioning profile. This expression can then be used in later commands
-      to include the ID in code-signing commands.
-    """
-    extract_plist_cmd = _extract_provisioning_plist_command(
-        ctx,
-        provisioning_profile,
-    )
-    return ("$( " +
-            "PLIST=$(mktemp -t cert.plist) && trap \"rm ${PLIST}\" EXIT && " +
-            extract_plist_cmd + " > ${PLIST} && " +
-            "/usr/libexec/PlistBuddy -c " +
-            "'Print DeveloperCertificates:0' " +
-            "${PLIST} | openssl x509 -inform DER -noout -fingerprint | " +
-            "cut -d= -f2 | sed -e s#:##g " +
-            ")")
-
-def _verify_signing_id_commands(identity, provisioning_profile):
-    """Returns commands that verify that the given identity is valid.
-
-    Args:
-      identity: The signing identity to verify.
-      provisioning_profile: The provisioning profile, if the signing identity was
-          extracted from it. If provided, this is included in the error message
-          that is printed if the identity is not valid.
-
-    Returns:
-      A string containing Bash commands that verify the signing identity and
-      assign it to the environment variable `VERIFIED_ID` if it is valid.
-    """
-    verified_id = ("VERIFIED_ID=" +
-                   "$( " +
-                   "security find-identity -v -p codesigning | " +
-                   "grep -F \"" + identity + "\" | " +
-                   "xargs | " +
-                   "cut -d' ' -f2 " +
-                   ")\n")
-
-    # If the identity was extracted from the provisioning profile (as opposed to
-    # being passed on the command line), include that as part of the error message
-    # to point the user at the source of the identity being used.
-    if provisioning_profile:
-        found_in_prov_profile_msg = (" found in provisioning profile " +
-                                     provisioning_profile.path)
-    else:
-        found_in_prov_profile_msg = ""
-
-    # Exit and report an Xcode-visible error if no matched identifiers were found.
-    error_handling = ("if [[ -z \"$VERIFIED_ID\" ]]; then\n" +
-                      "  " +
-                      "echo " +
-                      "error: Could not find a valid identity in the " +
-                      "keychain matching \"" + identity + "\"" +
-                      found_in_prov_profile_msg + "." +
-                      "\n" +
-                      "  " +
-                      "exit 1\n" +
-                      "fi\n")
-    return verified_id + error_handling
-
 def _embedded_provisioning_profile_name(ctx):
     """Returns the name of the embedded provisioning profile for the target.
 
@@ -155,7 +48,7 @@ def _embedded_provisioning_profile_name(ctx):
         return "embedded.provisionprofile"
     return "embedded.mobileprovision"
 
-def _codesign_command(ctx, path_to_sign, entitlements_file):
+def _codesign_command(ctx, path_to_sign, provisioning_profile, entitlements_file):
     """Returns a single `codesign` command invocation.
 
     Args:
@@ -181,23 +74,48 @@ def _codesign_command(ctx, path_to_sign, entitlements_file):
     if path_to_sign.optional:
         cmd_prefix += "ls %s >& /dev/null && " % path
 
+    cmd_codesigning = [
+        ctx.executable._codesigningtool.path,
+        "--codesign",
+        shell.quote("/usr/bin/codesign"),
+    ]
+
+    is_device = platform_support.is_device_build(ctx)
+    # First, try to use the identity passed on the command line, if any. If it's
+    # a simulator build, use an ad hoc identity.
+    identity = ctx.fragments.objc.signing_certificate_name if is_device else "-"
+    if identity == None and provisioning_profile:
+        cmd_codesigning.extend([
+            "--mobileprovision",
+            shell.quote(provisioning_profile.path),
+        ])
+    else:
+        cmd_codesigning.extend([
+            "--identity",
+            identity,
+        ])
+
     # The command returned by this function is executed as part of the final
     # bundling shell script. Each directory to be signed must be prefixed by
     # $WORK_DIR, which is the variable in that script that contains the path
     # to the directory where the bundle is being built.
-    if platform_support.is_device_build(ctx):
-        entitlements_flag = ""
+    if is_device:
         if entitlements_file:
-            entitlements_flag = (
-                "--entitlements %s" % shell.quote(entitlements_file.path)
-            )
-
-        return ((cmd_prefix + "/usr/bin/codesign --force " +
-                 "--sign $VERIFIED_ID %s %s") % (entitlements_flag, path))
+            cmd_codesigning.extend([
+                "--entitlements",
+                shell.quote(entitlements_file.path),
+            ])
+        cmd_codesigning.extend([
+            "--force",
+            path,
+        ])
     else:
-        # Use ad hoc signing for simulator builds.
-        return ((cmd_prefix + "/usr/bin/codesign --force " +
-                 "--timestamp=none --sign \"-\" %s") % path)
+        cmd_codesigning.extend([
+            "--force",
+            "--timestamp=none",
+            path,
+        ])
+    return (cmd_prefix + " ".join(cmd_codesigning))
 
 def _path_to_sign(path, optional = False, glob = None):
     """Returns a "path to sign" value to be passed to `signing_command_lines`.
@@ -255,19 +173,6 @@ def _signing_command_lines(
     # a simulator build, use an ad hoc identity.
     identity = ctx.fragments.objc.signing_certificate_name if is_device else "-"
 
-    # If no identity was passed on the command line, then for device builds that
-    # require signing (i.e., not macOS), try to extract one from the provisioning
-    # profile. Fail if one was not provided.
-    if not identity and is_device and provisioning_profile:
-        identity = _extracted_provisioning_profile_identity(
-            ctx,
-            provisioning_profile,
-        )
-
-    # If we still don't have an identity, fall back to ad hoc signing.
-    if not identity:
-        identity = "-"
-
     # Just like Xcode, ensure CODESIGN_ALLOCATE is set to point to the correct
     # version. DEVELOPER_DIR will already be set on the action that invokes
     # the script. Without this, codesign should already be using DEVELOPER_DIR
@@ -280,20 +185,9 @@ def _signing_command_lines(
          "Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate"),
     )
 
-    # If we're ad hoc signing or signing is mocked for tests, don't bother
-    # verifying the identity in the keychain. Otherwise, verify that the identity
-    # matches valid, unexpired entitlements in the keychain and return the first
-    # unique hexadecimal identifier.
-    if identity == "-" or mock_support.is_provisioning_mocked(ctx):
-        commands.append("VERIFIED_ID=" + shell.quote(identity) + "\n")
-    else:
-        commands.append(
-            _verify_signing_id_commands(identity, provisioning_profile),
-        )
-
     for path_to_sign in paths_to_sign:
-        commands.append(_codesign_command(ctx, path_to_sign, entitlements_file))
-
+        commands.append(_codesign_command(ctx, path_to_sign,
+            provisioning_profile, entitlements_file))
     return "\n".join(commands)
 
 def _should_sign_simulator_bundles(ctx):

--- a/apple/bundling/macos_rules.bzl
+++ b/apple/bundling/macos_rules.bzl
@@ -330,7 +330,7 @@ def _macos_command_line_application_impl(ctx):
         None,
     )
 
-    inputs = [ctx.file.binary]
+    inputs = [ctx.file.binary, ctx.executable._codesigningtool]
 
     platform_support.xcode_env_action(
         ctx,

--- a/apple/bundling/rule_factory.bzl
+++ b/apple/bundling/rule_factory.bzl
@@ -316,6 +316,11 @@ def _code_signing_attributes(code_signing):
         "_skip_simulator_signing_allowed": attr.bool(
             default = code_signing.skip_simulator_signing_allowed,
         ),
+        "_codesigningtool": attr.label(
+            cfg="host",
+            executable=True,
+            default=Label("@build_bazel_rules_apple//tools/codesigningtool"),
+        ),
     }
     if not code_signing.skip_signing:
         code_signing_attrs["entitlements"] = attr.label(

--- a/apple/utils.bzl
+++ b/apple/utils.bzl
@@ -20,41 +20,37 @@ XCRUNWRAPPER_LABEL = "@bazel_tools//tools/objc:xcrunwrapper"
 DARWIN_EXECUTION_REQUIREMENTS = {"requires-darwin": ""}
 """Standard execution requirements to force building on Mac."""
 
+_EXECUTION_REQUIREMENTS = {
+    "no_cache": "no-cache",
+}
+
+
+def _add_execution_requirements(kw):
+    """Adds and returns the execution requirements for an action."""
+    execution_requirements = kw.get("execution_requirements", {})
+    execution_requirements["requires-darwin"] = ""
+    for arg, tag in _EXECUTION_REQUIREMENTS.items():
+        if arg in kw and kw.pop(arg, False):
+            execution_requirements[tag] = "1"
+    kw["execution_requirements"] = execution_requirements
+    return kw
+
 def apple_action(ctx, **kw):
     """Creates an action that only runs on MacOS/Darwin.
 
     Call it similar to how you would call ctx.action:
-      apple_action(ctx, outputs=[...], inputs=[...],...)
+        apple_action(ctx, outputs=[...], inputs=[...],...)
     """
-    execution_requirements = kw.get("execution_requirements", {})
-    execution_requirements["requires-darwin"] = ""
-
-    no_sandbox = kw.pop("no_sandbox", False)
-    if no_sandbox:
-        execution_requirements["no-sandbox"] = "1"
-
-    kw["execution_requirements"] = execution_requirements
-    ctx.action(**kw)
+    ctx.action(**_add_execution_requirements(kw))
 
 def apple_actions_run(ctx_actions, **kw):
     """Creates an actions.run() that only runs on MacOS/Darwin.
 
-    Call it similar to how you would call ctx.actions.run:
-      apple_actions_run(ctx.actions, outputs=[...], inputs=[...],...)
-
     Args:
-      ctx_actions: The ctx.actions object to use.
-      **kw: Additional arguments that are passed directly to `actions.run`.
+        ctx_actions: The ctx.actions object to use.
+        **kw: Additional arguments that are passed directly to `actions.run`.
     """
-    execution_requirements = kw.get("execution_requirements", {})
-    execution_requirements["requires-darwin"] = ""
-
-    no_sandbox = kw.pop("no_sandbox", False)
-    if no_sandbox:
-        execution_requirements["no-sandbox"] = "1"
-
-    kw["execution_requirements"] = execution_requirements
-    ctx_actions.run(**kw)
+    ctx_actions.run(**_add_execution_requirements(kw))
 
 def apple_actions_runshell(ctx_actions, **kw):
     """Creates an actions.run_shell() that only runs on MacOS/Darwin.
@@ -63,19 +59,11 @@ def apple_actions_runshell(ctx_actions, **kw):
       apple_actions_runshell(ctx.actions, outputs=[...], inputs=[...],...)
 
     Args:
-      ctx_actions: The ctx.actions object to use.
-      **kw: Additional arguments that are passed directly to
+        ctx_actions: The ctx.actions object to use.
+        **kw: Additional arguments that are passed directly to
         `actions.run_shell`.
     """
-    execution_requirements = kw.get("execution_requirements", {})
-    execution_requirements["requires-darwin"] = ""
-
-    no_sandbox = kw.pop("no_sandbox", False)
-    if no_sandbox:
-        execution_requirements["no-sandbox"] = "1"
-
-    kw["execution_requirements"] = execution_requirements
-    ctx_actions.run_shell(**kw)
+    ctx_actions.run_shell(**_add_execution_requirements(kw))
 
 def full_label(l):
     """Converts a label to full format, e.g. //a/b/c -> //a/b/c:c.

--- a/apple/utils.bzl
+++ b/apple/utils.bzl
@@ -22,8 +22,9 @@ DARWIN_EXECUTION_REQUIREMENTS = {"requires-darwin": ""}
 
 _EXECUTION_REQUIREMENTS = {
     "no_cache": "no-cache",
+    "no_sandbox": "no-sandbox",
+    "no_remote": "no-remote",
 }
-
 
 def _add_execution_requirements(kw):
     """Adds and returns the execution requirements for an action."""

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -9,6 +9,7 @@ filegroup(
     srcs = glob(["**"]) + [
         "//tools/bundletool:for_bazel_tests",
         "//tools/clangrttool:for_bazel_tests",
+        "//tools/codesigningtool:for_bazel_tests",
         "//tools/environment_plist:for_bazel_tests",
         "//tools/plisttool:for_bazel_tests",
         "//tools/provisioning_profile_tool:for_bazel_tests",

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+py_binary(
+    name = "codesigningtool",
+    srcs = ["codesigningtool.py"],
+)
+
+# Consumed by bazel tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = [
+        "//tools:__pkg__",
+    ],
+)

--- a/tools/codesigningtool/README
+++ b/tools/codesigningtool/README
@@ -1,0 +1,1 @@
+codesigningtool selects the appropriate signing identity for iOS apps.

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -1,0 +1,84 @@
+import argparse
+import base64
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+
+def _check_output(args, inputstr=None):
+    proc = subprocess.Popen(args,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    return proc.communicate(input=inputstr)[0]
+
+
+def mobileprovision(mobileprovision_file):
+    plist_xml = subprocess.check_output([
+        "security", "cms",
+        "-D",
+        "-i", mobileprovision_file,
+    ])
+    if hasattr(plistlib, "readPlistFromString"):
+        # Python 2
+        return plistlib.readPlistFromString(plist_xml)
+    else:
+        # Python 3
+        return plistlib.readPlistFromBytes(plist_xml)
+
+
+def fingerprint(identity):
+    fingerprint = _check_output([
+        "openssl", "x509", "-inform", "DER", "-noout", "-fingerprint",
+    ], inputstr=identity).strip().decode("utf-8")
+    fingerprint = fingerprint.replace("SHA1 Fingerprint=", "")
+    fingerprint = fingerprint.replace(":", "")
+    return fingerprint
+
+
+def identities(mpf):
+    for identity in mpf["DeveloperCertificates"]:
+        yield fingerprint(identity.data)
+
+
+def identities_codesign():
+    ids = []
+    output = _check_output([
+        "security", "find-identity", "-v", "-p", "codesigning",
+    ]).strip().decode("utf-8")
+    for line in output.splitlines():
+        m = re.search(r"([A-F0-9]{40})", line)
+        if m:
+            ids.append(m.group(0))
+    return ids
+
+
+def codesign_identity(args):
+    if args.identity is not None:
+        return args.identity
+
+    mpf = mobileprovision(args.mobileprovision)
+    ids_codesign = set(identities_codesign())
+    for id_mpf in identities(mpf):
+        if id_mpf in ids_codesign:
+            return id_mpf
+
+    # If we still don't have an identity, fall back to ad hoc signing.
+    return "-"
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='codesign wrapper')
+    parser.add_argument('--mobileprovision', type=str, help='mobileprovision file')
+    parser.add_argument('--codesign', type=str, help='path to codesign binary')
+    parser.add_argument('--identity', type=str, help='specific identity to sign with')
+    args, codesign_args = parser.parse_known_args()
+    identity = codesign_identity(args)
+    print("Signing identity: %s" % identity)
+    os.execve(args.codesign, [args.codesign, "-v", "--sign", identity] + codesign_args, os.environ)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
This is a draft to engage conversation on the issue #172 

In order to support profiles with multiple identities, I replaced the shell command managing signing identites with a python tool that wraps `codesign`.

Naming can definitely be improved.

I am looking forward to your feedback.