### PR TITLE
Use last_downstream_green instead of last_green

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -17,7 +17,7 @@ x_defaults:
 tasks:
   macos_last_green:
     name: "Last Green Bazel"
-    bazel: last_green
+    bazel: last_downstream_green
     <<: *common
 
 


### PR DESCRIPTION
https://buildkite.com/bazel/rules-apple-darwin/builds/1941 is broken due to a bazel bug, we should not let this happen.

last_green refers to the Bazel binary that was built at the most recent commit that passed Bazel CI. Ideally this binary should be very close to Bazel-at-head.
last_downstream_green points to the most recent Bazel binary that builds and tests all downstream projects successfully.