### PR TITLE
Add platform_type to the test rules to allow Tulsi some time to migrate to AppleBundleInfo.platform_type.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -941,12 +941,17 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
         outputs = {"archive": archive_name},
     )
 
-def _create_apple_test_rule(implementation, doc):
+def _create_apple_test_rule(implementation, doc, platform_type):
     """Creates an Apple test rule."""
+
+    # TODO(cl/264421322): Once Tulsi propagates this change, remove this attribute.
+    extra_attrs = [{
+        "platform_type": attr.string(default = platform_type),
+    }]
 
     return rule(
         implementation = implementation,
-        attrs = dicts.add(_COMMON_PRIVATE_TOOL_ATTRS, _COMMON_TEST_ATTRS),
+        attrs = dicts.add(_COMMON_PRIVATE_TOOL_ATTRS, _COMMON_TEST_ATTRS, *extra_attrs),
         doc = doc,
         test = True,
     )

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -69,6 +69,7 @@ ios_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 ios_ui_test = rule_factory.create_apple_test_rule(
     implementation = _ios_ui_test_impl,
     doc = "iOS UI Test rule.",
+    platform_type = str(apple_common.platform_type.ios),
 )
 
 ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -81,4 +82,5 @@ ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 ios_unit_test = rule_factory.create_apple_test_rule(
     implementation = _ios_unit_test_impl,
     doc = "iOS Unit Test rule.",
+    platform_type = str(apple_common.platform_type.ios),
 )

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -69,6 +69,7 @@ macos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 macos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _macos_ui_test_impl,
     doc = "macOS UI Test rule.",
+    platform_type = str(apple_common.platform_type.macos),
 )
 
 macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -81,4 +82,5 @@ macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 macos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _macos_unit_test_impl,
     doc = "macOS Unit Test rule.",
+    platform_type = str(apple_common.platform_type.macos),
 )

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -69,6 +69,7 @@ tvos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
 tvos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_ui_test_impl,
     doc = "tvOS UI Test rule.",
+    platform_type = str(apple_common.platform_type.tvos),
 )
 
 tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
@@ -81,4 +82,5 @@ tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
 tvos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_unit_test_impl,
     doc = "tvOS Unit Test rule.",
+    platform_type = str(apple_common.platform_type.tvos),
 )


### PR DESCRIPTION
Add platform_type to the test rules to allow Tulsi some time to migrate to AppleBundleInfo.platform_type.