### PR TITLE
Fix PostProcessorError reference

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -125,7 +125,7 @@ class Bundler(object):
 
     post_processor = self._control.get('post_processor')
     if post_processor:
-      self._post_process_bundle(self, output_path, post_processor)
+      self._post_process_bundle(output_path, post_processor)
 
     code_signing_commands = self._control.get('code_signing_commands')
     if code_signing_commands:

--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -248,7 +248,7 @@ class Bundler(object):
     """
     exit_code = os.system('%s "%s"' % (post_processor, bundle_root))
     if exit_code:
-      raise PostProcessingError(exit_code)
+      raise PostProcessorError(exit_code)
 
   def _sign_bundle(self, bundle_root, command_lines):
     """Executes the signing command lines on the bundle.


### PR DESCRIPTION
Fixes an error class typo `PostProcessingError` => `PostProcessorError`.

Also removes an extraneous `self` argument.