### PR TITLE
Fix incompatible_restrict_named_params issue

### DIFF
--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -105,7 +105,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
-            embeddable_targets = getattr(ctx.attr, "frameworks", default = []),
+            embeddable_targets = getattr(ctx.attr, "frameworks", []),
         ),
         partials.framework_import_partial(
             targets = ctx.attr.deps,


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/8147