### PR TITLE
Move apple version tests to Skylark where possible.

### DIFF
--- a/test/apple_bundle_version_test.sh
+++ b/test/apple_bundle_version_test.sh
@@ -63,39 +63,6 @@ function tear_down() {
   rm -rf pkg
 }
 
-# Tests that manual version numbers work correctly.
-function test_manual_version_numbers() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_version = "1.2.3",
-    short_version_string = "1.2",
-)
-EOF
-
-  do_build ios //pkg:saved_version || \
-      fail "Should build"
-  assert_contains "\"build_version\": \"1.2.3\"" test-bin/pkg/saved_version.txt
-  assert_contains "\"short_version_string\": \"1.2\"" \
-      test-bin/pkg/saved_version.txt
-}
-
-# Tests that short_version_string defaults to the same value as build_version
-# if not specified.
-function test_short_version_string_defaults_to_build_version() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_version = "1.2.3",
-)
-EOF
-
-  do_build ios //pkg:saved_version || fail "Should build"
-  assert_contains "\"build_version\": \"1.2.3\"" test-bin/pkg/saved_version.txt
-  assert_contains "\"short_version_string\": \"1.2.3\"" \
-      test-bin/pkg/saved_version.txt
-}
-
 # Test that the build label passed via --embed_label can be parsed out
 # correctly.
 function test_build_label_substitution() {
@@ -116,31 +83,6 @@ EOF
       fail "Should build"
   assert_contains "\"build_version\": \"1.2.3\"" test-bin/pkg/saved_version.txt
   assert_contains "\"short_version_string\": \"1.2\"" \
-      test-bin/pkg/saved_version.txt
-}
-
-# Test that the fallback_build_label is used when --embed_label is not
-# passed on the build.
-function test_build_label_substitution_from_fallback_label() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
-    build_version = "{version}.{candidate}",
-    fallback_build_label = "MyApp_99.99_RC99",
-    short_version_string = "{version}",
-    capture_groups = {
-        "version": "\\d+\.\\d+",
-        "candidate": "\\d+",
-    },
-)
-EOF
-
-  do_build ios //pkg:saved_version || \
-      fail "Should build"
-  assert_contains "\"build_version\": \"99.99.99\"" \
-      test-bin/pkg/saved_version.txt
-  assert_contains "\"short_version_string\": \"99.99\"" \
       test-bin/pkg/saved_version.txt
 }
 
@@ -168,101 +110,10 @@ EOF
       test-bin/pkg/saved_version.txt
 }
 
-# Tests that short_version_string defaults to the same value as build_version
-# if not specified.
-function test_short_version_string_defaults_to_build_version_with_label_substitution() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
-    build_version = "{version}.{candidate}",
-    capture_groups = {
-        "version": "\\d+\.\\d+",
-        "candidate": "\\d+",
-    },
-)
-EOF
-
-  do_build ios //pkg:saved_version --embed_label=MyApp_1.2_RC03 || \
-      fail "Should build"
-  assert_contains "\"build_version\": \"1.2.3\"" test-bin/pkg/saved_version.txt
-  assert_contains "\"short_version_string\": \"1.2.3\"" \
-      test-bin/pkg/saved_version.txt
-}
-
-# Tests that a build_label_pattern that contains placeholders not found in
-# capture_groups fails.
-function test_pattern_referencing_missing_capture_groups_fails() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC00",
-    build_version = "{version}.{candidate}",
-    capture_groups = {
-        "version": "\\d+",
-    },
-)
-EOF
-
-  ! do_build ios //pkg:saved_version --embed_label=MyApp_1.2_RC03 || \
-      fail "Should fail"
-  expect_log "Some groups were not defined in capture_groups: \[candidate\]"
-}
-
-# Tests that the build fails if build_label_pattern is provided but
-# capture_groups is not.
-function test_build_label_pattern_requires_capture_groups() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
-    build_version = "{version}.{candidate}",
-)
-EOF
-
-  ! do_build ios //pkg:saved_version --embed_label=MyApp_1.2_RC03 || \
-      fail "Should fail"
-  expect_log "If either build_label_pattern or capture_groups is provided, then both must be provided"
-}
-
-# Tests that the build fails if capture_groups is provided but
-# build_label_pattern is not.
-function test_capture_groups_requires_build_label_pattern() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_version = "{version}.{candidate}",
-    capture_groups = {
-        "foo": "bar",
-    },
-)
-EOF
-
-  ! do_build ios //pkg:saved_version --embed_label=MyApp_1.2_RC03 || \
-      fail "Should fail"
-  expect_log "If either build_label_pattern or capture_groups is provided, then both must be provided"
-}
-
-# Tests that the build fails if fallback_build_label is provided but
-# build_label_pattern is not.
-function test_fallback_build_label_requires_build_label_pattern() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_version = "1.2",
-    fallback_build_label = "MyApp_1.2_RC03"
-)
-EOF
-
-  ! do_build ios //pkg:saved_version || \
-      fail "Should fail"
-  expect_log "If fallback_build_label is provided, then build_label_pattern and capture_groups must be provided."
-}
-
 
 # Test that the build fails if the build label does not match the regular
 # expression that is built after substituting the regex groups for the
-# placeholders.
+# placeholders. This fails during tool execution.
 function test_build_label_that_does_not_match_regex_fails() {
   cat >> pkg/BUILD <<EOF
 apple_bundle_version(
@@ -282,48 +133,5 @@ EOF
   expect_log "The build label (\"MyApp_1.2_RC03\") did not match the pattern"
 }
 
-# Test that substitution does not occur if there is a build label pattern but
-# --embed_label is not specified on the command line. (This supports local
-# builds).
-function test_no_substitution_if_build_label_not_present() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
-    build_version = "{version}.{candidate}",
-    short_version_string = "{version}",
-    capture_groups = {
-        "version": "\\d+\.\\d+",
-        "candidate": "\\d+",
-    },
-)
-EOF
-
-  do_build ios //pkg:saved_version || fail "Should build"
-  assert_contains "{}" test-bin/pkg/saved_version.txt
-}
-
-# Test that the presence of a build label pattern does not short circuit the
-# use of a literal version string, even if no --embed_label argument is
-# provided.
-function test_build_label_pattern_does_not_short_circuit_literal_version() {
-  cat >> pkg/BUILD <<EOF
-apple_bundle_version(
-    name = "bundle_version",
-    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
-    build_version = "1.2.3",
-    short_version_string = "1.2",
-    capture_groups = {
-        "version": "\\d+\.\\d+",
-        "candidate": "\\d+",
-    },
-)
-EOF
-
-  do_build ios //pkg:saved_version || fail "Should build"
-  assert_contains "\"build_version\": \"1.2.3\"" test-bin/pkg/saved_version.txt
-  assert_contains "\"short_version_string\": \"1.2\"" \
-      test-bin/pkg/saved_version.txt
-}
 
 run_suite "apple_bundle_version tests"

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -1,5 +1,6 @@
 licenses(["notice"])
 
+load(":apple_bundle_version_tests.bzl", "apple_bundle_version_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
 load(":ios_extension_tests.bzl", "ios_extension_test_suite")
 load(":ios_framework_tests.bzl", "ios_framework_test_suite")
@@ -19,6 +20,8 @@ load(":tvos_ui_test_tests.bzl", "tvos_ui_test_test_suite")
 load(":tvos_unit_test_tests.bzl", "tvos_unit_test_test_suite")
 load(":watchos_application_tests.bzl", "watchos_application_test_suite")
 load(":watchos_extension_tests.bzl", "watchos_extension_test_suite")
+
+apple_bundle_version_test_suite()
 
 ios_application_test_suite()
 

--- a/test/starlark_tests/apple_bundle_version_tests.bzl
+++ b/test/starlark_tests/apple_bundle_version_tests.bzl
@@ -1,0 +1,134 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""apple_bundle_version Starlark tests."""
+
+load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
+    ":rules/infoplist_contents_test.bzl",
+    "infoplist_contents_test",
+)
+
+def apple_bundle_version_test_suite():
+    """Test suite for apple_bundle_version."""
+    name = "apple_bundle_version"
+
+    # Tests that manual version numbers work correctly.
+    infoplist_contents_test(
+        name = "{}_manual_version".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:manual_1_2_build_1_2_3_bundle",
+        expected_values = {
+            "CFBundleVersion": "1.2.3",
+            "CFBundleShortVersionString": "1.2",
+        },
+        tags = [name],
+    )
+
+    # Tests that short_version_string defaults to the same value as build_version.
+    infoplist_contents_test(
+        name = "{}_short_version_defaults_to_build_version".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:only_build_version_1_2_3_bundle",
+        expected_values = {
+            "CFBundleVersion": "1.2.3",
+            "CFBundleShortVersionString": "1.2.3",
+        },
+        tags = [name],
+    )
+
+    # Test that the fallback_build_label is used when --embed_label is not passed on the build.
+    infoplist_contents_test(
+        name = "{}_build_label_substitution_from_fallback_label".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:build_label_substitution_from_fallback_label_bundle",
+        expected_values = {
+            "CFBundleVersion": "99.99.99",
+            "CFBundleShortVersionString": "99.99",
+        },
+        tags = [name],
+    )
+
+    # Tests that short_version_string defaults to the same value as build_version when using
+    # substitution.
+    infoplist_contents_test(
+        name = "{}_short_version_string_defaults_to_build_version_substitution".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:short_version_string_defaults_to_build_version_substitution_bundle",
+        expected_values = {
+            "CFBundleVersion": "1.2.3",
+            "CFBundleShortVersionString": "1.2.3",
+        },
+        tags = [name],
+    )
+
+    # Tests that a build_label_pattern that contains placeholders not found in capture_groups
+    # causes analysis to fail.
+    analysis_failure_message_test(
+        name = "{}_pattern_referencing_missing_capture_groups_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:pattern_referencing_missing_capture_groups_fail",
+        expected_error = "Some groups were not defined in capture_groups",
+    )
+
+    # Tests that the analysis fails if build_label_pattern is provided but capture_groups
+    # is not.
+    analysis_failure_message_test(
+        name = "{}_build_label_pattern_requires_capture_groups_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:build_label_pattern_requires_capture_groups_fail",
+        expected_error = "If either build_label_pattern or capture_groups is provided, then both must be provided.",
+    )
+
+    # Tests that the analysis fails if capture_groups is provided but build_label_pattern
+    # is not.
+    analysis_failure_message_test(
+        name = "{}_capture_groups_requires_build_label_pattern_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:capture_groups_requires_build_label_pattern_fail",
+        expected_error = "If either build_label_pattern or capture_groups is provided, then both must be provided.",
+    )
+
+    # Tests that the analysis fails if fallback_build_label is provided but build_label_pattern
+    # is not.
+    analysis_failure_message_test(
+        name = "{}_fallback_build_label_requires_build_label_pattern_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:fallback_build_label_requires_build_label_pattern_fail",
+        expected_error = "If fallback_build_label is provided, then build_label_pattern and capture_groups must be provided.",
+    )
+
+    # Test that substitution does not occur if there is a build label pattern but --embed_label
+    # is not specified on the command line. (This supports local builds).
+    infoplist_contents_test(
+        name = "{}_no_substitution_if_build_label_not_present".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:no_substitution_if_build_label_not_present_bundle",
+        expected_values = {
+            "CFBundleVersion": "1.0",
+            "CFBundleShortVersionString": "1.0",
+        },
+        tags = [name],
+    )
+
+    # Test that the presence of a build label pattern does not short circuit the use of a literal
+    # version string, even if no --embed_label argument is provided.
+    infoplist_contents_test(
+        name = "{}_build_label_pattern_does_not_short_circuit_literal".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:build_label_pattern_does_not_short_circuit_literal_bundle",
+        expected_values = {
+            "CFBundleVersion": "1.2.3",
+            "CFBundleShortVersionString": "1.2",
+        },
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1,0 +1,177 @@
+licenses(["notice"])
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//test/starlark_tests:__subpackages__"],
+)
+
+TARGETS_UNDER_TEST_TAGS = [
+    "manual",
+    "notap",
+]
+
+load(
+    "//apple:versioning.bzl",
+    "apple_bundle_version",
+)
+load(
+    "//apple:macos.bzl",
+    "macos_bundle",
+)
+
+# This is a list of Apple targets to be used for Starlark unit tests. These may not build correctly
+# since most of them do not have any source dependencies, so they are all tagged as manual and
+# notap to avoid them being built/tested when testing the
+# //test/... package.
+
+apple_bundle_version(
+    name = "manual_1_2_build_1_2_3_version",
+    build_version = "1.2.3",
+    short_version_string = "1.2",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "manual_1_2_build_1_2_3_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":manual_1_2_build_1_2_3_version",
+)
+
+apple_bundle_version(
+    name = "only_build_version_1_2_3_version",
+    build_version = "1.2.3",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "only_build_version_1_2_3_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":only_build_version_1_2_3_version",
+)
+
+apple_bundle_version(
+    name = "build_label_substitution_from_fallback_label_version",
+    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
+    build_version = "{version}.{candidate}",
+    capture_groups = {
+        "version": "\\d+\.\\d+",
+        "candidate": "\\d+",
+    },
+    fallback_build_label = "MyApp_99.99_RC99",
+    short_version_string = "{version}",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "build_label_substitution_from_fallback_label_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":build_label_substitution_from_fallback_label_version",
+)
+
+apple_bundle_version(
+    name = "short_version_string_defaults_to_build_version_substitution_version",
+    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
+    build_version = "{version}.{candidate}",
+    capture_groups = {
+        "version": "\\d+\.\\d+",
+        "candidate": "\\d+",
+    },
+    fallback_build_label = "MyApp_1.2_RC03",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "short_version_string_defaults_to_build_version_substitution_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":short_version_string_defaults_to_build_version_substitution_version",
+)
+
+apple_bundle_version(
+    name = "pattern_referencing_missing_capture_groups_fail",
+    build_label_pattern = "MyApp_{version}_RC00",
+    build_version = "{version}.{candidate}",
+    capture_groups = {
+        "version": "\\d+",
+    },
+    fallback_build_label = "MyApp_1.2_RC03",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+apple_bundle_version(
+    name = "build_label_pattern_requires_capture_groups_fail",
+    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
+    build_version = "{version}.{candidate}",
+    fallback_build_label = "MyApp_1.2_RC03",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+apple_bundle_version(
+    name = "capture_groups_requires_build_label_pattern_fail",
+    build_version = "{version}.{candidate}",
+    capture_groups = {
+        "foo": "bar",
+    },
+    fallback_build_label = "MyApp_1.2_RC03",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+apple_bundle_version(
+    name = "fallback_build_label_requires_build_label_pattern_fail",
+    build_version = "1.2",
+    fallback_build_label = "MyApp_1.2_RC03",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+apple_bundle_version(
+    name = "no_substitution_if_build_label_not_present_version",
+    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
+    build_version = "{version}.{candidate}",
+    capture_groups = {
+        "version": "\\d+\.\\d+",
+        "candidate": "\\d+",
+    },
+    short_version_string = "{version}",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "no_substitution_if_build_label_not_present_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":no_substitution_if_build_label_not_present_version",
+)
+
+apple_bundle_version(
+    name = "build_label_pattern_does_not_short_circuit_literal_version",
+    build_label_pattern = "MyApp_{version}_RC0*{candidate}",
+    build_version = "1.2.3",
+    capture_groups = {
+        "version": "\\d+\.\\d+",
+        "candidate": "\\d+",
+    },
+    short_version_string = "1.2",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+macos_bundle(
+    name = "build_label_pattern_does_not_short_circuit_literal_bundle",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "10.10",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    version = ":build_label_pattern_does_not_short_circuit_literal_version",
+)


### PR DESCRIPTION
Move apple version tests to Skylark where possible.

Two issues are making it impossible to migrate all tests:
 - The `embed_label` flag is not in the configuration and can't be modified in a transition
 - Some of the failures we test for happen when the action is run(the tool throws errors) and the Skylark testing framework currently doesn't have a way to test failures outside of the Analysis stage.