### PR TITLE
Use latest version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ replacing the version number in the `tag` attribute with the version of the
 rules you wish to depend on:
 
 ```python
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.14.0",
+    sha256 = "6efdde60c91724a2be7f89b0c0a64f01138a45e63ba5add2dca2645d981d23a1",
+    urls = [
+        "https://github.com/bazelbuild/rules_apple/releases/download/0.17.2/rules_apple.0.17.2.tar.gz",
+    ],
 )
 
 load(

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ load(
 )
 
 apple_support_dependencies()
+
+load(
+    "@com_google_protobuf//:protobuf_deps.bzl",
+    "protobuf_deps",
+)
+
+protobuf_deps()
 ```
 
 ## Examples


### PR DESCRIPTION
I think many people just copy and paste the README into their WORKSPACE file. It should use the latest version. It would be ideal to automate updating it on every release, but I don't know how releases are cut. Are they cut manually?

Also, without the protobuf stuff the WORKSPACE file didn't work, so I added it.