### PR TITLE
Add support for specific simulator IDs for iOS tests

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -14,6 +14,7 @@
 
 """iOS test runner rule."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@build_bazel_rules_apple//apple/testing:apple_test_rules.bzl",
     "AppleTestRunnerInfo",
@@ -26,6 +27,7 @@ def _get_template_substitutions(ctx):
     subs = {
         "device_type": device_type,
         "os_version": str(os_version),
+        "simulator_id": ctx.attr.simulator_id[BuildSettingInfo].value if ctx.attr.simulator_id else "",
         "testrunner_binary": ctx.executable._testrunner.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}
@@ -84,6 +86,14 @@ the runner. In most common cases, this should not be used.
 The os version of the iOS simulator to run test. The supported os versions
 correspond to the output of `xcrun simctl list runtimes`. ' 'E.g., 11.2, 9.3.
 By default, it is the latest supported version of the device type.'
+""",
+        ),
+        "simulator_id": attr.label(
+            default = None,
+            providers = [BuildSettingInfo],
+            doc = """
+The specific UDID for the simulator to be used. In this case the caller is
+responsible for making sure this simulator exists and is booted
 """,
         ),
         "_test_template": attr.label(

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -102,11 +102,25 @@ if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
   runner_flags+=("--launch_options_json_path=${LAUNCH_OPTIONS_JSON_PATH}")
 fi
 
+simulator_id="%(simulator_id)s"
+target_flags=()
+if [[ -n "$simulator_id" ]]; then
+  target_flags=(
+    "test"
+    "--id=$simulator_id"
+  )
+else
+  target_flags=(
+    "simulator_test"
+    "--device_type=%(device_type)s"
+    "--os_version=%(os_version)s"
+  )
+fi
+
+set -x
 cmd=("%(testrunner_binary)s"
   "${runner_flags[@]}"
-  simulator_test
-  "--device_type=%(device_type)s"
-  "--os_version=%(os_version)s"
+  "${target_flags[@]}"
   "$@")
 "${cmd[@]}" 2>&1
 status=$?


### PR DESCRIPTION
This allows users to pass configurable simulator UDIDs to run tests
with. This allows them to run test jobs on the same simulator without
the overhead of creating one each time.

Another benefit of this is if you want to setup simulators ahead of time for example for UI tests where you may need to set some simulator defaults to not show iOS' onboarding flows