### PR TITLE
Allow specifying custom umbrella header name in ios_static_framework

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -121,9 +121,10 @@ def _static_framework_header_modulemap_partial_impl(ctx, hdrs, binary_objc_provi
 
     bundle_files = []
 
-    umbrella_header_name = None
+    umbrella_header_name = ctx.attr.umbrella_header_name
     if hdrs:
-        umbrella_header_name = "{}.h".format(bundle_name)
+        if not umbrella_header_name:
+            umbrella_header_name = "{}.h".format(bundle_name)
         umbrella_header_file = intermediates.file(ctx.actions, ctx.label.name, umbrella_header_name)
         _create_umbrella_header(
             ctx.actions,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -473,7 +473,7 @@ be generated that imports all of the headers listed here.
             "umbrella_header_name": attr.string(
                 mandatory = False,
                 doc = """
-The basename of the umbrella header file, default is `%{bundle_name}.h` is not specified.
+The basename of the umbrella header file, default is `%{bundle_name}.h` if not specified.
 Mandatory if your framework has a public header that has the same name with its bundle name.
 """,
             ),

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -470,6 +470,13 @@ framework-relative imports, and if non-empty, an umbrella header named `%{bundle
 be generated that imports all of the headers listed here.
 """,
             ),
+            "umbrella_header_name": attr.string(
+                mandatory = False,
+                doc = """
+The basename of the umbrella header file, default is `%{bundle_name}.h` is not specified.
+Mandatory if your framework has a public header that has the same name with its bundle name.
+""",
+            ),
             "avoid_deps": attr.label_list(
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive


### PR DESCRIPTION
Previously, if your framework target has the same name with one of its
public headers, Bazel would yield an error like 'Multiple files would be
placed at "Buttons.framework/Headers/Buttons.h" in the bundle,
which is not allowed'. This patch adds a new attribute to the
`ios_static_framework` rule that allow specifying a custom umbrella header
name for the bundled framework.

Examples:

    objc_library(
        name = "ButtonsLib",
        srcs = [
            "Buttons.m",
        ],
        hdrs = [
            "Buttons.h",
        ],
        module_name = "Buttons",
    )

    ios_static_framework(
        name = "ButtonsStaticFramework",
        bundle_name = "Buttons",
        hdrs = [
            "Buttons.h",
        ],
        umbrella_header_name = "Buttons-umbrella.h",
        minimum_os_version = "8.0",
        deps = [":ButtonsLib"],
    )