### PR TITLE
Migrate to new code coverage provider

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -153,22 +153,23 @@ def _ios_application_impl(ctx):
 
     processor_result = processor.process(ctx, processor_partials)
 
-    return struct(
+    return [
         # TODO(b/121155041): Should we do the same for ios_framework and ios_extension?
-        instrumented_files = struct(dependency_attributes = ["binary"]),
-        providers = [
-            DefaultInfo(
-                files = processor_result.output_files,
-                runfiles = ctx.runfiles(
-                    files = run_actions.start_simulator(ctx),
-                ),
+        DefaultInfo(
+            files = processor_result.output_files,
+            runfiles = ctx.runfiles(
+                files = run_actions.start_simulator(ctx),
             ),
-            IosApplicationBundleInfo(),
-            # Propagate the binary provider so that this target can be used as bundle_loader in test
-            # rules.
-            binary_target[apple_common.AppleExecutableBinary],
-        ] + processor_result.providers,
-    )
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["binary"],
+        ),
+        IosApplicationBundleInfo(),
+        # Propagate the binary provider so that this target can be used as bundle_loader in test
+        # rules.
+        binary_target[apple_common.AppleExecutableBinary],
+    ] + processor_result.providers
 
 def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -117,14 +117,15 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         if x != outputs.archive(ctx)
     ]
 
-    return struct(
-        instrumented_files = struct(dependency_attributes = ["deps", "test_host"]),
-        providers = processor_result.providers + extra_providers + [
-            # TODO(kaipi): Remove this provider when apple_*_test is merged with the bundle and binary
-            # rules.
-            AppleExtraOutputsInfo(files = depset(filtered_outputs)),
-        ],
-    )
+    return processor_result.providers + extra_providers + [
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["deps", "test_host"],
+        ),
+        # TODO(kaipi): Remove this provider when apple_*_test is merged with the bundle and binary
+        # rules.
+        AppleExtraOutputsInfo(files = depset(filtered_outputs)),
+    ]
 
 def _assemble_test_targets(
         name,

--- a/apple/internal/testing/apple_test_rules.bzl
+++ b/apple/internal/testing/apple_test_rules.bzl
@@ -477,26 +477,26 @@ def _apple_test_impl(ctx, test_type):
             ctx.attr.test_bundle[apple_common.AppleDebugOutputs],
         )
 
-    return struct(
-        # TODO(b/79527231): Migrate to new style providers.
-        instrumented_files = struct(dependency_attributes = ["test_bundle"]),
-        providers = [
-            ctx.attr.test_bundle[AppleBundleInfo],
-            ctx.attr.test_bundle[AppleTestInfo],
-            testing.ExecutionInfo(execution_requirements),
-            testing.TestEnvironment(test_environment),
-            DefaultInfo(
-                executable = executable,
-                files = outputs,
-                runfiles = ctx.runfiles(
-                    files = direct_runfiles,
-                    transitive_files = depset(transitive = transitive_runfiles),
-                )
-                    .merge(ctx.attr.runner.default_runfiles)
-                    .merge(ctx.attr.runner.data_runfiles),
-            ),
-        ] + extra_providers,
-    )
+    return [
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["test_bundle"],
+        ),
+        ctx.attr.test_bundle[AppleBundleInfo],
+        ctx.attr.test_bundle[AppleTestInfo],
+        testing.ExecutionInfo(execution_requirements),
+        testing.TestEnvironment(test_environment),
+        DefaultInfo(
+            executable = executable,
+            files = outputs,
+            runfiles = ctx.runfiles(
+                files = direct_runfiles,
+                transitive_files = depset(transitive = transitive_runfiles),
+            )
+                .merge(ctx.attr.runner.default_runfiles)
+                .merge(ctx.attr.runner.data_runfiles),
+        ),
+    ] + extra_providers
 
 def _apple_unit_test_impl(ctx):
     """Implementation for the apple_unit_test rule."""


### PR DESCRIPTION
This fixes an incompatible change detailed here: https://github.com/bazelbuild/bazel/issues/7347

This relies on bazel 0.23.0