### PR TITLE
Ensure signing actions are not cached nor sandboxed

### DIFF
--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -329,6 +329,14 @@ def _bundle_partial_outputs_files(
             mnemonic = "BundleTreeApp",
             progress_message = "Bundling, processing and signing %s" % ctx.label.name,
             tools = bundling_tools,
+            execution_requirements = {
+                # Added so that the output of this action is not cached remotely, in case multiple
+                # developers sign the same artifact with different identities.
+                "no-cache": "1",
+                # Unsure, but may be needed for keychain access, especially for files that live in
+                # $HOME.
+                "no-sandbox": "1",
+            },
             **action_args
         )
     else:


### PR DESCRIPTION
Because of multiple signing identities, depending on who is building,
the signature will be different, thus not cacheable.

Also, the "security" tools, which is used to parse the mobileprovision
file, doesn't play well with sandboxing.

This fixes Tulsi builds, which are broken when enabling the new bundle
rules.