### PR TITLE
Add `bazel run` support to `macos_application`

### DIFF
--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -43,6 +43,10 @@ load(
     "rule_factory",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:run_support.bzl",
+    "run_support",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBinaryInfo",
     "MacosApplicationBundleInfo",
@@ -111,18 +115,17 @@ def _macos_application_impl(ctx):
 
     processor_result = processor.process(ctx, processor_partials)
 
-    # TODO(kaipi): Add support for `bazel run` for macos_application.
-    executable = ctx.actions.declare_file(ctx.label.name)
-    ctx.actions.write(
-        executable,
-        "#!/bin/bash\necho Unimplemented",
-        is_executable = True,
-    )
-
+    executable = outputs.executable(ctx)
+    run_support.register_macos_executable(ctx, executable)
     return [
         DefaultInfo(
             executable = executable,
             files = processor_result.output_files,
+            runfiles = ctx.runfiles(
+                files = [
+                    outputs.archive(ctx),
+                ],
+            ),
         ),
         MacosApplicationBundleInfo(),
         # Propagate the binary provider so that this target can be used as bundle_loader in test

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -137,6 +137,11 @@ _COMMON_PRIVATE_TOOL_ATTRS = dicts.add(
             allow_single_file = True,
             default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
         ),
+        "_macos_runner_template": attr.label(
+            cfg = "host",
+            allow_single_file = True,
+            default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
+        ),
         "_std_redirect_dylib": attr.label(
             cfg = "host",
             allow_single_file = True,

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -37,7 +37,25 @@ def _register_simulator_executable(ctx, output):
         },
     )
 
+def _register_macos_executable(ctx, output):
+    """Registers an action that runs the bundled macOS app.
+
+    Args:
+      ctx: The Skylark context.
+      output: The `File` representing where the executable should be generated.
+    """
+    ctx.actions.expand_template(
+        output = output,
+        is_executable = True,
+        template = ctx.file._macos_runner_template,
+        substitutions = {
+            "%app_name%": ctx.label.name,
+            "%app_path%": outputs.archive(ctx).short_path,
+        },
+    )
+
 # Define the loadable module that lists the exported symbols in this file.
 run_support = struct(
     register_simulator_executable = _register_simulator_executable,
+    register_macos_executable = _register_macos_executable,
 )

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -14,6 +14,7 @@
 
 """Common definitions used to make runnable Apple bundling rules."""
 
+load("@build_bazel_rules_apple//apple/internal:bundling_support.bzl", "bundling_support")
 load("@build_bazel_rules_apple//apple/internal:outputs.bzl", "outputs")
 load("@bazel_skylib//lib:shell.bzl", "shell")
 
@@ -49,7 +50,7 @@ def _register_macos_executable(ctx, output):
         is_executable = True,
         template = ctx.file._macos_runner_template,
         substitutions = {
-            "%app_name%": ctx.label.name,
+            "%app_name%": bundling_support.bundle_name(ctx),
             "%app_path%": outputs.archive(ctx).short_path,
         },
     )

--- a/apple/internal/templates/BUILD
+++ b/apple/internal/templates/BUILD
@@ -18,6 +18,15 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "macos_template",
+    srcs = ["macos.template.sh"],
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ "$(uname)" != Darwin ]]; then
+  echo "Cannot run macOS targets on a non-mac machine."
+  exit 1
+fi
+
+if [ -d '%app_path%' ]; then
+  # App bundles are directories with the .app extension
+  readonly APP_DIR="%app_path%"
+else
+  readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
+  trap 'rm -rf "${TEMP_DIR}"' ERR EXIT
+  # The app bundle is contained within an compressed archive (zip) 
+  # Unpack the archive
+  unzip -qq '%app_path%' -d "${TEMP_DIR}"
+  readonly APP_DIR="${TEMP_DIR}/%app_name%.app"
+fi
+
+# Get the bundle executable name of the app. Read this from the plist incase it differs from the app name
+readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
+readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
+
+# Launch the app binary 
+"${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_apple/issues/357

Primary changes to enable this:
- Add a new runner script for executing macos binaries (update
rule_factory to make this template available)
- Add method to run_support.bzl to enable execution of applications
without a simulator
- Update macos_application implementation to pass the archive as
runfiles, generate an executable script from the new template

RELNOTES: Adds support for executing `macos_application` targets using `bazel run`