### PR TITLE
Fix resources being re-processed from pre-built bundles

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -168,8 +168,10 @@ def _apple_static_framework_import_impl(ctx):
             resources.bundle_relative_parent_dir,
             extension = "bundle",
         )
-        resource_provider = resources.bucketize(
+        resource_provider = resources.bucketize_typed(
             bundle_files,
+            owner = str(ctx.label),
+            bucket_type = "unprocessed",
             parent_dir_param = parent_dir_param,
         )
         providers.append(resource_provider)

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -149,6 +149,11 @@ EOF
 Dummy resource
 EOF
 
+  mkdir -p app/fmwk.framework/fmwk.bundle
+  cat > app/fmwk.framework/fmwk.bundle/Some.plist <<EOF
+Dummy plist
+EOF
+
   mkdir -p app/fmwk.framework/Headers
   cat > app/fmwk.framework/Headers/fmwk.h <<EOF
 This shouldn't get included

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -151,7 +151,14 @@ EOF
 
   mkdir -p app/fmwk.framework/fmwk.bundle
   cat > app/fmwk.framework/fmwk.bundle/Some.plist <<EOF
-Dummy plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Foo</key>
+    <string>Bar</string>
+  </dict>
+</plist>
 EOF
 
   mkdir -p app/fmwk.framework/Headers

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -697,6 +697,19 @@ function test_prebuilt_static_apple_framework_import_dependency() {
       "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
 }
 
+# Tests that the resources in the bundle of the static framework are copied to
+# the final ipa, and that they are not re-processed
+function test_prebuilt_static_apple_static_framework_import_resources() {
+  create_common_files
+  create_minimal_ios_application_with_framework_import static apple_static_framework_import
+
+  do_build ios //app:app || fail "Should build"
+
+  # Verify that it's not bundled.
+  assert_plist_is_text "test-bin/app/app.ipa" \
+      "Payload/app.app/fmwk.bundle/Some.plist"
+}
+
 # Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
 # is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {


### PR DESCRIPTION
apple_static_framework_import supports frameworks that have bundle
directories inside them. In this case these are pre-built bundles that
were shipped with the framework. Previously we were re-processing those
files like they were normal asset files. Now we propagate them directly
without processing.