### PR TITLE
Don't explicitly set the python version on the tools/tests.

### DIFF
--- a/tools/bundletool/BUILD
+++ b/tools/bundletool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "bundletool",
     srcs = ["bundletool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -19,7 +18,6 @@ py_library(
 py_binary(
     name = "bundletool_experimental",
     srcs = ["bundletool_experimental.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -29,7 +27,6 @@ py_binary(
 py_test(
     name = "bundletool_unittest",
     srcs = ["bundletool_unittest.py"],
-    python_version = "PY2",
     deps = [
         ":bundletool_lib",
         "//:py_init_shim",

--- a/tools/clangrttool/BUILD
+++ b/tools/clangrttool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "clangrttool",
     srcs = ["clangrttool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "codesigningtool",
     srcs = ["codesigningtool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/plisttool/BUILD
+++ b/tools/plisttool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "plisttool",
     srcs = ["plisttool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -21,7 +20,6 @@ py_library(
 py_test(
     name = "plisttool_unittest",
     srcs = ["plisttool_unittest.py"],
-    python_version = "PY2",
     deps = [
         ":plisttool_lib",
         "//:py_init_shim",

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -33,7 +33,7 @@ _testing_target = '//plisttool:tests'
 
 
 def _xml_plist(content):
-  """Returns a StringIO for a plist with the given content.
+  """Returns a BytesIO for a plist with the given content.
 
   This helper function wraps plist XML (key/value pairs) in the necessary XML
   boilerplate for a plist with a root dictionary.
@@ -42,7 +42,7 @@ def _xml_plist(content):
     content: The XML content of the plist, which will be inserted into a
         dictionary underneath the root |plist| element.
   Returns:
-    A StringIO object containing the full XML text of the plist.
+    A BytesIO object containing the full XML text of the plist.
   """
   xml = ('<?xml version="1.0" encoding="UTF-8"?>\n'
          '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
@@ -59,9 +59,9 @@ def _xml_plist(content):
 def _plisttool_result(control):
   """Helper function that runs PlistTool with the given control struct.
 
-  This function inserts a StringIO object as the control's "output" key and
+  This function inserts a BytesIO object as the control's "output" key and
   returns the dictionary containing the result of the tool after parsing it
-  from that StringIO.
+  from that BytesIO.
 
   Args:
     control: The control struct to pass to PlistTool. See the module doc for

--- a/tools/provisioning_profile_tool/BUILD
+++ b/tools/provisioning_profile_tool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "provisioning_profile_tool",
     srcs = ["provisioning_profile_tool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/versiontool/BUILD
+++ b/tools/versiontool/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "versiontool",
     srcs = ["versiontool.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -19,7 +18,6 @@ py_library(
 py_test(
     name = "versiontool_unittest",
     srcs = ["versiontool_unittest.py"],
-    python_version = "PY2",
     deps = [
         ":versiontool_lib",
         "//:py_init_shim",

--- a/tools/versiontool/versiontool_unittest.py
+++ b/tools/versiontool/versiontool_unittest.py
@@ -14,12 +14,23 @@
 
 """Tests for VersionTool."""
 
+import io
 import json
-import StringIO
 import unittest
+
+try:
+  import StringIO  # Doesn't exist in Python 3
+except ImportError:
+  StringIO = None
 
 from build_bazel_rules_apple.tools.versiontool import versiontool
 
+
+def _str_io(*args, **kwargs):
+  """Helper for PY2/Py3 StringIO"""
+  if StringIO:
+    return StringIO.StringIO(*args, **kwargs)
+  return io.StringIO(*args, **kwargs)
 
 class VersionToolTest(unittest.TestCase):
 
@@ -55,7 +66,7 @@ class VersionToolTest(unittest.TestCase):
 
   def test_build_label_substitution(self):
     self._assert_versiontool_result({
-        'build_info_path': StringIO.StringIO(
+        'build_info_path': _str_io(
             'BUILD_EMBED_LABEL app_3.1_RC41'
         ),
         'build_label_pattern': 'app_{version}_RC{candidate}',
@@ -72,7 +83,7 @@ class VersionToolTest(unittest.TestCase):
 
   def test_build_label_substitution_multiline_input(self):
     self._assert_versiontool_result({
-        'build_info_path': StringIO.StringIO(
+        'build_info_path': _str_io(
             '\n'.join([
               'FOO BAR',
               'BUILD_EMBED_LABEL app_3.1_RC41',
@@ -93,7 +104,7 @@ class VersionToolTest(unittest.TestCase):
 
   def test_result_is_empty_if_label_is_missing_but_pattern_was_provided(self):
     self._assert_versiontool_result({
-        'build_info_path': StringIO.StringIO(),
+        'build_info_path': _str_io(),
         'build_label_pattern': 'app_{version}_RC{candidate}',
         'build_version_pattern': '{version}.{candidate}',
         'capture_groups': {
@@ -105,7 +116,7 @@ class VersionToolTest(unittest.TestCase):
 
   def test_build_label_substitution_from_fallback_label(self):
     self._assert_versiontool_result({
-        'build_info_path': StringIO.StringIO(
+        'build_info_path': _str_io(
             "FOO 123"
         ),
         'fallback_build_label': 'app_99.99_RC99',
@@ -123,7 +134,7 @@ class VersionToolTest(unittest.TestCase):
 
   def test_build_label_substitution_uses_file_over_fallback_label(self):
     self._assert_versiontool_result({
-        'build_info_path': StringIO.StringIO(
+        'build_info_path': _str_io(
             'BUILD_EMBED_LABEL app_3.1_RC41',
         ),
         'fallback_build_label': 'app_99.99_RC99',
@@ -142,7 +153,7 @@ class VersionToolTest(unittest.TestCase):
   def test_raises_if_label_is_present_but_does_not_match(self):
     with self.assertRaises(versiontool.VersionToolError) as context:
       versiontool.VersionTool({
-          'build_info_path': StringIO.StringIO(
+          'build_info_path': _str_io(
               'BUILD_EMBED_LABEL app_3.1_RC41',
           ),
           'build_label_pattern': 'app_{version}_RC{candidate}',
@@ -157,7 +168,7 @@ class VersionToolTest(unittest.TestCase):
   def test_raises_if_fallback_label_is_present_but_does_not_match(self):
     with self.assertRaises(versiontool.VersionToolError) as context:
       versiontool.VersionTool({
-          'build_info_path': StringIO.StringIO(
+          'build_info_path': _str_io(
               "FOO 123"
           ),
           'fallback_build_label': 'app_3.1_RC41',

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -12,7 +12,6 @@ py_library(
 py_test(
     name = "execute_test",
     srcs = ["execute_test.py"],
-    python_version = "PY2",
     deps = [
         ":execute",
         "//:py_init_shim",

--- a/tools/wrapper_common/execute_test.py
+++ b/tools/wrapper_common/execute_test.py
@@ -65,12 +65,12 @@ class ExecuteTest(unittest.TestCase):
 
     # io.StringIO() only accepts unicode in Py2, so use the older
     # StringIO.StringIO for Py2, which accepts str/unicode
-    if _PY3:
-      mock_stdout = io.StringIO()
-      mock_stderr = io.StringIO()
-    else:
+    if StringIO:
       mock_stdout = StringIO.StringIO()
       mock_stderr = StringIO.StringIO()
+    else:
+      mock_stdout = io.StringIO()
+      mock_stderr = io.StringIO()
 
     try:
       sys.stdout = mock_stdout

--- a/tools/xctoolrunner/BUILD
+++ b/tools/xctoolrunner/BUILD
@@ -3,7 +3,6 @@ licenses(["notice"])
 py_binary(
     name = "xctoolrunner",
     srcs = ["xctoolrunner.py"],
-    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -20,7 +19,6 @@ py_library(
 py_test(
     name = "xctoolrunner_test",
     srcs = ["xctoolrunner_test.py"],
-    python_version = "PY2",
     deps = [
         ":xctoolrunner_lib",
         "//:py_init_shim",


### PR DESCRIPTION
Don't explicitly set the python version on the tools/tests.

There doesn't seem to a complete answer yet on how bazel will handle the py2-3
transition, so continue to leave the version unset to hopefully keep things
"just working".