### PR TITLE
A rule to test the contents of an archive via environmental variables

### DIFF
--- a/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
+++ b/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
@@ -31,5 +31,21 @@ BUNDLE_ROOT="$ARCHIVE_ROOT/%{archive_relative_bundle}s"
 CONTENT_ROOT="$ARCHIVE_ROOT/%{archive_relative_contents}s"
 RESOURCE_ROOT="$ARCHIVE_ROOT/%{archive_relative_resources}s"
 
+# Parse any environmental variables passed into bash arrays for use within the
+# sourced verification scripts.
+if [[ -n "${APPLE_TEST_ENV_KEYS-}" ]]; then
+  for key in $APPLE_TEST_ENV_KEYS
+  do
+    eval "declare -a ${key}"
+    eval "${key}=()"
+    i="0"
+    while eval "[[ -n \${APPLE_TEST_ENV_${key}_${i}-} ]]"
+    do
+      eval "${key}+=(\"\${APPLE_TEST_ENV_${key}_${i}}\")"
+      i=$[$i+1]
+    done
+  done
+fi
+
 # Invoke the verifier script.
 source %{verifier_script}s

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+newline=$'\n'
+
+# This script allows many of the functions in apple_shell_testutils.sh to be
+# called through apple_verification_test_runner.sh.template by using environment
+# variables.
+#
+# Supported operations:
+#  CONTAINS: takes a list of files to test for existance
+#  NOT_CONTAINS: takes a list of files to test for non-existance
+
+# Test that the archive contains the specified files in the CONTAIN env var.
+if [[ -n "${CONTAINS-}" ]]; then
+  for path in "${CONTAINS[@]}"
+  do
+    if [[ ! -e "$ARCHIVE_ROOT/$path" ]]; then
+      fail "Archive did not contain \"$path\"" \
+        "contents were:$newline$(find $ARCHIVE_ROOT)"
+    fi
+  done
+fi
+
+# Test that the archive doesn't contains the specified files in NOT_CONTAINS.
+if [[ -n "${NOT_CONTAINS-}" ]]; then
+  for path in "${NOT_CONTAINS[@]}"
+  do
+    if [[ -e "$ARCHIVE_ROOT/$path" ]]; then
+      fail "Archive did contain \"$path\""
+    fi
+  done
+fi
+


### PR DESCRIPTION
A rule to test the contents of an archive via environmental variables

Currently this just tests for existance and non-existance, but will likely be expanded to cover other common tests(e.g. assert_plist_is_text, assert_binary_contains, etc