### PR TITLE
Propagate the platform type of the rule in AppleBundleInfo.

### DIFF
--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -65,6 +65,7 @@ def _apple_bundle_info_partial_impl(ctx, bundle_id):
                 entitlements = getattr(ctx.attr, "entitlements", None),
                 infoplist = infoplist,
                 minimum_os_version = platform_support.minimum_os(ctx),
+                platform_type = str(platform_support.platform_type(ctx)),
                 product_type = ctx.attr._product_type,
                 uses_swift = uses_swift,
             ),

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -68,6 +68,9 @@ extension-safe APIs only.
 `string`. The minimum OS version (as a dotted version
 number like "9.0") that this bundle was built to support.
 """,
+        "platform_type": """
+`string`. The platform type for the bundle (i.e. `ios` for iOS bundles).
+""",
         "product_type": """
 `string`. The dot-separated product type identifier associated
 with the bundle (for example, `com.apple.product-type.application`).


### PR DESCRIPTION
Propagate the platform type of the rule in AppleBundleInfo.

This will help in Starlark based unit tests.