### PR TITLE
Fix watchOS extension target under test as it does not build as is on Xcode 11

### DIFF
--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -11,6 +11,10 @@ load(
     "apple_resource_group",
 )
 load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+load(
     "//test/starlark_tests:rules/dummy_apple_resource_info.bzl",
     "dummy_apple_resource_info",
 )
@@ -32,6 +36,14 @@ objc_library(
 objc_library(
     name = "objc_main_lib",
     srcs = ["main.m"],
+)
+
+swift_library(
+    name = "watchkit_ext_main_lib",
+    srcs = ["WatchKitExtMain.swift"],
+    tags = [
+        "manual",
+    ],
 )
 
 objc_library(

--- a/test/starlark_tests/resources/WatchKitExtMain.swift
+++ b/test/starlark_tests/resources/WatchKitExtMain.swift
@@ -1,0 +1,47 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+
+  func applicationDidFinishLaunching() {
+  }
+
+  func applicationDidBecomeActive() {
+  }
+
+  func applicationWillResignActive() {
+  }
+
+  func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+    for task in backgroundTasks {
+      switch task {
+      case let backgroundTask as WKApplicationRefreshBackgroundTask:
+        backgroundTask.setTaskCompletedWithSnapshot(false)
+      case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+        snapshotTask.setTaskCompleted(restoredDefaultState: true,
+                                      estimatedSnapshotExpiration: Date.distantFuture,
+                                      userInfo: nil)
+      case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+        connectivityTask.setTaskCompletedWithSnapshot(false)
+      case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+        urlSessionTask.setTaskCompletedWithSnapshot(false)
+      default:
+        task.setTaskCompletedWithSnapshot(false)
+      }
+    }
+  }
+
+}

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -18,7 +18,7 @@ watchos_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     tags = [
         "manual",
         "notap",
@@ -32,7 +32,7 @@ watchos_extension(
     infoplists = [
         "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
     ],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     resources = [
         "//test/starlark_tests/resources:example_filegroup",
@@ -44,7 +44,7 @@ watchos_extension(
         "notap",
     ],
     deps = [
-        "//test/starlark_tests/resources:objc_main_lib",
+        "//test/starlark_tests/resources:watchkit_ext_main_lib",
     ],
 )
 
@@ -55,7 +55,7 @@ watchos_extension(
         "//test/starlark_tests/resources:Another.plist",
         "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
     ],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -52,7 +52,7 @@ def watchos_application_test_suite():
             "DTSDKName": "watchsimulator*",
             "DTXcode": "*",
             "DTXcodeBuild": "*",
-            "MinimumOSVersion": "3.0",
+            "MinimumOSVersion": "4.0",
             "UIDeviceFamily:0": "4",
         },
         tags = [name],

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -105,7 +105,7 @@ def watchos_extension_test_suite():
             "DTSDKName": "watchsimulator*",
             "DTXcode": "*",
             "DTXcodeBuild": "*",
-            "MinimumOSVersion": "3.0",
+            "MinimumOSVersion": "4.0",
             "NSExtension:NSExtensionAttributes:WKAppBundleIdentifier": "com.google.example",
             "NSExtension:NSExtensionPointIdentifier": "com.apple.watchkit",
             "UIDeviceFamily:0": "4",


### PR DESCRIPTION
Fix watchOS extension target under test as it does not build as is on Xcode 11