### PR TITLE
Add full workspace name to dependency

### DIFF
--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -199,7 +199,7 @@ into a bash array.
             default = "@build_bazel_rules_apple//test:apple_verification_test_deps",
         ),
         "_whitelist_function_transition": attr.label(
-            default = "@//tools/whitelists/function_transition_whitelist",
+            default = "@build_bazel_rules_apple//tools/whitelists/function_transition_whitelist",
         ),
     }),
     test = True,


### PR DESCRIPTION
This is necessary if you want to run the tests from another workspace