### PR TITLE
Specify maxsplit positionally instead of by keyword

### DIFF
--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -258,7 +258,7 @@ def _bundle_partial_outputs_files(
         for partial_output in partial_outputs:
             for _, parent_dir, _ in getattr(partial_output, "bundle_files", []):
                 if parent_dir:
-                    top_parent = parent_dir.split("/", maxsplit = 1)[0]
+                    top_parent = parent_dir.split("/", 1)[0]
                     if top_parent:
                         locale = bundle_paths.locale_for_path(top_parent)
                         if locale:

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -109,7 +109,7 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
     elif runners:
         tests = []
         for runner in runners:
-            test_name = "{}_{}".format(name, runner.rsplit(":", maxsplit = 1)[-1])
+            test_name = "{}_{}".format(name, runner.rsplit(":", 1)[-1])
             tests.append(":{}".format(test_name))
             test_rule(
                 name = test_name,


### PR DESCRIPTION
Specify maxsplit positionally instead of by keyword

Ability to specify maxsplit parameter of split() and rsplit() by keyword is deprecated from Starlark and will be removed soon.