### PR TITLE
Create a "dummy worker" for upstream integration tests.

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -363,6 +363,9 @@ function do_action() {
       "--announce_rc"
       "--symlink_prefix=test-"
       "--verbose_failures"
+      # See the comment in rules_swift/tools/worker/BUILD for why this
+      # workaround is necessary.
+      "--define=RULES_SWIFT_BUILD_DUMMY_WORKER=1"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then


### PR DESCRIPTION
Create a "dummy worker" for upstream integration tests.

The external dependencies used by the persistent worker are fairly heavyweight, and upstream integration tests (like those in rules_apple) should not be forced to mock them all out in their test workspace (which they would have to, because the worker is an implicit dependency of all toolchains). This change provides a flag that they can pass to Bazel to build a dummy executable that is dependency-free instead.