### PR TITLE
Force bsd sed on macOS

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -79,10 +79,10 @@ XCTESTRUN="$TEST_TMP_DIR/tests.xctestrun"
 cp -f "$BAZEL_XCTESTRUN_TEMPLATE" "$XCTESTRUN"
 
 # Replace the substitution values into the xctestrun file.
-sed -i '' 's@BAZEL_TEST_BUNDLE_PATH@'"$XCTESTRUN_TEST_BUNDLE_PATH"'@g' "$XCTESTRUN"
-sed -i '' 's@BAZEL_TEST_HOST_BASED@'"$XCTESTRUN_TEST_HOST_BASED"'@g' "$XCTESTRUN"
-sed -i '' 's@BAZEL_TEST_HOST_BINARY@'"$XCTESTRUN_TEST_HOST_BINARY"'@g' "$XCTESTRUN"
-sed -i '' 's@BAZEL_TEST_HOST_PATH@'"$XCTESTRUN_TEST_HOST_PATH"'@g' "$XCTESTRUN"
+/usr/bin/sed -i '' 's@BAZEL_TEST_BUNDLE_PATH@'"$XCTESTRUN_TEST_BUNDLE_PATH"'@g' "$XCTESTRUN"
+/usr/bin/sed -i '' 's@BAZEL_TEST_HOST_BASED@'"$XCTESTRUN_TEST_HOST_BASED"'@g' "$XCTESTRUN"
+/usr/bin/sed -i '' 's@BAZEL_TEST_HOST_BINARY@'"$XCTESTRUN_TEST_HOST_BINARY"'@g' "$XCTESTRUN"
+/usr/bin/sed -i '' 's@BAZEL_TEST_HOST_PATH@'"$XCTESTRUN_TEST_HOST_PATH"'@g' "$XCTESTRUN"
 
 # If XML_OUTPUT_FILE is not an absolute path, make it absolute with regards of
 # where this script is being run.


### PR DESCRIPTION
If a user has gnu-sed in their PATH, these commands would fail since the
`-i` arguments are incompatible. Since this script will only run on
macOS, we can be sure using the absolute path will be valid.