### PR TITLE
Add support for the debug_symbols output group.

### DIFF
--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -736,7 +736,7 @@ function test_all_dsyms_propagated() {
   create_minimal_ios_application_with_extension
   do_build ios \
       --apple_generate_dsym \
-      --define=apple.propagate_embedded_extra_outputs=1 \
+      --output_groups=+dsyms \
       //app:app || fail "Should build"
 
   assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"


### PR DESCRIPTION
Add support for the debug_symbols output group.

With this change, dSYM bundles and linkmaps for dependencies can be requested with the --output_groups=+debug_symbols flag. The --define=apple.propagate_embedded_extra_outputs=1 will continue to exist until the next release.