### PR TITLE
Rollback of commit 9348eec8b70417b7255a45353388da92132e3559

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -233,7 +233,7 @@ def _create_binary(
             name,
             deps,
             link_swift_statically,
-            is_test = bundling_args.get("testonly", False),
+            is_test = False,
             tags = tags,
             testonly = testonly,
         ),


### PR DESCRIPTION
Rollback of commit 9348eec8b70417b7255a45353388da92132e3559


*** Reason for rollback ***

Broke some internal projects.

*** Original change description ***

Copybara import of the project:

--
8f19a2e15329d4a6556cded33e27c759be62a2bc by Keith Smiley <keithbsmiley@gmail.com>:

Pass is_test = True for testonly binaries

rules_swift uses this value to determine if it should pass the new
library location to the linker. This is required to link a `testonly`
Swift framework that uses XCTest.