### PR TITLE
Annotate the unused variable to avoid warnings.

### DIFF
--- a/test/starlark_tests/resources/shared.m
+++ b/test/starlark_tests/resources/shared.m
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-static int unused = 1;
+static int unused __attribute__((unused,used)) = 1;


### PR DESCRIPTION
Annotate the unused variable to avoid warnings.

Incase clang/crosstool uses -Werror or turns the unused warning into
and error by default.