### PR TITLE
Fetch public headers via the multi arch split

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -59,6 +59,10 @@ load(
     "SwiftStaticFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:split.bzl",
+    "split",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "IosApplicationBundleInfo",
@@ -217,7 +221,7 @@ def _ios_framework_impl(ctx):
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = ctx.attr.extension_safe),
-        partials.framework_headers_partial(hdrs = ctx.files.hdrs),
+        partials.framework_headers_partial(hdrs = split.files(ctx.attr.hdrs)),
         partials.framework_provider_partial(
             binary_provider = binary_target[apple_common.AppleDylibBinary],
         ),
@@ -330,7 +334,7 @@ def _ios_static_framework_impl(ctx):
     else:
         processor_partials.append(
             partials.static_framework_header_modulemap_partial(
-                hdrs = ctx.files.hdrs,
+                hdrs = split.files(ctx.attr.hdrs),
                 umbrella_header = ctx.file.umbrella_header,
                 binary_objc_provider = binary_target[apple_common.Objc],
             ),

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -542,6 +542,7 @@ Required.
             # what to do with this.
             "hdrs": attr.label_list(
                 allow_files = [".h"],
+                cfg = apple_common.multi_arch_split,
             ),
             "extension_safe": attr.bool(
                 default = False,
@@ -555,6 +556,7 @@ use only extension-safe APIs.
         attrs.append({
             "hdrs": attr.label_list(
                 allow_files = [".h"],
+                cfg = apple_common.multi_arch_split,
                 doc = """
 A list of `.h` files that will be publicly exposed by this framework. These headers should have
 framework-relative imports, and if non-empty, an umbrella header named `%{bundle_name}.h` will also
@@ -563,6 +565,7 @@ be generated that imports all of the headers listed here.
             ),
             "umbrella_header": attr.label(
                 allow_single_file = [".h"],
+                cfg = apple_common.multi_arch_split,
                 doc = """
 An optional single .h file to use as the umbrella header for this framework. Usually, this header
 will have the same name as this target, so that clients can load the header using the #import
@@ -725,6 +728,7 @@ def _get_tvos_attrs(rule_descriptor):
             # what to do with this.
             "hdrs": attr.label_list(
                 allow_files = [".h"],
+                cfg = apple_common.multi_arch_split,
             ),
             "extension_safe": attr.bool(
                 default = False,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -51,6 +51,10 @@ load(
     "SwiftStaticFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:split.bzl",
+    "split",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "TvosApplicationBundleInfo",
@@ -176,7 +180,7 @@ def _tvos_framework_impl(ctx):
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = ctx.attr.extension_safe),
-        partials.framework_headers_partial(hdrs = ctx.files.hdrs),
+        partials.framework_headers_partial(hdrs = split.files(ctx.attr.hdrs)),
         partials.framework_provider_partial(binary_provider = binary_provider),
         partials.resources_partial(
             bundle_id = bundle_id,

--- a/apple/internal/utils/split.bzl
+++ b/apple/internal/utils/split.bzl
@@ -1,0 +1,25 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convenience functions for split_attr."""
+
+def _files(attr):
+    """Get the files from the first split."""
+    for v in attr:
+        return v.files.to_list()
+    return []
+
+split = struct(
+    files = _files,
+)


### PR DESCRIPTION
Fetch headers via the apple_common.multi_arch_split so that proper
transitions are done. Since headers are assumed to be the same for all
architectures, only the headers from the first split will be used.

This is mostly useful if headers are generated.

Fixes #466