### PR TITLE
Remove past array declarations in dynamic_framework_slicer.sh

### DIFF
--- a/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
+++ b/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
@@ -62,11 +62,9 @@ fi
 # Strip out any unnecessary slices from embedded dynamic frameworks to save space
 
 # Gather all binary slices
-declare -a all_bin_slices
 all_bin_slices=$(xcrun lipo -info "${BINARIES[@]}" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
 
 # Gather the slices in the framework
-declare -a framework_slices
 framework_slices=$(xcrun lipo -info "$IN" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
 
 if [[ $(echo -n $framework_slices | wc -w) -eq 1 || "$all_bin_slices" == "$framework_slices" ]]; then


### PR DESCRIPTION
These variables were arrays at one point in #647, but ended up as strings. This removes the no longer valid declarations.