### PR TITLE
Only package SwiftSupport for device builds

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -127,9 +127,7 @@ def _ios_application_impl(ctx):
             binary_artifact = binary_artifact,
             dependency_targets = embeddable_targets,
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
-            # least only for device builds.
-            package_swift_support = True,
+            package_swift_support = platform_support.is_device_build(ctx),
         ),
     ]
 
@@ -360,9 +358,7 @@ def _ios_imessage_application_impl(ctx):
             binary_artifact = None,
             dependency_targets = [ctx.attr.extension],
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
-            # least only for device builds.
-            package_swift_support = True,
+            package_swift_support = platform_support.is_device_build(ctx),
         ),
     ]
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -100,9 +100,7 @@ def _tvos_application_impl(ctx):
             binary_artifact = binary_artifact,
             dependency_targets = swift_dylib_dependencies,
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for non enterprise optimized
-            # builds, or at least only for device builds.
-            package_swift_support = True,
+            package_swift_support = platform_support.is_device_build(ctx),
         ),
     ]
 


### PR DESCRIPTION
For simulator builds the SwiftSupport directory isn't necessary in the
final ipa. It really isn't for all device builds either, only device
builds you will send to Apple, but we can't differentiate on that here.