### PR TITLE
Split test rules into a bundle rule and a test rule.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -35,10 +35,12 @@ load(
     "apple_resource_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_info_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "AppleTestRunnerInfo",
     "coverage_files_aspect",
-    "test_info_aspect",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
@@ -53,6 +55,7 @@ load(
     "AppleBundleInfo",
     "AppleBundleVersionInfo",
     "AppleResourceBundleInfo",
+    "AppleTestRunnerInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
@@ -162,42 +165,53 @@ _COMMON_PRIVATE_TOOL_ATTRS = dicts.add(
     apple_support.action_required_attrs(),
 )
 
-def _common_test_attributes(rule_descriptor):
-    return {
-        "data": attr.label_list(
-            allow_files = True,
-            default = [],
-            doc = "Files to be made available to the test during its execution.",
-        ),
-        "env": attr.string_dict(
-            doc = """
+_COMMON_TEST_ATTRS = {
+    "data": attr.label_list(
+        allow_files = True,
+        default = [],
+        doc = "Files to be made available to the test during its execution.",
+    ),
+    "env": attr.string_dict(
+        doc = """
 Dictionary of environment variables that should be set during the test execution.
 """,
-        ),
-        "runner": attr.label(
-            doc = """
+    ),
+    "runner": attr.label(
+        doc = """
 The runner target that will provide the logic on how to run the tests. Needs to provide the
 AppleTestRunnerInfo provider.
-    """,
-            default = Label(rule_descriptor.default_test_runner),
-            providers = [AppleTestRunnerInfo],
-        ),
-        "_apple_coverage_support": attr.label(
-            cfg = "host",
-            default = Label("@build_bazel_apple_support//tools:coverage_support"),
-        ),
-        # gcov and mcov are binary files required to calculate test coverage.
-        "_gcov": attr.label(
-            cfg = "host",
-            default = Label("@bazel_tools//tools/objc:gcov"),
-            allow_single_file = True,
-        ),
-        "_mcov": attr.label(
-            cfg = "host",
-            default = Label("@bazel_tools//tools/objc:mcov"),
-            allow_single_file = True,
-        ),
-    }
+""",
+        mandatory = True,
+        providers = [AppleTestRunnerInfo],
+    ),
+    # This is an implementation detail attribute, so it's not documented on purpose.
+    "deps": attr.label_list(
+        mandatory = True,
+        aspects = [coverage_files_aspect],
+        providers = [AppleBundleInfo],
+    ),
+    # TODO(b/139430318): This attribute exists to apease the Tulsi gods and is not actually used by
+    # the test rule implementation, and should be removed.
+    # This is an implementation detail attribute, so it's not documented on purpose.
+    "test_host": attr.label(
+        providers = [AppleBundleInfo],
+    ),
+    "_apple_coverage_support": attr.label(
+        cfg = "host",
+        default = Label("@build_bazel_apple_support//tools:coverage_support"),
+    ),
+    # gcov and mcov are binary files required to calculate test coverage.
+    "_gcov": attr.label(
+        cfg = "host",
+        default = Label("@bazel_tools//tools/objc:gcov"),
+        allow_single_file = True,
+    ),
+    "_mcov": attr.label(
+        cfg = "host",
+        default = Label("@bazel_tools//tools/objc:mcov"),
+        allow_single_file = True,
+    ),
+}
 
 def _common_binary_linking_attrs(rule_descriptor):
     deps_aspects = [
@@ -207,7 +221,7 @@ def _common_binary_linking_attrs(rule_descriptor):
         swift_usage_aspect,
     ]
     if _is_test_product_type(rule_descriptor.product_type):
-        deps_aspects.extend([coverage_files_aspect, test_info_aspect])
+        deps_aspects.extend([apple_test_info_aspect])
 
     return {
         "binary_type": attr.string(
@@ -587,7 +601,7 @@ the application bundle.
 
         attrs.append({
             "test_host": attr.label(
-                aspects = [coverage_files_aspect, framework_import_aspect],
+                aspects = [framework_import_aspect],
                 mandatory = test_host_mandatory,
                 providers = required_providers,
             ),
@@ -665,7 +679,7 @@ set, then the default extension is determined by the application's product_type.
         test_host_mandatory = rule_descriptor.product_type == apple_product_type.ui_test_bundle
         attrs.append({
             "test_host": attr.label(
-                aspects = [coverage_files_aspect, framework_import_aspect],
+                aspects = [framework_import_aspect],
                 mandatory = test_host_mandatory,
                 providers = [AppleBundleInfo, MacosApplicationBundleInfo],
             ),
@@ -707,7 +721,7 @@ use only extension-safe APIs.
         test_host_mandatory = rule_descriptor.product_type == apple_product_type.ui_test_bundle
         attrs.append({
             "test_host": attr.label(
-                aspects = [coverage_files_aspect, framework_import_aspect],
+                aspects = [framework_import_aspect],
                 mandatory = test_host_mandatory,
                 providers = [AppleBundleInfo, TvosApplicationBundleInfo],
             ),
@@ -890,8 +904,6 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
         rule_attrs.append(_common_binary_linking_attrs(rule_descriptor))
 
     is_test_product_type = _is_test_product_type(rule_descriptor.product_type)
-    if is_test_product_type:
-        rule_attrs.append(_common_test_attributes(rule_descriptor))
 
     # TODO(kaipi): Add support for all platforms.
     if platform_type == "ios":
@@ -921,11 +933,38 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
         fragments = ["apple", "cpp", "objc"],
         # TODO(kaipi): Remove the implicit output and use DefaultInfo instead.
         outputs = {"archive": archive_name},
-        test = is_test_product_type,
+    )
+
+def _create_apple_test_rule(implementation, doc, platform_type, cfg = None):
+    """Creates an Apple test rule."""
+
+    # Add the platform_type and minimum_os_version attribute to this rule so that we can apply the
+    # same configuration transition as the bundling rules. This is to ensure that the built
+    # artifacts from the test rules and bundling rules are placed in the same configuration-specific
+    # output.
+    extra_attrs = [{
+        "platform_type": attr.string(default = platform_type),
+        "minimum_os_version": attr.string(mandatory = True),
+    }]
+    if cfg:
+        extra_attrs.append({
+            "_whitelist_function_transition": attr.label(
+                default = "//tools/whitelists/function_transition_whitelist",
+            ),
+        })
+
+    return rule(
+        implementation = implementation,
+        attrs = dicts.add(_COMMON_PRIVATE_TOOL_ATTRS, _COMMON_TEST_ATTRS, *extra_attrs),
+        cfg = cfg,
+        doc = doc,
+        outputs = {"archive": "%{name}.zip"},
+        test = True,
     )
 
 rule_factory = struct(
     common_tool_attributes = _COMMON_PRIVATE_TOOL_ATTRS,
     create_apple_binary_rule = _create_apple_binary_rule,
     create_apple_bundling_rule = _create_apple_bundling_rule,
+    create_apple_test_rule = _create_apple_test_rule,
 )

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -1,0 +1,121 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper methods for assembling the test targets."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
+    "binary_support",
+)
+
+# Attributes belonging to the bundling rules that should be removed from the test targets.
+_BUNDLE_ATTRS = {
+    x: None
+    for x in [
+        "additional_contents",
+        "deps",
+        "dylibs",
+        "bundle_id",
+        "bundle_name",
+        "bundle_loader",
+        "families",
+        "frameworks",
+        "infoplists",
+        "linkopts",
+        "minimum_os_version",
+        "provisioning_profile",
+        "resources",
+        "test_host",
+    ]
+}
+
+def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwargs):
+    """Assembles the test bundle and test targets.
+
+    This method expects that either `runner` or `runners` is populated, but never both. If `runner`
+    is given, then a single test target will be created under the given name. If `runners` is given
+    then a test target will be created for each runner and a single `test_suite` target will be
+    created under the given name, wrapping the created targets.
+
+    The `kwargs` dictionary will contain both bundle and test attributes that this method will split
+    accordingly.
+
+    Attrs:
+        name: The name of the test target or test suite to create.
+        bundle_rule: The bundling rule to instantiate.
+        test_rule: The test rule to instantiate.
+        runner: A single runner target to use for the test target. Mutually exclusive with
+            `runners`.
+        runners: A list of runner targets to use for the test targets. Mutually exclusive with
+            `runner`.
+        **kwargs: The complete list of attributes to distribute between the bundle and test targets.
+    """
+    if runner != None and runners != None:
+        fail("Can't specify both runner and runners.")
+    elif not runner and not runners:
+        fail("Must specify one of runner or runners.")
+
+    test_bundle_name = name + ".__internal__.__test_bundle"
+
+    test_attrs = {k: v for (k, v) in kwargs.items() if k not in _BUNDLE_ATTRS}
+    bundle_attrs = {k: v for (k, v) in kwargs.items() if k in _BUNDLE_ATTRS}
+
+    if "bundle_name" in kwargs:
+        fail("bundle_name is not supported in test rules.")
+
+    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+        test_bundle_name,
+        bundle_name = name,
+        platform_type = str(apple_common.platform_type.ios),
+        include_entitlements = False,
+        testonly = True,
+        **bundle_attrs
+    )
+
+    bundle_rule(
+        name = test_bundle_name,
+        visibility = ["//visibility:private"],
+        **bundling_args
+    )
+
+    if runner:
+        test_rule(
+            name = name,
+            runner = runner,
+            minimum_os_version = bundling_args.get("minimum_os_version"),
+            test_host = bundling_args.get("test_host"),
+            deps = [":{}".format(test_bundle_name)],
+            **test_attrs
+        )
+    elif runners:
+        tests = []
+        for runner in runners:
+            test_name = "{}_{}".format(name, runner.rsplit(":", maxsplit = 1)[-1])
+            tests.append(":{}".format(test_name))
+            test_rule(
+                name = test_name,
+                runner = runner,
+                minimum_os_version = bundling_args.get("minimum_os_version"),
+                test_host = bundling_args.get("test_host"),
+                deps = [":{}".format(test_bundle_name)],
+                **test_attrs
+            )
+        native.test_suite(
+            name = name,
+            tests = tests,
+        )
+
+apple_test_assembler = struct(
+    assemble = _assemble,
+)

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -15,104 +15,19 @@
 """Helper methods for implementing test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
-    "outputs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
+    "@build_bazel_rules_apple//apple/internal:file_support.bzl",
+    "file_support",
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
+    "AppleExtraOutputsInfo",
+    "AppleTestInfo",
+    "AppleTestRunnerInfo",
 )
 load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
-)
-load(
-    "@bazel_skylib//lib:types.bzl",
-    "types",
-)
-
-AppleTestInfo = provider(
-    doc = """
-Provider that test targets propagate to be used for IDE integration.
-
-This includes information regarding test source files, transitive include paths,
-transitive module maps, and transitive Swift modules. Test source files are
-considered to be all of which belong to the first-level dependencies on the test
-target.
-""",
-    fields = {
-        "includes": """
-`depset` of `string`s representing transitive include paths which are needed by
-IDEs to be used for indexing the test sources.
-""",
-        "module_maps": """
-`depset` of `File`s representing module maps which are needed by IDEs to be used
-for indexing the test sources.
-""",
-        "module_name": """
-`string` representing the module name used by the test's sources. This is only
-set if the test only contains a single top-level Swift dependency. This may be
-used by an IDE to identify the Swift module (if any) used by the test's sources.
-""",
-        "non_arc_sources": """
-`depset` of `File`s containing non-ARC sources from the test's immediate
-deps.
-""",
-        "sources": """
-`depset` of `File`s containing sources from the test's immediate deps.
-""",
-        "swift_modules": """
-`depset` of `File`s representing transitive swift modules which are needed by
-IDEs to be used for indexing the test sources.
-""",
-        "deps": """
-`depset` of `string`s representing the labels of all immediate deps of the test.
-Only source files from these deps will be present in `sources`. This may be used
-by IDEs to differentiate a test target's transitive module maps from its direct
-module maps, as including the direct module maps may break indexing for the
-source files of the immediate deps.
-""",
-    },
-)
-
-AppleTestRunnerInfo = provider(
-    doc = """
-Provider that runner targets must propagate.
-
-In addition to the fields, all the runfiles that the runner target declares will be added to the
-test rules runfiles.
-""",
-    fields = {
-        "execution_requirements": """
-Optional dictionary that represents the specific hardware requirements for this test.
-""",
-        "execution_environment": """
-Optional dictionary with the environment variables that are to be set in the test action, and are
-not propagated into the XCTest invocation. These values will _not_ be added into the %(test_env)s
-substitution, but will be set in the test action.
-""",
-        "test_environment": """
-Optional dictionary with the environment variables that are to be propagated into the XCTest
-invocation. These values will be included in the %(test_env)s substitution and will _not_ be set in
-the test action.
-""",
-        "test_runner_template": """
-Required template file that contains the specific mechanism with which the tests will be run. The
-apple_ui_test and apple_unit_test rules will substitute the following values:
-    * %(test_host_path)s:   Path to the app being tested.
-    * %(test_bundle_path)s: Path to the test bundle that contains the tests.
-    * %(test_env)s:         Environment variables for the XCTest invocation (e.g FOO=BAR,BAZ=QUX).
-    * %(test_type)s:        The test type, whether it is unit or UI.
-""",
-    },
 )
 
 CoverageFilesInfo = provider(
@@ -162,6 +77,10 @@ def _coverage_files_aspect_impl(target, ctx):
         coverage_files.append(fmwk[CoverageFilesInfo].coverage_files)
         transitive_binaries_sets.append(fmwk[CoverageFilesInfo].covered_binaries)
 
+    if hasattr(ctx.rule.attr, "test_host") and ctx.rule.attr.test_host:
+        coverage_files.append(ctx.rule.attr.test_host[CoverageFilesInfo].coverage_files)
+        transitive_binaries_sets.append(ctx.rule.attr.test_host[CoverageFilesInfo].covered_binaries)
+
     return [
         CoverageFilesInfo(
             coverage_files = depset(transitive = coverage_files),
@@ -173,85 +92,15 @@ def _coverage_files_aspect_impl(target, ctx):
     ]
 
 coverage_files_aspect = aspect(
-    attr_aspects = ["deps", "frameworks"],
+    attr_aspects = ["deps", "frameworks", "test_host"],
     doc = """
-This aspect walks the dependency graph through the `deps` and `frameworks` attributes and collects
-all the sources and headers that are depended upon transitively. These files are needed to calculate
-test coverage on a test run.
+This aspect walks the dependency graph through the dependency graph and collects all the sources and
+headers that are depended upon transitively. These files are needed to calculate test coverage on a
+test run.
 
 This aspect propagates a `CoverageFilesInfo` provider.
 """,
     implementation = _coverage_files_aspect_impl,
-)
-
-def _collect_files(rule_attr, attr_name):
-    """Collects files from attr_name (if present) into a depset."""
-
-    attr_val = getattr(rule_attr, attr_name, None)
-    if not attr_val:
-        return depset()
-
-    attr_val_as_list = attr_val if types.is_list(attr_val) else [attr_val]
-    return depset(transitive = [f.files for f in attr_val_as_list])
-
-def _test_info_aspect_impl(target, ctx):
-    """See `test_info_aspect` for full documentation."""
-    includes = []
-    module_maps = []
-    swift_modules = []
-
-    # Not all deps (i.e. source files) will have an AppleTestInfo provider. If the
-    # dep doesn't, just filter it out.
-    test_infos = [
-        x[AppleTestInfo]
-        for x in getattr(ctx.rule.attr, "deps", [])
-        if AppleTestInfo in x
-    ]
-
-    # Collect transitive information from deps.
-    for test_info in test_infos:
-        includes.append(test_info.includes)
-        module_maps.append(test_info.module_maps)
-        swift_modules.append(test_info.swift_modules)
-
-    if apple_common.Objc in target:
-        objc_provider = target[apple_common.Objc]
-        includes.append(objc_provider.include)
-
-        # Module maps should only be used by Swift targets.
-        if SwiftInfo in target:
-            module_maps.append(objc_provider.module_map)
-
-    if (SwiftInfo in target and
-        hasattr(target[SwiftInfo], "transitive_swiftmodules")):
-        swift_modules.append(target[SwiftInfo].transitive_swiftmodules)
-
-    # Collect sources from the current target and add any relevant transitive
-    # information. Note that we do not propagate sources transitively as we
-    # intentionally only show test sources from the test's first-level of
-    # dependencies instead of all transitive dependencies.
-    non_arc_sources = _collect_files(ctx.rule.attr, "non_arc_srcs")
-    sources = _collect_files(ctx.rule.attr, "srcs")
-
-    return [AppleTestInfo(
-        includes = depset(transitive = includes),
-        module_maps = depset(transitive = module_maps),
-        non_arc_sources = non_arc_sources,
-        sources = sources,
-        swift_modules = depset(transitive = swift_modules),
-    )]
-
-test_info_aspect = aspect(
-    attr_aspects = [
-        "deps",
-    ],
-    doc = """
-This aspect walks the dependency graph through the `deps` attribute and collects sources, transitive
-includes, transitive module maps, and transitive Swift modules.
-
-This aspect propagates an `AppleTestInfo` provider.
-""",
-    implementation = _test_info_aspect_impl,
 )
 
 def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None):
@@ -284,53 +133,12 @@ def _get_coverage_execution_environment(ctx, covered_binaries):
         "TEST_BINARIES_FOR_LLVM_COV": ";".join(covered_binary_paths),
     }
 
-def _apple_test_info_provider(deps):
-    """Returns an AppleTestInfo provider by collecting the relevant data from dependencies."""
-    dep_labels = []
-    swift_infos = []
-
-    transitive_includes = []
-    transitive_module_maps = []
-    transitive_non_arc_sources = []
-    transitive_sources = []
-    transitive_swift_modules = []
-
-    for dep in deps:
-        dep_labels.append(str(dep.label))
-
-        if SwiftInfo in dep:
-            swift_infos.append(dep[SwiftInfo])
-
-        test_info = dep[AppleTestInfo]
-
-        transitive_includes.append(test_info.includes)
-        transitive_module_maps.append(test_info.module_maps)
-        transitive_non_arc_sources.append(test_info.non_arc_sources)
-        transitive_sources.append(test_info.sources)
-        transitive_swift_modules.append(test_info.swift_modules)
-
-    # Set module_name only for test targets with a single Swift dependency.
-    # This is not used if there are multiple Swift dependencies, as it will
-    # not be possible to reduce them into a single Swift module and picking
-    # an arbitrary one is fragile.
-    module_name = None
-    if len(swift_infos) == 1:
-        module_name = getattr(swift_infos[0], "module_name", None)
-
-    return AppleTestInfo(
-        deps = depset(dep_labels),
-        includes = depset(transitive = transitive_includes),
-        module_maps = depset(transitive = transitive_module_maps),
-        module_name = module_name,
-        non_arc_sources = depset(transitive = transitive_non_arc_sources),
-        sources = depset(transitive = transitive_sources),
-        swift_modules = depset(transitive = transitive_swift_modules),
-    )
-
-def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
+def _apple_test_rule_impl(ctx, test_type):
     """Implementation for the Apple test rules."""
     runner = ctx.attr.runner[AppleTestRunnerInfo]
     execution_requirements = getattr(runner, "execution_requirements", {})
+
+    test_bundle_target = ctx.attr.deps[0]
 
     # Environment variables to be set as the %(test_env)s substitution, which includes the
     # --test_env and env attribute values, but not the execution environment variables.
@@ -346,33 +154,15 @@ def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
     direct_runfiles = []
     transitive_runfiles = []
 
-    direct_outputs = []
-    transitive_outputs = []
-    if extra_output_files:
-        transitive_outputs.append(extra_output_files)
-
-    test_host = ctx.attr.test_host
-    test_host_archive = None
-    if test_host:
-        test_host_archive = test_host[AppleBundleInfo].archive
+    test_host_archive = test_bundle_target[AppleTestInfo].test_host
+    if test_host_archive:
         direct_runfiles.append(test_host_archive)
 
-    test_bundle = outputs.archive(ctx)
+    test_bundle = ctx.outputs.archive
     direct_runfiles.append(test_bundle)
 
     if ctx.configuration.coverage_enabled:
-        transitive_covered_binaries = []
-        transitive_coverage_files = []
-
-        for dep in ctx.attr.deps:
-            transitive_covered_binaries.append(dep[CoverageFilesInfo].covered_binaries)
-            transitive_coverage_files.append(dep[CoverageFilesInfo].coverage_files)
-
-        if test_host:
-            transitive_covered_binaries.append(test_host[CoverageFilesInfo].covered_binaries)
-            transitive_coverage_files.append(test_host[CoverageFilesInfo].coverage_files)
-
-        covered_binaries = depset([outputs.binary(ctx)], transitive = transitive_covered_binaries)
+        covered_binaries = test_bundle_target[CoverageFilesInfo].covered_binaries
         execution_environment = dicts.add(
             execution_environment,
             _get_coverage_execution_environment(
@@ -382,7 +172,7 @@ def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
         )
 
         transitive_runfiles.append(covered_binaries)
-        transitive_runfiles.extend(transitive_coverage_files)
+        transitive_runfiles.append(test_bundle_target[CoverageFilesInfo].coverage_files)
 
         transitive_runfiles.append(ctx.attr._gcov.files)
         transitive_runfiles.append(ctx.attr._mcov.files)
@@ -399,7 +189,15 @@ def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
             test_host = test_host_archive,
         ),
     )
-    direct_outputs.append(executable)
+
+    # Symlink the test bundle archive to the output of this rule. With this, we can return
+    # an archive with a name that's different from the test bundle rule. This is used when having
+    # a test such as `ios_unit_test(name = "Foo")` to declare a `:Foo.zip` target.
+    file_support.symlink(
+        ctx,
+        test_bundle_target[AppleTestInfo].test_bundle,
+        test_bundle,
+    )
 
     # Add required data into the runfiles to make it available during test
     # execution.
@@ -407,16 +205,22 @@ def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
         transitive_runfiles.append(data_dep.files)
 
     return [
-        _apple_test_info_provider(ctx.attr.deps),
+        # Repropagate the AppleBundleInfo and AppleTestInfo providers from the test bundle so that
+        # clients interacting with the test targets themselves can access the bundle's structure.
+        test_bundle_target[AppleBundleInfo],
+        test_bundle_target[AppleTestInfo],
         coverage_common.instrumented_files_info(
             ctx,
-            dependency_attributes = ["deps", "test_host"],
+            dependency_attributes = ["test_bundle"],
         ),
         testing.ExecutionInfo(execution_requirements),
         testing.TestEnvironment(execution_environment),
         DefaultInfo(
             executable = executable,
-            files = depset(direct_outputs, transitive = transitive_outputs),
+            files = depset(
+                [executable, test_bundle],
+                transitive = [test_bundle_target[AppleExtraOutputsInfo].files],
+            ),
             runfiles = ctx.runfiles(
                 files = direct_runfiles,
                 transitive_files = depset(transitive = transitive_runfiles),
@@ -426,16 +230,6 @@ def _apple_test_rule_impl(ctx, test_type, extra_output_files = None):
         ),
     ]
 
-def _apple_test_impl(ctx, test_type, extra_providers = []):
-    """Common implementation for the Apple bundle and test rules."""
-    bundle_providers, bundle_outputs = apple_test_bundle_support.apple_test_bundle_impl(ctx)
-    test_providers = _apple_test_rule_impl(
-        ctx,
-        test_type,
-        extra_output_files = bundle_outputs,
-    )
-    return bundle_providers + test_providers + extra_providers
-
 apple_test_rule_support = struct(
-    apple_test_impl = _apple_test_impl,
+    apple_test_rule_impl = _apple_test_rule_impl,
 )

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -19,6 +19,10 @@ load(
     "apple_test_rule_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -31,32 +35,52 @@ load(
     "IosXcTestBundleInfo",
 )
 
+def _ios_ui_test_bundle_impl(ctx):
+    """Implementation of ios_ui_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        IosXcTestBundleInfo(),
+    ]
+
+def _ios_unit_test_bundle_impl(ctx):
+    """Implementation of ios_unit_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        IosXcTestBundleInfo(),
+    ]
+
 def _ios_ui_test_impl(ctx):
     """Implementation of ios_ui_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xcuitest",
-        extra_providers = [IosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xcuitest") + [
+        IosXcTestBundleInfo(),
+    ]
 
 def _ios_unit_test_impl(ctx):
     """Implementation of ios_unit_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xctest",
-        extra_providers = [IosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xctest") + [
+        IosXcTestBundleInfo(),
+    ]
 
-ios_ui_test = rule_factory.create_apple_bundling_rule(
-    implementation = _ios_ui_test_impl,
+ios_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _ios_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.ios),
     product_type = apple_product_type.ui_test_bundle,
-    doc = "Builds and bundles a iOS UI Test Bundle.",
+    doc = "Builds and bundles an iOS UI Test Bundle. Internal target not to be depended upon.",
 )
 
-ios_unit_test = rule_factory.create_apple_bundling_rule(
-    implementation = _ios_unit_test_impl,
+ios_ui_test = rule_factory.create_apple_test_rule(
+    implementation = _ios_ui_test_impl,
+    doc = "iOS UI Test rule.",
+    platform_type = "ios",
+)
+
+ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _ios_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.ios),
     product_type = apple_product_type.unit_test_bundle,
-    doc = "Builds and bundles a iOS Unit Test Bundle.",
+    doc = "Builds and bundles an iOS Unit Test Bundle. Internal target not to be depended upon.",
+)
+
+ios_unit_test = rule_factory.create_apple_test_rule(
+    implementation = _ios_unit_test_impl,
+    doc = "iOS Unit Test rule.",
+    platform_type = "ios",
 )

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -19,6 +19,10 @@ load(
     "apple_test_rule_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -31,32 +35,52 @@ load(
     "MacosXcTestBundleInfo",
 )
 
+def _macos_ui_test_bundle_impl(ctx):
+    """Implementation of macos_ui_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        MacosXcTestBundleInfo(),
+    ]
+
+def _macos_unit_test_bundle_impl(ctx):
+    """Implementation of macos_unit_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        MacosXcTestBundleInfo(),
+    ]
+
 def _macos_ui_test_impl(ctx):
     """Implementation of macos_ui_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xcuitest",
-        extra_providers = [MacosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xcuitest") + [
+        MacosXcTestBundleInfo(),
+    ]
 
 def _macos_unit_test_impl(ctx):
     """Implementation of macos_unit_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xctest",
-        extra_providers = [MacosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xctest") + [
+        MacosXcTestBundleInfo(),
+    ]
 
-macos_ui_test = rule_factory.create_apple_bundling_rule(
-    implementation = _macos_ui_test_impl,
+macos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _macos_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.macos),
     product_type = apple_product_type.ui_test_bundle,
-    doc = "Builds and bundles a macOS UI Test Bundle.",
+    doc = "Builds and bundles an macOS UI Test Bundle.  Internal target not to be depended upon.",
 )
 
-macos_unit_test = rule_factory.create_apple_bundling_rule(
-    implementation = _macos_unit_test_impl,
+macos_ui_test = rule_factory.create_apple_test_rule(
+    implementation = _macos_ui_test_impl,
+    doc = "macOS UI Test rule.",
+    platform_type = "macos",
+)
+
+macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _macos_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.macos),
     product_type = apple_product_type.unit_test_bundle,
-    doc = "Builds and bundles a macOS Unit Test Bundle.",
+    doc = "Builds and bundles an macOS Unit Test Bundle.  Internal target not to be depended upon.",
+)
+
+macos_unit_test = rule_factory.create_apple_test_rule(
+    implementation = _macos_unit_test_impl,
+    doc = "macOS Unit Test rule.",
+    platform_type = "macos",
 )

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -19,6 +19,10 @@ load(
     "apple_test_rule_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -27,36 +31,62 @@ load(
     "rule_factory",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "TvosXcTestBundleInfo",
 )
 
+def _tvos_ui_test_bundle_impl(ctx):
+    """Implementation of tvos_ui_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        TvosXcTestBundleInfo(),
+    ]
+
+def _tvos_unit_test_bundle_impl(ctx):
+    """Implementation of tvos_unit_test."""
+    return apple_test_bundle_support.apple_test_bundle_impl(ctx) + [
+        TvosXcTestBundleInfo(),
+    ]
+
 def _tvos_ui_test_impl(ctx):
     """Implementation of tvos_ui_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xcuitest",
-        extra_providers = [TvosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xcuitest") + [
+        TvosXcTestBundleInfo(),
+    ]
 
 def _tvos_unit_test_impl(ctx):
     """Implementation of tvos_unit_test."""
-    return apple_test_rule_support.apple_test_impl(
-        ctx,
-        "xctest",
-        extra_providers = [TvosXcTestBundleInfo()],
-    )
+    return apple_test_rule_support.apple_test_rule_impl(ctx, "xctest") + [
+        TvosXcTestBundleInfo(),
+    ]
 
-tvos_ui_test = rule_factory.create_apple_bundling_rule(
-    implementation = _tvos_ui_test_impl,
+tvos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _tvos_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.tvos),
     product_type = apple_product_type.ui_test_bundle,
-    doc = "Builds and bundles a tvOS UI Test Bundle.",
+    doc = "Builds and bundles an tvOS UI Test Bundle.  Internal target not to be depended upon.",
 )
 
-tvos_unit_test = rule_factory.create_apple_bundling_rule(
-    implementation = _tvos_unit_test_impl,
+tvos_ui_test = rule_factory.create_apple_test_rule(
+    implementation = _tvos_ui_test_impl,
+    doc = "tvOS UI Test rule.",
+    platform_type = "tvos",
+    cfg = transition_support.apple_rule_transition,
+)
+
+tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+    implementation = _tvos_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.tvos),
     product_type = apple_product_type.unit_test_bundle,
-    doc = "Builds and bundles a tvOS Unit Test Bundle.",
+    doc = "Builds and bundles an tvOS Unit Test Bundle. Internal target not to be depended upon.",
+)
+
+tvos_unit_test = rule_factory.create_apple_test_rule(
+    implementation = _tvos_unit_test_impl,
+    doc = "tvOS Unit Test rule.",
+    platform_type = "tvos",
+    cfg = transition_support.apple_rule_transition,
 )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -171,6 +171,86 @@ requirement.
 """,
 )
 
+AppleTestInfo = provider(
+    doc = """
+Provider that test targets propagate to be used for IDE integration.
+
+This includes information regarding test source files, transitive include paths,
+transitive module maps, and transitive Swift modules. Test source files are
+considered to be all of which belong to the first-level dependencies on the test
+target.
+""",
+    fields = {
+        "includes": """
+`depset` of `string`s representing transitive include paths which are needed by
+IDEs to be used for indexing the test sources.
+""",
+        "module_maps": """
+`depset` of `File`s representing module maps which are needed by IDEs to be used
+for indexing the test sources.
+""",
+        "module_name": """
+`string` representing the module name used by the test's sources. This is only
+set if the test only contains a single top-level Swift dependency. This may be
+used by an IDE to identify the Swift module (if any) used by the test's sources.
+""",
+        "non_arc_sources": """
+`depset` of `File`s containing non-ARC sources from the test's immediate
+deps.
+""",
+        "sources": """
+`depset` of `File`s containing sources from the test's immediate deps.
+""",
+        "swift_modules": """
+`depset` of `File`s representing transitive swift modules which are needed by
+IDEs to be used for indexing the test sources.
+""",
+        "test_bundle": "The artifact representing the XCTest bundle for the test target.",
+        "test_host": """
+The artifact representing the test host for the test target, if the test requires a test host.
+""",
+        "deps": """
+`depset` of `string`s representing the labels of all immediate deps of the test.
+Only source files from these deps will be present in `sources`. This may be used
+by IDEs to differentiate a test target's transitive module maps from its direct
+module maps, as including the direct module maps may break indexing for the
+source files of the immediate deps.
+""",
+    },
+)
+
+AppleTestRunnerInfo = provider(
+    doc = """
+Provider that runner targets must propagate.
+
+In addition to the fields, all the runfiles that the runner target declares will be added to the
+test rules runfiles.
+""",
+    fields = {
+        "execution_requirements": """
+Optional dictionary that represents the specific hardware requirements for this test.
+""",
+        "execution_environment": """
+Optional dictionary with the environment variables that are to be set in the test action, and are
+not propagated into the XCTest invocation. These values will _not_ be added into the %(test_env)s
+substitution, but will be set in the test action.
+""",
+        "test_environment": """
+Optional dictionary with the environment variables that are to be propagated into the XCTest
+invocation. These values will be included in the %(test_env)s substitution and will _not_ be set in
+the test action.
+""",
+        "test_runner_template": """
+Required template file that contains the specific mechanism with which the tests will be run. The
+*_ui_test and *_unit_test rules will substitute the following values:
+    * %(test_host_path)s:   Path to the app being tested.
+    * %(test_bundle_path)s: Path to the test bundle that contains the tests.
+    * %(test_env)s:         Environment variables for the XCTest invocation (e.g FOO=BAR,BAZ=QUX).
+    * %(test_type)s:        The test type, whether it is unit or UI.
+""",
+    },
+)
+
 IosApplicationBundleInfo = provider(
     doc = """
 Denotes that a target is an iOS application.

--- a/apple/testing/apple_test_rules.bzl
+++ b/apple/testing/apple_test_rules.bzl
@@ -15,9 +15,12 @@
 """Proxy for exporting test symbols."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "@build_bazel_rules_apple//apple:providers.bzl",
     _AppleTestInfo = "AppleTestInfo",
     _AppleTestRunnerInfo = "AppleTestRunnerInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
     _CoverageFilesInfo = "CoverageFilesInfo",
     _coverage_files_aspect = "coverage_files_aspect",
 )

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -15,9 +15,15 @@
 """Bazel rules for creating tvOS applications and bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "apple_test_assembler",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:tvos_rules.bzl",
     _tvos_ui_test = "tvos_ui_test",
+    _tvos_ui_test_bundle = "tvos_ui_test_bundle",
     _tvos_unit_test = "tvos_unit_test",
+    _tvos_unit_test_bundle = "tvos_unit_test_bundle",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
@@ -84,53 +90,26 @@ def tvos_framework(name, **kwargs):
         **bundling_args
     )
 
-def tvos_unit_test(
-        name,
-        test_host = None,
-        **kwargs):
-    """Builds an tvOS XCTest test target."""
+_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:tvos_default_runner"
 
-    # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
-    # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method
-    # to have testonly to True since it's always going to be a dependency of a test target. This can
-    # be removed when we migrate the swift linkopts targets into the rule implementations.
-    testonly = kwargs.pop("testonly", None)
-
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
-        name,
-        platform_type = str(apple_common.platform_type.tvos),
-        include_entitlements = False,
-        testonly = True,
-        **kwargs
-    )
-
-    bundle_loader = None
-    if test_host:
-        bundle_loader = test_host
-    _tvos_unit_test(
+def tvos_unit_test(name, **kwargs):
+    runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
+    apple_test_assembler.assemble(
         name = name,
-        bundle_loader = bundle_loader,
-        test_host = test_host,
-        **bundling_args
-    )
-
-def tvos_ui_test(
-        name,
-        **kwargs):
-    """Builds an tvOS XCUITest test target."""
-
-    # Discard any testonly attributes that may have been passed in kwargs. Since this is a test
-    # rule, testonly should be a noop. Instead, force the add_entitlements_and_swift_linkopts method
-    # to have testonly to True since it's always going to be a dependency of a test target. This can
-    # be removed when we migrate the swift linkopts targets into the rule implementations.
-    testonly = kwargs.pop("testonly", None)
-
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
-        name,
-        platform_type = str(apple_common.platform_type.tvos),
-        include_entitlements = False,
-        testonly = True,
+        bundle_rule = _tvos_unit_test_bundle,
+        test_rule = _tvos_unit_test,
+        runner = runner,
+        bundle_loader = kwargs.get("test_host"),
+        dylibs = kwargs.get("frameworks"),
         **kwargs
     )
 
-    _tvos_ui_test(name = name, **bundling_args)
+def tvos_ui_test(name, **kwargs):
+    runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
+    apple_test_assembler.assemble(
+        name = name,
+        bundle_rule = _tvos_ui_test_bundle,
+        test_rule = _tvos_ui_test,
+        runner = runner,
+        **kwargs
+    )


### PR DESCRIPTION
Split test rules into a bundle rule and a test rule.

This change splits the test rules into a bundle target and a test target. This split allows us to improve the functionality of the test suite rules (e.g. ios_unit_test_suite) such that a single test bundle is created and shared amongst many test targets.

Previously, the test suite rules would create both a test bundle and a test rule for each runner, duplicating the resource processing and linking actions. With the new architecture, these actions would be shared into the single test bundle being created, reducing build times when running multiple tests simultaneously.

This change aims to maintain API compatibility with the current test and test suite rule targets and with IDE support, so no changes are required to take advantage of this new architecture.