### PR TITLE
Fix conflict test environment issues

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -21,23 +21,21 @@ load(
 
 def _get_template_substitutions(ctx):
     """Returns the template substitutions for this runner."""
-    test_env = ctx.configuration.test_env
     subs = {
         "device_type": ctx.attr.device_type,
         "os_version": ctx.attr.os_version,
-        "test_env": ",".join([k + "=" + v for (k, v) in test_env.items()]),
         "testrunner_binary": ctx.executable._testrunner.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}
 
-def _get_test_environment(ctx):
-    """Returns the test environment for this runner."""
-    test_environment = dict(ctx.configuration.test_env)
+def _get_execution_environment(ctx):
+    """Returns environment variables the test runner requires"""
+    execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        test_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION"] = xcode_version
 
-    return test_environment
+    return execution_environment
 
 def _ios_test_runner_impl(ctx):
     """Implementation for the ios_test_runner rule."""
@@ -50,7 +48,7 @@ def _ios_test_runner_impl(ctx):
         AppleTestRunnerInfo(
             test_runner_template = ctx.outputs.test_runner_template,
             execution_requirements = ctx.attr.execution_requirements,
-            test_environment = _get_test_environment(ctx),
+            execution_environment = _get_execution_environment(ctx),
         ),
         DefaultInfo(
             runfiles = ctx.runfiles(

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -55,14 +55,14 @@ def _get_template_substitutions(xctestrun_template):
 
     return {"%(" + k + ")s": subs[k] for k in subs}
 
-def _get_test_environment(ctx):
-    """Returns the test environment for this runner."""
-    test_environment = dict(ctx.configuration.test_env)
+def _get_execution_environment(ctx):
+    """Returns environment variables the test runner requires"""
+    execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        test_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION"] = xcode_version
 
-    return test_environment
+    return execution_environment
 
 def _macos_test_runner_impl(ctx):
     """Implementation for the macos_runner rule."""
@@ -86,7 +86,7 @@ def _macos_test_runner_impl(ctx):
         AppleTestRunnerInfo(
             test_runner_template = ctx.outputs.test_runner_template,
             execution_requirements = {"requires-darwin": ""},
-            test_environment = _get_test_environment(ctx),
+            execution_environment = _get_execution_environment(ctx),
         ),
         DefaultInfo(
             runfiles = ctx.runfiles(
@@ -126,8 +126,7 @@ Provides:
         with which the tests will be performed.
     execution_requirements: Dictionary that represents the specific hardware
         requirements for this test.
-    test_environment: Dictionary with the environment variables required for the
-        test.
+    execution_environment: Dictionary with the environment variables the test runner requires
   Runfiles:
     files: The files needed during runtime for the test to be performed.
 """,

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -21,23 +21,21 @@ load(
 
 def _get_template_substitutions(ctx):
     """Returns the template substitutions for this runner."""
-    test_env = ctx.configuration.test_env
     subs = {
         "device_type": ctx.attr.device_type,
         "os_version": ctx.attr.os_version,
-        "test_env": ",".join([k + "=" + v for (k, v) in test_env.items()]),
         "testrunner_binary": ctx.executable._testrunner.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}
 
-def _get_test_environment(ctx):
-    """Returns the test environment for this runner."""
-    test_environment = dict(ctx.configuration.test_env)
+def _get_execution_environment(ctx):
+    """Returns environment variables the test runner requires"""
+    execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        test_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION"] = xcode_version
 
-    return test_environment
+    return execution_environment
 
 def _tvos_test_runner_impl(ctx):
     """Implementation for the tvos_test_runner rule."""
@@ -50,7 +48,7 @@ def _tvos_test_runner_impl(ctx):
         AppleTestRunnerInfo(
             test_runner_template = ctx.outputs.test_runner_template,
             execution_requirements = ctx.attr.execution_requirements,
-            test_environment = _get_test_environment(ctx),
+            execution_environment = _get_execution_environment(ctx),
         ),
         DefaultInfo(
             runfiles = ctx.runfiles(

--- a/test/testdata/rules/dummy_test_runner.bzl
+++ b/test/testdata/rules/dummy_test_runner.bzl
@@ -30,7 +30,7 @@ def _dummy_test_runner_impl(ctx):
         AppleTestRunnerInfo(
             test_runner_template = ctx.outputs.test_runner_template,
             execution_requirements = {},
-            test_environment = {},
+            execution_environment = {},
         ),
         DefaultInfo(
             runfiles = ctx.runfiles(files = []),


### PR DESCRIPTION
Previously the test_env was being replaced in the test runner template
by the runner itself. At this point any value set for the `env` attr in
the test rule was not realized. Now we instead do the replacement in the
test rule itself, including the environment added by the runner.

Fixes https://github.com/bazelbuild/rules_apple/issues/304