### PR TITLE
Removing new_objc_provider from the apple_bundle_import implementation.

### DIFF
--- a/apple/internal/resource_rules/apple_bundle_import.bzl
+++ b/apple/internal/resource_rules/apple_bundle_import.bzl
@@ -49,9 +49,6 @@ def _apple_bundle_import_impl(ctx):
         parent_dir_param = parent_dir_param,
     )
     return [
-        # TODO(b/120904073): Remove the objc provider. It's here only because objc_library's bundles
-        # attribute requires it for now.
-        apple_common.new_objc_provider(),
         AppleResourceBundleInfo(),
         resource_provider,
     ]


### PR DESCRIPTION
Removing new_objc_provider from the apple_bundle_import implementation.