### PR TITLE
Use the use_entitlements flag when codesigning

### DIFF
--- a/apple/bundling/codesigning_support.bzl
+++ b/apple/bundling/codesigning_support.bzl
@@ -81,7 +81,7 @@ def _codesign_command(ctx, path_to_sign, provisioning_profile, entitlements_file
         cmd_codesigning.extend(["--identity", shell.quote(identity)])
 
     if is_device:
-        if entitlements_file:
+        if path_to_sign.use_entitlements and entitlements_file:
             cmd_codesigning.extend([
                 "--entitlements",
                 shell.quote(entitlements_file.path),


### PR DESCRIPTION
This seems to have been lost in the shuffle of some refactoring (original work was in #182, bug was #181)