### PR TITLE
Add error when no swift dylibs are copied

### DIFF
--- a/test/apple_core_ml_library_test.sh
+++ b/test/apple_core_ml_library_test.sh
@@ -52,6 +52,7 @@ swift_library(
     # smh.
     copts = ["-Xcc", "-Wno-nullability"],
     deps = [":SampleCoreML"],
+    alwayslink = True,
 )
 
 apple_core_ml_library(

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.sh
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.sh
@@ -129,4 +129,9 @@ readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/swift_stdlib_tool.XXXXXX")
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
 copy_swift_stdlibs "$TEMP_DIR"
+if ! ls "$TEMP_DIR/libswift"* > /dev/null 2>&1; then
+  echo "error: Expected to copy Swift Standard Lib dylibs, but none were copied." >&2
+  exit 1
+fi
+
 strip_dylibs "$TEMP_DIR" "$OUTPUT_PATH"


### PR DESCRIPTION
When Xcode changes how the Swift libraries are handled, we may need to
update rules_apple to be compatible. In the case of Xcode 11 no Swift
libraries were copied, meaning apps would crash only on OS versions
before 12.4. This way we find this issue sooner.

Rollback of commit c435695c1194b11f9b48a3145247b99ab9fb28c5