### PR TITLE
Migrate dsym build checks to Starlark.

### DIFF
--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -214,22 +214,6 @@ EOF
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_ios_application
-  do_build ios --apple_generate_dsym //app:app || fail "Should build"
-
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs ios) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
-  done
-}
-
 # Tests that the linkmap outputs are produced when --objc_generate_linkmap is
 # present.
 function disabled_test_linkmaps_generated() {  # Blocked on b/73547215

--- a/test/ios_ui_test_test.sh
+++ b/test/ios_ui_test_test.sh
@@ -233,22 +233,6 @@ function test_runner_script_contains_expected_values() {
   assert_contains "TEST_TYPE=XCUITEST" "test-bin/app/ui_tests"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_ios_application_with_tests
-  do_build ios --apple_generate_dsym //app:ui_tests || fail "Should build"
-
-  assert_exists "test-bin/app/ui_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs ios) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/ui_tests.xctest.dSYM/Contents/Resources/DWARF/ui_tests_${arch}"
-  done
-}
-
 # Tests that test bundles can depend on ios_frameworks.
 function test_target_can_depend_on_ios_framework() {
   create_common_files

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -307,22 +307,6 @@ EOF
   do_build ios --ios_minimum_os=9.0 //app:unit_tests || fail "Should build"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_ios_application_with_tests
-  do_build ios --apple_generate_dsym //app:unit_tests || fail "Should build"
-
-  assert_exists "test-bin/app/unit_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs ios) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/unit_tests.xctest.dSYM/Contents/Resources/DWARF/unit_tests_${arch}"
-  done
-}
-
 function test_logic_unit_test_packages_dynamic_framework_targets {
   cat > app/BUILD <<EOF
 load("@build_bazel_rules_apple//apple:apple.bzl",

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -193,25 +193,6 @@ EOF
       "app.app/Contents/Resources/inserted_by_post_processor.txt")"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-#
-# Enable this test once dSYM support in CROSSTOOL is working in a Bazel release
-# (currently only available in nightly/canary.)
-function DISABLED__test_dsyms_generated() {
-  create_common_files
-  create_minimal_macos_application
-  do_build macos --apple_generate_dsym //app:app || fail "Should build"
-
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs macos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
-  done
-}
-
 # Tests that linkopts get passed to the underlying apple_binary target.
 function test_linkopts_passed_to_binary() {
   create_common_files

--- a/test/macos_bundle_test.sh
+++ b/test/macos_bundle_test.sh
@@ -141,25 +141,6 @@ EOF
       "app.bundle/Contents/Resources/inserted_by_post_processor.txt")"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-#
-# Enable this test once dSYM support in CROSSTOOL is working in a Bazel release
-# (currently only available in nightly/canary.)
-function DISABLED__test_dsyms_generated() {
-  create_common_files
-  create_minimal_macos_bundle
-  do_build macos --apple_generate_dsym //app:app || fail "Should build"
-
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs macos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.bundle.dSYM/Contents/Resources/DWARF/app_${arch}"
-  done
-}
-
 # Tests that linkopts get passed to the underlying apple_binary target.
 function test_linkopts_passed_to_binary() {
   create_common_files

--- a/test/macos_quick_look_plugin_test.sh
+++ b/test/macos_quick_look_plugin_test.sh
@@ -141,25 +141,6 @@ EOF
       "app.qlgenerator/Contents/Resources/inserted_by_post_processor.txt")"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-#
-# Enable this test once dSYM support in CROSSTOOL is working in a Bazel release
-# (currently only available in nightly/canary.)
-function DISABLED__test_dsyms_generated() {
-  create_common_files
-  create_minimal_macos_quick_look_plugin
-  do_build macos --apple_generate_dsym //app:app || fail "Should build"
-
-  assert_exists "test-bin/app/app.qlgenerator.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs macos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.qlgenerator.dSYM/Contents/Resources/DWARF/app_${arch}"
-  done
-}
-
 # Tests that linkopts get passed to the underlying binary target.
 function test_linkopts_passed_to_binary() {
   create_common_files

--- a/test/macos_ui_test_test.sh
+++ b/test/macos_ui_test_test.sh
@@ -200,22 +200,6 @@ function test_runner_script_contains_expected_values() {
   assert_contains "TEST_TYPE=XCUITEST" "test-bin/app/ui_tests"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_macos_application_with_tests
-  do_build macos --apple_generate_dsym //app:ui_tests || fail "Should build"
-
-  assert_exists "test-bin/app/ui_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs macos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/ui_tests.xctest.dSYM/Contents/Resources/DWARF/ui_tests_${arch}"
-  done
-}
-
 # Tests that files passed in via the additional_contents attribute get placed at
 # the correct locations in the xctest bundle.
 function test_additional_contents() {

--- a/test/macos_unit_test_test.sh
+++ b/test/macos_unit_test_test.sh
@@ -203,22 +203,6 @@ function test_runner_script_contains_expected_values() {
   assert_contains "TEST_TYPE=XCTEST" "test-bin/app/unit_tests"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_macos_application_with_tests
-  do_build macos --apple_generate_dsym //app:unit_tests || fail "Should build"
-
-  assert_exists "test-bin/app/unit_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs macos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/unit_tests.xctest.dSYM/Contents/Resources/DWARF/unit_tests_${arch}"
-  done
-}
-
 # Tests that files passed in via the additional_contents attribute get placed at
 # the correct locations in the xctest bundle.
 function test_additional_contents() {

--- a/test/starlark_tests/apple_bundle_version_tests.bzl
+++ b/test/starlark_tests/apple_bundle_version_tests.bzl
@@ -78,6 +78,7 @@ def apple_bundle_version_test_suite():
         name = "{}_pattern_referencing_missing_capture_groups_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:pattern_referencing_missing_capture_groups_fail",
         expected_error = "Some groups were not defined in capture_groups",
+        tags = [name],
     )
 
     # Tests that the analysis fails if build_label_pattern is provided but capture_groups
@@ -86,6 +87,7 @@ def apple_bundle_version_test_suite():
         name = "{}_build_label_pattern_requires_capture_groups_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:build_label_pattern_requires_capture_groups_fail",
         expected_error = "If either build_label_pattern or capture_groups is provided, then both must be provided.",
+        tags = [name],
     )
 
     # Tests that the analysis fails if capture_groups is provided but build_label_pattern
@@ -94,6 +96,7 @@ def apple_bundle_version_test_suite():
         name = "{}_capture_groups_requires_build_label_pattern_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:capture_groups_requires_build_label_pattern_fail",
         expected_error = "If either build_label_pattern or capture_groups is provided, then both must be provided.",
+        tags = [name],
     )
 
     # Tests that the analysis fails if fallback_build_label is provided but build_label_pattern
@@ -102,6 +105,7 @@ def apple_bundle_version_test_suite():
         name = "{}_fallback_build_label_requires_build_label_pattern_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:fallback_build_label_requires_build_label_pattern_fail",
         expected_error = "If fallback_build_label is provided, then build_label_pattern and capture_groups must be provided.",
+        tags = [name],
     )
 
     # Test that substitution does not occur if there is a build label pattern but --embed_label

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def ios_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,7 @@ def ios_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -46,6 +52,7 @@ def ios_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -53,6 +60,7 @@ def ios_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -60,6 +68,14 @@ def ios_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        expected_dsyms = ["app.app"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def ios_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,7 @@ def ios_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -46,6 +52,14 @@ def ios_extension_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        expected_dsyms = ["app.app"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/ios_imessage_application_tests.bzl
+++ b/test/starlark_tests/ios_imessage_application_tests.bzl
@@ -32,6 +32,7 @@ def ios_imessage_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:imessage_app",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -32,6 +32,7 @@ def ios_sticker_pack_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/ios_ui_test_tests.bzl
+++ b/test/starlark_tests/ios_ui_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def ios_ui_test_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ui_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     infoplist_contents_test(
@@ -54,6 +59,13 @@ def ios_ui_test_test_suite():
             "MinimumOSVersion": "8.0",
             "UIDeviceFamily:0": "1",
         },
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ui_test",
+        expected_dsyms = ["ui_test.xctest"],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def ios_unit_test_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,14 @@ def ios_unit_test_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
+        expected_dsyms = ["unit_test.xctest"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def macos_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,7 @@ def macos_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -46,6 +52,14 @@ def macos_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        expected_dsyms = ["app.app"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def macos_bundle_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
+        expected_dsyms = ["bundle.bundle"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/macos_quick_look_plugin_tests.bzl
+++ b/test/starlark_tests/macos_quick_look_plugin_tests.bzl
@@ -32,6 +32,7 @@ def macos_quick_look_plugin_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/macos_ui_test_tests.bzl
+++ b/test/starlark_tests/macos_ui_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def macos_ui_test_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
+        expected_dsyms = ["ui_test.xctest"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def macos_unit_test_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
+        expected_dsyms = ["unit_test.xctest"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -1,0 +1,90 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark test rules for debug symbols."""
+
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+    "asserts",
+)
+
+def _dsyms_test_impl(ctx):
+    """Implementation of the dsyms_test rule."""
+    env = analysistest.begin(ctx)
+    target_under_test = ctx.attr.target_under_test[0]
+
+    platform_type = target_under_test[AppleBundleInfo].platform_type
+    if platform_type == "watchos":
+        architecture = "i386"
+    else:
+        architecture = "x86_64"
+
+    outputs = {
+        x.short_path: None
+        for x in target_under_test[OutputGroupInfo]["dsyms"].to_list()
+    }
+
+    package = target_under_test.label.package
+
+    expected_infoplists = [
+        "{0}/{1}.dSYM/Contents/Info.plist".format(package, x)
+        for x in ctx.attr.expected_dsyms
+    ]
+
+    expected_binaries = [
+        "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}_{3}".format(
+            package,
+            x,
+            paths.split_extension(x)[0],
+            architecture,
+        )
+        for x in ctx.attr.expected_dsyms
+    ]
+
+    for expected in expected_infoplists + expected_binaries:
+        asserts.true(
+            env,
+            expected in outputs,
+            msg = "Expected\n\n{0}\n\nto be built. Contents were:\n\n{1}\n\n".format(
+                expected,
+                "\n".join(outputs.keys()),
+            ),
+        )
+
+    return analysistest.end(env)
+
+dsyms_test = analysistest.make(
+    _dsyms_test_impl,
+    attrs = {
+        "expected_dsyms": attr.string_list(
+            mandatory = True,
+            doc = """
+List of bundle names in the format <bundle_name>.<bundle_extension> to verify that dSYMs bundles are
+created for them.
+""",
+        ),
+    },
+    config_settings = {
+        "//command_line_option:apple_generate_dsym": "true",
+    },
+)

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def tvos_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_fmwk",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,7 @@ def tvos_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -46,6 +52,7 @@ def tvos_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -53,6 +60,7 @@ def tvos_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -60,6 +68,14 @@ def tvos_application_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        expected_dsyms = ["app.app"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def tvos_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
+        expected_dsyms = ["ext.appex"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/tvos_ui_test_tests.bzl
+++ b/test/starlark_tests/tvos_ui_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def tvos_ui_test_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:ui_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ui_test",
+        expected_dsyms = ["ui_test.xctest"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,14 @@ def tvos_unit_test_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:unit_test",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:unit_test",
+        expected_dsyms = ["unit_test.xctest"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -32,6 +32,7 @@ def watchos_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +40,7 @@ def watchos_application_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
         verifier_script = "verifier_scripts/resources_verifier.sh",
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/dsyms_test.bzl",
+    "dsyms_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -32,6 +36,7 @@ def watchos_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -39,6 +44,7 @@ def watchos_extension_test_suite():
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
     )
 
     apple_verification_test(
@@ -46,6 +52,14 @@ def watchos_extension_test_suite():
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
+        expected_dsyms = ["ext.appex"],
+        tags = [name],
     )
 
     infoplist_contents_test(

--- a/test/tvos_application_test.sh
+++ b/test/tvos_application_test.sh
@@ -112,22 +112,6 @@ EOF
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_tvos_application
-  do_build tvos --apple_generate_dsym //app:app || fail "Should build"
-
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs tvos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
-  done
-}
-
 # Tests that the linkmap outputs are produced when --objc_generate_linkmap is
 # present.
 function disabled_test_linkmaps_generated() {  # Blocked on b/73547215

--- a/test/tvos_ui_test_test.sh
+++ b/test/tvos_ui_test_test.sh
@@ -202,20 +202,4 @@ function test_runner_script_contains_expected_values() {
   assert_contains "TEST_TYPE=XCUITEST" "test-bin/app/ui_tests"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_tvos_application_with_tests
-  do_build tvos --apple_generate_dsym //app:ui_tests || fail "Should build"
-
-  assert_exists "test-bin/app/ui_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs tvos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/ui_tests.xctest.dSYM/Contents/Resources/DWARF/ui_tests_${arch}"
-  done
-}
-
 run_suite "tvos_ui_test bundling tests"

--- a/test/tvos_unit_test_test.sh
+++ b/test/tvos_unit_test_test.sh
@@ -275,22 +275,6 @@ EOF
   do_build tvos --tvos_minimum_os=9.0 //app:unit_tests || fail "Should build"
 }
 
-# Tests that the dSYM outputs are produced when --apple_generate_dsym is
-# present.
-function test_dsyms_generated() {
-  create_common_files
-  create_minimal_tvos_application_with_tests
-  do_build tvos --apple_generate_dsym //app:unit_tests || fail "Should build"
-
-  assert_exists "test-bin/app/unit_tests.xctest.dSYM/Contents/Info.plist"
-
-  declare -a archs=( $(current_archs tvos) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/unit_tests.xctest.dSYM/Contents/Resources/DWARF/unit_tests_${arch}"
-  done
-}
-
 function test_logic_unit_test_packages_dynamic_framework_targets {
   cat > app/BUILD <<EOF
 load("@build_bazel_rules_apple//apple:apple.bzl",


### PR DESCRIPTION
Migrate dsym build checks to Starlark.

As part of this CL, I'm also adding the missing tags for each of the Starlark test suites.