### PR TITLE
Add modulemap support for dynamic frameworks (ios_framework)

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -210,9 +210,12 @@ def _ios_framework_impl(ctx):
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = ctx.attr.extension_safe),
-        partials.framework_headers_partial(hdrs = ctx.files.hdrs),
         partials.framework_provider_partial(
             binary_provider = binary_target[apple_common.AppleDylibBinary],
+        ),
+        partials.framework_header_modulemap_partial(
+            hdrs = ctx.files.hdrs,
+            binary_objc_provider = binary_target[apple_common.Objc],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,
@@ -309,7 +312,7 @@ def _ios_static_framework_impl(ctx):
     processor_partials = [
         partials.apple_bundle_info_partial(),
         partials.binary_partial(binary_artifact = binary_artifact),
-        partials.static_framework_header_modulemap_partial(
+        partials.framework_header_modulemap_partial(
             hdrs = ctx.files.hdrs,
             binary_objc_provider = binary_target[apple_common.Objc],
         ),

--- a/apple/internal/partials.bzl
+++ b/apple/internal/partials.bzl
@@ -80,7 +80,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:static_framework_header_modulemap.bzl",
-    _static_framework_header_modulemap_partial = "static_framework_header_modulemap_partial",
+    _framework_header_modulemap_partial = "framework_header_modulemap_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:swift_dylibs.bzl",
@@ -100,15 +100,15 @@ partials = struct(
     debug_symbols_partial = _debug_symbols_partial,
     embedded_bundles_partial = _embedded_bundles_partial,
     extension_safe_validation_partial = _extension_safe_validation_partial,
-    framework_import_partial = _framework_import_partial,
+    framework_header_modulemap_partial = _framework_header_modulemap_partial,
     framework_headers_partial = _framework_headers_partial,
+    framework_import_partial = _framework_import_partial,
     framework_provider_partial = _framework_provider_partial,
     macos_additional_contents_partial = _macos_additional_contents_partial,
     messages_stub_partial = _messages_stub_partial,
     provisioning_profile_partial = _provisioning_profile_partial,
     resources_partial = _resources_partial,
     settings_bundle_partial = _settings_bundle_partial,
-    static_framework_header_modulemap_partial = _static_framework_header_modulemap_partial,
     swift_dylibs_partial = _swift_dylibs_partial,
     watchos_stub_partial = _watchos_stub_partial,
 )

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -115,7 +115,7 @@ def _create_umbrella_header(actions, output, headers):
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
-def _static_framework_header_modulemap_partial_impl(ctx, hdrs, binary_objc_provider):
+def _framework_header_modulemap_partial_impl(ctx, hdrs, binary_objc_provider):
     """Implementation for the static framework headers and modulemaps partial."""
     bundle_name = bundling_support.bundle_name(ctx)
 
@@ -158,21 +158,21 @@ def _static_framework_header_modulemap_partial_impl(ctx, hdrs, binary_objc_provi
         bundle_files = bundle_files,
     )
 
-def static_framework_header_modulemap_partial(hdrs, binary_objc_provider):
-    """Constructor for the static framework headers and modulemaps partial.
+def framework_header_modulemap_partial(hdrs, binary_objc_provider):
+    """Constructor for the framework headers and modulemaps partial.
 
-    This partial bundles the headers and modulemaps for static frameworks.
+    This partial bundles the headers and modulemaps for frameworks.
 
     Args:
       hdrs: The list of headers to bundle.
       binary_objc_provider: The ObjC provider for the binary target.
 
     Returns:
-      A partial that returns the bundle location of the static framework header and modulemap
+      A partial that returns the bundle location of the framework header and modulemap
       artifacts.
     """
     return partial.make(
-        _static_framework_header_modulemap_partial_impl,
+        _framework_header_modulemap_partial_impl,
         hdrs = hdrs,
         binary_objc_provider = binary_objc_provider,
     )

--- a/test/ios_framework_test.sh
+++ b/test/ios_framework_test.sh
@@ -84,7 +84,7 @@ ios_extension(
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.bundle.id.framework",
     extension_safe = 1,
     families = ["iphone"],
@@ -96,7 +96,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     data = [":framework_structured_resources"],
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
 }
 EOF
 
-  cat > app/Framework.h <<EOF
+  cat > app/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -195,7 +195,7 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.framework.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
@@ -207,7 +207,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     deps = [":framework_dependent_lib"],
@@ -245,7 +245,7 @@ EOF
 }
 EOF
 
-  cat > framework/Framework.h <<EOF
+  cat > framework/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -382,7 +382,7 @@ ios_application(
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.bundle.id.framework",
     families = ["iphone"],
     infoplists = ["Info-Framework.plist"],
@@ -394,7 +394,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     data = [
@@ -430,7 +430,7 @@ int main(int argc, char **argv) {
 }
 EOF
 
-  cat > app/Framework.h <<EOF
+  cat > app/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -470,7 +470,7 @@ function test_framework_contains_expected_files() {
   assert_zip_contains "test-bin/framework/framework.zip" \
       "framework.framework/Info.plist"
   assert_zip_contains "test-bin/framework/framework.zip" \
-      "framework.framework/Headers/Framework.h"
+      "framework.framework/Headers/MyFramework.h"
 }
 
 # Tests that the correct rpath was added at link-time to the framework's binary.
@@ -485,7 +485,7 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 
 ios_framework(
   name = "framework",
-  hdrs = ["Framework.h"],
+  hdrs = ["MyFramework.h"],
   bundle_id = "my.framework.id",
   bundle_name = "FrameworkBundleName",
   families = ["iphone"],
@@ -498,7 +498,7 @@ ios_framework(
 objc_library(
   name = "framework_lib",
   srcs = [
-      "Framework.h",
+      "MyFramework.h",
       "Framework.m",
   ],
   deps = [":framework_dependent_lib"],
@@ -568,7 +568,7 @@ function test_application_contains_expected_files() {
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/framework.framework/Info.plist"
   assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/framework.framework/Headers/Framework.h"
+      "Payload/app.app/Frameworks/framework.framework/Headers/MyFramework.h"
 
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/PlugIns/extension.appex/Frameworks/"
@@ -626,7 +626,7 @@ ios_application(
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.bundle.id.framework",
     families = ["iphone"],
     infoplists = ["Info-Framework.plist"],
@@ -638,7 +638,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     deps = [":lib_with_resources"],
@@ -691,7 +691,7 @@ int main(int argc, char **argv) {
 }
 EOF
 
-  cat > app/Framework.h <<EOF
+  cat > app/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -808,7 +808,7 @@ EOF
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/framework.framework/Info.plist"
   assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/framework.framework/Headers/Framework.h"
+      "Payload/app.app/Frameworks/framework.framework/Headers/MyFramework.h"
   # The extension bundle should be intact, but have no inner framework.
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/PlugIns/ext.appex/ext"
@@ -883,7 +883,7 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.bundle.id.framework",
     families = ["iphone"],
     infoplists = ["Info-Framework.plist"],
@@ -895,7 +895,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     alwayslink = 1,
@@ -946,7 +946,7 @@ int main(int argc, char **argv) {
 }
 EOF
 
-  cat > framework/Framework.h <<EOF
+  cat > framework/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -1009,7 +1009,7 @@ ios_application(
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.bundle.id.framework",
     families = ["iphone"],
     infoplists = ["Info-Framework.plist"],
@@ -1021,7 +1021,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     data = [
@@ -1057,7 +1057,7 @@ int main(int argc, char **argv) {
 }
 EOF
 
-  cat > app/Framework.h <<EOF
+  cat > app/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -1428,7 +1428,7 @@ function test_extension_depends_on_unsafe_framework() {
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/framework.framework/Info.plist"
   assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/framework.framework/Headers/Framework.h"
+      "Payload/app.app/Frameworks/framework.framework/Headers/MyFramework.h"
 
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/PlugIns/extension.appex/Frameworks/"
@@ -1467,7 +1467,7 @@ ios_application(
 
 ios_framework(
     name = "framework",
-    hdrs = ["Framework.h"],
+    hdrs = ["MyFramework.h"],
     bundle_id = "my.framework.id",
     frameworks = [":depframework"],
     families = ["iphone"],
@@ -1478,7 +1478,7 @@ ios_framework(
 
 ios_framework(
     name = "depframework",
-    hdrs = ["DepFramework.h"],
+    hdrs = ["MyDepFramework.h"],
     bundle_id = "my.depframework.id",
     families = ["iphone"],
     infoplists = ["Framework-Info.plist", "Info-Common.plist"],
@@ -1489,7 +1489,7 @@ ios_framework(
 objc_library(
     name = "framework_lib",
     srcs = [
-        "Framework.h",
+        "MyFramework.h",
         "Framework.m",
     ],
     deps = [":framework_dependent_lib"],
@@ -1499,7 +1499,7 @@ objc_library(
 objc_library(
     name = "dep_framework_lib",
     srcs = [
-        "DepFramework.h",
+        "MyDepFramework.h",
         "DepFramework.m",
     ],
     deps = [":framework_dependent_lib"],
@@ -1560,7 +1560,7 @@ EOF
 }
 EOF
 
-  cat > app/Framework.h <<EOF
+  cat > app/MyFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 
@@ -1577,7 +1577,7 @@ void doStuff() {
 }
 EOF
 
-  cat > app/DepFramework.h <<EOF
+  cat > app/MyDepFramework.h <<EOF
 #ifndef FRAMEWORK_FRAMEWORK_H_
 #define FRAMEWORK_FRAMEWORK_H_
 


### PR DESCRIPTION
Without a modulemap, it is not possible for Xcode/Swift to see the modules defined in the framework.