### PR TITLE
Stop always including SwiftSupport

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -131,9 +131,7 @@ def _ios_application_impl(ctx):
             binary_artifact = binary_artifact,
             dependency_targets = embeddable_targets,
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
-            # least only for device builds.
-            package_swift_support = True,
+            package_swift_support_if_needed = True,
         ),
     ]
 
@@ -371,9 +369,7 @@ def _ios_imessage_application_impl(ctx):
             binary_artifact = None,
             dependency_targets = [ctx.attr.extension],
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for AppStore optimized builds, or at
-            # least only for device builds.
-            package_swift_support = True,
+            package_swift_support_if_needed = True,
         ),
     ]
 

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -35,6 +35,10 @@ load(
     "swift_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
@@ -88,7 +92,7 @@ def _swift_dylibs_partial_impl(
         binary_artifact,
         dependency_targets,
         bundle_dylibs,
-        package_swift_support):
+        package_swift_support_if_needed):
     """Implementation for the Swift dylibs processing partial."""
 
     # Collect transitive data.
@@ -135,7 +139,9 @@ def _swift_dylibs_partial_impl(
             swift_support_file = (platform_name, output_dir)
             transitive_swift_support_files.append(swift_support_file)
 
-        if package_swift_support:
+        swift_support_requested = defines.bool_value(ctx, "apple.package_swift_support", True)
+        needs_swift_support = platform_support.is_device_build(ctx) and swift_support_requested
+        if package_swift_support_if_needed and needs_swift_support:
             # Package all the transitive SwiftSupport dylibs into the archive for this target.
             bundle_files.extend([
                 (
@@ -165,7 +171,7 @@ def swift_dylibs_partial(
         binary_artifact,
         dependency_targets = [],
         bundle_dylibs = False,
-        package_swift_support = False):
+        package_swift_support_if_needed = False):
     """Constructor for the Swift dylibs processing partial.
 
     This partial handles the Swift dylibs that may need to be packaged or propagated.
@@ -176,8 +182,9 @@ def swift_dylibs_partial(
         Swift, so that the Swift dylibs can be collected.
       bundle_dylibs: Whether the partial should return the Swift files to be bundled inside the
         target's bundle.
-      package_swift_support: Whether the partial should also bundle the Swift dylib for each
-        dependency platform into the SwiftSupport directory at the root of the archive.
+      package_swift_support_if_needed: Whether the partial should also bundle the Swift dylib for each
+        dependency platform into the SwiftSupport directory at the root of the archive. It might still
+        not be included depending on what it is being built for.
 
     Returns:
       A partial that returns the bundle location of the Swift dylibs and propagates dylib
@@ -188,5 +195,5 @@ def swift_dylibs_partial(
         binary_artifact = binary_artifact,
         dependency_targets = dependency_targets,
         bundle_dylibs = bundle_dylibs,
-        package_swift_support = package_swift_support,
+        package_swift_support_if_needed = package_swift_support_if_needed,
     )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -108,9 +108,7 @@ def _tvos_application_impl(ctx):
             binary_artifact = binary_artifact,
             dependency_targets = swift_dylib_dependencies,
             bundle_dylibs = True,
-            # TODO(kaipi): Revisit if we can add this only for non enterprise optimized
-            # builds, or at least only for device builds.
-            package_swift_support = True,
+            package_swift_support_if_needed = True,
         ),
     ]
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -127,6 +127,13 @@ can pass `--define=apple.propagate_embedded_extra_outputs=(yes|true|1)` to
 bazel build --define=apple.propagate_embedded_extra_outputs=yes //your/target
 ```
 
+### Disable `SwiftSupport` in ipas
+
+The SwiftSupport directory in a final ipa is only necessary if you're
+shipping the build to Apple. If you want to disable bundling
+SwiftSupport in your ipa for other device or enterprise builds, you can
+pass `--define=apple.package_swift_support=no` to `bazel build`
+
 ### Codesign Bundles for the Simulator {#apple.codesign_simulator_bundles}
 
 The simulators are far more lax about a lot of things compared to working on


### PR DESCRIPTION
The only case where you need the SwiftSupport in the final archive is if
you're shipping the build to Apple. Since we can't know if the build
being created is being shipped to Apple, we can instead only bundle it
1) if it's a device build and 2) if you don't opt out with the new
`apple.package_swift_support` feature.