### PR TITLE
Remove xcode_version workaround for BuildKite since 0.25 has been released with the 

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,9 +3,6 @@ tasks:
   macos_latest:
     name: "Latest Bazel"
     platform: macos
-    # TODO(b/130360213): Remove this default to use whatever the default in
-    # BuildKite is.
-    xcode_version: "10.1"
     bazel: latest
     build_targets:
     - "tools/..."
@@ -25,9 +22,6 @@ tasks:
   macos_last_green:
     name: "Last Green Bazel"
     platform: macos
-    # TODO(b/130360213): Remove this default to use whatever the default in
-    # BuildKite is.
-    xcode_version: "10.1"
     bazel: last_green
     build_targets:
     - "tools/..."
@@ -47,9 +41,6 @@ tasks:
   macos_latest_head_deps:
     name: "Latest Bazel with Head Deps"
     platform: macos
-    # TODO(b/130360213): Remove this default to use whatever the default in
-    # BuildKite is.
-    xcode_version: "10.1"
     bazel: latest
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing


### PR DESCRIPTION
Remove xcode_version workaround for BuildKite since 0.25 has been released with the 