### PR TITLE
Tweak to avoid error from --incompatible_depset_is_not_iterable=false.

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -161,8 +161,8 @@ def _static_framework_header_modulemap_partial_impl(ctx, hdrs, umbrella_header, 
             modulemap_file,
             bundle_name,
             umbrella_header_name,
-            sorted(sdk_dylibs and sdk_dylibs.to_list()),
-            sorted(sdk_frameworks and sdk_frameworks.to_list()),
+            sorted(sdk_dylibs.to_list()) if sdk_dylibs else [],
+            sorted(sdk_frameworks.to_list() if sdk_frameworks else []),
         )
         bundle_files.append((processor.location.bundle, "Modules", depset([modulemap_file])))
 


### PR DESCRIPTION
Tweak to avoid error from --incompatible_depset_is_not_iterable=false.

The integration tests are failing with:

  ERROR: .../workspace/sdk/BUILD:3:1: in ios_static_framework rule //sdk:sdk:
  Traceback (most recent call last):
      File ".../workspace/sdk/BUILD", line 3
        ios_static_framework(name = 'sdk')
      File ".../external/build_bazel_rules_apple/apple/internal/ios_rules.bzl", line 322, in _ios_static_framework_impl
        processor.process(ctx, processor_partials)
      File ".../external/build_bazel_rules_apple/apple/internal/processor.bzl", line 425, in processor.process
        partial.call(p, ctx)
      File ".../external/bazel_skylib/lib/partial.bzl", line 38, in partial.call
        partial.function(*function_args, **function_kwargs)
      File ".../external/build_bazel_rules_apple/apple/internal/partials/static_framework_header_modulemap.bzl", line 159, in partial.function
        _create_modulemap(ctx.actions, modulemap_file, bundle_..., <3 more arguments>)
      File ".../external/build_bazel_rules_apple/apple/internal/partials/static_framework_header_modulemap.bzl", line 164, in _create_modulemap
        sorted((sdk_dylibs and sdk_dylibs.to_li...()))
  type 'depset' is not iterable. Use the `to_list()` method to get a list. Use --incompatible_depset_is_not_iterable=false to temporarily disable this check.

The original logic is a bit odd, it appears to be trying to deal with None and
only intended to pass the sorted list, but from the error, it seems like the
depet and the flattened depset were getting iterated, this should make it
more explicit and not attempt to iterate/flatten when they are None.