### PR TITLE
Disable tests since BuildKite is broken.

### DIFF
--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -3,7 +3,6 @@ load(
     "//apple:ios.bzl",
     "ios_application",
     "ios_static_framework",
-    "ios_ui_test",
     "ios_unit_test",
 )
 load(
@@ -94,12 +93,14 @@ ios_static_framework(
 
 ## Tests
 
-ios_unit_test(
-    name = "ButtonsTests",
-    minimum_os_version = "9.0",
-    test_host = ":Buttons",
-    deps = [":ButtonsTestsLib"],
-)
+# TODO(b/130360213): Enable these tests when Bazel 0.25 is available in
+# BuildKite.
+# ios_unit_test(
+#     name = "ButtonsTests",
+#     minimum_os_version = "9.0",
+#     test_host = ":Buttons",
+#     deps = [":ButtonsTestsLib"],
+# )
 
 ios_unit_test(
     name = "ButtonsLogicTests",
@@ -107,19 +108,22 @@ ios_unit_test(
     deps = [":ButtonsTestsLib"],
 )
 
-ios_ui_test(
-    name = "ButtonsUITests",
-    minimum_os_version = "9.0",
-    test_host = ":Buttons",
-    deps = [":ButtonsUITestsLib"],
-)
+# TODO(b/130360213): Enable these tests when Bazel 0.25 is available in
+# BuildKite.
+# ios_ui_test(
+#     name = "ButtonsUITests",
+#     minimum_os_version = "9.0",
+#     test_host = ":Buttons",
+#     deps = [":ButtonsUITestsLib"],
+# )
 
 test_suite(
     name = "iOSButtonsTestSuite",
     tests = [
         ":ButtonsLogicTests",
-        ":ButtonsTests",
-        ":ButtonsUITests",
+        # TODO(b/130360213): Enable these tests when Bazel 0.25 is available in BuildKite.
+        # ":ButtonsTests",
+        # ":ButtonsUITests",
     ],
 )
 


### PR DESCRIPTION
Disable tests since BuildKite is broken.

They will be reenabled when Bazel 0.25 is released.