### PR TITLE
Allow archive_contents_test() to test for binary plists

### DIFF
--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -62,10 +62,8 @@ def ios_application_test_suite():
     archive_contents_test(
         name = "{}_resources_simulator_test".format(name),
         build_type = "simulator",
-        contains = [
-            "$BUNDLE_ROOT/resource_bundle.bundle/Info.plist",
-            "$BUNDLE_ROOT/Another.plist",
-        ],
+        is_binary_plist = ["$BUNDLE_ROOT/resource_bundle.bundle/Info.plist"],
+        is_not_binary_plist = ["$BUNDLE_ROOT/Another.plist"],
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         tags = [name],
     )
@@ -73,10 +71,8 @@ def ios_application_test_suite():
     archive_contents_test(
         name = "{}_resources_device_test".format(name),
         build_type = "device",
-        contains = [
-            "$BUNDLE_ROOT/resource_bundle.bundle/Info.plist",
-            "$BUNDLE_ROOT/Another.plist",
-        ],
+        is_binary_plist = ["$BUNDLE_ROOT/resource_bundle.bundle/Info.plist"],
+        is_not_binary_plist = ["$BUNDLE_ROOT/Another.plist"],
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
         tags = [name],
     )

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -25,6 +25,8 @@ def archive_contents_test(
         target_under_test,
         contains = [],
         not_contains = [],
+        is_binary_plist = [],
+        is_not_binary_plist = [],
         **kwargs):
     """Macro for calling the apple_verification_test with archive_contents_test.sh.
 
@@ -43,6 +45,10 @@ def archive_contents_test(
             will be expanded with bash and can contain environmental variables (e.g. $BUNDLE_ROOT)
         not_contains:  Optional, List of paths to test for non-existance for within the bundle.
             The string will be expanded with bash and can contain env variables (e.g. $BUNDLE_ROOT)
+        is_binary_plist:  Optional, List of paths to files to test for a binary plist format. The
+            paths are expanded with bash. Test will fail if file doesn't exist.
+        is_not_binary_plist:  Optional, List of paths to files to test for the absense of a binary
+            plist format. The paths are expanded with bash. Test will fail if file doesn't exist.
         **kwargs: Other arguments are passed through to the apple_verification_test rule.
     """
 
@@ -52,6 +58,8 @@ def archive_contents_test(
         env = {
             "CONTAINS": contains,
             "NOT_CONTAINS": not_contains,
+            "IS_BINARY_PLIST": is_binary_plist,
+            "IS_NOT_BINARY_PLIST": is_not_binary_plist,
         },
         target_under_test = target_under_test,
         verifier_script = "verifier_scripts/archive_contents_test.sh",

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -27,6 +27,10 @@ newline=$'\n'
 #      expanded with bash and can contain variables (e.g. $BUNDLE_ROOT)
 #  NOT_CONTAINS: takes a list of files to test for non-existance. The filename
 #      will be expanded with bash and can contain variables (e.g. $BUNDLE_ROOT)
+#  IS_BINARY_PLIST: takes a list of paths to plist files and checks that they
+#      are `binary` format. Filenames are expanded with bash.
+#  IS_NOT_BINARY_PLIST: takes a list of paths to plist files and checks that
+#      they are not `binary` format. Filenames are expanded with bash.
 
 # Test that the archive contains the specified files in the CONTAIN env var.
 if [[ -n "${CONTAINS-}" ]]; then
@@ -46,7 +50,37 @@ if [[ -n "${NOT_CONTAINS-}" ]]; then
   do
     expanded_path=$(eval echo "$path")
     if [[ -e $expanded_path ]]; then
-      fail "Archive did contain \"expanded_path\""
+      fail "Archive did contain \"$expanded_path\""
+    fi
+  done
+fi
+
+# Test that plist files are in a binary format.
+if [[ -n "${IS_BINARY_PLIST-}" ]]; then
+  for path in "${IS_BINARY_PLIST[@]}"
+  do
+    expanded_path=$(eval echo "$path")
+    if [[ ! -e $expanded_path ]]; then
+      fail "Archive did not contain plist \"$expanded_path\"" \
+        "contents were:$newline$(find $ARCHIVE_ROOT)"
+    fi
+    if ! grep -sq "^bplist00" $expanded_path; then
+      fail "Plist does not have binary format \"$expanded_path\""
+    fi
+  done
+fi
+
+# Test that plist files are not in a binary format.
+if [[ -n "${IS_NOT_BINARY_PLIST-}" ]]; then
+  for path in "${IS_NOT_BINARY_PLIST[@]}"
+  do
+    expanded_path=$(eval echo "$path")
+    if [[ ! -e $expanded_path ]]; then
+      fail "Archive did not contain plist \"$expanded_path\"" \
+        "contents were:$newline$(find $ARCHIVE_ROOT)"
+    fi
+    if grep -sq "^bplist00" $expanded_path; then
+      fail "Plist has binary format \"$expanded_path\""
     fi
   done
 fi


### PR DESCRIPTION
Allow archive_contents_test() to test for binary plists

This is a replacement for the assert_plist_is_binary, assert_strings_is_binary, assert_plist_is_text, and assert_strings_is_text functions in apple_shell_testutils.sh