### PR TITLE
Expand execution_environment into 2 provider fields.

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.xctestrun
+++ b/apple/testing/default_runner/macos_test_runner.template.xctestrun
@@ -20,6 +20,7 @@
 			<string>%(xctestrun_insert_libraries)s</string>
 			<key>XCInjectBundleInto</key>
 			<string>BAZEL_TEST_HOST_BINARY</string>
+			BAZEL_TEST_ENVIRONMENT
 		</dict>
 	</dict>
 </dict>

--- a/test/testdata/rules/dummy_test_runner.bzl
+++ b/test/testdata/rules/dummy_test_runner.bzl
@@ -29,8 +29,6 @@ def _dummy_test_runner_impl(ctx):
     return [
         AppleTestRunnerInfo(
             test_runner_template = ctx.outputs.test_runner_template,
-            execution_requirements = {},
-            execution_environment = {},
         ),
         DefaultInfo(
             runfiles = ctx.runfiles(files = []),


### PR DESCRIPTION
Expand execution_environment into 2 provider fields.

There are cases where some environment variables are meant to be in the XCTest invocation and other to be only set in the Bazel action test.

This change splits them into 2 and makes it clearer which variables are used for what purpose.