### PR TITLE
Update for future incompatible bazel changes

### DIFF
--- a/apple/bundling/entitlements.bzl
+++ b/apple/bundling/entitlements.bzl
@@ -302,8 +302,7 @@ entitlements = rule(
             mandatory = True,
         ),
         "entitlements": attr.label(
-            allow_files = [".entitlements", ".plist"],
-            single_file = True,
+            allow_single_file = [".entitlements", ".plist"],
         ),
         "_plisttool": attr.label(
             cfg = "host",
@@ -322,8 +321,7 @@ entitlements = rule(
         # Used to pass the platform type through from the calling rule.
         "platform_type": attr.string(),
         "provisioning_profile": attr.label(
-            allow_files = [".mobileprovision", ".provisionprofile"],
-            single_file = True,
+            allow_single_file = [".mobileprovision", ".provisionprofile"],
         ),
         "validation_mode": attr.string(),
         # This needs to be an attribute on the rule for platform_support

--- a/apple/bundling/ios_rules.bzl
+++ b/apple/bundling/ios_rules.bzl
@@ -203,8 +203,7 @@ ios_application = rule_factory.make_bundling_rule(
         ),
         "launch_images": attr.label_list(allow_files = True),
         "launch_storyboard": attr.label(
-            allow_files = [".storyboard", ".xib"],
-            single_file = True,
+            allow_single_file = [".storyboard", ".xib"],
         ),
         "settings_bundle": attr.label(
             aspects = [new_apple_resource_aspect],

--- a/apple/bundling/macos_command_line_support.bzl
+++ b/apple/bundling/macos_command_line_support.bzl
@@ -137,7 +137,6 @@ macos_command_line_launchdplist = rule(
             "launchdplists": attr.label_list(
                 allow_files = [".plist"],
                 mandatory = False,
-                non_empty = False,
             ),
         },
     ),

--- a/apple/bundling/macos_rules.bzl
+++ b/apple/bundling/macos_rules.bzl
@@ -384,18 +384,16 @@ macos_command_line_application = rule(
             "binary": attr.label(
                 mandatory = True,
                 providers = [apple_common.AppleExecutableBinary],
-                single_file = True,
+                allow_single_file = True,
             ),
             "bundle_id": attr.string(mandatory = False),
             "infoplists": attr.label_list(
                 allow_files = [".plist"],
                 mandatory = False,
-                non_empty = False,
             ),
             "launchdplists": attr.label_list(
                 allow_files = [".plist"],
                 mandatory = False,
-                non_empty = False,
             ),
             "minimum_os_version": attr.string(mandatory = False),
             "version": attr.label(providers = [[AppleBundleVersionInfo]]),

--- a/apple/bundling/rule_factory.bzl
+++ b/apple/bundling/rule_factory.bzl
@@ -139,7 +139,7 @@ def _is_valid_attribute_mode(mode):
 _common_tool_attributes = {
     "_dsym_info_plist_template": attr.label(
         cfg = "host",
-        single_file = True,
+        allow_single_file = True,
         default = Label(
             "@build_bazel_rules_apple//apple/bundling:dsym_info_plist_template",
         ),
@@ -156,8 +156,7 @@ _common_tool_attributes = {
     ),
     "_realpath": attr.label(
         cfg = "host",
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("@build_bazel_rules_apple//tools/realpath"),
     ),
     "_xcrunwrapper": attr.label(
@@ -195,18 +194,16 @@ _bundling_tool_attributes = {
     # platform.
     "_runner_template": attr.label(
         cfg = "host",
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("@build_bazel_rules_apple//apple/bundling/runners:ios_sim_template"),
     ),
     "_process_and_sign_template": attr.label(
-        single_file = True,
+        allow_single_file = True,
         default = Label("@build_bazel_rules_apple//tools/bundletool:process_and_sign_template"),
     ),
     "_std_redirect_dylib": attr.label(
         cfg = "host",
-        allow_files = True,
-        single_file = True,
+        allow_single_file = True,
         default = Label("@bazel_tools//tools/objc:StdRedirect.dylib"),
     ),
     "_xctoolrunner": attr.label(
@@ -325,8 +322,7 @@ def _code_signing_attributes(code_signing):
             fail("Internal error: If code_signing.skip_signing = False, then " +
                  "code_signing.provision_profile_extension must be provided.")
         code_signing_attrs["provisioning_profile"] = attr.label(
-            allow_files = [code_signing.provision_profile_extension],
-            single_file = True,
+            allow_single_file = [code_signing.provision_profile_extension],
         )
         code_signing_attrs["entitlements_validation"] = attr.string(
             default = entitlements_validation_mode.loose,
@@ -443,7 +439,7 @@ def _make_bundling_rule(
         configurable_attrs["infoplists"] = attr.label_list(
             allow_files = [".plist"],
             mandatory = want_mandatory,
-            non_empty = want_mandatory,
+            allow_empty = not want_mandatory,
         )
 
     if use_binary_rule:
@@ -451,7 +447,7 @@ def _make_bundling_rule(
             "binary": attr.label(
                 mandatory = False,
                 providers = binary_providers,
-                single_file = True,
+                allow_single_file = True,
             ),
             # Even for rules that don't bundle a user-provided binary (like
             # watchos_application and some ios_application/extension targets), the

--- a/apple/testing/apple_test_rules.bzl
+++ b/apple/testing/apple_test_rules.bzl
@@ -321,23 +321,20 @@ The xctest bundle that contains the test code and resources. Required.
         ),
         # gcov and mcov are binary files required to calculate test coverage.
         "_gcov": attr.label(
-            allow_files = True,
             cfg = "host",
             default = Label("@bazel_tools//tools/objc:gcov"),
-            single_file = True,
+            allow_single_file = True,
         ),
         "_mcov": attr.label(
-            allow_files = True,
             cfg = "host",
             default = Label("@bazel_tools//tools/objc:mcov"),
-            single_file = True,
+            allow_single_file = True,
         ),
         # The realpath binary needed for symlinking.
         "_realpath": attr.label(
-            allow_files = True,
             cfg = "host",
             default = Label("@build_bazel_rules_apple//tools/realpath"),
-            single_file = True,
+            allow_single_file = True,
         ),
     }
 


### PR DESCRIPTION
These fixes are required to run bazel 0.19.0 with
`--all_incompatible_changes`. There are a few specific transformations I
did here:

1. If the rule's attributes contained an `allow_files` array and
`single_file = True`, I converted this to `allow_single_file` with the
same array.

2. If the attribute had `non_empty = False`, I removed it because this
would be migrated to `allow_empty = True` which is the default (if we
want to be more explicit, I can add this where I removed them)

3. If the attribute had only `single_file = True` it is now
`allow_single_file = True`

4. If the attribute had `allow_files = True` and `single_file = True`,
it is now `allow_single_file = True`