### PR TITLE
Add dynamic slicer tool to allow stripping of unneeded architectures in

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -60,6 +60,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
@@ -123,6 +124,7 @@ def _ios_application_impl(ctx):
         ),
         partials.framework_import_partial(
             targets = ctx.attr.deps + ctx.attr.extensions + ctx.attr.frameworks,
+            extra_binaries = [x[AppleBundleInfo].binary for x in ctx.attr.extensions],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -15,6 +15,10 @@
 """Partial implementation for framework import file processing."""
 
 load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
     "AppleFrameworkImportInfo",
 )
@@ -27,6 +31,14 @@ load(
     "bundle_paths",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "outputs",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
@@ -35,7 +47,7 @@ load(
     "paths",
 )
 
-def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
+def _framework_import_partial_impl(ctx, targets, targets_to_avoid, extra_binaries):
     """Implementation for the framework import file processing partial."""
     _ignored = [ctx]
 
@@ -60,6 +72,8 @@ def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
             files_to_bundle = [x for x in files_to_bundle if x not in avoid_files]
 
     bundle_files = []
+    slicer_args = []
+    main_binary = outputs.binary(ctx)
     for file in files_to_bundle:
         framework_path = bundle_paths.farthest_parent(file.short_path, "framework")
         framework_relative_path = paths.relativize(file.short_path, framework_path)
@@ -69,13 +83,39 @@ def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
         if framework_relative_dir:
             parent_dir = paths.join(parent_dir, framework_relative_dir)
 
-        bundle_files.append(
-            (processor.location.framework, parent_dir, depset([file])),
-        )
+        # check to see if the the parent is "Foo.[extension]" and the file is "Foo", thus "Foo.framework/Foo", so the binary within the framework.
+        if paths.replace_extension(parent_dir, "") == file.basename:
+            stripped = intermediates.file(
+                ctx.actions,
+                ctx.label.name,
+                paths.join("_imported_frameworks", file.basename),
+            )
+            bundle_files.append(
+                (processor.location.framework, parent_dir, depset([stripped])),
+            )
+
+            args = slicer_args + ["--in", file.path, "--out", stripped.path]
+            all_binaries = extra_binaries + [main_binary]
+            for binary in all_binaries:
+                args.append(binary.path)
+
+            apple_support.run(
+                ctx,
+                inputs = [file] + all_binaries,
+                tools = [ctx.executable._realpath],
+                executable = ctx.executable._dynamic_framework_slicer,
+                outputs = [stripped],
+                arguments = args,
+                mnemonic = "DynamicFrameworkSlicer",
+            )
+        else:
+            bundle_files.append(
+                (processor.location.framework, parent_dir, depset([file])),
+            )
 
     return struct(bundle_files = bundle_files)
 
-def framework_import_partial(targets, targets_to_avoid = []):
+def framework_import_partial(targets, targets_to_avoid = [], extra_binaries = []):
     """Constructor for the framework import file processing partial.
 
     This partial propagates framework import file bundle locations. The files are collected through
@@ -85,6 +125,8 @@ def framework_import_partial(targets, targets_to_avoid = []):
         targets: The list of targets through which to collect the framework import files.
         targets_to_avoid: The list of targets that may already be bundling some of the frameworks,
             to be used when deduplicating frameworks already bundled.
+        extra_binaries: Extra binaries to consider when collecting which archs should be
+            preserved in the imported dynamic frameworks.
 
     Returns:
         A partial that returns the bundle location of the framework import files.
@@ -93,4 +135,5 @@ def framework_import_partial(targets, targets_to_avoid = []):
         _framework_import_partial_impl,
         targets = targets,
         targets_to_avoid = targets_to_avoid,
+        extra_binaries = extra_binaries,
     )

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -171,6 +171,11 @@ _COMMON_PRIVATE_TOOL_ATTRS = dicts.add(
             executable = True,
             default = Label("@build_bazel_rules_apple//tools/xctoolrunner"),
         ),
+        "_dynamic_framework_slicer": attr.label(
+            cfg = "host",
+            executable = True,
+            default = Label("@build_bazel_rules_apple//tools/dynamic_framework_slicer"),
+        ),
     },
     apple_support.action_required_attrs(),
 )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -52,6 +52,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
     "TvosApplicationBundleInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
@@ -101,6 +102,7 @@ def _tvos_application_impl(ctx):
         ),
         partials.framework_import_partial(
             targets = ctx.attr.deps + embeddable_targets,
+            extra_binaries = [x[AppleBundleInfo].binary for x in ctx.attr.extensions],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,6 +17,7 @@ filegroup(
         "//tools/whitelists/function_transition_whitelist:for_bazel_tests",
         "//tools/wrapper_common:for_bazel_tests",
         "//tools/xctoolrunner:for_bazel_tests",
+        "//tools/dynamic_framework_slicer:for_bazel_tests",
     ],
     visibility = [
         "//:__pkg__",

--- a/tools/dynamic_framework_slicer/BUILD
+++ b/tools/dynamic_framework_slicer/BUILD
@@ -1,0 +1,20 @@
+licenses(["notice"])
+
+sh_binary(
+    name = "dynamic_framework_slicer",
+    srcs = ["dynamic_framework_slicer.sh"],
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)
+
+# Consumed by bazel tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = [
+        "//tools:__pkg__",
+    ],
+)

--- a/tools/dynamic_framework_slicer/README
+++ b/tools/dynamic_framework_slicer/README
@@ -1,0 +1,5 @@
+dynamic_framework_slicer takes a directory containing .app bundle structures,
+iterates over the frameworks in the .app, and ensures that each framework only
+contains the same slices as the app binary.
+
+dynamic_framework_slicer can run on Darwin only.

--- a/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
+++ b/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# dynamic_framework_slicer copies the required dylibs for the given
+# binaries into the specified output path. This tool will also remove any
+# architecture slices which are not used by the given binaries, reducing binary
+# size.
+#
+# This script only runs on darwin and you must have Xcode installed.
+#
+# --out <file>      - the filename where the resultant binary should be placed.
+# --in <file>       - the filename of the input binary
+# <positional_args> - any positional argument is considered to be a
+#                              path to a binary to be processed
+
+set -euo pipefail
+
+declare -a BINARIES
+IN=""
+OUT=""
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+  case $arg in
+      --in)
+      readonly IN="$2"
+      shift
+      ;;
+      --out)
+      readonly OUT="$2"
+      shift
+      ;;
+      *)
+      BINARIES+=("$1")
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$IN" || -z "$OUT" || "${#BINARIES[@]}" -eq 0 ]]; then
+    echo "Usage: $0 --in path/to/infile --out path/to/outfile binaries..."
+    exit 1
+fi
+
+if [[ ! -f "$IN" ]]; then
+    echo "Expected regular file with --in"
+    exit 1
+fi
+
+# Strip out any unnecessary slices from embedded dynamic frameworks to save space
+
+# Gather all binary slices
+declare -a all_bin_slices
+all_bin_slices=$(xcrun lipo -info "${BINARIES[@]}" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
+
+# Gather the slices in the framework
+declare -a framework_slices
+framework_slices=$(xcrun lipo -info "$IN" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
+
+if [[ $(echo -n $framework_slices | wc -w) -eq 1 || "$all_bin_slices" == "$framework_slices" ]]; then
+    # If we only have one slice or the slices match exactly, we don't need to do anything
+    cp "$IN" "$OUT"
+else
+    # Figure out what we should strip
+    for slice in $framework_slices; do
+        if echo "$all_bin_slices" | grep -q "$slice" ; then
+            slices_needed+=($slice)
+        fi
+    done
+
+    declare -a lipo_args
+    for slice in $all_bin_slices; do
+        lipo_args+=(-extract $slice)
+    done
+    xcrun lipo "$IN" "${lipo_args[@]}" -output "$OUT"
+fi


### PR DESCRIPTION
Add dynamic slicer tool to allow stripping of unneeded architectures in
dyanmic frameworks.

This was originally https://github.com/bazelbuild/rules_apple/pull/623 by @nblievers, but with a minor fix applied to use `apple_support.run` instead of `ctx.actions.run` so that the environment variables are set up correctly for `xcrun` when the action is invoked.