### PR TITLE
Update Travis to use xcode10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: swift
 # Travis does not use osx_image when it computes the matrix itself, if we want
 # to test on multiple versions, then it required manually building the matrix
 # to set a different osx_image for each configuration.
-osx_image: xcode9.4
+osx_image: xcode10
 
 # Build out the matrix ourselves so we can set multiple variables.
 # - `BAZEL`: Used in `before_install` to pick the version of bazel to use,


### PR DESCRIPTION
This updates Travis to build with Xcode 10. This matches bazelbuild/rules_swift#63.