### PR TITLE
Clean up all usages of binary_tags, since they no longer serve any purpose.

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -131,10 +131,6 @@ def ios_ui_test(
         **kwargs):
     """Builds an iOS XCUITest test target."""
 
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
-
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method
     # to have testonly to True since it's always going to be a dependency of a test target. This can
@@ -185,10 +181,6 @@ def ios_unit_test(
         test_host = None,
         **kwargs):
     """Builds an iOS XCTest test target."""
-
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
 
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -291,10 +291,6 @@ def macos_unit_test(
         **kwargs):
     """Builds macOS XCTest test target."""
 
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
-
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method
     # to have testonly to True since it's always going to be a dependency of a test target. This can
@@ -323,10 +319,6 @@ def macos_ui_test(
         name,
         **kwargs):
     """Builds an macOS XCUITest test target."""
-
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
 
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -90,10 +90,6 @@ def tvos_unit_test(
         **kwargs):
     """Builds an tvOS XCTest test target."""
 
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
-
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method
     # to have testonly to True since it's always going to be a dependency of a test target. This can
@@ -122,10 +118,6 @@ def tvos_ui_test(
         name,
         **kwargs):
     """Builds an tvOS XCUITest test target."""
-
-    # Discard binary_tags for now, as there is no apple_binary target any more to apply them to.
-    # TODO(kaipi): Cleanup binary_tags for tests and remove this.
-    kwargs.pop("binary_tags", None)
 
     # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
     # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method


### PR DESCRIPTION
Clean up all usages of binary_tags, since they no longer serve any purpose.