### PR TITLE
Fix macOS tests runner to support Xcode 11.

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.xctestrun
+++ b/apple/testing/default_runner/macos_test_runner.template.xctestrun
@@ -12,6 +12,8 @@
 		<string>BAZEL_TEST_HOST_PATH</string>
 		<key>TestingEnvironmentVariables</key>
 		<dict>
+			<key>DYLD_FALLBACK_LIBRARY_PATH</key>
+			<string>__PLATFORMS__/MacOSX.platform/Developer/usr/lib</string>
 			<key>DYLD_FRAMEWORK_PATH</key>
 			<string>__PLATFORMS__/MacOSX.platform/Developer/Library/Frameworks:__SHAREDFRAMEWORKS__</string>
 			<key>DYLD_LIBRARY_PATH</key>


### PR DESCRIPTION
Fix macOS tests runner to support Xcode 11.

We add the Xcode path for support test dylibs to DYLD_FALLBACK_LIBRARY_PATH so that they can be found at runtime.