### PR TITLE
Adding a field to the ios_application target to allow resources not associated with an objc_library to be included in the resulting application bundle.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -72,6 +72,7 @@ def _ios_application_impl(ctx):
         "launch_images",
         "launch_storyboard",
         "strings",
+        "resources",
     ]
 
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
@@ -219,6 +220,7 @@ def _ios_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             targets_to_avoid = ctx.attr.frameworks,
             version_keys_required = False,
+            top_level_attrs = ["resources"],
         ),
         partials.swift_dylibs_partial(
             binary_artifact = binary_artifact,
@@ -333,6 +335,7 @@ def _ios_imessage_application_impl(ctx):
     top_level_attrs = [
         "app_icons",
         "strings",
+        "resources",
     ]
 
     binary_artifact = stub_support.create_stub_binary(
@@ -393,6 +396,7 @@ def _ios_imessage_extension_impl(ctx):
     top_level_attrs = [
         "app_icons",
         "strings",
+        "resources",
     ]
 
     binary_descriptor = linking_support.register_linking_action(ctx)
@@ -458,6 +462,7 @@ def _ios_sticker_pack_extension_impl(ctx):
     top_level_attrs = [
         "sticker_assets",
         "strings",
+        "resources",
     ]
 
     binary_artifact = stub_support.create_stub_binary(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -99,6 +99,7 @@ def _macos_application_impl(ctx):
             top_level_attrs = [
                 "app_icons",
                 "strings",
+                "resources",
             ],
         ),
         partials.swift_dylibs_partial(
@@ -164,6 +165,7 @@ def _macos_bundle_impl(ctx):
             top_level_attrs = [
                 "app_icons",
                 "strings",
+                "resources",
             ],
         ),
         partials.swift_dylibs_partial(
@@ -209,6 +211,7 @@ def _macos_extension_impl(ctx):
             top_level_attrs = [
                 "app_icons",
                 "strings",
+                "resources",
             ],
         ),
         partials.swift_dylibs_partial(
@@ -261,6 +264,7 @@ def _macos_quick_look_plugin_impl(ctx):
             plist_attrs = ["infoplists"],
             top_level_attrs = [
                 "strings",
+                "resources",
             ],
         ),
         partials.swift_dylibs_partial(
@@ -303,6 +307,7 @@ def _macos_kernel_extension_impl(ctx):
         partials.resources_partial(
             bundle_id = bundle_id,
             plist_attrs = ["infoplists"],
+            top_level_attrs = ["resources"],
         ),
         partials.swift_dylibs_partial(
             binary_artifact = binary_artifact,

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -220,12 +220,13 @@ def _resources_partial_impl(
         version_keys_required):
     """Implementation for the resource processing partial."""
     providers = []
-    if hasattr(ctx.attr, "deps"):
-        providers.extend([
-            x[AppleResourceInfo]
-            for x in ctx.attr.deps
-            if AppleResourceInfo in x
-        ])
+    for attr in ["deps", "resources"]:
+        if hasattr(ctx.attr, attr):
+            providers.extend([
+                x[AppleResourceInfo]
+                for x in getattr(ctx.attr, attr)
+                if AppleResourceInfo in x
+            ])
 
     # TODO(kaipi): Bucket top_level_attrs directly instead of collecting and
     # splitting.

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -371,6 +371,13 @@ directory is named `*.lproj`, in which case it will be placed under a directory 
 in the bundle.
 """,
         ),
+        "resources": attr.label_list(
+            allow_files = True,
+            doc = """
+A list of resources or files bundled with the bundle. The resources will be stored in the
+appropriate resources location within the bundle.
+""",
+        ),
         "version": attr.label(
             providers = [[AppleBundleVersionInfo]],
             doc = """

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -116,6 +116,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
             plist_attrs = ["infoplists"],
             targets_to_avoid = targets_to_avoid,
             version_keys_required = False,
+            top_level_attrs = ["resources"],
         ),
         partials.swift_dylibs_partial(
             binary_artifact = binary_artifact,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -60,6 +60,7 @@ def _tvos_application_impl(ctx):
         "app_icons",
         "launch_images",
         "strings",
+        "resources",
     ]
 
     binary_descriptor = linking_support.register_linking_action(ctx)
@@ -175,6 +176,7 @@ def _tvos_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             targets_to_avoid = ctx.attr.frameworks,
             version_keys_required = False,
+            top_level_attrs = ["resources"],
         ),
         partials.swift_dylibs_partial(
             binary_artifact = binary_artifact,
@@ -194,6 +196,7 @@ def _tvos_extension_impl(ctx):
     top_level_attrs = [
         "app_icons",
         "strings",
+        "resources",
     ]
 
     binary_descriptor = linking_support.register_linking_action(ctx)

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -68,6 +68,7 @@ def _watchos_application_impl(ctx):
         "app_icons",
         "storyboards",
         "strings",
+        "resources",
     ]
 
     binary_artifact = stub_support.create_stub_binary(
@@ -132,6 +133,7 @@ def _watchos_extension_impl(ctx):
     top_level_attrs = [
         "app_icons",
         "strings",
+        "resources",
     ]
 
     # Xcode 11 requires this flag to be passed to the linker, but it is not accepted by earlier

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -7,7 +7,7 @@
 ios_application(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, extensions, families, frameworks, infoplists,
 ipa_post_processor, launch_images, launch_storyboard, linkopts,
-minimum_os_version, provisioning_profile, settings_bundle, strings, version,
+minimum_os_version, provisioning_profile, resources, settings_bundle, strings, version,
 watch_application, deps)
 ```
 
@@ -182,6 +182,14 @@ Builds and bundles an iOS application.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>settings_bundle</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -237,7 +245,7 @@ Builds and bundles an iOS application.
 ```python
 ios_imessage_application(name, app_icons, bundle_id, bundle_name, extension,
 families, infoplists, ipa_post_processor, minimum_os_version,
-provisioning_profile, strings, version)
+provisioning_profile, resources, strings, version)
 ```
 
 Builds and bundles an iOS iMessage application. iOS iMessage applications do not
@@ -350,6 +358,14 @@ iMessage extension or a Sticker Pack extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -378,7 +394,7 @@ iMessage extension or a Sticker Pack extension.
 ```python
 ios_extension(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, families, frameworks, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, provisioning_profile, strings, version, deps)
+linkopts, minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles an iOS application extension.
@@ -522,6 +538,14 @@ Builds and bundles an iOS application extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -559,7 +583,7 @@ Builds and bundles an iOS application extension.
 ```python
 ios_imessage_extension(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, families, frameworks, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, provisioning_profile, strings, version, deps)
+linkopts, minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles an iOS iMessage extension.
@@ -703,6 +727,14 @@ Builds and bundles an iOS iMessage extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -740,7 +772,7 @@ Builds and bundles an iOS iMessage extension.
 ```python
 ios_sticker_pack_extension(name, sticker_assets, bundle_id, bundle_name,
 families, infoplists, ipa_post_processor, minimum_os_version,
-provisioning_profile, strings, version)
+provisioning_profile, resources, strings, version)
 ```
 
 Builds and bundles an iOS Sticker Pack extension.
@@ -844,6 +876,14 @@ Builds and bundles an iOS Sticker Pack extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -871,7 +911,7 @@ Builds and bundles an iOS Sticker Pack extension.
 
 ```python
 ios_framework(name, bundle_id, bundle_name, extension_safe, families,
-frameworks, infoplists, ipa_post_processor, linkopts, minimum_os_version,
+frameworks, infoplists, ipa_post_processor, linkopts, minimum_os_version, resources,
 strings, version, deps)
 ```
 
@@ -978,6 +1018,14 @@ app and extensions, list it in the `frameworks` attributes of those
         target, represented as a dotted version number (for example,
         <code>"9.0"</code>). If this attribute is omitted, then the value specified
         by the flag <code>--ios_minimum_os</code> will be used instead.
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
       </td>
     </tr>
     <tr>
@@ -1178,8 +1226,9 @@ build a single framework artifact that works for all architectures by specifying
 ## ios_ui_test
 
 ```python
-ios_ui_test(name, bundle_id, infoplists, frameworks, minimum_os_version, runner,
-test_host, data, deps, provisioning_profile, [test specific attributes])
+ios_ui_test(name, bundle_id, infoplists, frameworks, minimum_os_version,
+resources, runner, test_host, data, deps, provisioning_profile,
+[test specific attributes])
 ```
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -1254,6 +1303,14 @@ of the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -1279,7 +1336,10 @@ of the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the `*.runfiles`
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+          a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>
@@ -1461,7 +1521,7 @@ except `runner` is replaced by `runners`.
 
 ```python
 ios_unit_test(name, bundle_id, env, frameworks, infoplists, minimum_os_version,
-runner, test_host, data, deps, [test specific attributes])
+resources, runner, test_host, data, deps, [test specific attributes])
 ```
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -1552,6 +1612,14 @@ of the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -1579,7 +1647,10 @@ of the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the `*.runfiles`
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+        a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -6,7 +6,7 @@
 ```python
 macos_application(name, additional_contents, app_icons, bundle_id, bundle_name,
 entitlements, entitlements_validation, extensions, infoplists,
-ipa_post_processor, linkopts, minimum_os_version, provisioning_profile, strings,
+ipa_post_processor, linkopts, minimum_os_version, provisioning_profile, resources, strings,
 version, deps)
 ```
 
@@ -159,6 +159,14 @@ simple command line tool as a standalone binary, use
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -204,7 +212,7 @@ simple command line tool as a standalone binary, use
 ```python
 macos_bundle(name, additional_contents, app_icons, bundle_id, bundle_name,
 entitlements, entitlements_validation, infoplists, ipa_post_processor, linkopts,
-minimum_os_version, provisioning_profile, strings, version, deps)
+minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles a macOS loadable bundle.
@@ -353,6 +361,14 @@ Builds and bundles a macOS loadable bundle.
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
         <p>The provisioning profile (<code>.provisionprofile</code> file) to use
         when bundling the bundle.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
       </td>
     </tr>
     <tr>
@@ -574,7 +590,7 @@ Builds a macOS dylib.
 ```python
 macos_extension(name, additional_contents, bundle_id, bundle_name,
 entitlements, entitlements_validation, infoplists, ipa_post_processor,
-linkopts, minimum_os_version, provisioning_profile, strings, version, deps)
+linkopts, minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles a macOS extension.
@@ -705,6 +721,14 @@ Builds and bundles a macOS extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -742,7 +766,7 @@ Builds and bundles a macOS extension.
 ```python
 macos_bundle(name, additional_contents, bundle_id, bundle_name, entitlements,
 entitlements_validation, infoplists, ipa_post_processor, linkopts,
-minimum_os_version, provisioning_profile, strings, version, deps)
+minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles a macOS Kernel Extension.
@@ -869,6 +893,14 @@ Builds and bundles a macOS Kernel Extension.
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
         <p>The provisioning profile (<code>.provisionprofile</code> file) to use
         when bundling the target.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
       </td>
     </tr>
     <tr>
@@ -1074,8 +1106,8 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_unit_test
 
 ```python
-macos_unit_test(name, additional_contents, bundle_id, infoplists, minimum_os_version, runner,
-test_host, data, deps)
+macos_unit_test(name, additional_contents, bundle_id, infoplists,
+minimum_os_version, resources, runner, test_host, data, deps)
 ```
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -1168,6 +1200,14 @@ of the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -1193,7 +1233,10 @@ of the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the <code>*.runfiles</code>
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+        a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>
@@ -1212,8 +1255,9 @@ of the attributes inherited by all test rules, please check the
 ## macos_ui_test
 
 ```python
-macos_ui_test(name, additional_contents, bundle_id, infoplists, minimum_os_version, runner,
-test_host, data, deps, [test specific attributes])
+macos_ui_test(name, additional_contents, bundle_id, infoplists,
+minimum_os_version, resources, runner, test_host, data, deps,
+[test specific attributes])
 ```
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -1298,6 +1342,14 @@ of the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -1323,7 +1375,10 @@ of the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the `*.runfiles`
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+        a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -7,7 +7,7 @@
 tvos_application(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, extensions, frameworks, infoplists, ipa_post_processor,
 launch_images, linkopts, minimum_os_version, provisioning_profile,
-settings_bundle, strings, version, deps)
+resources, settings_bundle, strings, version, deps)
 ```
 
 Builds and bundles a tvOS application.
@@ -159,6 +159,14 @@ Builds and bundles a tvOS application.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>settings_bundle</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -206,7 +214,7 @@ Builds and bundles a tvOS application.
 ```python
 tvos_extension(name, bundle_id, bundle_name, entitlements,
 entitlements_validation, frameworks, infoplists, ipa_post_processor, linkopts,
-minimum_os_version, strings, version, deps)
+minimum_os_version, resources, strings, version, deps)
 ```
 
 Builds and bundles a tvOS extension.
@@ -332,6 +340,14 @@ Builds and bundles a tvOS extension.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -367,7 +383,7 @@ Builds and bundles a tvOS extension.
 
 ```python
 tvos_framework(name, bundle_id, bundle_name, extension_safe, frameworks,
-infoplists, ipa_post_processor, linkopts, minimum_os_version, strings, version,
+infoplists, ipa_post_processor, linkopts, minimum_os_version, resources, strings, version,
 deps)
 ```
 
@@ -469,6 +485,14 @@ and extensions, list it in the `frameworks` attributes of those
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final application.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>strings</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -503,7 +527,7 @@ and extensions, list it in the `frameworks` attributes of those
 ## tvos_ui_test
 
 ```python
-tvos_ui_test(name, bundle_id, infoplists, minimum_os_version, runner,
+tvos_ui_test(name, bundle_id, infoplists, minimum_os_version, resources, runner,
 test_host, data, deps, provisioning_profile, [test specific attributes])
 ```
 
@@ -566,6 +590,14 @@ the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -591,7 +623,10 @@ the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the `*.runfiles`
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+        a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>
@@ -627,7 +662,7 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 ```python
-tvos_unit_test(name, bundle_id, infoplists, minimum_os_version, runner,
+tvos_unit_test(name, bundle_id, infoplists, minimum_os_version, resources, runner,
 test_host, data, deps, [test specific attributes])
 ```
 
@@ -706,6 +741,14 @@ of the attributes inherited by all test rules, please check the
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>runner</code></td>
       <td>
         <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
@@ -730,7 +773,10 @@ of the attributes inherited by all test rules, please check the
         <p>The list of files needed by this rule at runtime.</p>
         <p>Targets named in the data attribute will appear in the `*.runfiles`
         area of this rule, if it has one. This may include data files needed by
-        a binary or library, or other programs needed by it.</p>
+        a binary or library, or other programs needed by it.
+        <strong>NOTE</strong>: Files will be made available to the test runner,
+        but will not be bundled into the resulting <code>.xctest</code>
+        bundle.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -6,7 +6,7 @@
 ```python
 watchos_application(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, extension, infoplists, ipa_post_processor,
-minimum_os_version, provisioning_profile, storyboards, strings, version, deps)
+minimum_os_version, provisioning_profile, resources, storyboards, strings, version, deps)
 ```
 
 Builds and bundles a watchOS application.
@@ -142,6 +142,14 @@ rule.
       </td>
     </tr>
     <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>storyboards</code></td>
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
@@ -190,7 +198,7 @@ rule.
 ```python
 watchos_extension(name, app_icons, bundle_id, bundle_name, entitlements,
 entitlements_validation, infoplists, ipa_post_processor, linkopts,
-minimum_os_version, provisioning_profile, strings, version, deps)
+minimum_os_version, provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles a watchOS extension.
@@ -318,6 +326,14 @@ do not support that version of the platform.
         when bundling the extension. This value is optional for simulator
         builds as the simulator doesn't fully enforce entitlements, but is
         <strong>required for device builds.</strong></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
       </td>
     </tr>
     <tr>

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -48,6 +48,20 @@ def ios_application_test_suite():
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
     )
 
+    apple_verification_test(
+        name = "{}_resources_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
+    apple_verification_test(
+        name = "{}_resources_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -34,6 +34,13 @@ def ios_unit_test_test_suite():
         verifier_script = "verifier_scripts/codesign_verifier.sh",
     )
 
+    apple_verification_test(
+        name = "{}_resources_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -41,6 +41,13 @@ def macos_application_test_suite():
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
     )
 
+    apple_verification_test(
+        name = "{}_resources_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -4,6 +4,8 @@ package(
     default_visibility = ["//test/starlark_tests:__subpackages__"],
 )
 
+load("//apple:resources.bzl", "apple_resource_bundle")
+
 # Exports all files in this package as targets to make it easier to depend on them.
 # Because these are for Starlark tests, we can scope the visibility to just this
 # package.
@@ -25,4 +27,16 @@ objc_library(
 objc_library(
     name = "objc_test_lib",
     srcs = ["test.m"],
+)
+
+apple_resource_bundle(
+    name = "resource_bundle",
+    infoplists = ["Another.plist"],
+)
+
+filegroup(
+    name = "example_filegroup",
+    srcs = [
+        ":Another.plist",
+    ],
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -31,6 +31,10 @@ ios_application(
     ],
     minimum_os_version = "8.0",
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
     tags = [
         "manual",
         "notap",
@@ -302,6 +306,10 @@ ios_unit_test(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "8.0",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -23,6 +23,10 @@ macos_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "10.10",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -23,6 +23,10 @@ tvos_application(
     ],
     minimum_os_version = "8.0",
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -19,6 +19,10 @@ watchos_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "3.0",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -48,6 +48,20 @@ def tvos_application_test_suite():
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
     )
 
+    apple_verification_test(
+        name = "{}_resources_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
+    apple_verification_test(
+        name = "{}_resources_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",

--- a/test/starlark_tests/verifier_scripts/resources_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/resources_verifier.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+find "${ARCHIVE_ROOT}"
+# Verify that bundled resources have been properly copied into the resulting build product.
+assert_exists "${RESOURCE_ROOT}/resource_bundle.bundle/Info.plist"
+# Verify that individual files have been properly copied into the resulting build product.
+assert_exists "${RESOURCE_ROOT}/Another.plist"

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -34,6 +34,13 @@ def watchos_application_test_suite():
         verifier_script = "verifier_scripts/codesign_verifier.sh",
     )
 
+    apple_verification_test(
+        name = "{}_resources_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
+        verifier_script = "verifier_scripts/resources_verifier.sh",
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",


### PR DESCRIPTION
Adding a field to the ios_application target to allow resources not associated with an objc_library to be included in the resulting application bundle.