### PR TITLE
Rewrite resource owner tracking to avoid quadratic blowup

### DIFF
--- a/apple/internal/resource_rules/apple_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_resource_bundle.bzl
@@ -83,7 +83,10 @@ def _apple_resource_bundle_impl(ctx):
     else:
         # If there were no resources to bundle, propagate an empty provider to signal that this
         # target has already been processed anyways.
-        complete_resource_provider = AppleResourceInfo(owners = {})
+        complete_resource_provider = AppleResourceInfo(
+            owners = depset(),
+            unowned_resources = depset(),
+        )
 
     return [
         # TODO(b/122578556): Remove this ObjC provider instance.

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -154,8 +154,8 @@ only be bucketed with the `bucketize_typed` method.""",
         "texture_atlases": "Texture atlas files.",
         "unprocessed": "Generic resources not mapped to the other types.",
         "xibs": "XIB Interface files.",
-        "owners": """Map of resource short paths to a depset of strings that represent targets that
-declare ownership of that resource.""",
+        "owners": """Depset of (resource, owner) pairs.""",
+        "unowned_resources": """Depset of unowned resources.""",
     },
 )
 

--- a/test/ios_application_resources_test.sh
+++ b/test/ios_application_resources_test.sh
@@ -623,7 +623,11 @@ def _impl(ctx):
     outputs = depset([output])
     return [
         DefaultInfo(files = outputs),
-        AppleResourceInfo(unprocessed = [(None, None, outputs)], owners = {}),
+        AppleResourceInfo(
+            unprocessed = [(None, None, outputs)],
+            owners = depset(),
+            unowned_resources = depset(),
+        ),
     ]
 
 custom_rule = rule(_impl)


### PR DESCRIPTION
Rewrite resource owner tracking to avoid quadratic blowup

Instead of merging dictionaries of resources at every intermediate rule, we
keep a nested set of (path, owner) pairs as well as a nested set of unowned
resources, and reconstruct the implicit map at the binary level only when we
actually need it to filter the resources, and drop it immediately afterwards.

For a benchmark run, this reduces post-analysis memory from ~5.9 GB to ~5 GB.