### PR TITLE
Add feature for disabling SwiftSupport

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -51,6 +51,10 @@ load(
     "stub_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
@@ -89,6 +93,8 @@ def _ios_application_impl(ctx):
                 parent_bundle_id_reference = ["WKCompanionAppBundleIdentifier"],
             ),
         )
+
+    package_swift_support = defines.bool_value(ctx, "apple.package_swift_support", True)
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -129,7 +135,7 @@ def _ios_application_impl(ctx):
             bundle_dylibs = True,
             # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
             # least only for device builds.
-            package_swift_support = True,
+            package_swift_support = package_swift_support,
         ),
     ]
 
@@ -334,6 +340,7 @@ def _ios_imessage_application_impl(ctx):
 
     bundle_verification_targets = [struct(target = ctx.attr.extension)]
     embeddable_targets = [ctx.attr.extension]
+    package_swift_support = defines.bool_value(ctx, "apple.package_swift_support", True)
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -362,7 +369,7 @@ def _ios_imessage_application_impl(ctx):
             bundle_dylibs = True,
             # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
             # least only for device builds.
-            package_swift_support = True,
+            package_swift_support = package_swift_support,
         ),
     ]
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -43,6 +43,10 @@ load(
     "rule_factory",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "TvosApplicationBundleInfo",
     "TvosExtensionBundleInfo",
@@ -66,6 +70,7 @@ def _tvos_application_impl(ctx):
 
     embeddable_targets = ctx.attr.extensions
     swift_dylib_dependencies = ctx.attr.extensions
+    package_swift_support = defines.bool_value(ctx, "apple.package_swift_support", True)
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -102,7 +107,7 @@ def _tvos_application_impl(ctx):
             bundle_dylibs = True,
             # TODO(kaipi): Revisit if we can add this only for non enterprise optimized
             # builds, or at least only for device builds.
-            package_swift_support = True,
+            package_swift_support = package_swift_support,
         ),
     ]
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -127,6 +127,13 @@ can pass `--define=apple.propagate_embedded_extra_outputs=(yes|true|1)` to
 bazel build --define=apple.propagate_embedded_extra_outputs=yes //your/target
 ```
 
+### Disable `SwiftSupport` in ipas
+
+The SwiftSupport directory in a final ipa is only necessary if you're
+shipping the build to Apple. If you want to disable bundling
+SwiftSupport in your ipa for other device or enterprise builds, you can
+pass `--define=apple.package_swift_support=no` to `bazel build`
+
 ### Codesign Bundles for the Simulator {#apple.codesign_simulator_bundles}
 
 The simulators are far more lax about a lot of things compared to working on


### PR DESCRIPTION
The SwiftSupport directory in a final ipa is only necessary for builds
shipped to Apple. Any other device or enterprise builds don't need it.
For us having this extra directory greatly bloats the ipa size. This
gives an feature to control disabling it in that case.