### PR TITLE
Use --ios_simulator_device argument when testing a ios test target.

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -28,6 +28,11 @@ def _get_template_substitutions(ctx):
         "testrunner_binary": ctx.executable._testrunner.short_path,
         "device_type": ctx.attr.device_type,
     }
+    # if ios_simulator_device and ios_simulator_version are specified in the bazel test command, override device_type
+    if ctx.fragments.objc.ios_simulator_device:
+        subs["device_type"] = ctx.fragments.objc.ios_simulator_device
+    if ctx.fragments.objc.ios_simulator_device:
+        subs["os_version"] = str(ctx.fragments.objc.ios_simulator_version)
     return {"%(" + k + ")s": subs[k] for k in subs}
 
 def _get_test_environment(ctx):


### PR DESCRIPTION
The arg also overrides device_type specified in a custom test runner.