### PR TITLE
Remove static linking swift test for command line apps.

### DIFF
--- a/test/macos_command_line_application_swift_test.sh
+++ b/test/macos_command_line_application_swift_test.sh
@@ -69,25 +69,4 @@ EOF
   assert_not_contains "__TEXT,__info_plist" $TEST_TMPDIR/otool.out
 }
 
-# Tests that the Swift runtime got statically linked into the binary by
-# checking the linkage of a symbol from the runtime.
-function test_swift_is_statically_linked() {
-  create_common_files
-
-  cat >> app/BUILD <<EOF
-macos_command_line_application(
-    name = "app",
-    minimum_os_version = "10.11",
-    deps = [":lib"],
-)
-EOF
-
-  do_build macos //app:app || fail "Should build"
-
-  # The symbol should be labeled "T" for text section if statically linked, not
-  # "U" (which would indicate dynamic linkage).
-  nm test-bin/app/app | grep "T _swift_slowAlloc" > /dev/null \
-      || fail "Should have found _swift_slowAlloc in TEXT section, but did not"
-}
-
 run_suite "macos_command_line_application with Swift tests"


### PR DESCRIPTION
Remove static linking swift test for command line apps.

In the future, all command line apps will have to link against the system dylibs, and the effort to check if the local Xcode is at least version 10.2 in bash (to disable the test in that case) is too great to just keep this test around.