### PR TITLE
Pass is_test = True for testonly binaries

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -233,7 +233,7 @@ def _create_binary(
             name,
             deps,
             link_swift_statically,
-            is_test = False,
+            is_test = testonly or False,
             tags = tags,
             testonly = testonly,
         ),


### PR DESCRIPTION
rules_swift uses this value to determine if it should pass the new
library location to the linker. This is required to link a testonly
Swift framework that uses XCTest.

If testonly isn't present, or is set to None, we must pass False or it
fails further down.

Fixes this rollback https://github.com/bazelbuild/rules_apple/pull/594