### PR TITLE
Default iOS tests to passed versions

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -21,9 +21,11 @@ load(
 
 def _get_template_substitutions(ctx):
     """Returns the template substitutions for this runner."""
+    os_version = ctx.attr.os_version or str(ctx.fragments.objc.ios_simulator_version)
+    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device
     subs = {
-        "device_type": ctx.attr.device_type,
-        "os_version": ctx.attr.os_version,
+        "device_type": device_type,
+        "os_version": os_version,
         "testrunner_binary": ctx.executable._testrunner.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -21,11 +21,11 @@ load(
 
 def _get_template_substitutions(ctx):
     """Returns the template substitutions for this runner."""
-    os_version = ctx.attr.os_version or str(ctx.fragments.objc.ios_simulator_version)
-    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device
+    os_version = ctx.attr.os_version or ctx.fragments.objc.ios_simulator_version or ""
+    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or ""
     subs = {
         "device_type": device_type,
-        "os_version": os_version,
+        "os_version": str(os_version),
         "testrunner_binary": ctx.executable._testrunner.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}


### PR DESCRIPTION
This makes the --ios_simulator_version and --ios_simulator_device flags,
affect which devices are used for testing if you don't otherwise provide
a device or OS version

This reverts commit 1a5bd8e3163e6966a18a451c8bb455bb97e7a9d6.