### PR TITLE
Work around dwarfdump regression

### DIFF
--- a/apple/internal/partials/bitcode_symbols.bzl
+++ b/apple/internal/partials/bitcode_symbols.bzl
@@ -62,8 +62,8 @@ def _bitcode_symbols_partial_impl(
             # Get the UUID of the arch slice and use that to name the bcsymbolmap file.
             copy_commands.append(
                 ("cp {bitcode_file} " +
-                 "${{OUTPUT_DIR}}/$(dwarfdump -u -arch {arch} {binary} " +
-                 "| cut -d' ' -f2).bcsymbolmap").format(
+                 "${{OUTPUT_DIR}}/$(dwarfdump -u {binary} " +
+                 "| grep \"({arch})\" | cut -d' ' -f2).bcsymbolmap").format(
                     arch = arch,
                     binary = binary_artifact.path,
                     bitcode_file = bitcode_file.path,


### PR DESCRIPTION
In Xcode 10.2 filtering by architecture no longer works correctly.
Instead we can stop filtering and parse the output.

Fixes https://github.com/bazelbuild/rules_apple/issues/374