### PR TITLE
Add plist value checking to archive_contents_test()

### DIFF
--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -50,21 +50,8 @@ def ios_unit_test_test_suite():
             "$BUNDLE_ROOT/resource_bundle.bundle/Info.plist",
             "$BUNDLE_ROOT/Another.plist",
         ],
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
-        tags = [name],
-    )
-
-    dsyms_test(
-        name = "{}_dsyms_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
-        expected_dsyms = ["unit_test.xctest"],
-        tags = [name],
-    )
-
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
-        expected_values = {
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "unit_test",
             "CFBundleIdentifier": "com.google.exampleTests",
@@ -81,6 +68,14 @@ def ios_unit_test_test_suite():
             "MinimumOSVersion": "8.0",
             "UIDeviceFamily:0": "1",
         },
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
+        expected_dsyms = ["unit_test.xctest"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -26,10 +26,6 @@ load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
-load(
-    ":rules/infoplist_contents_test.bzl",
-    "infoplist_contents_test",
-)
 
 def macos_bundle_test_suite():
     """Test suite for macos_bundle."""
@@ -51,21 +47,8 @@ def macos_bundle_test_suite():
             "$CONTENT_ROOT/Nested/non_nested.txt",
             "$CONTENT_ROOT/Nested/nested/nested.txt",
         ],
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
-        tags = [name],
-    )
-
-    dsyms_test(
-        name = "{}_dsyms_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
-        expected_dsyms = ["bundle.bundle"],
-        tags = [name],
-    )
-
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
-        expected_values = {
+        plist_test_file = "$CONTENT_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "bundle",
             "CFBundleIdentifier": "com.google.example",
@@ -81,6 +64,14 @@ def macos_bundle_test_suite():
             "DTXcodeBuild": "*",
             "LSMinimumSystemVersion": "10.10",
         },
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
+        expected_dsyms = ["bundle.bundle"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_quick_look_plugin_tests.bzl
+++ b/test/starlark_tests/macos_quick_look_plugin_tests.bzl
@@ -22,10 +22,6 @@ load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
-load(
-    ":rules/infoplist_contents_test.bzl",
-    "infoplist_contents_test",
-)
 
 def macos_quick_look_plugin_test_suite():
     """Test suite for macos_quick_look_plugin."""
@@ -47,14 +43,8 @@ def macos_quick_look_plugin_test_suite():
             "$CONTENT_ROOT/Nested/non_nested.txt",
             "$CONTENT_ROOT/Nested/nested/nested.txt",
         ],
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
-        tags = [name],
-    )
-
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
-        expected_values = {
+        plist_test_file = "$CONTENT_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "ql_plugin",
             "CFBundleIdentifier": "com.google.example",
@@ -70,6 +60,7 @@ def macos_quick_look_plugin_test_suite():
             "DTXcodeBuild": "*",
             "LSMinimumSystemVersion": "10.10",
         },
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_ui_test_tests.bzl
+++ b/test/starlark_tests/macos_ui_test_tests.bzl
@@ -26,10 +26,6 @@ load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
-load(
-    ":rules/infoplist_contents_test.bzl",
-    "infoplist_contents_test",
-)
 
 def macos_ui_test_test_suite():
     """Test suite for macos_ui_test."""
@@ -51,21 +47,8 @@ def macos_ui_test_test_suite():
             "$CONTENT_ROOT/Nested/non_nested.txt",
             "$CONTENT_ROOT/Nested/nested/nested.txt",
         ],
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
-        tags = [name],
-    )
-
-    dsyms_test(
-        name = "{}_dsyms_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
-        expected_dsyms = ["ui_test.xctest"],
-        tags = [name],
-    )
-
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
-        expected_values = {
+        plist_test_file = "$CONTENT_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "ui_test",
             "CFBundleIdentifier": "com.google.exampleTests",
@@ -81,6 +64,14 @@ def macos_ui_test_test_suite():
             "DTXcodeBuild": "*",
             "LSMinimumSystemVersion": "10.10",
         },
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
+        expected_dsyms = ["ui_test.xctest"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -26,10 +26,6 @@ load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
-load(
-    ":rules/infoplist_contents_test.bzl",
-    "infoplist_contents_test",
-)
 
 def macos_unit_test_test_suite():
     """Test suite for macos_unit_test."""
@@ -51,21 +47,8 @@ def macos_unit_test_test_suite():
             "$CONTENT_ROOT/Nested/non_nested.txt",
             "$CONTENT_ROOT/Nested/nested/nested.txt",
         ],
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
-        tags = [name],
-    )
-
-    dsyms_test(
-        name = "{}_dsyms_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
-        expected_dsyms = ["unit_test.xctest"],
-        tags = [name],
-    )
-
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
-        expected_values = {
+        plist_test_file = "$CONTENT_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "unit_test",
             "CFBundleIdentifier": "com.google.exampleTests",
@@ -81,6 +64,14 @@ def macos_unit_test_test_suite():
             "DTXcodeBuild": "*",
             "LSMinimumSystemVersion": "10.10",
         },
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
+        tags = [name],
+    )
+
+    dsyms_test(
+        name = "{}_dsyms_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
+        expected_dsyms = ["unit_test.xctest"],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -27,6 +27,8 @@ def archive_contents_test(
         not_contains = [],
         is_binary_plist = [],
         is_not_binary_plist = [],
+        plist_test_file = "",
+        plist_test_values = {},
         **kwargs):
     """Macro for calling the apple_verification_test with archive_contents_test.sh.
 
@@ -49,8 +51,20 @@ def archive_contents_test(
             paths are expanded with bash. Test will fail if file doesn't exist.
         is_not_binary_plist:  Optional, List of paths to files to test for the absense of a binary
             plist format. The paths are expanded with bash. Test will fail if file doesn't exist.
+        plist_test_file: Optional, The plist file to test with `plist_test_values`(see next Arg).
+        plist_test_values: Optional, The key/value pairs to test. Keys are specified in PlistBuddy
+            format(e.g. "UIDeviceFamily:1"). The test will fail if the key does not exist or if
+            its value doesn't match the specified value. * can be used as a wildcard value.
+            See `plist_test_file`(previous Arg) to specify plist file to test.
         **kwargs: Other arguments are passed through to the apple_verification_test rule.
     """
+
+    # Concatonate the keys and values of the test values so they can be passed as env vars.
+    plist_test_values_list = []
+    for key, value in plist_test_values.items():
+        if " " in key:
+            fail("Plist key has a space: \"{}\"".format(key))
+        plist_test_values_list.append("{} {}".format(key, value))
 
     apple_verification_test(
         name = name,
@@ -60,6 +74,8 @@ def archive_contents_test(
             "NOT_CONTAINS": not_contains,
             "IS_BINARY_PLIST": is_binary_plist,
             "IS_NOT_BINARY_PLIST": is_not_binary_plist,
+            "PLIST_TEST_FILE": [plist_test_file],
+            "PLIST_TEST_VALUES": plist_test_values_list,
         },
         target_under_test = target_under_test,
         verifier_script = "verifier_scripts/archive_contents_test.sh",


### PR DESCRIPTION
Add plist value checking to archive_contents_test()

This handles special characters that infoplist_contents_test() doesn't handle(e.g. "{"). It can't test targets that don't build, so it isn't a drop-in replacement for infoplist_contents_test().