### PR TITLE
Fix codesigningtool.py py3 compatibility.

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -102,7 +102,11 @@ def _certificate_fingerprint(identity):
 def _get_identities_from_provisioning_profile(mpf):
   """Iterates through all the identities in a provisioning profile, lazily."""
   for identity in mpf["DeveloperCertificates"]:
-    yield _certificate_fingerprint(identity.data)
+    if not isinstance(identity, bytes):
+      # Old versions of plistlib return the deprecated plistlib.Data type
+      # instead of bytes.
+      identity = identity.data
+    yield _certificate_fingerprint(identity)
 
 
 def _find_codesign_identities(identity=None):


### PR DESCRIPTION
In recent versions of plistlib, binary data entries are returned as instances of the built-in bytes class, and plistlib.Data is deprecated.
Since this script was expecting a plistlib.Data, it would fail with the error "AttributeError: 'bytes' object has no attribute 'data'".
This change makes it compatible with both new and old versions of plistlib.

In practice, this fixes an "AttributeError: 'bytes' object has no attribute 'data'" error seen with recent versions of Bazel and macOS.