### PR TITLE
Migrate macos_command_line_application and macos_dylib from macros to rules.

### DIFF
--- a/apple/internal/entitlement_rules.bzl
+++ b/apple/internal/entitlement_rules.bzl
@@ -27,10 +27,6 @@ load(
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
-    "linking_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
 )
@@ -282,10 +278,19 @@ def _entitlements_impl(ctx):
     # the binary; for device builds, the entitlements are applied during signing.
     if not is_device:
         return [
-            linking_support.sectcreate_objc_provider(
-                "__TEXT",
-                "__entitlements",
-                final_entitlements,
+            # TODO(kaipi): Remove this provider once the entitlements rule is no longer needed.
+            apple_common.new_objc_provider(
+                linkopt = depset(
+                    [
+                        "-Wl,-sectcreate,{0},{1},{2}".format(
+                            "__TEXT",
+                            "__entitlements",
+                            final_entitlements.path,
+                        ),
+                    ],
+                    order = "topological",
+                ),
+                link_inputs = depset([final_entitlements]),
             ),
             AppleEntitlementsInfo(final_entitlements = final_entitlements),
         ]

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -23,7 +23,7 @@ load(
     "collections",
 )
 
-def _sectcreate_objc_provider(segname, sectname, file):
+def _sectcreate_link_flag(segname, sectname, file):
     """Returns an objc provider that propagates a section in a linked binary.
 
     This function creates a new objc provider that contains the necessary linkopts
@@ -43,11 +43,7 @@ def _sectcreate_objc_provider(segname, sectname, file):
 
     # linkopts get deduped, so use a single option to pass then through as a
     # set.
-    linkopts = ["-Wl,-sectcreate,%s,%s,%s" % (segname, sectname, file.path)]
-    return apple_common.new_objc_provider(
-        linkopt = depset(linkopts, order = "topological"),
-        link_inputs = depset([file]),
-    )
+    return "-Wl,-sectcreate,{0},{1},{2}".format(segname, sectname, file.path)
 
 def _register_linking_action(ctx, extra_linkopts = []):
     """Registers linking actions using the Starlark Linking API for Apple binaries.
@@ -91,5 +87,5 @@ def _register_linking_action(ctx, extra_linkopts = []):
 
 linking_support = struct(
     register_linking_action = _register_linking_action,
-    sectcreate_objc_provider = _sectcreate_objc_provider,
+    sectcreate_link_flag = _sectcreate_link_flag,
 )

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -15,10 +15,6 @@
 """Internal helper definitions used by macOS command line rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
-    "apple_product_type",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -30,45 +26,8 @@ load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
-    "rule_factory",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleVersionInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
 
-def _macos_binary_infoplist_impl(ctx):
-    """Implementation of the internal `macos_command_line_infoplist` rule.
-
-    This rule is an internal implementation detail of
-    `macos_command_line_application` and should not be used directly by clients.
-    It merges Info.plists as would occur for a bundle but then propagates an
-    `objc` provider with the necessary linkopts to embed the plist in a binary.
-
-    Args:
-      ctx: The rule context.
-
-    Returns:
-      A `struct` containing the `objc` provider that should be propagated to a
-      binary that should have this plist embedded.
-    """
-    bundle_id = ctx.attr.bundle_id
-    infoplists = ctx.files.infoplists
-    if ctx.attr.version and AppleBundleVersionInfo in ctx.attr.version:
-        version = ctx.attr.version[AppleBundleVersionInfo]
-    else:
-        version = None
-
-    if not bundle_id and not infoplists and not version:
-        fail("Internal error: at least one of bundle_id, infoplists, or version " +
-             "should have been provided")
-
+def _macos_binary_infoplist_link_flag(ctx, bundle_id, infoplists):
     merged_infoplist = intermediates.file(
         ctx.actions,
         ctx.label.name,
@@ -84,46 +43,9 @@ def _macos_binary_infoplist_impl(ctx):
         include_executable_name = False,
     )
 
-    return [
-        linking_support.sectcreate_objc_provider(
-            "__TEXT",
-            "__info_plist",
-            merged_infoplist,
-        ),
-    ]
+    return linking_support.sectcreate_link_flag("__TEXT", "__info_plist", merged_infoplist)
 
-macos_binary_infoplist = rule(
-    implementation = _macos_binary_infoplist_impl,
-    attrs = dicts.add(
-        rule_factory.common_tool_attributes,
-        {
-            "bundle_id": attr.string(mandatory = False),
-            "infoplists": attr.label_list(
-                allow_files = [".plist"],
-                mandatory = False,
-                allow_empty = True,
-            ),
-            "minimum_os_version": attr.string(mandatory = False),
-            # TODO(kaipi): Make this private when it isn't also used by
-            # apple_binary (when there is a linking api to use). It is public
-            # for consistency and because this rule is an internal
-            # implementation detail.
-            "platform_type": attr.string(
-                default = str(apple_common.platform_type.macos),
-            ),
-            "version": attr.label(providers = [[AppleBundleVersionInfo]]),
-            "_product_type": attr.string(default = apple_product_type.tool),
-        },
-    ),
-    fragments = ["apple", "objc"],
-)
-
-def _macos_command_line_launchdplist_impl(ctx):
-    launchdplists = ctx.files.launchdplists
-
-    if not launchdplists:
-        fail("Internal error: launchdplists should have been provided")
-
+def _macos_binary_launchdplist_link_flag(ctx, launchdplists):
     merged_launchdplist = intermediates.file(
         ctx.actions,
         ctx.label.name,
@@ -137,24 +59,9 @@ def _macos_command_line_launchdplist_impl(ctx):
         output_plist = merged_launchdplist,
     )
 
-    return [
-        linking_support.sectcreate_objc_provider(
-            "__TEXT",
-            "__launchd_plist",
-            merged_launchdplist,
-        ),
-    ]
+    return linking_support.sectcreate_link_flag("__TEXT", "__launchd_plist", merged_launchdplist)
 
-macos_command_line_launchdplist = rule(
-    implementation = _macos_command_line_launchdplist_impl,
-    attrs = dicts.add(
-        rule_factory.common_tool_attributes,
-        {
-            "launchdplists": attr.label_list(
-                allow_files = [".plist"],
-                mandatory = False,
-            ),
-        },
-    ),
-    fragments = ["apple", "objc"],
+macos_binary_support = struct(
+    macos_binary_infoplist_link_flag = _macos_binary_infoplist_link_flag,
+    macos_binary_launchdplist_link_flag = _macos_binary_launchdplist_link_flag,
 )

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -25,6 +25,10 @@ load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
 
 def _describe_bundle_locations(
         archive_relative = "",
@@ -361,19 +365,23 @@ _RULE_TYPE_DESCRIPTORS = {
         apple_product_type.tool: _describe_rule_type(
             allowed_device_families = ["mac"],
             bundle_extension = "",
+            deps_cfg = apple_common.multi_arch_split,
             is_executable = True,
             product_type = apple_product_type.tool,
             provisioning_profile_extension = ".provisionprofile",
             requires_provisioning_profile = True,
             requires_signing_for_device = False,
+            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_dylib
         apple_product_type.dylib: _describe_rule_type(
             allowed_device_families = ["mac"],
             binary_type = "dylib",
             bundle_extension = "",
+            deps_cfg = apple_common.multi_arch_split,
             product_type = apple_product_type.dylib,
             requires_signing_for_device = False,
+            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_extension
         apple_product_type.app_extension: _describe_rule_type(


### PR DESCRIPTION
Migrate macos_command_line_application and macos_dylib from macros to rules.