### PR TITLE
Use transitions for all Apple rules by default.

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -169,7 +169,7 @@ def _describe_rule_type(
         requires_provisioning_profile = requires_provisioning_profile,
         requires_signing_for_device = requires_signing_for_device,
         rpaths = rpaths,
-        rule_transition = rule_transition,
+        rule_transition = transition_support.apple_rule_transition,
         skip_simulator_signing_allowed = skip_simulator_signing_allowed,
         skip_signing = skip_signing,
         stub_binary_path = stub_binary_path,

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -97,8 +97,6 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         **bundling_args
     )
 
-    test_bundle_output = "{}.zip".format(name)
-
     if runner:
         test_rule(
             name = name,


### PR DESCRIPTION
Use transitions for all Apple rules by default.