### PR TITLE
Add apple_static_framework_import

### DIFF
--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -16,9 +16,9 @@
 
 load(
     "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
-    _apple_framework_import = "apple_framework_import",
+    _apple_framework_import = "apple_dynamic_framework_import",
     _apple_static_framework_import = "apple_static_framework_import",
 )
 
-apple_framework_import = _apple_framework_import
+apple_dynamic_framework_import = _apple_framework_import
 apple_static_framework_import = _apple_static_framework_import

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -17,6 +17,8 @@
 load(
     "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
     _apple_framework_import = "apple_framework_import",
+    _apple_static_framework_import = "apple_static_framework_import",
 )
 
 apple_framework_import = _apple_framework_import
+apple_static_framework_import = _apple_static_framework_import

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -16,9 +16,9 @@
 
 load(
     "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
-    _apple_framework_import = "apple_dynamic_framework_import",
+    _apple_dynamic_framework_import = "apple_dynamic_framework_import",
     _apple_static_framework_import = "apple_static_framework_import",
 )
 
-apple_dynamic_framework_import = _apple_framework_import
+apple_dynamic_framework_import = _apple_dynamic_framework_import
 apple_static_framework_import = _apple_static_framework_import

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -81,7 +81,7 @@ def _get_framework_binary_file(framework_dir, framework_imports):
         if framework_import.short_path == framework_short_path:
             return framework_import
 
-    fail("There has to be a binary file in the imported framework.")
+    fail("ERORR: There has to be a binary file in the imported framework.")
 
 def _framework_dirs(framework_imports):
     """Implementation for the apple_dynamic_framework_import rule."""

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implementation of apple_framework_import and apple_static_framework_import of framework import rules."""
+"""Implementation of apple_dynamic_framework_import and apple_static_framework_import of framework import rules."""
 
 load(
     "@build_bazel_rules_apple//apple:utils.bzl",
@@ -72,7 +72,7 @@ def _validate_single_framework(framework_paths):
         )
 
 def _framework_dirs(framework_imports):
-    """Implementation for the apple_framework_import rule."""
+    """Implementation for the apple_dynamic_framework_import rule."""
     framework_groups = group_files_by_directory(
         framework_imports,
         ["framework"],
@@ -94,7 +94,7 @@ def _objc_provider(ctx, objc_provider_fields):
     return apple_common.new_objc_provider(**objc_provider_fields)
 
 def _apple_framework_import_impl(ctx):
-    """Implementation for the apple_framework_import rule."""
+    """Implementation for the apple_dynamic_framework_import rule."""
     transitive_sets = []
     for dep in ctx.attr.deps:
         if hasattr(dep[AppleFrameworkImportInfo], "framework_imports"):
@@ -141,7 +141,7 @@ def _apple_static_framework_import_impl(ctx):
 
     return [_objc_provider(ctx, objc_provider_fields)]
 
-apple_framework_import = rule(
+apple_dynamic_framework_import = rule(
     implementation = _apple_framework_import_impl,
     attrs = {
         "framework_imports": attr.label_list(
@@ -165,7 +165,7 @@ linked into that target.
     },
     doc = """
 This rule encapsulates an already-built framework. It is defined by a list of files in exactly one
-.framework directory. apple_framework_import targets need to be added to library targets through the
+.framework directory. apple_dynamic_framework_import targets need to be added to library targets through the
 `deps` attribute.
 """,
 )

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implementation of apple_framework_import and apple_static_framework_import."""
+"""Implementation of apple_framework_import and apple_static_framework_import of framework import rules."""
 
 load(
     "@build_bazel_rules_apple//apple:utils.bzl",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -94,7 +94,7 @@ def _objc_provider(ctx, objc_provider_fields):
     objc_provider_fields["providers"] = [dep[apple_common.Objc] for dep in ctx.attr.deps]
     return apple_common.new_objc_provider(**objc_provider_fields)
 
-def _apple_framework_import_impl(ctx):
+def _apple_dynamic_framework_import_impl(ctx):
     """Implementation for the apple_dynamic_framework_import rule."""
     transitive_sets = []
     for dep in ctx.attr.deps:
@@ -176,7 +176,7 @@ def _apple_static_framework_import_impl(ctx):
     return providers
 
 apple_dynamic_framework_import = rule(
-    implementation = _apple_framework_import_impl,
+    implementation = _apple_dynamic_framework_import_impl,
     attrs = {
         "framework_imports": attr.label_list(
             allow_empty = False,

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -70,7 +70,7 @@ def filter_framework_imports_for_bundling(framework_imports):
 
 def _all_framework_binaries(frameworks_groups):
     return [
-        _get_framework_binary_file(framework_dir, frameworks_imports.to_list())
+        _get_framework_binary_file(framework_dir, framework_imports.to_list())
         for framework_dir, framework_imports in frameworks_groups.items()
     ]
 

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -68,11 +68,16 @@ def filter_framework_imports_for_bundling(framework_imports):
 
     return filtered_imports
 
-def _get_framework_binary_file(framework_groups):
-    framework_dir = framework_groups.keys()[0]
+def _all_framework_binaries(frameworks_groups):
+    return [
+        _get_framework_binary_file(framework_dir, frameworks_imports.to_list())
+        for framework_dir, framework_imports in frameworks_groups.items()
+    ]
+
+def _get_framework_binary_file(framework_dir, framework_imports):
     framework_name = paths.split_extension(paths.basename(framework_dir))[0]
     framework_short_path = paths.join(framework_dir, framework_name)
-    for framework_import in framework_groups[framework_dir].to_list():
+    for framework_import in framework_imports:
         if framework_import.short_path == framework_short_path:
             return framework_import
 
@@ -147,7 +152,7 @@ def _apple_static_framework_import_impl(ctx):
     framework_groups = _framework_dirs(ctx.files.framework_imports)
     if ctx.attr.alwayslink:
         objc_provider_fields["force_load_library"] = depset(
-            [_get_framework_binary_file(framework_groups)],
+            _all_framework_binaries(framework_groups),
         )
     if ctx.attr.sdk_dylibs:
         objc_provider_fields["sdk_dylib"] = depset(ctx.attr.sdk_dylibs)

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -225,7 +225,7 @@ contain no symbols referenced by the binary. This is useful if your code isn't
 explicitly called by code in the binary; for example, if you rely on runtime
 checks for protocol conformances added in extensions in the library but do not
 directly reference any other symbols in the object file that adds that
-conformance. Only applicable for static frameworks (i.e. `is_dynamic = False`).
+conformance.
 """,
         ),
         "sdk_dylibs": attr.string_list(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -95,7 +95,7 @@ def _framework_dirs(framework_imports):
 
     return framework_groups
 
-def _objc_provider(ctx, objc_provider_fields):
+def _objc_provider_with_dependencies(ctx, objc_provider_fields):
     objc_provider_fields["providers"] = [dep[apple_common.Objc] for dep in ctx.attr.deps]
     return apple_common.new_objc_provider(**objc_provider_fields)
 
@@ -119,7 +119,7 @@ def _apple_dynamic_framework_import_impl(ctx):
 
     framework_groups = _framework_dirs(ctx.files.framework_imports)
     framework_dirs_set = depset(framework_groups.keys())
-    objc_provider = _objc_provider(ctx, {
+    objc_provider = _objc_provider_with_dependencies(ctx, {
         "dynamic_framework_file": depset(ctx.files.framework_imports),
         "dynamic_framework_dir": framework_dirs_set,
     })
@@ -161,7 +161,7 @@ def _apple_static_framework_import_impl(ctx):
     if ctx.attr.weak_sdk_frameworks:
         objc_provider_fields["weak_sdk_framework"] = depset(ctx.attr.weak_sdk_frameworks)
 
-    providers.append(_objc_provider(ctx, objc_provider_fields))
+    providers.append(_objc_provider_with_dependencies(ctx, objc_provider_fields))
 
     bundle_files = [x for x in framework_imports if ".bundle/" in x.short_path]
     if bundle_files:

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -52,25 +52,6 @@ def filter_framework_imports_for_bundling(framework_imports):
 
     return filtered_imports
 
-def _validate_single_framework(framework_paths):
-    """Validates that there is only 1 framework being imported.
-
-    This method validates that only 1 framework is imported by this target, even if it is composed
-    by multiple .framework bundles. In such a case, all of them must have the same name.
-
-    Args:
-        framework_paths: List of .framework containers being imported by the target.
-    """
-    framework_names = {}
-    for framework_path in framework_paths:
-        framework_names[paths.basename(framework_path)] = None
-    if len(framework_names) > 1:
-        fail(
-            "There has to be exactly 1 imported framework. Found:\n{}".format(
-                "\n".join(framework_names),
-            ),
-        )
-
 def _framework_dirs(framework_imports):
     """Implementation for the apple_dynamic_framework_import rule."""
     framework_groups = group_files_by_directory(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -173,10 +173,7 @@ def _apple_static_framework_import_impl(ctx):
             bundle_files,
             parent_dir_param = parent_dir_param,
         )
-        providers += [
-            AppleResourceBundleInfo(),
-            resource_provider,
-        ]
+        providers.append(resource_provider)
 
     return providers
 

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -117,7 +117,7 @@ def _apple_dynamic_framework_import_impl(ctx):
         provider_fields["framework_imports"] = depset(transitive = transitive_sets)
     providers.append(providers.append(AppleFrameworkImportInfo(**provider_fields)))
 
-    framework_groups = framework_groups(ctx.files.framework_imports)
+    framework_groups = _framework_dirs(ctx.files.framework_imports)
     framework_dirs_set = depset(framework_groups.keys())
     objc_provider = _objc_provider(ctx, {
         "dynamic_framework_file": depset(ctx.files.framework_imports),

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implementation of apple_dynamic_framework_import and apple_static_framework_import of framework import rules."""
+"""Implementation of framework import rules."""
 
 load(
     "@bazel_skylib//lib:partial.bzl",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -23,10 +23,6 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
-    "resources",
-)
-load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleResourceBundleInfo",
 )

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -119,7 +119,7 @@ def _apple_framework_import_impl(ctx):
         provider_fields["framework_imports"] = depset(transitive = transitive_sets)
     providers = [AppleFrameworkImportInfo(**provider_fields)]
 
-    framework_dirs_set = _framework_dirs(ctx.file.framework_imports)
+    framework_dirs_set = _framework_dirs(ctx.files.framework_imports)
     objc_provider_fields = {
         "dynamic_framework_file": depset(ctx.files.framework_imports),
         "dynamic_framework_dir": framework_dirs_set,
@@ -140,7 +140,7 @@ def _apple_static_framework_import_impl(ctx):
     if ctx.attr.weak_sdk_frameworks:
         objc_provider_fields["weak_sdk_framework"] = depset(ctx.attr.weak_sdk_frameworks)
 
-    framework_dirs_set = _framework_dirs(ctx.file.framework_imports)
+    framework_dirs_set = _framework_dirs(ctx.files.framework_imports)
     return _apple_providers(ctx, objc_provider_fields, framework_dirs_set)
 
 apple_framework_import = rule(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -208,8 +208,8 @@ are not present at runtime.
         ),
         "deps": attr.label_list(
             doc = """
-A list of targets that are dependencies of the target being built, which will
-be linked into that target.
+A list of targets that are dependencies of the target being built, which will be
+linked into that target.
 """,
             providers = [
                 [apple_common.Objc, AppleFrameworkImportInfo],

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -23,8 +23,8 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleResourceBundleInfo",
+    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "resources",
 )
 load(
     "@build_bazel_rules_apple//apple:utils.bzl",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -115,7 +115,7 @@ def _apple_dynamic_framework_import_impl(ctx):
     provider_fields = {}
     if transitive_sets:
         provider_fields["framework_imports"] = depset(transitive = transitive_sets)
-    providers.append(providers.append(AppleFrameworkImportInfo(**provider_fields)))
+    providers.append(AppleFrameworkImportInfo(**provider_fields))
 
     framework_groups = _framework_dirs(ctx.files.framework_imports)
     framework_dirs_set = depset(framework_groups.keys())

--- a/doc/index.md
+++ b/doc/index.md
@@ -94,7 +94,7 @@ below.
     </tr>
     <tr>
       <td valign="top"><code>@build_bazel_rules_apple//apple:apple.bzl</code></td>
-      <td valign="top"><code><a href="rules-general.md#apple_framework_import">apple_framework_import</a></code><br/></td>
+      <td valign="top"><code><a href="rules-general.md#apple_dynamic_framework_import">apple_dynamic_framework_import</a></code><br/></td>
     </tr>
     <tr>
       <th align="left" valign="top" rowspan="2">Resources</th>

--- a/doc/index.md
+++ b/doc/index.md
@@ -95,6 +95,7 @@ below.
     <tr>
       <td valign="top"><code>@build_bazel_rules_apple//apple:apple.bzl</code></td>
       <td valign="top"><code><a href="rules-general.md#apple_dynamic_framework_import">apple_dynamic_framework_import</a></code><br/></td>
+      <td valign="top"><code><a href="rules-general.md#apple_static_framework_import">apple_static_framework_import</a></code><br/></td>
     </tr>
     <tr>
       <th align="left" valign="top" rowspan="2">Resources</th>

--- a/doc/rules-general.md
+++ b/doc/rules-general.md
@@ -161,27 +161,27 @@ ios_application(
 </table>
 
 
-<a name="apple_framework_import"></a>
-## apple_framework_import
+<a name="apple_dynamic_framework_import"></a>
+## apple_dynamic_framework_import
 
 ```python
-apple_framework_import(name, framework_import, is_dynamic, sdk_dylibs,
+apple_dynamic_framework_import(name, framework_import, is_dynamic, sdk_dylibs,
 sdk_frameworks, weak_sdk_frameworks, deps)
 ```
 
 This rule encapsulates an already-built framework. It is defined by a list of
-files in exactly one `.framework` directory. `apple_framework_import` targets
+files in exactly one `.framework` directory. `apple_dynamic_framework_import` targets
 need to be added to library targets through the `deps` attribute.
 ### Examples
 
 ```python
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "my_dynamic_framework",
     framework_imports = glob(["my_dynamic_framework.framework/**"]),
     is_dynamic = True,
 )
 
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "my_static_framework",
     framework_imports = glob(["my_static_framework.framework/**"]),
     is_dynamic = False,

--- a/doc/rules-general.md
+++ b/doc/rules-general.md
@@ -165,11 +165,10 @@ ios_application(
 ## apple_dynamic_framework_import
 
 ```python
-apple_dynamic_framework_import(name, framework_import, is_dynamic, sdk_dylibs,
-sdk_frameworks, weak_sdk_frameworks, deps)
+apple_dynamic_framework_import(name, framework_import, deps)
 ```
 
-This rule encapsulates an already-built framework. It is defined by a list of
+This rule encapsulates an already-built dynamic framework. It is defined by a list of
 files in exactly one `.framework` directory. `apple_dynamic_framework_import` targets
 need to be added to library targets through the `deps` attribute.
 ### Examples
@@ -178,13 +177,6 @@ need to be added to library targets through the `deps` attribute.
 apple_dynamic_framework_import(
     name = "my_dynamic_framework",
     framework_imports = glob(["my_dynamic_framework.framework/**"]),
-    is_dynamic = True,
-)
-
-apple_dynamic_framework_import(
-    name = "my_static_framework",
-    framework_imports = glob(["my_static_framework.framework/**"]),
-    is_dynamic = False,
 )
 
 objc_library(
@@ -192,6 +184,70 @@ objc_library(
     ...,
     deps = [
         ":my_dynamic_framework",
+    ],
+)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#name">Name</a>, required</code></p>
+        <p>A unique name for the target.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>framework_imports</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; required</code></p>
+        <p>The list of files under a <code>.framework</code> directory which are
+        provided to Apple based targets that depend on this target.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <p><code>List of labels; optional</code></p>
+        <p>A list of targets that are dependencies of the target being built,
+        which will be linked into that target.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<a name="apple_static_framework_import"></a>
+## apple_static_framework_import
+
+```python
+apple_static_framework_import(name, framework_import, alwayslink, sdk_dylibs,
+sdk_frameworks, weak_sdk_frameworks, deps)
+```
+
+This rule encapsulates an already-built static framework. It is defined by a list of
+files in exactly one `.framework` directory. `apple_static_framework_import` targets
+need to be added to library targets through the `deps` attribute.
+### Examples
+
+```python
+apple_static_framework_import(
+    name = "my_static_framework",
+    framework_imports = glob(["my_static_framework.framework/**"]),
+)
+
+objc_library(
+    name = "foo_lib",
+    ...,
+    deps = [
         ":my_static_framework",
     ],
 )
@@ -224,18 +280,6 @@ objc_library(
       </td>
     </tr>
     <tr>
-      <td><code>is_dynamic</code></td>
-      <td>
-        <p><code>Bool; required</code></p>
-        <p>Indicates whether this framework is linked dynamically or not. If
-        this attribute is set to <code>True</code>, the final application binary
-        will link against this framework and also be copied into the final
-        application bundle inside the <code>Frameworks</code> directory. If this
-        attribute is <code>False</code>, the framework will be statically linked
-        into the final application binary instead.</p>
-      </td>
-    </tr>
-    <tr>
       <td><code>alwayslink</code></td>
       <td>
         <p><code>Bool; optional</code></p>
@@ -245,7 +289,7 @@ objc_library(
         explicitly called by code in the binary; for example, if you rely on runtime
         checks for protocol conformances added in extensions in the library but do not
         directly reference any other symbols in the object file that adds that
-        conformance. Only applicable for static frameworks (i.e. `is_dynamic = False`).</p>
+        conformance.</p>
       </td>
     </tr>
     <tr>
@@ -257,8 +301,7 @@ objc_library(
         <code>libc++</code> is included automatically if the binary has any
         C++ or Objective-C++ sources in its dependency tree. When linking a
         binary, all libraries named in that binary's transitive dependency graph
-        are used. Only applicable for static frameworks (i.e.
-        `is_dynamic = False`).</p>
+        are used.</p>
       </td>
     </tr>
     <tr>
@@ -271,8 +314,7 @@ objc_library(
         when building for the iOS, tvOS and watchOS platforms. For macOS, only
         <code>Foundation</code> is always included. When linking a top level
         binary, all SDK frameworks listed in that binary's transitive dependency
-        graph are linked. Only applicable for static frameworks (i.e.
-        `is_dynamic = False`).</p>
+        graph are linked.</p>
       </td>
     </tr>
     <tr>
@@ -282,8 +324,7 @@ objc_library(
         <p>Names of SDK frameworks to weakly link with. For instance,
         <code>MediaAccessibility</code>. In difference to regularly linked SDK
         frameworks, symbols from weakly linked frameworks do not cause an error
-        if they are not present at runtime. Only applicable for static
-        frameworks (i.e. `is_dynamic = False`).</p>
+        if they are not present at runtime.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-general.md
+++ b/doc/rules-general.md
@@ -236,6 +236,19 @@ objc_library(
       </td>
     </tr>
     <tr>
+      <td><code>alwayslink</code></td>
+      <td>
+        <p><code>Bool; optional</code></p>
+        <p>If true, any binary that depends (directly or indirectly) on this framework
+        will link in all the object files for the framework file, even if some
+        contain no symbols referenced by the binary. This is useful if your code isn't
+        explicitly called by code in the binary; for example, if you rely on runtime
+        checks for protocol conformances added in extensions in the library but do not
+        directly reference any other symbols in the object file that adds that
+        conformance. Only applicable for static frameworks (i.e. `is_dynamic = False`).</p>
+      </td>
+    </tr>
+    <tr>
       <td><code>sdk_dylibs</code></td>
       <td>
         <p><code>List of strings; optional</code></p>

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -35,6 +35,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
      "apple_framework_import",
+     "apple_static_framework_import",
     )
 
 objc_library(

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -104,15 +104,6 @@ function create_minimal_ios_application_with_framework_import() {
   readonly framework_type="$1"
   readonly import_rule="$2"
 
-  local is_dynamic
-  if [[ $import_rule == objc_* ]]; then
-    local dynamic
-    [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
-    is_dynamic="is_dynamic = $dynamic,"
-  else
-    is_dynamic=""
-  fi
-
   cat >> app/BUILD <<EOF
 ios_application(
     name = "app",
@@ -136,7 +127,6 @@ objc_library(
 $import_rule(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
-    $is_dynamic
 )
 EOF
 
@@ -702,27 +692,6 @@ EOF
   fi
 }
 
-# Tests that a prebuilt static framework (i.e., objc_framework with is_dynamic
-# set to False) is not bundled with the application.
-function test_prebuilt_static_framework_dependency() {
-  create_common_files
-  create_minimal_ios_application_with_framework_import static objc_framework
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that it's not bundled.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-}
-
 # Tests that a prebuilt static framework (i.e., apple_static_framework_import)
 # is not bundled with the application.
 function test_prebuilt_static_apple_framework_import_dependency() {
@@ -738,29 +707,6 @@ function test_prebuilt_static_apple_framework_import_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-}
-
-# Tests that a prebuilt dynamic framework (i.e., objc_framework with is_dynamic
-# set to True) is bundled properly with the application.
-function test_prebuilt_dynamic_framework_dependency() {
-  create_common_files
-  create_minimal_ios_application_with_framework_import dynamic objc_framework
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that the binary, plist, and resources are included.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-
-  # Verify that Headers and Modules directories are excluded.
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
   assert_zip_not_contains "test-bin/app/app.ipa" \

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -105,7 +105,7 @@ function create_minimal_ios_application_with_framework_import() {
   readonly import_rule="$2"
 
   local is_dynamic
-  if [[ $import_rule == objc_import ]]; then
+  if [[ $import_rule == objc_* ]]; then
     local dynamic
     [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
     is_dynamic="is_dynamic = $dynamic,"

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -34,7 +34,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_application"
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_dynamic_framework_import",
      "apple_static_framework_import",
     )
 
@@ -723,7 +723,7 @@ function test_prebuilt_static_framework_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt static framework (i.e., apple_framework_import with
+# Tests that a prebuilt static framework (i.e., apple_dynamic_framework_import with
 # is_dynamic set to False) is not bundled with the application.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
@@ -767,11 +767,11 @@ function test_prebuilt_dynamic_framework_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt dynamic framework (i.e., apple_framework_import with
+# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import with
 # is_dynamic set to True) is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {
   create_common_files
-  create_minimal_ios_application_with_framework_import dynamic apple_framework_import
+  create_minimal_ios_application_with_framework_import dynamic apple_dynamic_framework_import
 
   do_build ios //app:app || fail "Should build"
 

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -723,8 +723,8 @@ function test_prebuilt_static_framework_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt static framework (i.e., apple_dynamic_framework_import with
-# is_dynamic set to False) is not bundled with the application.
+# Tests that a prebuilt static framework (i.e., apple_static_framework_import)
+# is not bundled with the application.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
   create_minimal_ios_application_with_framework_import static apple_static_framework_import
@@ -767,8 +767,8 @@ function test_prebuilt_dynamic_framework_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import with
-# is_dynamic set to True) is bundled properly with the application.
+# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
+# is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {
   create_common_files
   create_minimal_ios_application_with_framework_import dynamic apple_dynamic_framework_import

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -103,6 +103,15 @@ function create_minimal_ios_application_with_framework_import() {
   readonly framework_type="$1"
   readonly import_rule="$2"
 
+  local is_dynamic
+  if [[ $import_rule == objc_import ]]; then
+    local dynamic
+    [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
+    is_dynamic="is_dynamic = $dynamic,"
+  else
+    is_dynamic=""
+  fi
+
   cat >> app/BUILD <<EOF
 ios_application(
     name = "app",
@@ -126,7 +135,7 @@ objc_library(
 $import_rule(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
-    is_dynamic = $([[ "$framework_type" == dynamic ]] && echo True || echo False),
+    $is_dynamic
 )
 EOF
 
@@ -717,7 +726,7 @@ function test_prebuilt_static_framework_dependency() {
 # is_dynamic set to False) is not bundled with the application.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
-  create_minimal_ios_application_with_framework_import static apple_framework_import
+  create_minimal_ios_application_with_framework_import static apple_static_framework_import
 
   do_build ios //app:app || fail "Should build"
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -139,7 +139,7 @@ function create_minimal_ios_application_and_extension_with_framework_import() {
   readonly import_rule="$2"
 
   local is_dynamic
-  if [[ $import_rule == objc_import ]]; then
+  if [[ $import_rule == objc_* ]]; then
     local dynamic
     [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
     is_dynamic="is_dynamic = $dynamic,"

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -36,6 +36,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
      "apple_framework_import",
+     "apple_static_framework_import",
     )
 
 objc_library(

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -137,6 +137,15 @@ function create_minimal_ios_application_and_extension_with_framework_import() {
   readonly framework_type="$1"
   readonly import_rule="$2"
 
+  local is_dynamic
+  if [[ $import_rule == objc_import ]]; then
+    local dynamic
+    [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
+    is_dynamic="is_dynamic = $dynamic,"
+  else
+    is_dynamic=""
+  fi
+
   cat >> app/BUILD <<EOF
 ios_application(
     name = "app",
@@ -170,7 +179,7 @@ objc_library(
 $import_rule(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
-    is_dynamic = $([[ "$framework_type" == dynamic ]] && echo True || echo False),
+    $is_dynamic
 )
 EOF
 
@@ -585,7 +594,7 @@ function test_prebuilt_static_framework_dependency() {
 # is_dynamic set to False) is not bundled with the application or extension.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import static apple_framework_import
+  create_minimal_ios_application_and_extension_with_framework_import static apple_static_framework_import
 
   do_build ios //app:app || fail "Should build"
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -35,7 +35,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_extension",
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_dynamic_framework_import",
      "apple_static_framework_import",
     )
 
@@ -591,7 +591,7 @@ function test_prebuilt_static_framework_dependency() {
       "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt static framework (i.e., apple_framework_import with
+# Tests that a prebuilt static framework (i.e., apple_dynamic_framework_import with
 # is_dynamic set to False) is not bundled with the application or extension.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
@@ -658,11 +658,11 @@ function test_prebuilt_dynamic_framework_dependency() {
       "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt dynamic framework (i.e., apple_framework_import with
+# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import with
 # is_dynamic set to True) is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {
   create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import dynamic apple_framework_import
+  create_minimal_ios_application_and_extension_with_framework_import dynamic apple_dynamic_framework_import
 
   do_build ios //app:app || fail "Should build"
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -138,15 +138,6 @@ function create_minimal_ios_application_and_extension_with_framework_import() {
   readonly framework_type="$1"
   readonly import_rule="$2"
 
-  local is_dynamic
-  if [[ $import_rule == objc_* ]]; then
-    local dynamic
-    [[ $framework_type == dynamic ]] && dynamic=True || dynamic=False
-    is_dynamic="is_dynamic = $dynamic,"
-  else
-    is_dynamic=""
-  fi
-
   cat >> app/BUILD <<EOF
 ios_application(
     name = "app",
@@ -180,7 +171,6 @@ objc_library(
 $import_rule(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
-    $is_dynamic
 )
 EOF
 
@@ -560,37 +550,6 @@ EOF
   expect_log "While processing target \"//app:app\"; the CFBundleVersion of the child target \"//app:ext\" should be the same as its parent's version string \"1.0\", but found \"1.1\"."
 }
 
-# Tests that a prebuilt static framework (i.e., objc_framework with is_dynamic
-# set to False) is not bundled with the application or extension.
-function test_prebuilt_static_framework_dependency() {
-  create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import static objc_framework
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that it's not bundled.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
-}
-
 # Tests that a prebuilt static framework (i.e., apple_static_framework_import)
 # is not bundled with the application or extension.
 function test_prebuilt_static_apple_framework_import_dependency() {
@@ -610,42 +569,6 @@ function test_prebuilt_static_apple_framework_import_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
-}
-
-# Tests that a prebuilt dynamic framework (i.e., objc_framework with is_dynamic
-# set to True) is bundled properly with the application.
-function test_prebuilt_dynamic_framework_dependency() {
-  create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import dynamic objc_framework
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that the framework is bundled with the application and that the
-  # binary, plist, and resources are included.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-
-  # Verify that Headers and Modules directories are excluded.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-
-  # Verify that the framework is not bundled with the extension.
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/fmwk"
   assert_zip_not_contains "test-bin/app/app.ipa" \

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -591,8 +591,8 @@ function test_prebuilt_static_framework_dependency() {
       "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt static framework (i.e., apple_dynamic_framework_import with
-# is_dynamic set to False) is not bundled with the application or extension.
+# Tests that a prebuilt static framework (i.e., apple_static_framework_import)
+# is not bundled with the application or extension.
 function test_prebuilt_static_apple_framework_import_dependency() {
   create_common_files
   create_minimal_ios_application_and_extension_with_framework_import static apple_static_framework_import
@@ -658,8 +658,8 @@ function test_prebuilt_dynamic_framework_dependency() {
       "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
-# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import with
-# is_dynamic set to True) is bundled properly with the application.
+# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
+# is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {
   create_common_files
   create_minimal_ios_application_and_extension_with_framework_import dynamic apple_dynamic_framework_import

--- a/test/ios_framework_test.sh
+++ b/test/ios_framework_test.sh
@@ -1995,7 +1995,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_framework"
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_static_framework_import",
     )
 
 objc_library(

--- a/test/ios_framework_test.sh
+++ b/test/ios_framework_test.sh
@@ -1390,7 +1390,6 @@ objc_library(
 apple_framework_import(
     name = "inner_framework",
     framework_imports = glob(["inner_framework.framework/**"]),
-    is_dynamic = True,
 )
 EOF
 
@@ -2053,10 +2052,9 @@ genrule(
     cmd = "cp \$< \$@",
 )
 
-apple_framework_import(
+apple_static_framework_import(
     name = "inner_framework",
     framework_imports = glob(["InnerFramework.framework/**"]) + ["InnerFramework.framework/InnerFramework"],
-    is_dynamic = False,
 )
 EOF
 

--- a/test/ios_framework_test.sh
+++ b/test/ios_framework_test.sh
@@ -1333,7 +1333,7 @@ EOF
 }
 
 # Test that if an ios_framework target depends on a prebuilt framework (i.e.,
-# apple_framework_import), that the inner framework is propagated up to the
+# apple_dynamic_framework_import), that the inner framework is propagated up to the
 # application and not nested in the outer framework.
 #
 # NOTE: This does not use xibs, storyboards, xcassets to avoid flake from
@@ -1345,7 +1345,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_framework"
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_dynamic_framework_import",
     )
 
 objc_library(
@@ -1387,7 +1387,7 @@ objc_library(
     alwayslink = 1,
 )
 
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "inner_framework",
     framework_imports = glob(["inner_framework.framework/**"]),
 )
@@ -1986,7 +1986,7 @@ EOF
 }
 
 # Test that if an ios_framework target depends on a prebuilt static library
-# framework (i.e., apple_framework_import), that the inner framework is
+# framework (i.e., apple_dynamic_framework_import), that the inner framework is
 # propagated up to the application and not nested in the outer framework.
 function test_framework_depends_on_prebuilt_static_apple_framework_import() {
   cat > app/BUILD <<EOF

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -441,10 +441,10 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_unit_test",
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_dynamic_framework_import",
     )
 
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "my_framework",
     framework_imports = ["my_framework.framework/my_framework"],
 )
@@ -608,10 +608,10 @@ load("@build_bazel_rules_apple//apple:ios.bzl",
      "ios_application",
     )
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import",
+     "apple_dynamic_framework_import",
     )
 
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "my_framework",
     framework_imports = ["my_framework.framework/my_framework"],
 )

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -447,7 +447,6 @@ load("@build_bazel_rules_apple//apple:apple.bzl",
 apple_framework_import(
     name = "my_framework",
     framework_imports = ["my_framework.framework/my_framework"],
-    is_dynamic = 1,
 )
 
 objc_library(
@@ -615,7 +614,6 @@ load("@build_bazel_rules_apple//apple:apple.bzl",
 apple_framework_import(
     name = "my_framework",
     framework_imports = ["my_framework.framework/my_framework"],
-    is_dynamic = 1,
 )
 
 objc_library(

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -97,7 +97,6 @@ objc_library(
 apple_dynamic_framework_import(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
-    is_dynamic = True,
 )
 EOF
 

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -33,7 +33,7 @@ load("@build_bazel_rules_apple//apple:macos.bzl",
      "macos_application",
      "macos_bundle")
 load("@build_bazel_rules_apple//apple:apple.bzl",
-     "apple_framework_import")
+     "apple_dynamic_framework_import")
 
 objc_library(
     name = "lib",
@@ -94,7 +94,7 @@ objc_library(
     deps = [":fmwk"],
 )
 
-apple_framework_import(
+apple_dynamic_framework_import(
     name = "fmwk",
     framework_imports = glob(["fmwk.framework/**"]),
     is_dynamic = True,


### PR DESCRIPTION
This adds `apple_static_framework_import ` and makes the existing `apple_framework_import` to be dynamic only. This is based on #266 and conversation in https://github.com/bazelbuild/rules_apple/pull/251#issuecomment-441919876.

Static and dynamic framework imports have different interfaces, and #266 adds another attr which applies only to static frameworks. Having separate functions seems like a good way to ensure their use is straight forward and correct.

- [x] Incorporate resource propagation (#263) 
- [x] Incorporate force loading (#266)
- [x] Rename apple_framework_import into apple_dynamic_framework_import
- [x] Update API docs
- [x] Handle `alwayslink` for multiple frameworks
- [x] If it makes migrating the tests easier, you can go ahead and remove any support for objc_framework from the integration tests
