### PR TITLE
Ensuring the absolute path is used for actool actions.

### DIFF
--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -212,7 +212,7 @@ def compile_asset_catalog(ctx, asset_files, output_dir, output_plist):
         attr = "asset_catalogs",
     ).keys()
 
-    args.extend(xcassets)
+    args.extend([xctoolrunner.prefixed_path(xcasset) for xcasset in xcassets])
 
     legacy_actions.run(
         ctx,


### PR DESCRIPTION
Ensuring the absolute path is used for actool actions.

This prevents tool failures if an asset catalog is located at the root of a workspace as the build process creates symbolic links to the original source folder during the build. actool appears to not follow symbolic links.

RELNOTES:
Ensuring the absolute path is used for actool actions.