### PR TITLE
Remove the transition from the test rules and create symlinks from the extra outputs coming from the bundle to coordinate the roots of all outputs of the test rule.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -935,28 +935,12 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
         outputs = {"archive": archive_name},
     )
 
-def _create_apple_test_rule(implementation, doc, platform_type, cfg = None):
+def _create_apple_test_rule(implementation, doc):
     """Creates an Apple test rule."""
-
-    # Add the platform_type and minimum_os_version attribute to this rule so that we can apply the
-    # same configuration transition as the bundling rules. This is to ensure that the built
-    # artifacts from the test rules and bundling rules are placed in the same configuration-specific
-    # output.
-    extra_attrs = [{
-        "platform_type": attr.string(default = platform_type),
-        "minimum_os_version": attr.string(mandatory = True),
-    }]
-    if cfg:
-        extra_attrs.append({
-            "_whitelist_function_transition": attr.label(
-                default = "//tools/whitelists/function_transition_whitelist",
-            ),
-        })
 
     return rule(
         implementation = implementation,
-        attrs = dicts.add(_COMMON_PRIVATE_TOOL_ATTRS, _COMMON_TEST_ATTRS, *extra_attrs),
-        cfg = cfg,
+        attrs = dicts.add(_COMMON_PRIVATE_TOOL_ATTRS, _COMMON_TEST_ATTRS),
         doc = doc,
         outputs = {"archive": "%{name}.zip"},
         test = True,

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -93,7 +93,6 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         test_rule(
             name = name,
             runner = runner,
-            minimum_os_version = bundling_args.get("minimum_os_version"),
             test_host = bundling_args.get("test_host"),
             deps = [":{}".format(test_bundle_name)],
             **test_attrs
@@ -106,7 +105,6 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
             test_rule(
                 name = test_name,
                 runner = runner,
-                minimum_os_version = bundling_args.get("minimum_os_version"),
                 test_host = bundling_args.get("test_host"),
                 deps = [":{}".format(test_bundle_name)],
                 **test_attrs

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -69,7 +69,6 @@ ios_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 ios_ui_test = rule_factory.create_apple_test_rule(
     implementation = _ios_ui_test_impl,
     doc = "iOS UI Test rule.",
-    platform_type = "ios",
 )
 
 ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -82,5 +81,4 @@ ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 ios_unit_test = rule_factory.create_apple_test_rule(
     implementation = _ios_unit_test_impl,
     doc = "iOS Unit Test rule.",
-    platform_type = "ios",
 )

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -69,7 +69,6 @@ macos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 macos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _macos_ui_test_impl,
     doc = "macOS UI Test rule.",
-    platform_type = "macos",
 )
 
 macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -82,5 +81,4 @@ macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 macos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _macos_unit_test_impl,
     doc = "macOS Unit Test rule.",
-    platform_type = "macos",
 )

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -31,10 +31,6 @@ load(
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
-    "transition_support",
-)
-load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "TvosXcTestBundleInfo",
 )
@@ -73,8 +69,6 @@ tvos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 tvos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_ui_test_impl,
     doc = "tvOS UI Test rule.",
-    platform_type = "tvos",
-    cfg = transition_support.apple_rule_transition,
 )
 
 tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -87,6 +81,4 @@ tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 tvos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_unit_test_impl,
     doc = "tvOS Unit Test rule.",
-    platform_type = "tvos",
-    cfg = transition_support.apple_rule_transition,
 )


### PR DESCRIPTION
Remove the transition from the test rules and create symlinks from the extra outputs coming from the bundle to coordinate the roots of all outputs of the test rule.