### PR TITLE
Add umbrella_header to ios_static_framework

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -311,6 +311,7 @@ def _ios_static_framework_impl(ctx):
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.static_framework_header_modulemap_partial(
             hdrs = ctx.files.hdrs,
+            umbrella_header = ctx.file.umbrella_header,
             binary_objc_provider = binary_target[apple_common.Objc],
         ),
     ]

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -527,6 +527,15 @@ framework-relative imports, and if non-empty, an umbrella header named `%{bundle
 be generated that imports all of the headers listed here.
 """,
             ),
+            "umbrella_header": attr.label(
+                allow_single_file = [".h"],
+                doc = """
+A single .h file to use as the umbrella header for this framework. Usually, this header will have the
+same name as this target, so that clients can load the header using the #import <MyFramework/MyFramework.h>
+format. If this attribute is not specified, an umbrella header will be generated under the same name as this
+target.
+""",
+            ),
             "avoid_deps": attr.label_list(
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive


### PR DESCRIPTION
This attribute allows users to specify an umbrella header to use for the
framework in place of generating a default one. This is useful for
frameworks that have multiple headers, including a natural umbrella
header, that has a conflicting name with the one that would be
generated.

The idea for this came out of the discussion on https://github.com/bazelbuild/rules_apple/pull/359

Fixes https://github.com/bazelbuild/rules_apple/issues/408