### PR TITLE
Disable CI test for ButtonsMacTests since there is something borked.

### DIFF
--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -294,6 +294,7 @@ macos_unit_test(
 macos_unit_test(
     name = "ButtonsMacTests",
     minimum_os_version = "10.10",
+    tags = ["manual"],
     test_host = ":ButtonsMac",
     deps = [":ButtonsMacTestsLib"],
 )


### PR DESCRIPTION
Disable CI test for ButtonsMacTests since there is something borked.