### PR TITLE
Pass tags to bundling support

### DIFF
--- a/apple/bundling/binary_support.bzl
+++ b/apple/bundling/binary_support.bzl
@@ -28,7 +28,7 @@ def _create_swift_runtime_linkopts_target(
         deps,
         is_static,
         tags,
-        testonly = None):
+        testonly):
     """Creates a build target to propagate Swift runtime linker flags.
 
     Args:

--- a/apple/bundling/binary_support.bzl
+++ b/apple/bundling/binary_support.bzl
@@ -27,7 +27,7 @@ def _create_swift_runtime_linkopts_target(
         name,
         deps,
         is_static,
-        tags = None,
+        tags,
         testonly = None):
     """Creates a build target to propagate Swift runtime linker flags.
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -188,6 +188,7 @@ def _assemble_test_targets(
         include_entitlements = False,
         testonly = True,
         deps = deps,
+        tags = kwargs.get("tags"),
     )
 
     if uses_provisioning_profile:
@@ -200,7 +201,6 @@ def _assemble_test_targets(
         infoplists = infoplists,
         linkopts = linkopts,
         minimum_os_version = minimum_os_version,
-        tags = kwargs.get("tags"),
         test_host = test_host,
         **bundling_args
     )


### PR DESCRIPTION
This makes sure that the nested Foo.swift_runtime_linkopts gets the same
tags as the binary that it's created for.

I remove tags from the second rule because bundle_args contains the tags
we pass in the first.