### PR TITLE
Add feature to force ipa compression

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -303,9 +303,10 @@ def _post_process_and_sign_archive_action(
         processing_tools.append(ipa_post_processor)
         ipa_post_processor_path = ipa_post_processor.path
 
-    # Only compress the IPA for optimized (release) builds. For debug builds,
-    # zip without compression, which will speed up the build.
-    should_compress = (ctx.var["COMPILATION_MODE"] == "opt")
+    # Only compress the IPA for optimized (release) builds or when requested.
+    # For debug builds, zip without compression, which will speed up the build.
+    compression_requested = defines.bool_value(ctx, "apple.compress_ipa", False)
+    should_compress = (ctx.var["COMPILATION_MODE"] == "opt") or compression_requested
 
     process_and_sign_template = intermediates.file(
         ctx.actions,

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -111,6 +111,14 @@ have added it):
 bazel build --define=apple.add_debugger_entitlement=no //your/target
 ```
 
+### Force ipa compression {#apple.compress_ipa}
+
+By default the final `App.ipa` produced from building an app is
+uncompressed, unless you're building with `--compilation_mode=opt`. This
+flag allows you to force compression if the size is more important than
+the CPU time for your build. To use this pass
+`--define=apple.compress_ipa=(yes|true|1)` to `bazel build`.
+
 ### Include Embedded Bundles in Rule Output {#apple.propagate_embedded_extra_outputs}
 
 Some Apple bundles include other bundles within them (for example, an


### PR DESCRIPTION
For some use cases you may want to compress the final ipa file even if
you're not building an optimized build. For example for enterprise
distribution where you want the builds to be faster.