### PR TITLE
Improve module map formatting

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -92,14 +92,14 @@ def _create_modulemap(
         )
     declarations.extend([
         "export *",
-        "module * { export *}",
+        "module * { export * }",
     ])
     declarations.extend(_get_link_declarations(sdk_dylibs, sdk_frameworks))
 
     content = (
         ("framework module %s {\n" % module_name) +
         "\n".join(["  " + decl for decl in declarations]) +
-        "}\n"
+        "\n}\n"
     )
     actions.write(output = output, content = content)
 


### PR DESCRIPTION
Before this looked a bit weird, and different from what you'd see from
the format from other tools.

Before:

```
framework module foo {
  umbrella header "foo.h"
  export *
  module * { export *}}
```

After:

```
framework module foo {
  umbrella header "foo.h"
  export *
  module * { export * }
}
```