### PR TITLE
Disable i386 tests for ios_application_swift_test. 

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -127,7 +127,7 @@ apple_multi_shell_test(
     name = "ios_application_swift_test",
     size = "medium",
     src = "ios_application_swift_test.sh",
-    configurations = IOS_CONFIGURATIONS,
+    configurations = IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS,
     shard_count = 4,
 )
 

--- a/test/ios_application_swift_test.sh
+++ b/test/ios_application_swift_test.sh
@@ -210,9 +210,7 @@ swift_library(
 )
 EOF
 
-    # Override --ios_multi_cpus to only contain the 64 bit simulator, as 32 bit
-    # is not supported.
-    do_build ios //app:app --features=tsan --ios_multi_cpus=x86_64\
+    do_build ios //app:app --features=tsan \
         || fail "Should build"
     assert_zip_contains "test-bin/app/app.ipa" \
         "Payload/app.app/Frameworks/libclang_rt.tsan_iossim_dynamic.dylib"


### PR DESCRIPTION
Disable i386 tests for ios_application_swift_test. 

This is to bypass the fact that tsan is only compatible with 64bit simulators.