### PR TITLE
Validate beta-reports-active in entitlements

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -297,6 +297,11 @@ ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH = (
     'match the value in the provisioning profile ("%s").'
 )
 
+ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH = (
+    'In target "%s"; the entitlements "beta-reports-active" ("%s") did not '
+    'match the value in the provisioning profile ("%s").'
+)
+
 ENTITLEMENTS_HAS_GROUP_ENTRY_PROFILE_DOES_NOT = (
     'Target "%s" uses entitlements "%s" value of "%s", but the profile does '
     'not support it (["%s"]).'
@@ -1175,6 +1180,15 @@ class EntitlementsTask(PlistToolTask):
               ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH % (
                 self.target, aps_environment, profile_aps_environment),
               **report_extras)
+
+    beta_reports_active = entitlements.get('beta-reports-active')
+    if beta_reports_active is not None or profile_entitlements:
+      profile_key = (profile_entitlements or {}).get('beta-reports-active')
+      if profile_key != beta_reports_active:
+        self._report(
+            ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
+                self.target, beta_reports_active, profile_key),
+            **report_extras)
 
     # keychain-access-groups
     self._check_entitlements_array(

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1187,7 +1187,7 @@ class EntitlementsTask(PlistToolTask):
               **report_extras)
 
     # If beta-reports-active is in either the profile or the entitlements file
-    # it must be in both or the upload will get rejected by Applejk
+    # it must be in both or the upload will get rejected by Apple
     beta_reports_active = entitlements.get('beta-reports-active')
     profile_key = (profile_entitlements or {}).get('beta-reports-active')
     if beta_reports_active is not None and profile_key != beta_reports_active:

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -302,11 +302,6 @@ ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH = (
     'match the value in the provisioning profile ("%s").'
 )
 
-ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_ENTITLEMENTS = (
-    'In target "%s"; the profile has "beta-reports-active" ("%s") so it must '
-    'also exist in the entitlements file.'
-)
-
 ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_PROFILE = (
     'In target "%s"; the entitlements file has "beta-reports-active" ("%s") '
     'but it does not exist in the profile.'
@@ -1195,15 +1190,12 @@ class EntitlementsTask(PlistToolTask):
     # it must be in both or the upload will get rejected by Applejk
     beta_reports_active = entitlements.get('beta-reports-active')
     profile_key = (profile_entitlements or {}).get('beta-reports-active')
-    if profile_key != beta_reports_active:
+    if beta_reports_active is not None and profile_key != beta_reports_active:
       error_msg = ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
         self.target, beta_reports_active, profile_key)
       if profile_key is None:
         error_msg = ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_PROFILE % (
           self.target, beta_reports_active)
-      elif beta_reports_active is None:
-        error_msg = ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_ENTITLEMENTS % (
-          self.target, profile_key)
       self._report(error_msg, **report_extras)
 
     # keychain-access-groups

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1182,13 +1182,12 @@ class EntitlementsTask(PlistToolTask):
               **report_extras)
 
     beta_reports_active = entitlements.get('beta-reports-active')
-    if beta_reports_active is not None or profile_entitlements:
-      profile_key = (profile_entitlements or {}).get('beta-reports-active')
-      if profile_key != beta_reports_active:
-        self._report(
-            ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
-                self.target, beta_reports_active, profile_key),
-            **report_extras)
+    profile_key = (profile_entitlements or {}).get('beta-reports-active')
+    if profile_key != beta_reports_active:
+      self._report(
+          ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
+              self.target, beta_reports_active, profile_key),
+          **report_extras)
 
     # keychain-access-groups
     self._check_entitlements_array(

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1761,23 +1761,18 @@ class PlistToolTest(unittest.TestCase):
       }, plist)
 
   def test_entitlements_missing_beta_reports_active(self):
-    with self.assertRaisesRegexp(
-        plisttool.PlistToolError,
-        re.escape(
-            plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_ENTITLEMENTS % (
-                _testing_target, 'True'))):
-      plist = {}
-      self._assert_plisttool_result({
-          'plists': [plist],
-          'entitlements_options': {
-              'profile_metadata_file': {
-                  'Entitlements': {
-                      'beta-reports-active': True,
-                  },
-                  'Version': 1,
-              },
-          },
-      }, plist)
+    plist = {}
+    self._assert_plisttool_result({
+        'plists': [plist],
+        'entitlements_options': {
+            'profile_metadata_file': {
+                'Entitlements': {
+                    'beta-reports-active': True,
+                },
+                'Version': 1,
+            },
+        },
+    }, plist)
 
   def test_entitlements_beta_reports_active_mismatch(self):
     with self.assertRaisesRegexp(

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1760,6 +1760,57 @@ class PlistToolTest(unittest.TestCase):
           },
       }, plist)
 
+  def test_entitlements_missing_beta_reports_active(self):
+    with self.assertRaisesRegexp(
+        plisttool.PlistToolError,
+        re.escape(plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
+            _testing_target, 'None', 'True'))):
+      plist = {}
+      self._assert_plisttool_result({
+          'plists': [plist],
+          'entitlements_options': {
+              'profile_metadata_file': {
+                  'Entitlements': {
+                      'beta-reports-active': True,
+                  },
+                  'Version': 1,
+              },
+          },
+      }, plist)
+
+  def test_entitlements_beta_reports_active_mismatch(self):
+    with self.assertRaisesRegexp(
+        plisttool.PlistToolError,
+        re.escape(plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
+            _testing_target, 'False', 'True'))):
+      plist = {'beta-reports-active': False}
+      self._assert_plisttool_result({
+          'plists': [plist],
+          'entitlements_options': {
+              'profile_metadata_file': {
+                  'Entitlements': {
+                      'beta-reports-active': True,
+                  },
+                  'Version': 1,
+              },
+          },
+      }, plist)
+
+  def test_entitlements_profile_missing_beta_reports_active(self):
+    with self.assertRaisesRegexp(
+        plisttool.PlistToolError,
+        re.escape(plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
+            _testing_target, 'True', 'None'))):
+      plist = {'beta-reports-active': True}
+      self._assert_plisttool_result({
+          'plists': [plist],
+          'entitlements_options': {
+              'profile_metadata_file': {
+                  'Version': 1,
+              },
+          },
+      }, plist)
+
   def test_entitlements_associated_domains_match(self):
     # This is really looking for the lack of an error being raised.
     plist1 = {

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1763,8 +1763,9 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_missing_beta_reports_active(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
-            _testing_target, 'None', 'True'))):
+        re.escape(
+            plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_ENTITLEMENTS % (
+                _testing_target, 'True'))):
       plist = {}
       self._assert_plisttool_result({
           'plists': [plist],
@@ -1799,8 +1800,9 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_profile_missing_beta_reports_active(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH % (
-            _testing_target, 'True', 'None'))):
+        re.escape(
+            plisttool.ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_PROFILE % (
+                _testing_target, 'True'))):
       plist = {'beta-reports-active': True}
       self._assert_plisttool_result({
           'plists': [plist],


### PR DESCRIPTION
This key is validated against your profile by iTunes Connect, so we
should too. This is a case where having it in the profile at all
requires it's in your entitlements.