### PR TITLE
Remove duplicate /usr/bin/swift rpath

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -15,16 +15,8 @@
 """Support for linking related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:xcode_support.bzl",
-    "xcode_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
-    "swift_support",
 )
 load(
     "@bazel_skylib//lib:collections.bzl",
@@ -77,17 +69,6 @@ def _register_linking_action(ctx, extra_linkopts = []):
     rule_descriptor = rule_support.rule_descriptor(ctx)
 
     rpaths = rule_descriptor.rpaths
-
-    if swift_support.uses_swift(ctx.attr.deps):
-        if xcode_support.is_xcode_at_least_version(
-            ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
-            "10.2",
-        ):
-            # If this target uses Swift and is built with Xcode >= 10.2, include the /usr/lib/swift
-            # location at the beginning of the rpaths, since it needs to be the first one to be
-            # found.
-            rpaths = ["/usr/lib/swift"] + rpaths
-
     linkopts = []
     if rpaths:
         linkopts.extend(collections.before_each("-rpath", rpaths))

--- a/apple/internal/swift_support.bzl
+++ b/apple/internal/swift_support.bzl
@@ -15,10 +15,6 @@
 """Support functions for working with Swift."""
 
 load(
-    "@build_bazel_apple_support//lib:xcode_support.bzl",
-    "xcode_support",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftUsageInfo",
     "swift_common",
@@ -85,18 +81,6 @@ def _swift_runtime_linkopts_impl(ctx):
             toolchain = swift_usage_info.toolchain,
         ))
 
-        if xcode_support.is_xcode_at_least_version(
-            ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
-            "10.2",
-        ):
-            # Add the /usr/lib/swift Swift dylib location so that apps that need to bundle the swift
-            # dylibs, still find the system one when present. Because Bazel adds provider linkopts
-            # before other linkopts, this path will appear first in the LC_RPATH list, ensuring the
-            # expected result.
-            # Once all rules migrate from macros to rules, there won't be a need to use this
-            # workaround and all rpaths will be ordered as required.
-            linkopts.extend(["-rpath", "/usr/lib/swift"])
-
     if linkopts:
         return [apple_common.new_objc_provider(linkopt = depset(linkopts, order = "topological"))]
     else:
@@ -109,12 +93,6 @@ swift_runtime_linkopts = rule(
         "deps": attr.label_list(
             aspects = [swift_usage_aspect],
             mandatory = True,
-        ),
-        "_xcode_config": attr.label(
-            default = configuration_field(
-                name = "xcode_config_label",
-                fragment = "apple",
-            ),
         ),
     },
     fragments = ["apple", "objc"],


### PR DESCRIPTION
rules_swift has been updated https://github.com/bazelbuild/rules_swift/commit/19db162c614af9c9db354e14d68965c8eb58e348 to add this rpath itself so we no longer need to add them here.

examples/multi_platform/Buttons before:

```
@executable_path/Frameworks
/usr/lib/swift
/usr/lib/swift
@executable_path/Frameworks
```

examples/multi_platform/Buttons after:

```
@executable_path/Frameworks
/usr/lib/swift
@executable_path/Frameworks
```

examples/ios/iMessageApp:iMessageExtension before:

```
@executable_path/Frameworks
/usr/lib/swift
/usr/lib/swift
/usr/lib/swift
@executable_path/../../Frameworks
```

examples/ios/iMessageApp:iMessageExtension after:

```
@executable_path/Frameworks
/usr/lib/swift
@executable_path/../../Frameworks
```