### PR TITLE
Pass is_test to swift_runtime_linkopts

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -35,6 +35,7 @@ def _create_swift_runtime_linkopts_target(
         name,
         deps,
         is_static,
+        is_test,
         tags,
         testonly):
     """Creates a build target to propagate Swift runtime linker flags.
@@ -44,6 +45,7 @@ def _create_swift_runtime_linkopts_target(
       deps: The list of dependencies of the base target.
       is_static: True to use the static Swift runtime, or False to use the
           dynamic Swift runtime.
+      is_test: True to make sure test specific linkopts are propagated.
       tags: Tags to add to the created targets.
       testonly: Whether the target should be testonly.
 
@@ -54,6 +56,7 @@ def _create_swift_runtime_linkopts_target(
     swift_runtime_linkopts(
         name = swift_runtime_linkopts_name,
         is_static = is_static,
+        is_test = is_test,
         testonly = testonly,
         tags = tags,
         deps = deps,
@@ -66,6 +69,7 @@ def _add_entitlements_and_swift_linkopts(
         include_entitlements = True,
         is_stub = False,
         link_swift_statically = False,
+        is_test = False,
         **kwargs):
     """Adds entitlements and Swift linkopts targets for a bundle target.
 
@@ -86,6 +90,7 @@ def _add_entitlements_and_swift_linkopts(
           stub executable.
       link_swift_statically: True/False, indicates whether the static versions of the Swift standard
           libraries should be used during linking. Only used if include_swift_linkopts is True.
+      is_test: True/False, indicates if test specific linker flags should be propagated.
       **kwargs: The arguments that were passed into the top-level macro.
 
     Returns:
@@ -129,6 +134,7 @@ def _add_entitlements_and_swift_linkopts(
                 name,
                 deps,
                 link_swift_statically,
+                is_test,
                 tags = tags,
                 testonly = testonly,
             ),
@@ -227,6 +233,7 @@ def _create_binary(
             name,
             deps,
             link_swift_statically,
+            is_test = False,
             tags = tags,
             testonly = testonly,
         ),

--- a/apple/internal/swift_support.bzl
+++ b/apple/internal/swift_support.bzl
@@ -72,12 +72,11 @@ def _swift_runtime_linkopts_impl(ctx):
       binary to dynamically or statically link the Swift runtime.
     """
     linkopts = []
-    is_static = ctx.attr.is_static
-
     swift_usage_info = _swift_usage_info(ctx.attr.deps)
     if swift_usage_info:
         linkopts.extend(swift_common.swift_runtime_linkopts(
-            is_static = is_static,
+            is_static = ctx.attr.is_static,
+            is_test = ctx.attr.is_test,
             toolchain = swift_usage_info.toolchain,
         ))
 
@@ -89,7 +88,8 @@ def _swift_runtime_linkopts_impl(ctx):
 swift_runtime_linkopts = rule(
     _swift_runtime_linkopts_impl,
     attrs = {
-        "is_static": attr.bool(),
+        "is_static": attr.bool(mandatory = True),
+        "is_test": attr.bool(mandatory = True),
         "deps": attr.label_list(
             aspects = [swift_usage_aspect],
             mandatory = True,

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -83,6 +83,7 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         test_bundle_name,
         bundle_name = name,
         platform_type = str(apple_common.platform_type.ios),
+        is_test = True,
         include_entitlements = False,
         testonly = True,
         **bundle_attrs


### PR DESCRIPTION
rules_swift uses this flag to determine if extra linker options specific
to Swift should be propagated. Previously this worked just because there
is some duplication in which flags are passed. With Xcode 11 a new
directory has been added that we only want to pass to the linker for
tests.