### PR TITLE
Correct argument: -application_extension vs -fapplication_extension

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -250,7 +250,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".appex",
             deps_cfg = apple_common.multi_arch_split,
             extra_linkopts = [
-                "-application_extension",
+                "-fapplication-extension",
                 "-e",
                 "_NSExtensionMain",
             ],
@@ -548,7 +548,7 @@ _RULE_TYPE_DESCRIPTORS = {
             extra_linkopts = [
                 "-e",
                 "_TVExtensionMain",
-                "-application_extension",
+                "-fapplication-extension",
                 "-framework",
                 "TVServices",
             ],
@@ -639,7 +639,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".appex",
             deps_cfg = apple_common.multi_arch_split,
             extra_linkopts = [
-                "-application_extension",
+                "-fapplication-extension",
             ],
             product_type = apple_product_type.watch2_extension,
             rpaths = [


### PR DESCRIPTION
Correct argument: -application_extension vs -fapplication_extension

Compiling the examples helped flag this with:
  clang: warning: argument unused during compilation: '-application_extension' [-Wunused-command-line-argument]