### PR TITLE
Disable i386 tests for sanitizers.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,6 @@
 load(
     "//test:configurations.bzl",
+    "IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS",
     "IOS_CONFIGURATIONS",
     "IOS_TEST_CONFIGURATIONS",
     "MACOS_CONFIGURATIONS",
@@ -378,7 +379,7 @@ apple_multi_shell_test(
     name = "ios_application_clang_rt_test",
     size = "medium",
     src = "ios_application_clang_rt_test.sh",
-    configurations = IOS_CONFIGURATIONS,
+    configurations = IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS,
     shard_count = 4,
 )
 

--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -36,6 +36,18 @@ IOS_CONFIGURATIONS = {
     "simulator": IOS_SIMULATOR_OPTIONS,
 }
 
+# Configuration for 64 bit simulators and fat devices. Useful for testing sanitizers since thread
+# sanitizer is only supported in 64 bit simulator. It's easier to skip device tests than a specific
+# simulator architecture test, so instead create a special configuration for the sanitizer tests.
+IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS = {
+    "device": IOS_DEVICE_OPTIONS,
+    # Blocked on b/73546952
+    # "device_bitcode": IOS_DEVICE_OPTIONS + [
+    #    "--apple_bitcode=embedded_markers",
+    #],
+    "simulator": COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=x86_64"],
+}
+
 IOS_TEST_CONFIGURATIONS = {
     "device": IOS_DEVICE_OPTIONS,
     "simulator": IOS_SIMULATOR_OPTIONS,

--- a/test/ios_application_clang_rt_test.sh
+++ b/test/ios_application_clang_rt_test.sh
@@ -98,9 +98,7 @@ function disabled_test_tsan_bundle() {  # Blocked on b/73547309
     create_common_files
     create_minimal_ios_application
 
-    # Override --ios_multi_cpus to only contain the 64 bit simulator, as 32 bit
-    # is not supported.
-    do_build ios --features=tsan --ios_multi_cpus=x86_64\
+    do_build ios --features=tsan \
         //app:app || fail "Should build"
     assert_zip_contains "test-bin/app/app.ipa" \
         "Payload/app.app/Frameworks/libclang_rt.tsan_iossim_dynamic.dylib"


### PR DESCRIPTION
Disable i386 tests for sanitizers.

Given that --ios_multi_cpus is now additive, the override for tsan does not work any more. In order to work around this, it's easier to disable i386 builds when testing the sanitizer.