### PR TITLE
Python 2 and 3 tweaks.

### DIFF
--- a/tools/bundletool/BUILD
+++ b/tools/bundletool/BUILD
@@ -1,8 +1,11 @@
+load("//tools:py2and3_test.bzl", "py2and3_test")
+
 licenses(["notice"])
 
 py_binary(
     name = "bundletool",
     srcs = ["bundletool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -13,18 +16,20 @@ py_binary(
 py_library(
     name = "bundletool_lib",
     srcs = ["bundletool.py"],
+    srcs_version = "PY2AND3",
 )
 
 py_binary(
     name = "bundletool_experimental",
     srcs = ["bundletool_experimental.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
     visibility = ["//visibility:public"],
 )
 
-py_test(
+py2and3_test(
     name = "bundletool_unittest",
     srcs = ["bundletool_unittest.py"],
     deps = [

--- a/tools/bundletool/bundletool.py
+++ b/tools/bundletool/bundletool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,8 +53,8 @@ following keys:
       Apple at the root of the archive as well as within the bundle itself.
 """
 
-import json
 import hashlib
+import json
 import os
 import sys
 import zipfile

--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/bundletool/bundletool_unittest.py
+++ b/tools/bundletool/bundletool_unittest.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/clangrttool/BUILD
+++ b/tools/clangrttool/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])
 py_binary(
     name = "clangrttool",
     srcs = ["clangrttool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/clangrttool/clangrttool.py
+++ b/tools/clangrttool/clangrttool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,8 +28,9 @@ import sys
 import zipfile
 
 # Third party imports
-from macholib.MachO import MachO
+
 from macholib import mach_o
+from macholib.MachO import MachO
 from macholib.ptypes import sizeof
 
 
@@ -150,4 +152,3 @@ if __name__ == "__main__":
     # Log tools errors cleanly for build output.
     sys.stderr.write('ERROR: %s\n' % e)
     sys.exit(1)
-

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])
 py_binary(
     name = "codesigningtool",
     srcs = ["codesigningtool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,79 +36,95 @@ _BENIGN_CODESIGN_OUTPUT_REGEX = re.compile(
 
 
 def _check_output(args, inputstr=None):
-    proc = subprocess.Popen(args,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
-    stdout, stderr = proc.communicate(input=inputstr)
-    if proc.returncode != 0:
-        # print the stdout and stderr, as the exception won't print it.
-        print("ERROR:{stdout}\n\n{stderr}".format(stdout=stdout, stderr=stderr))
-        raise subprocess.CalledProcessError(proc.returncode, args)
-    return stdout, stderr
+  proc = subprocess.Popen(
+      args,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE)
+  stdout, stderr = proc.communicate(input=inputstr)
+  if proc.returncode != 0:
+    # print the stdout and stderr, as the exception won't print it.
+    print("ERROR:{stdout}\n\n{stderr}".format(stdout=stdout, stderr=stderr))
+    raise subprocess.CalledProcessError(proc.returncode, args)
+  return stdout, stderr
+
 
 def plist_from_bytes(byte_content):
-    try:
-        return plistlib.loads(byte_content)
-    except AttributeError:
-        return plistlib.readPlistFromString(byte_content)
+  try:
+    return plistlib.loads(byte_content)
+  except AttributeError:
+    return plistlib.readPlistFromString(byte_content)
+
 
 def _parse_mobileprovision_file(mobileprovision_file):
-    """Reads and parses a mobileprovision file."""
-    plist_xml = subprocess.check_output([
-        "security", "cms",
-        "-D",
-        "-i", mobileprovision_file,
-    ])
-    return plist_from_bytes(plist_xml)
+  """Reads and parses a mobileprovision file."""
+  plist_xml = subprocess.check_output([
+      "security",
+      "cms",
+      "-D",
+      "-i",
+      mobileprovision_file,
+  ])
+  return plist_from_bytes(plist_xml)
+
 
 def _certificate_fingerprint(identity):
-    """Extracts a fingerprint given identity in a mobileprovision file."""
-    fingerprint, stderr = _check_output([
-        "openssl", "x509", "-inform", "DER", "-noout", "-fingerprint",
-    ], inputstr=identity)
-    fingerprint = fingerprint.decode("utf-8").strip()
-    fingerprint = fingerprint.replace("SHA1 Fingerprint=", "")
-    fingerprint = fingerprint.replace(":", "")
-    return fingerprint
+  """Extracts a fingerprint given identity in a mobileprovision file."""
+  fingerprint, stderr = _check_output([
+      "openssl",
+      "x509",
+      "-inform",
+      "DER",
+      "-noout",
+      "-fingerprint",
+  ],
+                                      inputstr=identity)
+  fingerprint = fingerprint.decode("utf-8").strip()
+  fingerprint = fingerprint.replace("SHA1 Fingerprint=", "")
+  fingerprint = fingerprint.replace(":", "")
+  return fingerprint
 
 
 def _get_identities_from_provisioning_profile(mpf):
-    """Iterates through all the identities in a provisioning profile, lazily."""
-    for identity in mpf["DeveloperCertificates"]:
-        yield _certificate_fingerprint(identity.data)
+  """Iterates through all the identities in a provisioning profile, lazily."""
+  for identity in mpf["DeveloperCertificates"]:
+    yield _certificate_fingerprint(identity.data)
 
 
 def _find_codesign_identities(identity=None):
-    """Finds code signing identities on the current system."""
-    ids = []
-    output, stderr = _check_output([
-        "security", "find-identity", "-v", "-p", "codesigning",
-    ])
-    output = output.decode("utf-8").strip()
-    pattern = "(?P<hash>[A-F0-9]{40})"
-    if identity:
-        pattern += r'\s+"(?P<full_name>.*?{}.*?)"'.format(re.escape(identity))
-    regex = re.compile(pattern)
-    for line in output.splitlines():
-        # CSSMERR_TP_CERT_REVOKED comes from Security.framework/cssmerr.h
-        if "CSSMERR_TP_CERT_REVOKED" in line:
-            continue
-        m = regex.search(line)
-        if m:
-            groups = m.groupdict()
-            id = groups.get("full_name") or groups["hash"]
-            ids.append(id)
-    return ids
+  """Finds code signing identities on the current system."""
+  ids = []
+  output, stderr = _check_output([
+      "security",
+      "find-identity",
+      "-v",
+      "-p",
+      "codesigning",
+  ])
+  output = output.decode("utf-8").strip()
+  pattern = "(?P<hash>[A-F0-9]{40})"
+  if identity:
+    pattern += r'\s+"(?P<full_name>.*?{}.*?)"'.format(re.escape(identity))
+  regex = re.compile(pattern)
+  for line in output.splitlines():
+    # CSSMERR_TP_CERT_REVOKED comes from Security.framework/cssmerr.h
+    if "CSSMERR_TP_CERT_REVOKED" in line:
+      continue
+    m = regex.search(line)
+    if m:
+      groups = m.groupdict()
+      id = groups.get("full_name") or groups["hash"]
+      ids.append(id)
+  return ids
 
 
 def _find_codesign_identity(mobileprovision):
-    """Finds a valid identity on the system given a mobileprovision file."""
-    mpf = _parse_mobileprovision_file(mobileprovision)
-    ids_codesign = set(_find_codesign_identities())
-    for id_mpf in _get_identities_from_provisioning_profile(mpf):
-        if id_mpf in ids_codesign:
-            return id_mpf
+  """Finds a valid identity on the system given a mobileprovision file."""
+  mpf = _parse_mobileprovision_file(mobileprovision)
+  ids_codesign = set(_find_codesign_identities())
+  for id_mpf in _get_identities_from_provisioning_profile(mpf):
+    if id_mpf in ids_codesign:
+      return id_mpf
 
 
 def _filter_codesign_output(codesign_output):
@@ -115,48 +132,46 @@ def _filter_codesign_output(codesign_output):
   filtered_lines = []
   for line in codesign_output.split("\n"):
     if line and not _BENIGN_CODESIGN_OUTPUT_REGEX.search(line):
-        filtered_lines.append(line)
+      filtered_lines.append(line)
   return "\n".join(filtered_lines)
 
 def main(argv):
-    parser = argparse.ArgumentParser(description="codesign wrapper")
-    parser.add_argument("--mobileprovision", type=str,
-        help="mobileprovision file")
-    parser.add_argument("--codesign", required=True, type=str,
-        help="path to codesign binary")
-    parser.add_argument("--identity", type=str,
-        help="specific identity to sign with")
-    args, codesign_args = parser.parse_known_args()
-    identity = args.identity
-    if identity is None:
-        identity = _find_codesign_identity(args.mobileprovision)
-    elif identity != "-":
-        matching_identities = _find_codesign_identities(identity)
-        if matching_identities:
-            identity = matching_identities[0]
-        else:
-            print(
-                "ERROR: No signing identity found for '{}'".format(identity),
-                file=sys.stderr
-            )
-            return -1
-    # No identity was found, fail
-    if identity == None:
-        print("ERROR: Unable to find an identity on the system matching the "\
-            "ones in %s" % args.mobileprovision, file=sys.stderr)
-        return 1
-    stdout, stderr = _check_output(
-        [args.codesign, "-v", "--sign", identity] + codesign_args,
-    )
-    if stdout:
-        filtered_stdout = _filter_codesign_output(stdout)
-        if filtered_stdout:
-            print(filtered_stdout)
-    if stderr:
-        filtered_stderr = _filter_codesign_output(stderr)
-        if filtered_stderr:
-            print(filtered_stderr)
+  parser = argparse.ArgumentParser(description="codesign wrapper")
+  parser.add_argument(
+      "--mobileprovision", type=str, help="mobileprovision file")
+  parser.add_argument(
+      "--codesign", required=True, type=str, help="path to codesign binary")
+  parser.add_argument(
+      "--identity", type=str, help="specific identity to sign with")
+  args, codesign_args = parser.parse_known_args()
+  identity = args.identity
+  if identity is None:
+    identity = _find_codesign_identity(args.mobileprovision)
+  elif identity != "-":
+    matching_identities = _find_codesign_identities(identity)
+    if matching_identities:
+      identity = matching_identities[0]
+    else:
+      print(
+          "ERROR: No signing identity found for '{}'".format(identity),
+          file=sys.stderr)
+      return -1
+  # No identity was found, fail
+  if identity == None:
+    print("ERROR: Unable to find an identity on the system matching the "\
+        "ones in %s" % args.mobileprovision, file=sys.stderr)
+    return 1
+  stdout, stderr = _check_output([args.codesign, "-v", "--sign", identity] +
+                                 codesign_args,)
+  if stdout:
+    filtered_stdout = _filter_codesign_output(stdout)
+    if filtered_stdout:
+      print(filtered_stdout)
+  if stderr:
+    filtered_stderr = _filter_codesign_output(stderr)
+    if filtered_stderr:
+      print(filtered_stderr)
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv))
+  sys.exit(main(sys.argv))

--- a/tools/plisttool/BUILD
+++ b/tools/plisttool/BUILD
@@ -1,8 +1,11 @@
+load("//tools:py2and3_test.bzl", "py2and3_test")
+
 licenses(["notice"])
 
 py_binary(
     name = "plisttool",
     srcs = ["plisttool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -15,9 +18,10 @@ py_library(
     srcs = [
         "plisttool.py",
     ],
+    srcs_version = "PY2AND3",
 )
 
-py_test(
+py2and3_test(
     name = "plisttool_unittest",
     srcs = ["plisttool_unittest.py"],
     deps = [

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1175,16 +1176,15 @@ class EntitlementsTask(PlistToolTask):
 
     aps_environment = entitlements.get('aps-environment')
     if aps_environment and profile_entitlements:
-        profile_aps_environment = profile_entitlements.get('aps-environment')
-        if not profile_aps_environment:
-          self._report(
-              ENTITLEMENTS_APS_ENVIRONMENT_MISSING % self.target,
-              **report_extras)
-        elif aps_environment != profile_aps_environment:
-          self._report(
-              ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH % (
-                self.target, aps_environment, profile_aps_environment),
-              **report_extras)
+      profile_aps_environment = profile_entitlements.get('aps-environment')
+      if not profile_aps_environment:
+        self._report(ENTITLEMENTS_APS_ENVIRONMENT_MISSING % self.target,
+                     **report_extras)
+      elif aps_environment != profile_aps_environment:
+        self._report(
+            ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH %
+            (self.target, aps_environment, profile_aps_environment),
+            **report_extras)
 
     # If beta-reports-active is in either the profile or the entitlements file
     # it must be in both or the upload will get rejected by Apple
@@ -1315,9 +1315,9 @@ class EntitlementsTask(PlistToolTask):
 
     for src_grp in src_grps:
       if '*' in src_grp and not allow_wildcards_in_entitlements:
-       self._report(
-          ENTITLEMENTS_VALUE_HAS_WILDCARD % (target, key_name, src_grp),
-          **report_extras)
+        self._report(
+            ENTITLEMENTS_VALUE_HAS_WILDCARD % (target, key_name, src_grp),
+            **report_extras)
 
       if not self._does_id_match_list(src_grp, profile_grps,
           allowed_supports_wildcards=supports_wildcards):

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # coding=utf-8
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
@@ -16,14 +17,15 @@
 """Tests for PlistTool."""
 
 from __future__ import absolute_import
+
 import datetime
+import io
 import json
 import os
 import plistlib
 import random
 import re
 import tempfile
-import io
 import unittest
 
 from build_bazel_rules_apple.tools.plisttool import plisttool
@@ -342,7 +344,7 @@ class PlistToolGetWithKeyPath(unittest.TestCase):
     self.assertEqual(plisttool.GetWithKeyPath(d, ['b']), 2)
     self.assertEqual(plisttool.GetWithKeyPath(d, [3]), 'c')
     self.assertEqual(plisttool.GetWithKeyPath(d, ['list']), ['x', 'y'])
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['dict']), {1:2, 3:4})
+    self.assertEqual(plisttool.GetWithKeyPath(d, ['dict']), {1: 2, 3: 4})
 
   def test_two_level(self):
     d = { 'list': [ 'x', 'y' ], 'dict': { 1: 2, 3: 4} }

--- a/tools/provisioning_profile_tool/BUILD
+++ b/tools/provisioning_profile_tool/BUILD
@@ -3,6 +3,7 @@ licenses(["notice"])
 py_binary(
     name = "provisioning_profile_tool",
     srcs = ["provisioning_profile_tool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.

--- a/tools/provisioning_profile_tool/provisioning_profile_tool.py
+++ b/tools/provisioning_profile_tool/provisioning_profile_tool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/py2and3_test.bzl
+++ b/tools/py2and3_test.bzl
@@ -1,0 +1,58 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper to test under python 2 and 3."""
+
+def py2and3_test(**kwargs):
+    """Wrapper to test under python 2 and 3.
+
+    NOTE: This is only to be used within the rules_apple tests, it is not
+    for use from other places as it will eventually go away.
+
+    Args:
+      **kwargs: py_test keyword arguments.
+    """
+    name = kwargs.pop("name")
+    py2_name = name + ".python2"
+    py3_name = name + ".python3"
+
+    main = kwargs.pop("main", name + ".py")
+    base_tags = kwargs.pop("tags", [])
+
+    native.py_test(
+        name = py2_name,
+        python_version = "PY2",
+        main = main,
+        tags = base_tags + ["python2"],
+        **kwargs
+    )
+
+    native.py_test(
+        name = py3_name,
+        python_version = "PY3",
+        main = main,
+        tags = base_tags + ["python3"],
+        **kwargs
+    )
+
+    suite_kwargs = {}
+    if kwargs.get("visibility"):
+        suite_kwargs["visibility"] = kwargs.get("visibility")
+
+    native.test_suite(
+        name = name,
+        tags = base_tags,
+        tests = [py2_name, py3_name],
+        **suite_kwargs
+    )

--- a/tools/versiontool/BUILD
+++ b/tools/versiontool/BUILD
@@ -1,8 +1,11 @@
+load("//tools:py2and3_test.bzl", "py2and3_test")
+
 licenses(["notice"])
 
 py_binary(
     name = "versiontool",
     srcs = ["versiontool.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -13,9 +16,10 @@ py_binary(
 py_library(
     name = "versiontool_lib",
     srcs = ["versiontool.py"],
+    srcs_version = "PY2AND3",
 )
 
-py_test(
+py2and3_test(
     name = "versiontool_unittest",
     srcs = ["versiontool_unittest.py"],
     deps = [

--- a/tools/versiontool/versiontool.py
+++ b/tools/versiontool/versiontool.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/versiontool/versiontool_unittest.py
+++ b/tools/versiontool/versiontool_unittest.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,22 +116,21 @@ class VersionToolTest(unittest.TestCase):
     }, {})
 
   def test_build_label_substitution_from_fallback_label(self):
-    self._assert_versiontool_result({
-        'build_info_path': _str_io(
-            "FOO 123"
-        ),
-        'fallback_build_label': 'app_99.99_RC99',
-        'build_label_pattern': 'app_{version}_RC{candidate}',
-        'build_version_pattern': '{version}.{candidate}',
-        'capture_groups': {
-            'version': r'\d+\.\d+',
-            'candidate': r'\d+',
-        },
-        'short_version_string_pattern': '{version}',
-    }, {
-        'build_version': '99.99.99',
-        'short_version_string': '99.99',
-    })
+    self._assert_versiontool_result(
+        {
+            'build_info_path': _str_io('FOO 123'),
+            'fallback_build_label': 'app_99.99_RC99',
+            'build_label_pattern': 'app_{version}_RC{candidate}',
+            'build_version_pattern': '{version}.{candidate}',
+            'capture_groups': {
+                'version': r'\d+\.\d+',
+                'candidate': r'\d+',
+            },
+            'short_version_string_pattern': '{version}',
+        }, {
+            'build_version': '99.99.99',
+            'short_version_string': '99.99',
+        })
 
   def test_build_label_substitution_uses_file_over_fallback_label(self):
     self._assert_versiontool_result({
@@ -168,9 +168,7 @@ class VersionToolTest(unittest.TestCase):
   def test_raises_if_fallback_label_is_present_but_does_not_match(self):
     with self.assertRaises(versiontool.VersionToolError) as context:
       versiontool.VersionTool({
-          'build_info_path': _str_io(
-              "FOO 123"
-          ),
+          'build_info_path': _str_io('FOO 123'),
           'fallback_build_label': 'app_3.1_RC41',
           'build_label_pattern': 'app_{version}_RC{candidate}',
           'build_version_pattern': '{version}.{candidate}',

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -1,15 +1,18 @@
+load("//tools:py2and3_test.bzl", "py2and3_test")
+
 licenses(["notice"])
 
 py_library(
     name = "execute",
     srcs = ["execute.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
     visibility = ["//visibility:public"],
 )
 
-py_test(
+py2and3_test(
     name = "execute_test",
     srcs = ["execute_test.py"],
     deps = [

--- a/tools/wrapper_common/execute.py
+++ b/tools/wrapper_common/execute.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/wrapper_common/execute_test.py
+++ b/tools/wrapper_common/execute_test.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,10 +19,11 @@ from __future__ import division
 from __future__ import print_function
 
 import contextlib
-import sys
-import os
-import unittest
 import io
+import os
+import sys
+import unittest
+
 from build_bazel_rules_apple.tools.wrapper_common import execute
 
 try:
@@ -34,9 +36,10 @@ _PY3 = sys.version_info[0] == 3
 _INVALID_UTF8 = b'\xa0\xa1'
 
 def _cmd_filter(cmd_result, stdout, stderr):
-    # Concat the input to a native string literal, to make sure
-    # it doesn't trigger a unicode encode/decode error
-    return stdout + ' filtered', stderr + ' filtered'
+  # Concat the input to a native string literal, to make sure
+  # it doesn't trigger a unicode encode/decode error
+  return stdout + ' filtered', stderr + ' filtered'
+
 
 class ExecuteTest(unittest.TestCase):
 

--- a/tools/xctoolrunner/BUILD
+++ b/tools/xctoolrunner/BUILD
@@ -1,8 +1,11 @@
+load("//tools:py2and3_test.bzl", "py2and3_test")
+
 licenses(["notice"])
 
 py_binary(
     name = "xctoolrunner",
     srcs = ["xctoolrunner.py"],
+    srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
@@ -13,10 +16,11 @@ py_binary(
 py_library(
     name = "xctoolrunner_lib",
     srcs = ["xctoolrunner.py"],
+    srcs_version = "PY2AND3",
     deps = ["//tools/wrapper_common:execute"],
 )
 
-py_test(
+py2and3_test(
     name = "xctoolrunner_test",
     srcs = ["xctoolrunner_test.py"],
     deps = [

--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,9 +81,10 @@ def ibtool_filtering(tool_exit_status, raw_stdout, raw_stderr):
     A tuple of the filtered stdout and strerr.
   """
 
-  spurious_patterns = list(map(re.compile, [
-      r"WARNING: Unhandled destination metrics: \(null\)"
-  ]))
+  spurious_patterns = [
+      re.compile(x)
+      for x in [r"WARNING: Unhandled destination metrics: \(null\)"]
+  ]
 
   def is_spurious_message(line):
     for pattern in spurious_patterns:
@@ -151,11 +153,14 @@ def actool_filtering(tool_exit_status, raw_stdout, raw_stderr):
 
   excluded_sections = ["com.apple.actool.compilation-results"]
 
-  spurious_patterns = list(map(re.compile, [
-      r"\[\]\[ipad\]\[76x76\]\[\]\[\]\[1x\]\[\]\[\]: notice: \(null\)",
-      r"\[\]\[ipad\]\[76x76\]\[\]\[\]\[1x\]\[\]\[\]: notice: 76x76@1x app icons"
-      r" only apply to iPad apps targeting releases of iOS prior to 10\.0\.",
-  ]))
+  spurious_patterns = [
+      re.compile(x) for x in [
+          r"\[\]\[ipad\]\[76x76\]\[\]\[\]\[1x\]\[\]\[\]: notice: \(null\)",
+          r"\[\]\[ipad\]\[76x76\]\[\]\[\]\[1x\]\[\]\[\]: notice: 76x76@1x app "
+          r"icons only apply to iPad apps targeting releases of iOS prior to "
+          r"10\.0\.",
+      ]
+  ]
 
   def is_spurious_message(line):
     for pattern in spurious_patterns:

--- a/tools/xctoolrunner/xctoolrunner_test.py
+++ b/tools/xctoolrunner/xctoolrunner_test.py
@@ -1,3 +1,4 @@
+# Lint as: python2, python3
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Python 2 and 3 tweaks.

Working toward https://github.com/bazelbuild/rules_apple/issues/456.

- Add a wrap to test under python 2 and 3.
- Minor tweaks to improve support for both pythons.