### PR TITLE
Lock apple_support to commit

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -107,7 +107,8 @@ def apple_rules_dependencies(ignore_version_differences = False):
         git_repository,
         name = "build_bazel_apple_support",
         remote = "https://github.com/bazelbuild/apple_support.git",
-        tag = "0.5.0",
+        commit = "dabf718975760b4d45bd7db3e18bc12e7b4ef485",
+        shallow_since = "1551297696 -0500",
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
Bazel warns about this unless you lock this to a specific version:

```
DEBUG: Rule 'build_bazel_apple_support' indicated that a canonical reproducible form can be obtained by modifying arguments commit = "77c9d5371949352c00bc74d4755c93e00199172b", shallow_since = "1547834515 -0500" and dropping ["tag"]
```

More info: https://github.com/bazelbuild/bazel/issues/7389