### PR TITLE
Delete common shell test versions of infoplist.

### DIFF
--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -201,65 +201,6 @@ This shouldn't get included
 EOF
 }
 
-# Tests that the Info.plist in the extension has the correct content.
-function test_extension_plist_contents() {
-  create_common_files
-  create_minimal_ios_application_with_extension
-  create_dump_plist "//app:app.ipa" "Payload/app.app/PlugIns/ext.appex/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build ios //app:dump_plist \
-      || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "ext" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id.extension" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "ext" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "1" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build ios ; then
-    assert_equals "iPhoneOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "iphoneos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "iphoneos.*" \
-        "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "iPhoneSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "iphonesimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "iphonesimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that the extension inside the app bundle is properly signed.
 function test_extension_is_signed() {
   create_common_files

--- a/test/ios_imessage_test.sh
+++ b/test/ios_imessage_test.sh
@@ -152,12 +152,8 @@ EOF
 function test_sticker_pack_extension() {
   create_common_files
   create_minimal_ios_application_with_stickerpack
-  create_dump_plist "//app:app.ipa" "Payload/app.app/PlugIns/stickerpack.appex/Info.plist" \
-      LSApplicationIsStickerProvider
 
-  do_build ios //app:dump_plist || fail "Should build"
-
-  assert_equals "YES" "$(cat "test-genfiles/app/LSApplicationIsStickerProvider")"
+  do_build ios //app:app || fail "Should build"
 
   # Ignore the check for simulator builds.
   is_device_build ios || return 0
@@ -297,17 +293,14 @@ EOF
 function test_message_application() {
   create_common_files
   create_minimal_ios_imessage_application_with_stickerpack
-  create_dump_plist "//app:app.ipa" "Payload/app.app/Info.plist" \
-      LSApplicationLaunchProhibited
 
-  do_build ios //app:dump_plist || fail "Should build"
+  do_build ios //app:app || fail "Should build"
 
   # Ignore the following checks for simulator builds.
   is_device_build ios || return 0
 
   assert_zip_contains "test-bin/app/app.ipa" \
       "MessagesApplicationSupport/MessagesApplicationSupportStub"
-  assert_equals "true" "$(cat "test-genfiles/app/LSApplicationLaunchProhibited")"
 }
 
 run_suite "imessage bundling resource tests"

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -176,66 +176,6 @@ ios_unit_test(
 EOF
 }
 
-# Tests that the Info.plist in the packaged test has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_ios_application_with_tests
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build ios --ios_minimum_os=9.0 //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleExecutable")"
-
-  # When not providing a bundle_id, it uses the test host's and appends "Tests"
-  assert_equals "my.bundle.idTests" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "9.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "1" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build ios ; then
-    assert_equals "iPhoneOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "iphoneos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "iphoneos.*" \
-        "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "iPhoneSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "iphonesimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "iphonesimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that tests can override the bundle id.
 function test_bundle_id_override() {
   create_common_files
@@ -252,10 +192,8 @@ function test_bundle_id_override() {
 function test_bundle_id_same_as_test_host_error() {
   create_common_files
   create_minimal_ios_application_with_tests "my.bundle.id"
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Info.plist" \
-      CFBundleIdentifier
 
-  ! do_build ios --ios_minimum_os=9.0 //app:dump_plist || fail "Should build"
+  ! do_build ios --ios_minimum_os=9.0 //app:unit_tests || fail "Should build"
   expect_log "can't be the same as the test host's bundle identifier"
 }
 

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -123,51 +123,6 @@ This shouldn't get included
 EOF
 }
 
-# Tests that the Info.plist in the packaged application has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_macos_application
-  create_dump_plist "//app:app.zip" "app.app/Contents/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      LSMinimumSystemVersion
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.11" "$(cat "test-genfiles/app/LSMinimumSystemVersion")"
-
-  assert_equals "MacOSX" \
-      "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-  assert_contains "macosx.*" "test-genfiles/app/DTSDKName"
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files
@@ -208,36 +163,6 @@ EOF
     || fail "Should fail build"
 
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
-}
-
-# Tests that multiple infoplists are merged properly.
-function test_multiple_plist_merging() {
-  create_common_files
-
-  cat >> app/BUILD <<EOF
-macos_application(
-    name = "app",
-    bundle_id = "my.bundle.id",
-    infoplists = ["Info.plist", "Another.plist"],
-    minimum_os_version = "10.11",
-    deps = [":lib"],
-)
-EOF
-
-  cat > app/Another.plist <<EOF
-{
-  AnotherKey = "AnotherValue";
-}
-EOF
-
-  create_dump_plist "//app:app.zip" "app.app/Contents/Info.plist" \
-      CFBundleIdentifier \
-      AnotherKey
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify that we have keys from both plists.
-  assert_equals "my.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "AnotherValue" "$(cat "test-genfiles/app/AnotherKey")"
 }
 
 # Tests that the IPA post-processor is executed and can modify the bundle.

--- a/test/macos_bundle_test.sh
+++ b/test/macos_bundle_test.sh
@@ -71,51 +71,6 @@ macos_bundle(
 EOF
 }
 
-# Tests that the Info.plist in the packaged bundle has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_macos_bundle
-  create_dump_plist "//app:app.zip" "app.bundle/Contents/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      LSMinimumSystemVersion
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.11" "$(cat "test-genfiles/app/LSMinimumSystemVersion")"
-
-  assert_equals "MacOSX" \
-      "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-  assert_contains "macosx.*" "test-genfiles/app/DTSDKName"
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files
@@ -156,36 +111,6 @@ EOF
     || fail "Should fail build"
 
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
-}
-
-# Tests that multiple infoplists are merged properly.
-function test_multiple_plist_merging() {
-  create_common_files
-
-  cat >> app/BUILD <<EOF
-macos_bundle(
-    name = "app",
-    bundle_id = "my.bundle.id",
-    infoplists = ["Info.plist", "Another.plist"],
-    minimum_os_version = "10.10",
-    deps = [":lib"],
-)
-EOF
-
-  cat > app/Another.plist <<EOF
-{
-  AnotherKey = "AnotherValue";
-}
-EOF
-
-  create_dump_plist "//app:app.zip" "app.bundle/Contents/Info.plist" \
-      CFBundleIdentifier \
-      AnotherKey
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify that we have keys from both plists.
-  assert_equals "my.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "AnotherValue" "$(cat "test-genfiles/app/AnotherKey")"
 }
 
 # Tests that the IPA post-processor is executed and can modify the bundle.

--- a/test/macos_quick_look_plugin_test.sh
+++ b/test/macos_quick_look_plugin_test.sh
@@ -71,51 +71,6 @@ macos_quick_look_plugin(
 EOF
 }
 
-# Tests that the Info.plist in the packaged bundle has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_macos_quick_look_plugin
-  create_dump_plist "//app:app.zip" "app.qlgenerator/Contents/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      LSMinimumSystemVersion
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id.qlgenerator" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.11" "$(cat "test-genfiles/app/LSMinimumSystemVersion")"
-
-  assert_equals "MacOSX" \
-      "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-  assert_contains "macosx.*" "test-genfiles/app/DTSDKName"
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files
@@ -156,36 +111,6 @@ EOF
     || fail "Should fail build"
 
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
-}
-
-# Tests that multiple infoplists are merged properly.
-function test_multiple_plist_merging() {
-  create_common_files
-
-  cat >> app/BUILD <<EOF
-macos_quick_look_plugin(
-    name = "app",
-    bundle_id = "my.bundle.id.qlgenerator",
-    infoplists = ["Info.plist", "Another.plist"],
-    minimum_os_version = "10.10",
-    deps = [":lib"],
-)
-EOF
-
-  cat > app/Another.plist <<EOF
-{
-  AnotherKey = "AnotherValue";
-}
-EOF
-
-  create_dump_plist "//app:app.zip" "app.qlgenerator/Contents/Info.plist" \
-      CFBundleIdentifier \
-      AnotherKey
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify that we have keys from both plists.
-  assert_equals "my.bundle.id.qlgenerator" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "AnotherValue" "$(cat "test-genfiles/app/AnotherKey")"
 }
 
 # Tests that the IPA post-processor is executed and can modify the bundle.

--- a/test/macos_ui_test_test.sh
+++ b/test/macos_ui_test_test.sh
@@ -160,56 +160,6 @@ macos_ui_test(
 EOF
 }
 
-# Tests that the Info.plist in the packaged test has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_macos_application_with_tests
-  create_dump_plist "//app:ui_tests.zip" "ui_tests.xctest/Contents/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      LSMinimumSystemVersion
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "ui_tests" "$(cat "test-genfiles/app/CFBundleExecutable")"
-
-  # When not providing a bundle_id, it uses the test host's and appends "Tests"
-  assert_equals "my.bundle.idTests" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "ui_tests" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.11" "$(cat "test-genfiles/app/LSMinimumSystemVersion")"
-
-  assert_equals "MacOSX" \
-      "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-  assert_equals "macosx" \
-      "$(cat "test-genfiles/app/DTPlatformName")"
-  assert_contains "macosx.*" \
-      "test-genfiles/app/DTSDKName"
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that tests can override the bundle id.
 function test_bundle_id_override() {
   create_common_files
@@ -226,10 +176,8 @@ function test_bundle_id_override() {
 function test_bundle_id_same_as_test_host_error() {
   create_common_files
   create_minimal_macos_application_with_tests "my.bundle.id"
-  create_dump_plist "//app:ui_tests.zip" "ui_tests.xctest/Contents/Info.plist" \
-      CFBundleIdentifier
 
-  ! do_build macos //app:dump_plist || fail "Should build"
+  ! do_build macos //app:ui_tests || fail "Should build"
   expect_log "can't be the same as the test host's bundle identifier"
 }
 

--- a/test/macos_unit_test_test.sh
+++ b/test/macos_unit_test_test.sh
@@ -163,56 +163,6 @@ macos_unit_test(
 EOF
 }
 
-# Tests that the Info.plist in the packaged test has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_macos_application_with_tests
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Contents/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      LSMinimumSystemVersion
-  do_build macos //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleExecutable")"
-
-  # When not providing a bundle_id, it uses the test host's and appends "Tests"
-  assert_equals "my.bundle.idTests" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.11" "$(cat "test-genfiles/app/LSMinimumSystemVersion")"
-
-  assert_equals "MacOSX" \
-      "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-  assert_equals "macosx" \
-      "$(cat "test-genfiles/app/DTPlatformName")"
-  assert_contains "macosx.*" \
-      "test-genfiles/app/DTSDKName"
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that tests can override the bundle id.
 function test_bundle_id_override() {
   create_common_files
@@ -229,10 +179,8 @@ function test_bundle_id_override() {
 function test_bundle_id_same_as_test_host_error() {
   create_common_files
   create_minimal_macos_application_with_tests "my.bundle.id"
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Contents/Info.plist" \
-      CFBundleIdentifier
 
-  ! do_build macos //app:dump_plist || fail "Should build"
+  ! do_build macos //app:unit_tests || fail "Should build"
   expect_log "can't be the same as the test host's bundle identifier"
 }
 

--- a/test/tvos_application_test.sh
+++ b/test/tvos_application_test.sh
@@ -72,64 +72,6 @@ tvos_application(
 EOF
 }
 
-# Tests that the Info.plist in the packaged application has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_tvos_application
-  create_dump_plist "//app:app.ipa" "Payload/app.app/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build tvos //app:dump_plist \
-      || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "app" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "3" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build tvos ; then
-    assert_equals "AppleTVOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "tvos.*" "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "AppleTVSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvsimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvsimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files

--- a/test/tvos_extension_test.sh
+++ b/test/tvos_extension_test.sh
@@ -98,64 +98,6 @@ EOF
 EOF
 }
 
-# Tests that the Info.plist in the extension has the correct content.
-function test_extension_plist_contents() {
-  create_minimal_tvos_application_with_extension
-  create_dump_plist "//app:app.ipa" "Payload/app.app/PlugIns/ext.appex/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build tvos //app:dump_plist \
-      || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "ext" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "my.bundle.id.extension" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "ext" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "10.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "3" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build tvos ; then
-    assert_equals "AppleTVOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvos.*" \
-        "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "AppleTVSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvsimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvsimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_minimal_tvos_application_with_extension

--- a/test/tvos_ui_test_test.sh
+++ b/test/tvos_ui_test_test.sh
@@ -162,66 +162,6 @@ tvos_ui_test(
 EOF
 }
 
-# Tests that the Info.plist in the packaged test has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_tvos_application_with_tests
-  create_dump_plist "//app:ui_tests.zip" "ui_tests.xctest/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "ui_tests" "$(cat "test-genfiles/app/CFBundleExecutable")"
-
-  # When not providing a bundle_id, it uses the test host's and appends "Tests"
-  assert_equals "my.bundle.idTests" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "ui_tests" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "9.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "3" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build tvos ; then
-    assert_equals "AppleTVOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvos.*" \
-        "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "AppleTVSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvsimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvsimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that tests can override the bundle id.
 function test_bundle_id_override() {
   create_common_files
@@ -238,10 +178,8 @@ function test_bundle_id_override() {
 function test_bundle_id_same_as_test_host_error() {
   create_common_files
   create_minimal_tvos_application_with_tests "my.bundle.id"
-  create_dump_plist "//app:ui_tests.zip" "ui_tests.xctest/Info.plist" \
-      CFBundleIdentifier
 
-  ! do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
+  ! do_build tvos --tvos_minimum_os=9.0 //app:ui_tests || fail "Should build"
   expect_log "can't be the same as the test host's bundle identifier"
 }
 

--- a/test/tvos_unit_test_test.sh
+++ b/test/tvos_unit_test_test.sh
@@ -174,66 +174,6 @@ tvos_unit_test(
 EOF
 }
 
-# Tests that the Info.plist in the packaged test has the correct content.
-function test_plist_contents() {
-  create_common_files
-  create_minimal_tvos_application_with_tests
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
-
-  # Verify the values injected by the Skylark rule.
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleExecutable")"
-
-  # When not providing a bundle_id, it uses the test host's and appends "Tests"
-  assert_equals "my.bundle.idTests" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "unit_tests" "$(cat "test-genfiles/app/CFBundleName")"
-  assert_equals "9.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "3" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
-
-  if is_device_build tvos ; then
-    assert_equals "AppleTVOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvos.*" \
-        "test-genfiles/app/DTSDKName"
-  else
-    assert_equals "AppleTVSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
-    assert_equals "appletvsimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "appletvsimulator.*" "test-genfiles/app/DTSDKName"
-  fi
-
-  # Verify the values injected by the environment_plist script. Some of these
-  # are dependent on the version of Xcode being used, and since we don't want to
-  # force a particular version to always be present, we just make sure that
-  # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
-  assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
-}
-
 # Tests that tests can override the bundle id.
 function test_bundle_id_override() {
   create_common_files
@@ -250,10 +190,8 @@ function test_bundle_id_override() {
 function test_bundle_id_same_as_test_host_error() {
   create_common_files
   create_minimal_tvos_application_with_tests "my.bundle.id"
-  create_dump_plist "//app:unit_tests.zip" "unit_tests.xctest/Info.plist" \
-      CFBundleIdentifier
 
-  ! do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
+  ! do_build tvos --tvos_minimum_os=9.0 //app:unit_tests || fail "Should build"
   expect_log "can't be the same as the test host's bundle identifier"
 }
 

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -174,68 +174,6 @@ function assert_common_watch_app_and_extension_plist_values() {
   assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
 }
 
-# Tests that the Info.plist in the embedded watch application has the correct
-# content.
-function test_watch_app_plist_contents() {
-  create_minimal_watchos_application_with_companion
-  create_dump_plist "//app:app.ipa" \
-      "Payload/app.app/Watch/watch_app.app/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build watchos --watchos_minimum_os=2.0 //app:dump_plist \
-      || fail "Should build"
-
-  assert_equals "my.bundle.id.watch-app" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "watch_app" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "watch_app" "$(cat "test-genfiles/app/CFBundleName")"
-
-  assert_common_watch_app_and_extension_plist_values
-}
-
-# Tests that the Info.plist in the embedded watch extension has the correct
-# content.
-function test_watch_ext_plist_contents() {
-  create_minimal_watchos_application_with_companion
-  create_dump_plist "//app:app.ipa" \
-      "Payload/app.app/Watch/watch_app.app/PlugIns/watch_ext.appex/Info.plist" \
-      BuildMachineOSBuild \
-      CFBundleExecutable \
-      CFBundleIdentifier \
-      CFBundleName \
-      CFBundleSupportedPlatforms:0 \
-      DTCompiler \
-      DTPlatformBuild \
-      DTPlatformName \
-      DTPlatformVersion \
-      DTSDKBuild \
-      DTSDKName \
-      DTXcode \
-      DTXcodeBuild \
-      MinimumOSVersion \
-      UIDeviceFamily:0
-  do_build watchos //app:dump_plist \
-      || fail "Should build"
-
-  assert_equals "my.bundle.id.watch-app.watch-ext" "$(cat "test-genfiles/app/CFBundleIdentifier")"
-  assert_equals "watch_ext" "$(cat "test-genfiles/app/CFBundleExecutable")"
-  assert_equals "watch_ext" "$(cat "test-genfiles/app/CFBundleName")"
-
-  assert_common_watch_app_and_extension_plist_values
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_watch_app_missing_version_fails() {
   create_minimal_watchos_application_with_companion


### PR DESCRIPTION
Delete common shell test versions of infoplist.

They have been migrated to Starlark tests instead.