### PR TITLE
Rollback of commit 5e0a159df612cb815ac58237485564ac53b08d60.

### DIFF
--- a/test/apple_core_ml_library_test.sh
+++ b/test/apple_core_ml_library_test.sh
@@ -52,7 +52,6 @@ swift_library(
     # smh.
     copts = ["-Xcc", "-Wno-nullability"],
     deps = [":SampleCoreML"],
-    alwayslink = True,
 )
 
 apple_core_ml_library(

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.sh
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.sh
@@ -129,9 +129,4 @@ readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swift_stdlib_tool.XXXXXX")
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
 copy_swift_stdlibs "$TEMP_DIR"
-if ! ls "$TEMP_DIR/libswift"* > /dev/null 2>&1; then
-  echo "error: Expected to copy Swift Standard Lib dylibs, but none were copied." >&2
-  exit 1
-fi
-
 strip_dylibs "$TEMP_DIR" "$OUTPUT_PATH"


### PR DESCRIPTION
Rollback of commit 5e0a159df612cb815ac58237485564ac53b08d60.

*** Reason for rollback ***

Broke internal projects

*** Original change description ***

5e0a159df612cb815ac58237485564ac53b08d60 by Keith Smiley <keithbsmiley@gmail.com>:

Add error when no swift dylibs are copied

When Xcode changes how the Swift libraries are handled, we may need to
update rules_apple to be compatible. In the case of Xcode 11 no Swift
libraries were copied, meaning apps would crash only on OS versions
before 12.4. This way we find this issue sooner.