### PR TITLE
Move to shared environment.plist generation

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -29,7 +29,32 @@ filegroup(
 )
 
 environment_plist(
-    name = "environment_plist",
+    name = "environment_plist_ios",
+    platform_type = "ios",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+environment_plist(
+    name = "environment_plist_macos",
+    platform_type = "macos",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+environment_plist(
+    name = "environment_plist_watchos",
+    platform_type = "watchos",
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+environment_plist(
+    name = "environment_plist_tvos",
+    platform_type = "tvos",
     visibility = [
         "//visibility:public",
     ],

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -5,6 +5,11 @@
 
 licenses(["notice"])
 
+load(
+    "@build_bazel_rules_apple//apple/internal:environment_plist.bzl",
+    "environment_plist",
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",
@@ -20,5 +25,12 @@ filegroup(
     ],
     visibility = [
         "//apple:__subpackages__",
+    ],
+)
+
+environment_plist(
+    name = "environment_plist",
+    visibility = [
+        "//visibility:public",
     ],
 )

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+A rule for generating the environment plist
+"""
+
 load(
     "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
     "rule_factory",
@@ -27,10 +31,6 @@ load(
 load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _environment_plist(ctx):

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -20,25 +20,19 @@ load(
 )
 
 def _environment_plist(ctx):
-    environment_plist = ctx.actions.declare_file(
-        paths.join("{}-intermediates".format(ctx.label.name), "Environment-Info.plist"),
-    )
-
     platform, sdk_version = platform_support.platform_and_sdk_version(ctx)
     platform_with_version = platform.name_in_plist.lower() + str(sdk_version)
     legacy_actions.run(
         ctx,
-        outputs = [environment_plist],
+        outputs = [ctx.outputs.plist],
         executable = ctx.executable._environment_plist,
         arguments = [
             "--platform",
             platform_with_version,
             "--output",
-            environment_plist.path,
+            ctx.outputs.plist.path,
         ],
     )
-
-    return [DefaultInfo(files = depset([environment_plist]))]
 
 environment_plist = rule(
     attrs = dicts.add(
@@ -49,9 +43,10 @@ environment_plist = rule(
                 executable = True,
                 default = Label("@build_bazel_rules_apple//tools/environment_plist"),
             ),
-            "platform_type": attr.string(default = str(apple_common.platform_type.ios)),
+            "platform_type": attr.string(mandatory = True),
         },
     ),
     fragments = ["apple"],
+    outputs = {"plist": "%{name}.plist"},
     implementation = _environment_plist,
 )

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -1,3 +1,17 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load(
     "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
     "rule_factory",
@@ -25,7 +39,7 @@ def _environment_plist(ctx):
     legacy_actions.run(
         ctx,
         outputs = [ctx.outputs.plist],
-        executable = ctx.executable._environment_plist,
+        executable = ctx.executable._environment_plist_tool,
         arguments = [
             "--platform",
             platform_with_version,
@@ -38,14 +52,24 @@ environment_plist = rule(
     attrs = dicts.add(
         rule_factory.common_tool_attributes,
         {
-            "_environment_plist": attr.label(
+            "_environment_plist_tool": attr.label(
                 cfg = "host",
                 executable = True,
                 default = Label("@build_bazel_rules_apple//tools/environment_plist"),
             ),
-            "platform_type": attr.string(mandatory = True),
+            "platform_type": attr.string(
+                mandatory = True,
+                doc = """
+The platform for which the plist is being generated
+""",
+            ),
         },
     ),
+    doc = """
+This rule generates the plist containing the required variables about the versions the target is being
+built for and with. This is used by Apple when submitting to the App Store. This reduces the amount of
+duplicative work done generating these plists for the same platforms.
+""",
     fragments = ["apple"],
     outputs = {"plist": "%{name}.plist"},
     implementation = _environment_plist,

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -1,0 +1,57 @@
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:legacy_actions.bzl",
+    "legacy_actions",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "platform_support",
+)
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+
+def _environment_plist(ctx):
+    environment_plist = ctx.actions.declare_file(
+        paths.join("{}-intermediates".format(ctx.label.name), "Environment-Info.plist"),
+    )
+
+    platform, sdk_version = platform_support.platform_and_sdk_version(ctx)
+    platform_with_version = platform.name_in_plist.lower() + str(sdk_version)
+    legacy_actions.run(
+        ctx,
+        outputs = [environment_plist],
+        executable = ctx.executable._environment_plist,
+        arguments = [
+            "--platform",
+            platform_with_version,
+            "--output",
+            environment_plist.path,
+        ],
+    )
+
+    return [DefaultInfo(files = depset([environment_plist]))]
+
+environment_plist = rule(
+    attrs = dicts.add(
+        rule_factory.common_tool_attributes,
+        {
+            "_environment_plist": attr.label(
+                cfg = "host",
+                executable = True,
+                default = Label("@build_bazel_rules_apple//tools/environment_plist"),
+            ),
+            "platform_type": attr.string(default = str(apple_common.platform_type.ios)),
+        },
+    ),
+    fragments = ["apple"],
+    implementation = _environment_plist,
+)

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -111,6 +111,10 @@ macos_binary_infoplist = rule(
             "platform_type": attr.string(
                 default = str(apple_common.platform_type.macos),
             ),
+            "_environment_plist": attr.label(
+                allow_single_file = True,
+                default = "@build_bazel_rules_apple//apple/internal:environment_plist_macos",
+            ),
             "version": attr.label(providers = [[AppleBundleVersionInfo]]),
             "_product_type": attr.string(default = apple_product_type.tool),
         },

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -19,10 +19,6 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:legacy_actions.bzl",
-    "legacy_actions",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
     "bundling_support",
 )

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -276,20 +276,18 @@ def merge_root_infoplists(
     else:
         plist_key = "MinimumOSVersion"
 
-    if hasattr(ctx.attr, "_environment_plist"):
-        input_files.extend(ctx.attr._environment_plist.files.to_list())
-        forced_plists.extend([x.path for x in ctx.attr._environment_plist.files.to_list()])
-
+    input_files.append(ctx.file._environment_plist)
     platform, sdk_version = platform_support.platform_and_sdk_version(ctx)
     platform_with_version = platform.name_in_plist.lower() + str(sdk_version)
-    forced_plists.append(
+    forced_plists.extend([
+        ctx.file._environment_plist.path,
         struct(
             CFBundleSupportedPlatforms = [platform.name_in_plist],
             DTPlatformName = platform.name_in_plist.lower(),
             DTSDKName = platform_with_version,
             **{plist_key: platform_support.minimum_os(ctx)}
         ),
-    )
+    ])
 
     output_files = [output_plist]
     if output_pkginfo:

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -114,11 +114,6 @@ _COMMON_PRIVATE_TOOL_ATTRS = dicts.add(
                 "@build_bazel_rules_apple//apple/internal/templates:dsym_info_plist_template",
             ),
         ),
-        "_environment_plist": attr.label(
-            cfg = "host",
-            executable = True,
-            default = Label("@build_bazel_rules_apple//tools/environment_plist"),
-        ),
         "_plisttool": attr.label(
             cfg = "host",
             default = Label("@build_bazel_rules_apple//tools/plisttool"),
@@ -381,6 +376,13 @@ in the bundle.
             doc = """
 An `apple_bundle_version` target that represents the version for this target. See
 [`apple_bundle_version`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-general.md?cl=head#apple_bundle_version).
+""",
+        ),
+        "_environment_plist": attr.label(
+            default = "@build_bazel_rules_apple//apple/internal:environment_plist",
+            doc = """
+A generated Info.plist containing environment information required for uploading
+builds to Apple.
 """,
         ),
     })

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -378,13 +378,6 @@ An `apple_bundle_version` target that represents the version for this target. Se
 [`apple_bundle_version`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-general.md?cl=head#apple_bundle_version).
 """,
         ),
-        "_environment_plist": attr.label(
-            default = "@build_bazel_rules_apple//apple/internal:environment_plist",
-            doc = """
-A generated Info.plist containing environment information required for uploading
-builds to Apple.
-""",
-        ),
     })
 
     if len(rule_descriptor.allowed_device_families) > 1:
@@ -834,6 +827,10 @@ def _create_apple_binary_rule(implementation, platform_type, product_type, doc):
             # API.
             "platform_type": attr.string(default = platform_type),
             "_product_type": attr.string(default = product_type),
+            "_environment_plist": attr.label(
+                allow_single_file = True,
+                default = "@build_bazel_rules_apple//apple/internal:environment_plist_{}".format(platform_type),
+            ),
         },
     ]
 
@@ -870,6 +867,10 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
             # API.
             "platform_type": attr.string(default = platform_type),
             "_product_type": attr.string(default = product_type),
+            "_environment_plist": attr.label(
+                allow_single_file = True,
+                default = "@build_bazel_rules_apple//apple/internal:environment_plist_{}".format(platform_type),
+            ),
         },
     ]
 


### PR DESCRIPTION
This introduces a new rule that bundling rules depend on to generate the
environment plist a single time. This file is required when uploading
builds to Apple, and doesn't change if you build many similar targets.
This can greatly decrease build times if you have a lot of targets that
require this.