### PR TITLE
Update macOS test bundle injection path

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -19,9 +19,17 @@ load(
     "AppleTestRunner",
 )
 
+def _get_bundle_inject_path(ctx):
+    xcode_version = ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version()
+    if xcode_version and xcode_version < apple_common.dotted_version("10.0"):
+        return "Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection"
+
+    return "usr/lib/libXCTestBundleInject.dylib"
+
 def _get_template_substitutions(ctx):
     """Returns the template substitutions for this runner."""
     subs = {
+        "xctestrun_bundle_inject_path": _get_bundle_inject_path(ctx),
         "xctestrun_template": ctx.file._xctestrun_template.short_path,
     }
 

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -83,6 +83,7 @@ cp -f "$BAZEL_XCTESTRUN_TEMPLATE" "$XCTESTRUN"
 /usr/bin/sed -i '' 's@BAZEL_TEST_HOST_BASED@'"$XCTESTRUN_TEST_HOST_BASED"'@g' "$XCTESTRUN"
 /usr/bin/sed -i '' 's@BAZEL_TEST_HOST_BINARY@'"$XCTESTRUN_TEST_HOST_BINARY"'@g' "$XCTESTRUN"
 /usr/bin/sed -i '' 's@BAZEL_TEST_HOST_PATH@'"$XCTESTRUN_TEST_HOST_PATH"'@g' "$XCTESTRUN"
+/usr/bin/sed -i '' 's@BAZEL_TEST_BUNDLE_INJECT_PATH@%(xctestrun_bundle_inject_path)s@g' "$XCTESTRUN"
 
 # If XML_OUTPUT_FILE is not an absolute path, make it absolute with regards of
 # where this script is being run.

--- a/apple/testing/default_runner/macos_test_runner.template.xctestrun
+++ b/apple/testing/default_runner/macos_test_runner.template.xctestrun
@@ -17,7 +17,7 @@
 			<key>DYLD_LIBRARY_PATH</key>
 			<string>__PLATFORMS__/MacOSX.platform/Developer/Library/Frameworks:__SHAREDFRAMEWORKS__</string>
 			<key>DYLD_INSERT_LIBRARIES</key>
-			<string>__PLATFORMS__/MacOSX.platform/Developer/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection</string>
+			<string>__PLATFORMS__/MacOSX.platform/Developer/BAZEL_TEST_BUNDLE_INJECT_PATH</string>
 			<key>XCInjectBundleInto</key>
 			<string>BAZEL_TEST_HOST_BINARY</string>
 		</dict>


### PR DESCRIPTION
The path to this binary changed with Xcode 10

Related https://github.com/facebook/xctool/pull/755/