### PR TITLE
Use plistlib.dump over plistlib.writePlist.

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -754,7 +754,14 @@ class PlistIO(object):
       binary: If True and path_or_file was a file name, reformat the file
           in binary form.
     """
-    plistlib.writePlist(plist, path_or_file)
+    if hasattr(plistlib, 'dump'):
+      if isinstance(path_or_file, _string_types):
+        with open(path_or_file, 'wb') as fp:
+          plistlib.dump(plist, fp)
+      else:
+        plistlib.dump(plist, path_or_file)
+    else:
+      plistlib.writePlist(plist, path_or_file)
 
     if binary and isinstance(path_or_file, _string_types):
       subprocess.check_call(['plutil', '-convert', 'binary1', path_or_file])

--- a/tools/provisioning_profile_tool/provisioning_profile_tool.py
+++ b/tools/provisioning_profile_tool/provisioning_profile_tool.py
@@ -139,7 +139,11 @@ class ProvisioningProfileTool(object):
       provisioning_profile: The provisioning profile.
     """
     entitlements = provisioning_profile['Entitlements']
-    plistlib.writePlist(entitlements, output_path)
+    if hasattr(plistlib, 'dump'):
+      with open(output_path, 'wb') as fp:
+        plistlib.dump(entitlements, fp)
+    else:
+      plistlib.writePlist(entitlements, output_path)
 
   @classmethod
   def _write_metadata(self, output_path, provisioning_profile):
@@ -161,7 +165,11 @@ class ProvisioningProfileTool(object):
         'TimeToLive', 'UUID', 'Version',
     )
     output_data = {k: provisioning_profile[k] for k in keys}
-    plistlib.writePlist(output_data, output_path)
+    if hasattr(plistlib, 'dump'):
+      with open(output_path, 'wb') as fp:
+        plistlib.dump(output_data, fp)
+    else:
+      plistlib.writePlist(output_data, output_path)
 
   @classmethod
   def _extract_raw_plist(self, target, profile_path):


### PR DESCRIPTION
Use plistlib.dump over plistlib.writePlist.

For PY2, plistlib.writePlist is still needed, but use plistlib.dump if it
is available instead to avoid deprecation output at runtime.