### PR TITLE
Remove outdated SwiftInfo link from providers.md TOC

### DIFF
--- a/doc/providers.md
+++ b/doc/providers.md
@@ -17,7 +17,6 @@ rules, then you will use these providers to communicate between them.
 * [IosXcTestBundleInfo](#IosXcTestBundleInfo)
 * [MacosApplicationBundleInfo](#MacosApplicationBundleInfo)
 * [MacosExtensionBundleInfo](#MacosExtensionBundleInfo)
-* [SwiftInfo](#SwiftInfo)
 * [TvosApplicationBundleInfo](#TvosApplicationBundleInfo)
 * [TvosExtensionBundleInfo](#TvosExtensionBundleInfo)
 * [WatchosApplicationBundleInfo](#WatchosApplicationBundleInfo)


### PR DESCRIPTION
While looking for `SwiftInfo` use, I noticed this no longer active reference in the docs.

Closes #351.

RELNOTES: None
PiperOrigin-RevId: 238444466