### PR TITLE
Stop processing structured_resources files that should not be processed.

### DIFF
--- a/apple/internal/resource_rules.bzl
+++ b/apple/internal/resource_rules.bzl
@@ -130,7 +130,7 @@ def _apple_resource_bundle_impl(ctx):
                     resources.structured_resources_parent_dir,
                     parent_dir = bundle_name,
                 ),
-                avoid_buckets = ["pngs"],
+                allowed_buckets = ["strings", "plists"],
             ),
         )
 
@@ -246,7 +246,7 @@ def _apple_resource_group_impl(ctx):
                 parent_dir_param = partial.make(
                     resources.structured_resources_parent_dir,
                 ),
-                avoid_buckets = ["pngs"],
+                allowed_buckets = ["strings", "plists"],
             ),
         )
 


### PR DESCRIPTION
Stop processing structured_resources files that should not be processed.

This also refactors the resources.bucketize method to apply a whitelist bucket list instead of a blacklist.