### PR TITLE
Handle ambiguous signer in codesigningtool.py

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -288,6 +288,16 @@ _RULE_TYPE_DESCRIPTORS = {
             requires_provisioning_profile = False,
             skip_signing = True,
         ),
+        apple_product_type.bundle: _describe_rule_type(
+            allowed_device_families = ["iphone", "ipad"],
+            bundle_extension = ".bundle",
+            has_infoplist = True,
+            product_type = apple_product_type.bundle,
+            requires_bundle_id = True,
+            requires_provisioning_profile = False,
+            requires_signing_for_device = False,
+            skip_signing = True,
+        ),
         # ios_ui_test
         apple_product_type.ui_test_bundle: _describe_rule_type(
             allowed_device_families = ["iphone", "ipad"],

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -288,16 +288,6 @@ _RULE_TYPE_DESCRIPTORS = {
             requires_provisioning_profile = False,
             skip_signing = True,
         ),
-        apple_product_type.bundle: _describe_rule_type(
-            allowed_device_families = ["iphone", "ipad"],
-            bundle_extension = ".bundle",
-            has_infoplist = True,
-            product_type = apple_product_type.bundle,
-            requires_bundle_id = True,
-            requires_provisioning_profile = False,
-            requires_signing_for_device = False,
-            skip_signing = True,
-        ),
         # ios_ui_test
         apple_product_type.ui_test_bundle: _describe_rule_type(
             allowed_device_families = ["iphone", "ipad"],


### PR DESCRIPTION
This resolves a case we hit recently. Someone had more than one developer certificate for with the exact same common name, including the hex string identifier. All were valid. Calling `codesign` with an ambiguous signing identity is an error.

This change addresses this case by passing the unique hash. An example `codesign` invocation could look like:

```sh
codesign --sign "434FA21B6A3CE7FE758E7EA843ED159B24E8C43F" ...
```