### PR TITLE
Add infrastructure to selectively add rule class transitions to rule_descriptors.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -843,10 +843,18 @@ def _create_apple_binary_rule(implementation, platform_type, product_type, doc):
 
     rule_attrs.extend(_get_macos_binary_attrs(rule_descriptor))
 
+    if rule_descriptor.rule_transition:
+        rule_attrs.append({
+            "_whitelist_function_transition": attr.label(
+                default = "//tools/whitelists/function_transition_whitelist",
+            ),
+        })
+
     return rule(
         implementation = implementation,
         # TODO(kaipi): Replace dicts.add with a version that errors on duplicate keys.
         attrs = dicts.add(*rule_attrs),
+        cfg = rule_descriptor.rule_transition,
         doc = doc,
         executable = rule_descriptor.is_executable,
         fragments = ["apple", "cpp", "objc"],
@@ -885,11 +893,19 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
     elif platform_type == "watchos":
         rule_attrs.extend(_get_watchos_attrs(rule_descriptor))
 
+    if rule_descriptor.rule_transition:
+        rule_attrs.append({
+            "_whitelist_function_transition": attr.label(
+                default = "//tools/whitelists/function_transition_whitelist",
+            ),
+        })
+
     archive_name = "%{name}" + rule_descriptor.archive_extension
     return rule(
         implementation = implementation,
         # TODO(kaipi): Replace dicts.add with a version that errors on duplicate keys.
         attrs = dicts.add(*rule_attrs),
+        cfg = rule_descriptor.rule_transition,
         doc = doc,
         executable = rule_descriptor.is_executable,
         fragments = ["apple", "cpp", "objc"],

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -74,6 +74,7 @@ def _describe_rule_type(
         requires_provisioning_profile = True,
         requires_signing_for_device = True,
         rpaths = [],
+        rule_transition = None,
         skip_signing = False,
         skip_simulator_signing_allowed = True,
         stub_binary_path = None):
@@ -120,6 +121,7 @@ def _describe_rule_type(
         requires_signing_for_device: Whether signing is required when building for devices (as
             opposed to simulators).
         rpaths: List of rpaths to add to the linker.
+        rule_transition: Starlark transition to apply to the rule.
         skip_signing: Whether this rule skips the signing step.
         skip_simulator_signing_allowed: Whether this rule is allowed to skip signing when building
             for the simulator.
@@ -160,6 +162,7 @@ def _describe_rule_type(
         requires_provisioning_profile = requires_provisioning_profile,
         requires_signing_for_device = requires_signing_for_device,
         rpaths = rpaths,
+        rule_transition = rule_transition,
         skip_simulator_signing_allowed = skip_simulator_signing_allowed,
         skip_signing = skip_signing,
         stub_binary_path = stub_binary_path,

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -1,0 +1,98 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark transition support for Apple rules."""
+
+def _cpu_string(platform_type, settings):
+    """Generates a <platform>_<arch> string for the current target based on the given parameters."""
+    if platform_type == "ios":
+        ios_cpus = settings["//command_line_option:ios_multi_cpus"]
+        if ios_cpus:
+            return "ios_{}".format(settings["//command_line_option:ios_multi_cpus"][0])
+        if settings["//command_line_option:cpu"].startswith("ios_"):
+            return settings["//command_line_option:cpu"]
+        return "ios_x86_64"
+    elif platform_type == "macos":
+        macos_cpus = settings["//command_line_option:macos_cpus"]
+        if macos_cpus:
+            return "darwin_{}".format(macos_cpus[0])
+        return "darwin_x86_64"
+    elif platform_type == "tvos":
+        tvos_cpus = settings["//command_line_option:tvos_cpus"]
+        if tvos_cpus:
+            return "tvos_{}".format(tvos_cpus[0])
+        return "tvos_x86_64"
+    elif platform_type == "watchos":
+        watchos_cpus = settings["//command_line_option:watchos_cpus"]
+        if watchos_cpus:
+            return "watchos_{}".format(watchos_cpus[0])
+        return "watchos_i386"
+
+    fail("ERROR: Unknown platform type: {}".format(platform_type))
+
+def _min_os_version_or_none(attr, platform):
+    if attr.platform_type == platform:
+        return attr.minimum_os_version
+    return None
+
+def _apple_rule_transition_impl(settings, attr):
+    """Rule transition for Apple rules."""
+    return {
+        "//command_line_option:apple configuration distinguisher": "applebin_" + attr.platform_type,
+        "//command_line_option:apple_platform_type": attr.platform_type,
+        "//command_line_option:apple_split_cpu": "",
+        "//command_line_option:compiler": settings["//command_line_option:apple_compiler"],
+        "//command_line_option:cpu": _cpu_string(attr.platform_type, settings),
+        "//command_line_option:crosstool_top": (
+            settings["//command_line_option:apple_crosstool_top"]
+        ),
+        "//command_line_option:fission": [],
+        "//command_line_option:grte_top": settings["//command_line_option:apple_grte_top"],
+        "//command_line_option:ios_minimum_os": _min_os_version_or_none(attr, "ios"),
+        "//command_line_option:macos_minimum_os": _min_os_version_or_none(attr, "macos"),
+        "//command_line_option:tvos_minimum_os": _min_os_version_or_none(attr, "tvos"),
+        "//command_line_option:watchos_minimum_os": _min_os_version_or_none(attr, "watchos"),
+    }
+
+_apple_rule_transition = transition(
+    implementation = _apple_rule_transition_impl,
+    inputs = [
+        "//command_line_option:apple_compiler",
+        "//command_line_option:apple_crosstool_top",
+        "//command_line_option:apple_grte_top",
+        "//command_line_option:cpu",
+        "//command_line_option:ios_multi_cpus",
+        "//command_line_option:macos_cpus",
+        "//command_line_option:tvos_cpus",
+        "//command_line_option:watchos_cpus",
+    ],
+    outputs = [
+        "//command_line_option:apple configuration distinguisher",
+        "//command_line_option:apple_platform_type",
+        "//command_line_option:apple_split_cpu",
+        "//command_line_option:compiler",
+        "//command_line_option:cpu",
+        "//command_line_option:crosstool_top",
+        "//command_line_option:fission",
+        "//command_line_option:grte_top",
+        "//command_line_option:ios_minimum_os",
+        "//command_line_option:macos_minimum_os",
+        "//command_line_option:tvos_minimum_os",
+        "//command_line_option:watchos_minimum_os",
+    ],
+)
+
+transition_support = struct(
+    apple_rule_transition = _apple_rule_transition,
+)


### PR DESCRIPTION
Add infrastructure to selectively add rule class transitions to rule_descriptors.

With this, we'll be able to migrate from macros to rules selectively per platform and product type.