### PR TITLE
Migrates integration tests to use test-bin instead of test-genfiles. 

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -125,7 +125,7 @@ function build_path() {
 #         CFBundleIdentifier CFBundleSupportedPlatforms:0
 #     do_build ios //app:dump_plist
 #     assert_equals "my.bundle.id" \
-#         "$(cat "test-genfiles/app/CFBundleIdentifier")"
+#         "$(cat "test-bin/app/CFBundleIdentifier")"
 function create_dump_plist() {
   if [[ "$1" == "--suffix" ]]; then
     shift; SUFFIX="_$1"; shift
@@ -201,7 +201,7 @@ EOF
 #     create_whole_dump_plist //app:app Payload/app.app/Info.plist
 #     do_build ios //app:dump_plist
 #     assert_contains "my.bundle.id" \
-#         "$(cat "test-genfiles/app/dump_whole_plist.txt")"
+#         "$(cat "test-bin/app/dump_whole_plist.txt")"
 function create_whole_dump_plist() {
   if [[ "$1" == "--suffix" ]]; then
     shift; SUFFIX="_$1"; shift
@@ -324,7 +324,7 @@ function current_archs() {
 # the platform required; the remaining arguments are passed directly to bazel.
 #
 # Test builds use "test-" as the output directory symlink prefix, so tests
-# should expect to find their outputs in "test-bin" and "test-genfiles".
+# should expect to find their outputs in "test-bin".
 #
 # Example:
 #     do_build ios --some_other_flag //foo:bar
@@ -341,7 +341,7 @@ function do_build() {
 # the platform required; the remaining arguments are passed directly to bazel.
 #
 # Test builds use "test-" as the output directory symlink prefix, so tests
-# should expect to find their outputs in "test-bin" and "test-genfiles".
+# should expect to find their outputs in "test-bin".
 #
 # Example:
 #     do_test ios --some_other_flag //foo:bar_tests
@@ -357,7 +357,7 @@ function do_test() {
 # the platform required; the remaining arguments are passed directly to bazel.
 #
 # Test builds use "test-" as the output directory symlink prefix, so tests
-# should expect to find their outputs in "test-bin" and "test-genfiles".
+# should expect to find their outputs in "test-bin".
 #
 # Example:
 #     do_coverage ios --some_other_flag //foo:bar_tests
@@ -376,7 +376,7 @@ function do_coverage() {
 # bazel.
 #
 # Test builds use "test-" as the output directory symlink prefix, so tests
-# should expect to find their outputs in "test-bin" and "test-genfiles".
+# should expect to find their outputs in "test-bin".
 #
 # Example:
 #     do_action build ios --some_other_flag //foo:bar
@@ -394,6 +394,9 @@ function do_action() {
       # Used so that if there's a single configuration transition, its output
       # directory gets mapped into the bazel-bin symlink.
       "--use_top_level_targets_for_symlinks"
+      # Explicitly pass this flag to ensure the external testing infrastructure
+      # matches the internal one.
+      "--incompatible_merge_genfiles_directory"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then

--- a/test/dtrace_test.sh
+++ b/test/dtrace_test.sh
@@ -53,9 +53,9 @@ EOF
 
   do_build dtrace //dtrace:CompileTest || fail "should build"
   assert_contains "PROVIDERA_MYFUNC" \
-      test-genfiles/dtrace/CompileTest/folder1/probes.h
+      test-bin/dtrace/CompileTest/folder1/probes.h
   assert_contains "PROVIDERB_MYFUNC" \
-      test-genfiles/dtrace/CompileTest/folder2/probes.h
+      test-bin/dtrace/CompileTest/folder2/probes.h
 }
 
 run_suite "dtrace tests"

--- a/test/ios_application_resources_test.sh
+++ b/test/ios_application_resources_test.sh
@@ -407,13 +407,13 @@ EOF
   do_build ios //app:dump_plist || fail "Should build"
 
   assert_equals "app_icon29x29" \
-      "$(cat "test-genfiles/app/CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles.0")"
+      "$(cat "test-bin/app/CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconFiles.0")"
   assert_equals "launch_image-800-Portrait-736h" \
-      "$(cat "test-genfiles/app/UILaunchImages.0.UILaunchImageName")"
+      "$(cat "test-bin/app/UILaunchImages.0.UILaunchImageName")"
   assert_equals "Portrait" \
-      "$(cat "test-genfiles/app/UILaunchImages.0.UILaunchImageOrientation")"
+      "$(cat "test-bin/app/UILaunchImages.0.UILaunchImageOrientation")"
   assert_equals "{414, 736}" \
-      "$(cat "test-genfiles/app/UILaunchImages.0.UILaunchImageSize")"
+      "$(cat "test-bin/app/UILaunchImages.0.UILaunchImageSize")"
 }
 
 # Tests that the launch storyboard is bundled with the application and that
@@ -444,7 +444,7 @@ EOF
   do_build ios //app:dump_plist || fail "Should build"
 
   assert_equals "launch_screen_ios" \
-      "$(cat "test-genfiles/app/UILaunchStoryboardName")"
+      "$(cat "test-bin/app/UILaunchStoryboardName")"
 }
 
 # Tests that apple_bundle_import files are bundled correctly with the
@@ -573,11 +573,11 @@ EOF
   # Verify the values injected by the Skylark rule for bundle_library's
   # info.plist.
   assert_equals "org.bazel.bundle-library-ios" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier")"
+      "$(cat "test-bin/app/CFBundleIdentifier")"
   assert_equals "bundle_library_ios.bundle" \
-      "$(cat "test-genfiles/app/CFBundleName")"
+      "$(cat "test-bin/app/CFBundleName")"
   assert_equals "bundle_library_ios" \
-      "$(cat "test-genfiles/app/TargetName")"
+      "$(cat "test-bin/app/TargetName")"
 
   do_build ios //app:app || fail "Should build"
 

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -354,7 +354,7 @@ EOF
     create_dump_codesign "//app:app" "Payload/app.app" -d --entitlements :-
     do_build ios "$@" //app:dump_codesign || fail "Should build"
 
-    readonly FILE_TO_CHECK="test-genfiles/app/codesign_output"
+    readonly FILE_TO_CHECK="test-bin/app/codesign_output"
     readonly SHOULD_CONTAIN="${FOR_DEVICE}"
   else
     # For simulator builds, entitlements are added as a Mach-O section in
@@ -712,8 +712,8 @@ EOF
       CFBundleShortVersionString
   do_build ios //app:dump_plist || fail "Should build"
 
-  assert_equals "9.8.7" "$(cat "test-genfiles/app/CFBundleVersion")"
-  assert_equals "6.5" "$(cat "test-genfiles/app/CFBundleShortVersionString")"
+  assert_equals "9.8.7" "$(cat "test-bin/app/CFBundleVersion")"
+  assert_equals "6.5" "$(cat "test-bin/app/CFBundleShortVersionString")"
 }
 
 # Tests tree artifacts builds and disable codesigning for simulator play along.

--- a/test/ios_framework_test.sh
+++ b/test/ios_framework_test.sh
@@ -549,9 +549,9 @@ EOF
   do_build ios //framework:dump_whole_plist || fail "Should build"
 
   assert_not_contains "CFBundleVersion" \
-      "test-genfiles/framework/dump_whole_plist.txt"
+      "test-bin/framework/dump_whole_plist.txt"
   assert_not_contains "CFBundleShortVersionString" \
-      "test-genfiles/framework/dump_whole_plist.txt"
+      "test-bin/framework/dump_whole_plist.txt"
 }
 
 # Tests that the bundled application contains the framework but that the
@@ -1060,9 +1060,9 @@ EOF
   # Verify the values injected by the Skylark rule for bundle_library's
   # info.plist
   assert_equals "org.bazel.simple-bundle-library" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier")"
+      "$(cat "test-bin/app/CFBundleIdentifier")"
   assert_equals "simple_bundle_library.bundle" \
-      "$(cat "test-genfiles/app/CFBundleName")"
+      "$(cat "test-bin/app/CFBundleName")"
 
   do_build ios //app:app || fail "Should build"
 
@@ -1621,23 +1621,23 @@ EOF
   # They also all share a common file to add a custom key, ensure that
   # isn't duped away because of the overlap.
   assert_equals "my.bundle.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_app")"
+      "$(cat "test-bin/app/CFBundleIdentifier_app")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_app")"
+      "$(cat "test-bin/app/CommonKey_app")"
 
   do_build ios //app:dump_plist_framework || fail "Should build"
 
   assert_equals "my.framework.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_framework")"
+      "$(cat "test-bin/app/CFBundleIdentifier_framework")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_framework")"
+      "$(cat "test-bin/app/CommonKey_framework")"
 
   do_build ios //app:dump_plist_depframework || fail "Should build"
 
   assert_equals "my.depframework.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_depframework")"
+      "$(cat "test-bin/app/CFBundleIdentifier_depframework")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_depframework")"
+      "$(cat "test-bin/app/CommonKey_depframework")"
 }
 
 # Verifies that, when an extension depends on a framework with different
@@ -1889,7 +1889,7 @@ EOF
   do_build ios //staticlib:gen_staticlib \
       || fail "Should build static lib"
 
-  cp test-genfiles/staticlib/staticlib.a \
+  cp test-bin/staticlib/staticlib.a \
       app/inner_framework_pregen
 
   do_build ios //app:app -s || fail "Should build"
@@ -2070,7 +2070,7 @@ EOF
 
   do_build ios //staticlib:gen_staticlib || fail "Should build static lib"
 
-  cp test-genfiles/staticlib/staticlib.a \
+  cp test-bin/staticlib/staticlib.a \
       app/inner_framework_pregen
 
   do_build ios //app:app -s || fail "Should build"

--- a/test/ios_ui_test_test.sh
+++ b/test/ios_ui_test_test.sh
@@ -202,7 +202,7 @@ function test_bundle_id_override() {
 
   do_build ios --ios_minimum_os=9.0 //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/ios_unit_test_test.sh
+++ b/test/ios_unit_test_test.sh
@@ -214,7 +214,7 @@ function test_bundle_id_override() {
 
   do_build ios --ios_minimum_os=9.0 //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/macos_application_resources_test.sh
+++ b/test/macos_application_resources_test.sh
@@ -371,9 +371,9 @@ EOF
   # Verify the values injected by the Skylark rule for bundle_library's
   # info.plist
   assert_equals "org.bazel.bundle-library-macos" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier")"
+      "$(cat "test-bin/app/CFBundleIdentifier")"
   assert_equals "bundle_library_macos.bundle" \
-      "$(cat "test-genfiles/app/CFBundleName")"
+      "$(cat "test-bin/app/CFBundleName")"
 
   do_build macos //app:app || fail "Should build"
 

--- a/test/macos_ui_test_test.sh
+++ b/test/macos_ui_test_test.sh
@@ -169,7 +169,7 @@ function test_bundle_id_override() {
 
   do_build macos //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/macos_unit_test_test.sh
+++ b/test/macos_unit_test_test.sh
@@ -172,7 +172,7 @@ function test_bundle_id_override() {
 
   do_build macos //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/tvos_framework_test.sh
+++ b/test/tvos_framework_test.sh
@@ -555,9 +555,9 @@ EOF
   do_build tvos //framework:dump_whole_plist || fail "Should build"
 
   assert_not_contains "CFBundleVersion" \
-      "test-genfiles/framework/dump_whole_plist.txt"
+      "test-bin/framework/dump_whole_plist.txt"
   assert_not_contains "CFBundleShortVersionString" \
-      "test-genfiles/framework/dump_whole_plist.txt"
+      "test-bin/framework/dump_whole_plist.txt"
 }
 
 # Tests that the bundled application contains the framework but that the
@@ -1066,9 +1066,9 @@ EOF
   # Verify the values injected by the Skylark rule for bundle_library's
   # info.plist
   assert_equals "org.bazel.simple-bundle-library" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier")"
+      "$(cat "test-bin/app/CFBundleIdentifier")"
   assert_equals "simple_bundle_library.bundle" \
-      "$(cat "test-genfiles/app/CFBundleName")"
+      "$(cat "test-bin/app/CFBundleName")"
 
   do_build tvos //app:app || fail "Should build"
 
@@ -1469,23 +1469,23 @@ EOF
   do_build tvos //app:dump_plist_app || fail "Should build"
 
   assert_equals "my.bundle.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_app")"
+      "$(cat "test-bin/app/CFBundleIdentifier_app")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_app")"
+      "$(cat "test-bin/app/CommonKey_app")"
 
   do_build tvos //app:dump_plist_framework || fail "Should build"
 
   assert_equals "my.framework.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_framework")"
+      "$(cat "test-bin/app/CFBundleIdentifier_framework")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_framework")"
+      "$(cat "test-bin/app/CommonKey_framework")"
 
   do_build tvos //app:dump_plist_depframework || fail "Should build"
 
   assert_equals "my.depframework.id" \
-      "$(cat "test-genfiles/app/CFBundleIdentifier_depframework")"
+      "$(cat "test-bin/app/CFBundleIdentifier_depframework")"
   assert_equals "CommonValue" \
-      "$(cat "test-genfiles/app/CommonKey_depframework")"
+      "$(cat "test-bin/app/CommonKey_depframework")"
 }
 
 # Verifies that, when an extension depends on a framework with different
@@ -1740,7 +1740,7 @@ EOF
 
   do_build tvos //staticlib:gen_staticlib || fail "Should build static lib"
 
-  cp test-genfiles/staticlib/staticlib.a \
+  cp test-bin/staticlib/staticlib.a \
       app/inner_framework_pregen
 
   do_build tvos //app:app -s || fail "Should build"

--- a/test/tvos_ui_test_test.sh
+++ b/test/tvos_ui_test_test.sh
@@ -171,7 +171,7 @@ function test_bundle_id_override() {
 
   do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/tvos_unit_test_test.sh
+++ b/test/tvos_unit_test_test.sh
@@ -183,7 +183,7 @@ function test_bundle_id_override() {
 
   do_build tvos --tvos_minimum_os=9.0 //app:dump_plist || fail "Should build"
 
-  assert_equals "my.test.bundle.id" "$(cat "test-genfiles/app/CFBundleIdentifier")"
+  assert_equals "my.test.bundle.id" "$(cat "test-bin/app/CFBundleIdentifier")"
 }
 
 # Tests that tests can't reuse the test host's bundle id.

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -143,35 +143,35 @@ EOF
 # Asserts that the common OS and environment plist values in the watch
 # application and extension have the correct values.
 function assert_common_watch_app_and_extension_plist_values() {
-  assert_equals "2.0" "$(cat "test-genfiles/app/MinimumOSVersion")"
-  assert_equals "4" "$(cat "test-genfiles/app/UIDeviceFamily.0")"
+  assert_equals "2.0" "$(cat "test-bin/app/MinimumOSVersion")"
+  assert_equals "4" "$(cat "test-bin/app/UIDeviceFamily.0")"
 
   if is_device_build watchos ; then
     assert_equals "WatchOS" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
+        "$(cat "test-bin/app/CFBundleSupportedPlatforms.0")"
     assert_equals "watchos" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "watchos.*" "test-genfiles/app/DTSDKName"
+        "$(cat "test-bin/app/DTPlatformName")"
+    assert_contains "watchos.*" "test-bin/app/DTSDKName"
   else
     assert_equals "WatchSimulator" \
-        "$(cat "test-genfiles/app/CFBundleSupportedPlatforms.0")"
+        "$(cat "test-bin/app/CFBundleSupportedPlatforms.0")"
     assert_equals "watchsimulator" \
-        "$(cat "test-genfiles/app/DTPlatformName")"
-    assert_contains "watchsimulator.*" "test-genfiles/app/DTSDKName"
+        "$(cat "test-bin/app/DTPlatformName")"
+    assert_contains "watchsimulator.*" "test-bin/app/DTSDKName"
   fi
 
   # Verify the values injected by the environment_plist script. Some of these
   # are dependent on the version of Xcode being used, and since we don't want to
   # force a particular version to always be present, we just make sure that
   # *something* is getting into the plist.
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTSDKBuild")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTPlatformVersion")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcode")"
-  assert_not_equals "" "$(cat "test-genfiles/app/DTXcodeBuild")"
+  assert_not_equals "" "$(cat "test-bin/app/DTPlatformBuild")"
+  assert_not_equals "" "$(cat "test-bin/app/DTSDKBuild")"
+  assert_not_equals "" "$(cat "test-bin/app/DTPlatformVersion")"
+  assert_not_equals "" "$(cat "test-bin/app/DTXcode")"
+  assert_not_equals "" "$(cat "test-bin/app/DTXcodeBuild")"
   assert_equals "com.apple.compilers.llvm.clang.1_0" \
-      "$(cat "test-genfiles/app/DTCompiler")"
-  assert_not_equals "" "$(cat "test-genfiles/app/BuildMachineOSBuild")"
+      "$(cat "test-bin/app/DTCompiler")"
+  assert_not_equals "" "$(cat "test-bin/app/BuildMachineOSBuild")"
 }
 
 # Test missing the CFBundleVersion fails the build.


### PR DESCRIPTION
Migrates integration tests to use test-bin instead of test-genfiles. 

test-genfiles has been a symlink to test-bin for a while and is being deleted in a future version of Bazel.