### PR TITLE
Add arm64_32 architecture for watchOS tests.

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -550,7 +550,7 @@ function assert_ipa_contains_bitcode_maps() {
   unzip_single_file "$archive" "$binary" > $TEST_TMPDIR/tmp_bin
   declare -a archs=( $(current_archs "$platform") )
   for arch in "${archs[@]}"; do
-    BIN_UUID=$(dwarfdump -u "$TEST_TMPDIR"/tmp_bin -arch "${arch}" | cut -d' ' -f2)
+    BIN_UUID=$(dwarfdump -u "$TEST_TMPDIR"/tmp_bin | grep "${arch}" | cut -d' ' -f2)
     assert_zip_contains "$archive" \
       "BCSymbolMaps/${BIN_UUID}.bcsymbolmap"
   done

--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -84,7 +84,7 @@ TVOS_TEST_CONFIGURATIONS = {
 # well.
 WATCHOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + [
     "--ios_multi_cpus=arm64,armv7",
-    "--watchos_cpus=armv7k",
+    "--watchos_cpus=armv7k,arm64_32",
 ]
 WATCHOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [
     "--ios_multi_cpus=i386,x86_64",


### PR DESCRIPTION
Add arm64_32 architecture for watchOS tests.