### PR TITLE
Make dynamic framework slicer more robust for some inputs.

### DIFF
--- a/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
+++ b/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
@@ -62,10 +62,10 @@ fi
 # Strip out any unnecessary slices from embedded dynamic frameworks to save space
 
 # Gather all binary slices
-all_bin_slices=$(xcrun lipo -info "${BINARIES[@]}" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
+all_bin_slices=$(xcrun lipo -info "${BINARIES[@]}" | cut -d: -f3 | tr ' ' '\n' | sort -u)
 
 # Gather the slices in the framework
-framework_slices=$(xcrun lipo -info "$IN" | cut -d: -f3 | awk '{ for(i = 1; i <= NF; i++) { print $0; } }' | sort -u)
+framework_slices=$(xcrun lipo -info "$IN" | cut -d: -f3 | tr ' ' '\n' | sort -u)
 
 if [[ $(echo -n $framework_slices | wc -w) -eq 1 || "$all_bin_slices" == "$framework_slices" ]]; then
     # If we only have one slice or the slices match exactly, we don't need to do anything
@@ -79,7 +79,7 @@ else
     done
 
     declare -a lipo_args
-    for slice in $all_bin_slices; do
+    for slice in $slices_needed; do
         lipo_args+=(-extract $slice)
     done
     xcrun lipo "$IN" "${lipo_args[@]}" -output "$OUT"


### PR DESCRIPTION
Make dynamic framework slicer more robust for some inputs.

This change replaces the `awk` command that was used to flatten the `lipo` outputs, since it wasn't actually doing the right thing in all cases. It also corrects a bug where the wrong variable was being used at the end to construct the list of slices to pass to the final `lipo` command.