### PR TITLE
Move the stopgap for python issues.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,15 +18,9 @@ tasks:
     name: "Last Green Bazel"
     platform: macos
     bazel: last_green
-    build_flags:
-    # Stop gap for https://github.com/bazelbuild/rules_apple/issues/456
-    - "--host_force_python=PY2"
     build_targets:
     - "tools/..."
     - "test/..."
-    test_flags:
-    # Stop gap
-    - "--host_force_python=PY2"
     test_targets:
     - "tools/..."
     - "test/..."

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,3 +34,11 @@ build --experimental_starlark_config_transitions
 # TODO(b/134144964): Formality to track removing this, but we all know it'll be
 # here forever.
 build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
+
+# Stop gap for https://github.com/bazelbuild/rules_apple/issues/456
+# This sucks, this is really only wanted when testing against the head bazel,
+# that could be hooked within our config when making that config, but then
+# things still fail on https://buildkite.com/bazel/bazel-at-head-plus-downstream
+# because there is no way to add the flag there so it has to be blindly add to
+# all configs here, hoping it doesn't have any side effects.
+build "--host_force_python=PY2"


### PR DESCRIPTION
Move the stopgap for python issues.

Due to upstream bazel testing, the flag has to be globally applied instead
of targeted to specific bazel versions. Opened
  https://github.com/bazelbuild/continuous-integration/issues/709
to see if there is a better path around screening/suppressing stuff like
this.