### PR TITLE
Fix framework imports with Swift modules

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -63,8 +63,13 @@ def _classify_framework_imports(framework_imports):
             # This matches /Headers/ and /PrivateHeaders/
             header_imports.append(file)
             continue
-        if "/Modules/" in file_short_path:
-            module_map_imports.append(file)
+        if file_short_path.endswith(".swiftmodule") or file_short_path.endswith(".swiftinterface"):
+            # Add Swift's module files to header_imports so that they are correctly included in the build
+            # by Bazel but they aren't processed in any way
+            header_imports.append(file)
+            continue
+        if file_short_path.endswith(".swiftdoc"):
+            # Ignore swiftdoc files, they don't matter in the build, only for IDEs
             continue
         bundling_imports.append(file)
 


### PR DESCRIPTION
With bazel 0.27.0 and the flip of `incompatible_objc_framework_cleanup`
https://github.com/bazelbuild/bazel/issues/7944 framework imports of
Swift frameworks broke because the modules were included and processed
as module map files. This change makes them available in the build
but without processing them. They are handled automatically by clang /
swift since the framework is included using `-F`

RELNOTES: Fix Swift frameworks for Bazel 0.27.0 and incompatible_objc_framework_cleanup