### PR TITLE
Add bundle type for iOS

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -277,6 +277,16 @@ _RULE_TYPE_DESCRIPTORS = {
             requires_provisioning_profile = False,
             skip_signing = True,
         ),
+        apple_product_type.bundle: _describe_rule_type(
+            allowed_device_families = ["iphone", "ipad"],
+            bundle_extension = ".bundle",
+            has_infoplist = True,
+            product_type = apple_product_type.bundle,
+            requires_bundle_id = True,
+            requires_provisioning_profile = False,
+            requires_signing_for_device = False,
+            skip_signing = True,
+        ),
         # ios_ui_test
         apple_product_type.ui_test_bundle: _describe_rule_type(
             allowed_device_families = ["iphone", "ipad"],


### PR DESCRIPTION
iOS supports bundle types for resource bundles, but rules_apple
currently doesn't build any with this type. In theory
apple_resource_bundle could use this type instead of the type it
inherits from the final rule that includes the bundle. Another possible
use case is a new rule that pre-compiled resource bundles for others to
include using apple_bundle_import.