### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -154,6 +154,7 @@ import subprocess
 import sys
 
 # Python 2/3 compatibility setup.
+# We don't want to depend on `six`, so we recreate the bits we need here.
 
 try:
   _string_types = basestring

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -154,15 +154,13 @@ import subprocess
 import sys
 
 # Python 2/3 compatibility setup.
-# We don't want to depend on `six`, so we recreate the bits we need here.
-_PY3 = sys.version_info[0] == 3
 
-if _PY3:
-  _string_types = str
-  _integer_types = int
-else:
+try:
   _string_types = basestring
   _integer_types = int, long
+except NameError:
+  _string_types = str
+  _integer_types = int
 
 # Format strings for errors that are raised, exposed here to the tests
 # can validate against them.
@@ -374,9 +372,9 @@ CF_BUNDLE_SHORT_VERSION_RE = re.compile(
 )
 
 def plist_from_bytes(byte_content):
-  if _PY3:
+  try:
     return plistlib.loads(byte_content)
-  else:
+  except AttributeError:
     return plistlib.readPlistFromString(byte_content)
 
 


### PR DESCRIPTION
Python porting best practice https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection