### PR TITLE
Allow running an iOS application with a custom bundle_name

### DIFF
--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -30,7 +30,7 @@ def _register_simulator_executable(ctx, output):
         is_executable = True,
         template = ctx.file._runner_template,
         substitutions = {
-            "%app_name%": ctx.label.name,
+            "%app_name%": bundling_support.bundle_name(ctx),
             "%ipa_file%": outputs.archive(ctx).short_path,
             "%sdk_version%": str(ctx.fragments.objc.ios_simulator_version),
             "%sim_device%": shell.quote(ctx.fragments.objc.ios_simulator_device),


### PR DESCRIPTION
Currently if you have a different `bundle_name` https://github.com/bazelbuild/rules_apple/blob/5b03711941f1201bae28d4e6ac8040dd7d1c7317/apple/internal/templates/ios_sim.template.sh#L164 will fail since it will be looking for the `ios_application`'s `name`, not `bundle_name`. This matches what is done below in `_register_macos_executable` and uses `bundling_support.bundle_name` to get the correct `.app` name.