### PR TITLE
Remove use of --host_force_python

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,11 +34,3 @@ build --experimental_starlark_config_transitions
 # TODO(b/134144964): Formality to track removing this, but we all know it'll be
 # here forever.
 build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
-
-# Stop gap for https://github.com/bazelbuild/rules_apple/issues/456
-# This sucks, this is really only wanted when testing against the head bazel,
-# that could be hooked within our config when making that config, but then
-# things still fail on https://buildkite.com/bazel/bazel-at-head-plus-downstream
-# because there is no way to add the flag there so it has to be blindly add to
-# all configs here, hoping it doesn't have any side effects.
-build "--host_force_python=PY2"

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -382,10 +382,6 @@ function do_action() {
       # See the comment in rules_swift/tools/worker/BUILD for why this
       # workaround is necessary.
       "--define=RULES_SWIFT_BUILD_DUMMY_WORKER=1"
-      # Stop gap for https://github.com/bazelbuild/rules_apple/issues/456
-      # Really only needed (at the moment) for the 'last green' bazel
-      # build, but no good way to inject for just that case.
-      "--host_force_python=PY2"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then


### PR DESCRIPTION
Remove use of --host_force_python

Since the tests run under both python2 and python3, hopefully things
will "just work" with whatever python a developer has installed.