### PR TITLE
Update get-task-allow entitlement

### DIFF
--- a/apple/internal/entitlement_rules.bzl
+++ b/apple/internal/entitlement_rules.bzl
@@ -228,7 +228,7 @@ def _entitlements_impl(ctx):
     if signing_info.entitlements:
         plists.append(signing_info.entitlements)
     if _include_debug_entitlements(ctx):
-        get_task_allow = {"get-task-allow": True}
+        get_task_allow = {"com.apple.security.get-task-allow": True}
         forced_plists.append(struct(**get_task_allow))
 
     inputs = list(plists)

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -116,24 +116,24 @@ you'll need to specify the `--output_groups=+linkmaps` flag.
 
 ### Debugging Entitlement Support {#apple.add_debugger_entitlement}
 
-Some Apple platforms require an entitlement (`get-task-allow`) to support
-debugging tools. The rules will auto add the entitlement for non optimized
-builds (i.e. - anything that isn't `-c opt`). However when looking at specific
-issues (performance of a release build via Instruments), the entitlement is also
-needed.
+Some Apple platforms require an entitlement
+(`com.apple.security.get-task-allow`) to support debugging tools. The rules will
+auto add the entitlement for non optimized builds (i.e. - anything that isn't
+`-c opt`). However when looking at specific issues (performance of a release
+build via Instruments), the entitlement is also needed.
 
 The rules support direct control over the inclusion/exclusion of any bundle
 being built by
 `--define=apple.add_debugger_entitlement=(yes|true|1|no|false|0)`.
 
-Add `get-task-allow` entitlement:
+Add `com.apple.security.get-task-allow` entitlement:
 
 ```shell
 bazel build --define=apple.add_debugger_entitlement=yes //your/target
 ```
 
-Ensure `get-task-allow` entitlement is *not* added (even if the default would
-have added it):
+Ensure `com.apple.security.get-task-allow` entitlement is *not* added (even if
+the default would have added it):
 
 ```shell
 bazel build --define=apple.add_debugger_entitlement=no //your/target

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -335,7 +335,7 @@ ios_application(
 EOF
 
   # Use a local entitlements file so the default isn't extracted from the
-  # provisioning profile (which likely has get-task-allow).
+  # provisioning profile (which likely has com.apple.security.get-task-allow).
   cat > app/entitlements.plist <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -368,9 +368,9 @@ EOF
   fi
 
   if [[ "${SHOULD_CONTAIN}" == "y" ]] ; then
-    assert_contains "<key>get-task-allow</key>" "${FILE_TO_CHECK}"
+    assert_contains "<key>com.apple.security.get-task-allow</key>" "${FILE_TO_CHECK}"
   else
-    assert_not_contains "<key>get-task-allow</key>" "${FILE_TO_CHECK}"
+    assert_not_contains "<key>com.apple.security.get-task-allow</key>" "${FILE_TO_CHECK}"
   fi
 }
 

--- a/test/testdata/provisioning/integration_testing_ios.mobileprovision
+++ b/test/testdata/provisioning/integration_testing_ios.mobileprovision
@@ -33,7 +33,7 @@
         <array>
             <string>FOOBARBAZ1.*</string>
         </array>
-        <key>get-task-allow</key>
+        <key>com.apple.security.get-task-allow</key>
         <true/>
         <key>application-identifier</key>
         <string>FOOBARBAZ1.*</string>

--- a/test/testdata/provisioning/integration_testing_tvos.mobileprovision
+++ b/test/testdata/provisioning/integration_testing_tvos.mobileprovision
@@ -33,7 +33,7 @@
         <array>
             <string>FOOBARBAZ1.*</string>
         </array>
-        <key>get-task-allow</key>
+        <key>com.apple.security.get-task-allow</key>
         <true/>
         <key>application-identifier</key>
         <string>FOOBARBAZ1.*</string>


### PR DESCRIPTION
When building from Xcode these days you get this full
`com.apple.security.get-task-allow` entitlement. As far as I know
there's no difference between these too but it's good to keep in line
with what Xcode is doing.