### PR TITLE
Make codesigningtool compatible with Bazel 0.27+.

### DIFF
--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -3,7 +3,8 @@ licenses(["notice"])
 py_binary(
     name = "codesigningtool",
     srcs = ["codesigningtool.py"],
-    srcs_version = "PY2AND3",
+    srcs_version = "PY2",
+    python_version = "PY2",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.


### PR DESCRIPTION
Prior to Bazel 0.27, when no `python_version` attribute was specified in a
`py_binary` target, Python 2 was used as the default interpreter version.
After 0.27, the default interpreter version was switched to Python 3.
Although the binary is marked as source compatible with both Python 2
and Python 3, gRPC has seen failures in its CI system from this binary
while attempting the Bazel upgrade.

```
ERROR: /Volumes/BuildData/tmpfs/src/github/grpc/workspace_objc_macos_opt_native/src/objective-c/examples/BUILD:118:1: Processing and signing tvOS-sample failed (Exit 1)
Traceback (most recent call last):
  File "/Volumes/BuildData/tmpfs/tmp/bazel/fb29e378133afd959be023fae47df9ad/execroot/com_github_grpc_grpc/bazel-out/host/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 162, in <module>
    sys.exit(main(sys.argv))
  File "/Volumes/BuildData/tmpfs/tmp/bazel/fb29e378133afd959be023fae47df9ad/execroot/com_github_grpc_grpc/bazel-out/host/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 156, in main
    filtered_stderr = _filter_codesign_output(stderr)
  File "/Volumes/BuildData/tmpfs/tmp/bazel/fb29e378133afd959be023fae47df9ad/execroot/com_github_grpc_grpc/bazel-out/host/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 116, in _filter_codesign_output
    for line in codesign_output.split("\n"):
TypeError: a bytes-like object is required, not 'str'
```

This change ensures that the binary will run under an interpreter with
which it is actually compatible.