### PR TITLE
Rollback rules_swift version update. rules_swift release was rolled back.

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -118,9 +118,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
         http_archive,
         name = "build_bazel_rules_swift",
         urls = [
-            "https://github.com/bazelbuild/rules_swift/releases/download/0.10.0/rules_swift.0.10.0.tar.gz",
+            "https://github.com/bazelbuild/rules_swift/releases/download/0.9.0/rules_swift.0.9.0.tar.gz",
         ],
-        sha256 = "d71d5e5e81df88c52d23ad5d224d4408a79fb34e33fdc631f29c2685f88ecb69",
+        sha256 = "9efe9699e9765e6b4a5e063e4a08f6b163cccaf0443f775d935baf5c3cd6ed0e",
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
Rollback rules_swift version update. rules_swift release was rolled back.