### PR TITLE
Update documentation to sync with minimum_os_version being a required attribute.

### DIFF
--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -164,11 +164,10 @@ Builds and bundles an iOS application.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -340,11 +339,10 @@ iMessage extension or a Sticker Pack extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -520,11 +518,10 @@ Builds and bundles an iOS application extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -709,11 +706,10 @@ Builds and bundles an iOS iMessage extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -858,11 +854,10 @@ Builds and bundles an iOS Sticker Pack extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1014,10 +1009,9 @@ app and extensions, list it in the `frameworks` attributes of those
       <td><code>minimum_os_version</code></td>
       <td>
         <p><code>String; required</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1191,10 +1185,9 @@ build a single framework artifact that works for all architectures by specifying
       <td><code>minimum_os_version</code></td>
       <td>
         <p><code>String; required</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1307,11 +1300,10 @@ of the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1461,11 +1453,10 @@ except `runner` is replaced by `runners`.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1616,11 +1607,10 @@ of the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>
@@ -1761,11 +1751,10 @@ containing an [ios_unit_test](#ios_unit_test) for each of the given `runners`.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <code>"9.0"</code>).
       </td>
     </tr>
     <tr>

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -143,11 +143,10 @@ simple command line tool as a standalone binary, use
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -348,11 +347,10 @@ Builds and bundles a macOS loadable bundle.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -471,11 +469,10 @@ Targets created with `macos_command_line_application` can be executed using
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -557,11 +554,10 @@ Builds a macOS dylib.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -705,11 +701,10 @@ Builds and bundles a macOS extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -880,11 +875,10 @@ Builds and bundles a macOS Kernel Extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -1055,11 +1049,10 @@ Builds and bundles a macOS Spotlight Importer.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -1192,11 +1185,10 @@ of the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.10"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -1334,11 +1326,10 @@ of the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum iOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.12"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--ios_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>
@@ -1521,11 +1512,10 @@ Builds and bundles a macOS XPC Service.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum macOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.11"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--macos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum macOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.11"</code>).
       </td>
     </tr>
     <tr>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -141,11 +141,10 @@ Builds and bundles a tvOS application.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum tvOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--tvos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum tvOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.0"</code>).
       </td>
     </tr>
     <tr>
@@ -322,11 +321,10 @@ Builds and bundles a tvOS extension.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum tvOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"10.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--tvos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum tvOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.0"</code>).
       </td>
     </tr>
     <tr>
@@ -477,11 +475,10 @@ and extensions, list it in the `frameworks` attributes of those
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum tvOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--tvos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum tvOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.0"</code>).
       </td>
     </tr>
     <tr>
@@ -582,11 +579,10 @@ the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum tvOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--tvos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum tvOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.0"</code>).
       </td>
     </tr>
     <tr>
@@ -733,11 +729,10 @@ of the attributes inherited by all test rules, please check the
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum tvOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"9.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--tvos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum tvOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"10.0"</code>).
       </td>
     </tr>
     <tr>

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -124,11 +124,10 @@ rule.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum watchOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"2.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--watchos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum watchOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"4.0"</code>).
       </td>
     </tr>
     <tr>
@@ -311,11 +310,10 @@ do not support that version of the platform.
     <tr>
       <td><code>minimum_os_version</code></td>
       <td>
-        <p><code>String; optional</code></p>
-        <p>An optional string indicating the minimum watchOS version supported by the
-        target, represented as a dotted version number (for example,
-        <code>"2.0"</code>). If this attribute is omitted, then the value specified
-        by the flag <code>--watchos_minimum_os</code> will be used instead.
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum watchOS version supported by
+        the target, represented as a dotted version number (for example,
+        <code>"4.0"</code>).
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Update documentation to sync with minimum_os_version being a required attribute.