### PR TITLE
AppleBundleVersionInfo load statement fix for ci tests

### DIFF
--- a/test/apple_bundle_version_test.sh
+++ b/test/apple_bundle_version_test.sh
@@ -22,7 +22,7 @@ function set_up() {
   mkdir -p pkg
 
   cat > pkg/saver.bzl <<EOF
-load("@build_bazel_rules_apple//apple:versioning.bzl",
+load("@build_bazel_rules_apple//apple:providers.bzl",
      "AppleBundleVersionInfo")
 
 def _saver_impl(ctx):


### PR DESCRIPTION
- "@build_bazel_rules_apple//apple:providers.bzl" is the new location of
AppleBundleVersionInfo but there was a test that is failing on CI