### PR TITLE
Move flags from presubmit to .bazelrc so that they can be reused when testing locally.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,13 +7,6 @@ tasks:
     build_targets:
     - "tools/..."
     - "test/..."
-    test_flags:
-    - "--spawn_strategy=local"
-    - "--test_env=PATH"
-    # `bazel test` tries to build everything also by default, so skip that so the
-    # *_library targets in examples/... aren't built (and fail since they are
-    # platform specific).
-    - "--build_tests_only"
     test_targets:
     - "tools/..."
     - "test/..."
@@ -26,13 +19,6 @@ tasks:
     build_targets:
     - "tools/..."
     - "test/..."
-    test_flags:
-    - "--spawn_strategy=local"
-    - "--test_env=PATH"
-    # `bazel test` tries to build everything also by default, so skip that so the
-    # *_library targets in examples/... aren't built (and fail since they are
-    # platform specific).
-    - "--build_tests_only"
     test_targets:
     - "tools/..."
     - "test/..."
@@ -49,13 +35,6 @@ tasks:
     build_targets:
     - "tools/..."
     - "test/..."
-    test_flags:
-    - "--spawn_strategy=local"
-    - "--test_env=PATH"
-    # `bazel test` tries to build everything also by default, so skip that so the
-    # *_library targets in examples/... aren't built (and fail since they are
-    # platform specific).
-    - "--build_tests_only"
     test_targets:
     - "tools/..."
     - "test/..."

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,12 @@
+# Force the tests to not run in sandboxed mode, since it can introduce
+# errors and flakes.
+test --spawn_strategy=local
+
+# Add the PATH to the test environment so that common macOS tools can be found
+# during a test run.
+test --test_env=PATH
+
+# `bazel test` tries to build everything also by default, so skip that so the
+# *_library targets in examples/... aren't built (and fail since they are
+# platform specific).
+test --build_tests_only


### PR DESCRIPTION
Move flags from presubmit to .bazelrc so that they can be reused when testing locally.