### PR TITLE
Use a proper bash conditional to handle failures.

### DIFF
--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -88,8 +88,10 @@ def compile_plist(ctx, input_file, output_file):
     # empty, it will echo an new line and then pipe it into plutil. We do this
     # to handle empty files as plutil doesn't handle them very well.
     plutil_command = "plutil -convert binary1 -o %s --" % output_file.path
-    complete_command = ("([[ -s {in_file} ]] && {plutil_command} {in_file} ) " +
-                        "|| ( echo | {plutil_command} -)").format(
+    complete_command = ("if [[ -s {in_file} ]] ; then {plutil_command} {in_file} ; " +
+                        "elif [[ -f {in_file} ]] ; then echo | {plutil_command} - ; " +
+                        "else exit 1 ; " +
+                        "fi").format(
         in_file = input_file.path,
         plutil_command = plutil_command,
     )


### PR DESCRIPTION
Use a proper bash conditional to handle failures.

Also ensure that if the input file wasn't provided the action errors.