### PR TITLE
Add notes pointing at the other files.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,4 +1,6 @@
 ---
+# NOTE: To avoid listing the same things for build_flags/test_flags for each
+# of these tasks, they are listed in the .bazelrc instead.
 tasks:
   macos_latest:
     name: "Latest Bazel"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# NOTE: These are mainly just for the BazelCI setup so they don't have
+# to be repeated multiple times in .bazelci/presubmit.yml.
+
 # Force the tests to not run in sandboxed mode, since it can introduce
 # errors and flakes.
 test --spawn_strategy=local


### PR DESCRIPTION
Add notes pointing at the other files.

The need for the flags to run the tests (and the flags being for the test)
is only documented in revision history, add comments so anyone looking at
the files will also realize the connection/needs.