### PR TITLE
Have all Apple rules that perform linking apply the J2ObjC providers aspect to their deps

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -211,6 +211,12 @@ def _common_binary_linking_attrs(rule_descriptor):
         framework_import_aspect,
         swift_usage_aspect,
     ]
+
+    # TODO(markrowe): j2objc_providers_aspect should be included unconditionally
+    # once it is generally available.
+    if hasattr(apple_common, "j2objc_providers_aspect"):
+        deps_aspects.append(apple_common.j2objc_providers_aspect)
+
     if _is_test_product_type(rule_descriptor.product_type):
         deps_aspects.extend([coverage_files_aspect, test_info_aspect])
 


### PR DESCRIPTION
Have all Apple rules that perform linking apply the J2ObjC providers aspect to their deps

An aspect is being added to Bazel that will propagate the providers used by J2ObjC. The aspect is applied automatically by apple_binary, but needs to be applied manually by targets that will use apple_common.link_multi_arch_binary.