### PR TITLE
Actually delete temporary simulator after use

### DIFF
--- a/apple/bundling/runners/ios_sim.template.sh
+++ b/apple/bundling/runners/ios_sim.template.sh
@@ -110,6 +110,7 @@ function CleanupSimulator() {
 }
 
 readonly STD_REDIRECT_DYLIB="$PWD/%std_redirect_dylib_path%"
+
 readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
 
 trap 'rm -rf "${TEMP_DIR}"; CleanupSimulator ${TEST_DEVICE_ID}' ERR EXIT

--- a/apple/bundling/runners/ios_sim.template.sh
+++ b/apple/bundling/runners/ios_sim.template.sh
@@ -109,12 +109,12 @@ function CleanupSimulator() {
   xcrun simctl delete "$1"
 }
 
-trap "CleanupSimulator ${TEST_DEVICE_ID}" EXIT
-
 readonly STD_REDIRECT_DYLIB="$PWD/%std_redirect_dylib_path%"
 
 readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
-trap 'rm -rf "${TEMP_DIR}"' ERR EXIT
+
+trap 'rm -rf "${TEMP_DIR}"' ERR
+trap 'rm -rf "${TEMP_DIR}" && CleanupSimulator ${TEST_DEVICE_ID}' EXIT
 
 readonly APP_DIR="${TEMP_DIR}/extracted_app"
 mkdir "${APP_DIR}"

--- a/apple/bundling/runners/ios_sim.template.sh
+++ b/apple/bundling/runners/ios_sim.template.sh
@@ -110,11 +110,9 @@ function CleanupSimulator() {
 }
 
 readonly STD_REDIRECT_DYLIB="$PWD/%std_redirect_dylib_path%"
-
 readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
 
-trap 'rm -rf "${TEMP_DIR}"' ERR
-trap 'rm -rf "${TEMP_DIR}" && CleanupSimulator ${TEST_DEVICE_ID}' EXIT
+trap 'rm -rf "${TEMP_DIR}"; CleanupSimulator ${TEST_DEVICE_ID}' ERR EXIT
 
 readonly APP_DIR="${TEMP_DIR}/extracted_app"
 mkdir "${APP_DIR}"


### PR DESCRIPTION
A simulator is created for each test run, but is not deleted as expected after completion. This is happening because an `EXIT` trap is specified twice, with the second (cleanup for `$TEMP_DIR`) overwriting the first (cleanup of the temporary simulator).

This change combines the two cleanups into a single trap command.