### PR TITLE
"Hide" the *_bundle test rules names.

### DIFF
--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -59,12 +59,16 @@ def _ios_unit_test_impl(ctx):
         IosXcTestBundleInfo(),
     ]
 
-ios_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_ios_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _ios_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.ios),
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an iOS UI Test Bundle. Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+ios_internal_ui_test_bundle = _ios_internal_ui_test_bundle
 
 ios_ui_test = rule_factory.create_apple_test_rule(
     implementation = _ios_ui_test_impl,
@@ -72,12 +76,16 @@ ios_ui_test = rule_factory.create_apple_test_rule(
     platform_type = str(apple_common.platform_type.ios),
 )
 
-ios_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_ios_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _ios_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.ios),
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an iOS Unit Test Bundle. Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+ios_internal_unit_test_bundle = _ios_internal_unit_test_bundle
 
 ios_unit_test = rule_factory.create_apple_test_rule(
     implementation = _ios_unit_test_impl,

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -59,12 +59,16 @@ def _macos_unit_test_impl(ctx):
         MacosXcTestBundleInfo(),
     ]
 
-macos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_macos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _macos_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.macos),
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an macOS UI Test Bundle.  Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+macos_internal_ui_test_bundle = _macos_internal_ui_test_bundle
 
 macos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _macos_ui_test_impl,
@@ -72,12 +76,16 @@ macos_ui_test = rule_factory.create_apple_test_rule(
     platform_type = str(apple_common.platform_type.macos),
 )
 
-macos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_macos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _macos_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.macos),
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an macOS Unit Test Bundle.  Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+macos_internal_unit_test_bundle = _macos_internal_unit_test_bundle
 
 macos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _macos_unit_test_impl,

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -59,12 +59,16 @@ def _tvos_unit_test_impl(ctx):
         TvosXcTestBundleInfo(),
     ]
 
-tvos_ui_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_tvos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _tvos_ui_test_bundle_impl,
     platform_type = str(apple_common.platform_type.tvos),
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an tvOS UI Test Bundle.  Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+tvos_internal_ui_test_bundle = _tvos_internal_ui_test_bundle
 
 tvos_ui_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_ui_test_impl,
@@ -72,12 +76,16 @@ tvos_ui_test = rule_factory.create_apple_test_rule(
     platform_type = str(apple_common.platform_type.tvos),
 )
 
-tvos_unit_test_bundle = rule_factory.create_apple_bundling_rule(
+# Declare it with an underscore so it shows up that way in queries.
+_tvos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _tvos_unit_test_bundle_impl,
     platform_type = str(apple_common.platform_type.tvos),
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an tvOS Unit Test Bundle. Internal target not to be depended upon.",
 )
+
+# Alias to import it.
+tvos_internal_unit_test_bundle = _tvos_internal_unit_test_bundle
 
 tvos_unit_test = rule_factory.create_apple_test_rule(
     implementation = _tvos_unit_test_impl,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -20,10 +20,10 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
+    _ios_internal_ui_test_bundle = "ios_internal_ui_test_bundle",
+    _ios_internal_unit_test_bundle = "ios_internal_unit_test_bundle",
     _ios_ui_test = "ios_ui_test",
-    _ios_ui_test_bundle = "ios_ui_test_bundle",
     _ios_unit_test = "ios_unit_test",
-    _ios_unit_test_bundle = "ios_unit_test_bundle",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -183,7 +183,7 @@ def ios_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _ios_unit_test_bundle,
+        bundle_rule = _ios_internal_unit_test_bundle,
         test_rule = _ios_unit_test,
         runner = runner,
         bundle_loader = kwargs.get("test_host"),
@@ -195,7 +195,7 @@ def ios_ui_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _ios_ui_test_bundle,
+        bundle_rule = _ios_internal_ui_test_bundle,
         test_rule = _ios_ui_test,
         runner = runner,
         dylibs = kwargs.get("frameworks"),
@@ -205,7 +205,7 @@ def ios_ui_test(name, **kwargs):
 def ios_unit_test_suite(name, **kwargs):
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _ios_unit_test_bundle,
+        bundle_rule = _ios_internal_unit_test_bundle,
         test_rule = _ios_unit_test,
         bundle_loader = kwargs.get("test_host"),
         dylibs = kwargs.get("frameworks"),
@@ -215,7 +215,7 @@ def ios_unit_test_suite(name, **kwargs):
 def ios_ui_test_suite(name, **kwargs):
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _ios_ui_test_bundle,
+        bundle_rule = _ios_internal_ui_test_bundle,
         test_rule = _ios_ui_test,
         dylibs = kwargs.get("frameworks"),
         **kwargs

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -20,10 +20,10 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
+    _macos_internal_ui_test_bundle = "macos_internal_ui_test_bundle",
+    _macos_internal_unit_test_bundle = "macos_internal_unit_test_bundle",
     _macos_ui_test = "macos_ui_test",
-    _macos_ui_test_bundle = "macos_ui_test_bundle",
     _macos_unit_test = "macos_unit_test",
-    _macos_unit_test_bundle = "macos_unit_test_bundle",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
@@ -280,7 +280,7 @@ def macos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _macos_unit_test_bundle,
+        bundle_rule = _macos_internal_unit_test_bundle,
         test_rule = _macos_unit_test,
         runner = runner,
         bundle_loader = kwargs.get("test_host"),
@@ -292,7 +292,7 @@ def macos_ui_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _macos_ui_test_bundle,
+        bundle_rule = _macos_internal_ui_test_bundle,
         test_rule = _macos_ui_test,
         runner = runner,
         dylibs = kwargs.get("frameworks"),

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -20,10 +20,10 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple/internal/testing:tvos_rules.bzl",
+    _tvos_internal_ui_test_bundle = "tvos_internal_ui_test_bundle",
+    _tvos_internal_unit_test_bundle = "tvos_internal_unit_test_bundle",
     _tvos_ui_test = "tvos_ui_test",
-    _tvos_ui_test_bundle = "tvos_ui_test_bundle",
     _tvos_unit_test = "tvos_unit_test",
-    _tvos_unit_test_bundle = "tvos_unit_test_bundle",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
@@ -124,7 +124,7 @@ def tvos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _tvos_unit_test_bundle,
+        bundle_rule = _tvos_internal_unit_test_bundle,
         test_rule = _tvos_unit_test,
         runner = runner,
         bundle_loader = kwargs.get("test_host"),
@@ -136,7 +136,7 @@ def tvos_ui_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
     apple_test_assembler.assemble(
         name = name,
-        bundle_rule = _tvos_ui_test_bundle,
+        bundle_rule = _tvos_internal_ui_test_bundle,
         test_rule = _tvos_ui_test,
         runner = runner,
         **kwargs


### PR DESCRIPTION
"Hide" the *_bundle test rules names.

They are implementation details, so folks should really use them, this also
ensures a query with `kind(ios_unit_test, ...)` doesn't pick them up since a
query that doesn't end in " rule" is an unanchored pattern can hence can match
even just a leading underscore on the name (_ios_unit_test_bundle).

Fixes #624