### PR TITLE
Fix Buildifier version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,4 +39,4 @@ tasks:
     - "examples/..."
 
 # Need to check the state of the code
-#buildifier: true
+#buildifier: latest


### PR DESCRIPTION
"buildifier: true" has been deprecated by https://github.com/bazelbuild/continuous-integration/pull/542