### PR TITLE
Make grep-includes available to apple starlark build rules

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -117,6 +117,12 @@ _COMMON_PRIVATE_TOOL_ATTRS = dicts.add(
                 "@build_bazel_rules_apple//apple/internal/templates:dsym_info_plist_template",
             ),
         ),
+        "_grep_includes": attr.label(
+            cfg = "host",
+            allow_single_file = True,
+            executable = True,
+            default = Label("@bazel_tools//tools/cpp:grep-includes"),
+        ),
         "_plisttool": attr.label(
             cfg = "host",
             default = Label("@build_bazel_rules_apple//tools/plisttool"),


### PR DESCRIPTION
Make grep-includes available to apple starlark build rules

This is in preparation for making include scanning available for objc.
It will be needed for include scanning, for any rule that invokes
compile actions.