### PR TITLE
Allow using a different test runner

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -101,11 +101,14 @@ if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
   runner_flags+=("--launch_options_json_path=${LAUNCH_OPTIONS_JSON_PATH}")
 fi
 
+extra_args=( %(extra_args)s )
+
 cmd=("%(testrunner_binary)s"
   "${runner_flags[@]}"
   simulator_test
   "--device_type=%(device_type)s"
   "--os_version=%(os_version)s"
+  "${extra_args[@]}"
   "$@")
 "${cmd[@]}" 2>&1
 status=$?


### PR DESCRIPTION
This change allows changing the test runner. For example, to use GitHub.com/linkedin/bluepill you can add this to your `WORKSPACE`:

```
git_repository(
  name = "bptestrunner",
  remote = "https://github.com/ob/bluepill.git",
  commit = "5e9c6ae",
)
```

And use this in your `BUILD.bazel` file:
```
ios_test_runner(
    name = "bp_test_runner_parallel",
    device_type = "iPhone 6s",
    extra_args = ["--num-sims", "4"],
    testrunner = "@bptestrunner//bptestrunner:bptestrunner.par",
)

ios_unit_test(
  name = "some_name",
  runner = "bp_test_runner_parallel",
  # other attributes here... 
)
```

When using KIF or EarlGray, I have found that setting `--num-sims` to run tests in parallel saves about 40% of the test time. For unit tests, parallelism slows tests down so it's better to set `--num-sims` to 1.

