### PR TITLE
ios_framework: Allow bundle_name argument to override name when constructing rpath.

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -258,7 +258,8 @@ def ios_framework(name, **kwargs):
           final framework.
     """
     linkopts = kwargs.pop("linkopts", [])
-    linkopts += ["-install_name", "@rpath/%s.framework/%s" % (name, name)]
+	bundle_name = kwargs.get("bundle_name", name)
+    linkopts += ["-install_name", "@rpath/%s.framework/%s" % (bundle_name, bundle_name)]
 
     # Link the executable from any library deps and sources provided.
     bundling_args = binary_support.create_linked_binary_target(

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -258,7 +258,7 @@ def ios_framework(name, **kwargs):
           final framework.
     """
     linkopts = kwargs.pop("linkopts", [])
-	bundle_name = kwargs.get("bundle_name", name)
+    bundle_name = kwargs.get("bundle_name", name)
     linkopts += ["-install_name", "@rpath/%s.framework/%s" % (bundle_name, bundle_name)]
 
     # Link the executable from any library deps and sources provided.


### PR DESCRIPTION
fixes #193
