### PR TITLE
Migrate watchos_application_tests to skylark

### DIFF
--- a/test/starlark_tests/resources/WatchosAppInfo.plist
+++ b/test/starlark_tests/resources/WatchosAppInfo.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.google.example.watch</string>
+</dict>
+</plist>

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -43,6 +43,7 @@ ios_application(
         "manual",
         "notap",
     ],
+    watch_application = "//test/starlark_tests/targets_under_test/watchos:app",
     deps = [
         "//test/starlark_tests/resources:basic_bundle_lib",
         "//test/starlark_tests/resources:bundle_library_ios_lib",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -14,12 +14,13 @@ load(
 watchos_application(
     name = "app",
     app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
-    bundle_id = "com.google.example",
+    bundle_id = "com.google.example.WatchKitApp",
     extension = ":ext",
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = "4.0",
+    minimum_os_version = "4.2",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = [
         "manual",
         "notap",
@@ -28,12 +29,12 @@ watchos_application(
 
 watchos_extension(
     name = "ext",
-    bundle_id = "com.google.example.ext",
+    bundle_id = "com.google.example.WatchKitApp.WatchKitExtension",
     entitlements = "//test/starlark_tests/resources:entitlements.plist",
     infoplists = [
         "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
     ],
-    minimum_os_version = "4.0",
+    minimum_os_version = "4.2",
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     resources = [
         "//test/starlark_tests/resources:example_filegroup",
@@ -51,12 +52,12 @@ watchos_extension(
 
 watchos_extension(
     name = "ext_multiple_infoplists",
-    bundle_id = "com.google.example.ext",
+    bundle_id = "com.google.example.WatchKitApp.WatchKitExtension",
     infoplists = [
         "//test/starlark_tests/resources:Another.plist",
         "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
     ],
-    minimum_os_version = "4.0",
+    minimum_os_version = "4.2",
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -19,8 +19,8 @@ load(
     "apple_verification_test",
 )
 load(
-    ":rules/infoplist_contents_test.bzl",
-    "infoplist_contents_test",
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
 )
 load(
     ":rules/analysis_xcasset_argv_test.bzl",
@@ -39,13 +39,16 @@ def watchos_application_test_suite():
         tags = [name],
     )
 
-    infoplist_contents_test(
-        name = "{}_plist_test".format(name),
+    # Test the expected values in a watchOS app's Info.plist when compiling for simulators.
+    archive_contents_test(
+        name = "{}_app_plist_simulator_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
-        expected_values = {
+        build_type = "simulator",
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
             "BuildMachineOSBuild": "*",
             "CFBundleExecutable": "app",
-            "CFBundleIdentifier": "com.google.example",
+            "CFBundleIdentifier": "com.google.example.watch",
             "CFBundleName": "app",
             "CFBundleSupportedPlatforms:0": "WatchSimulator*",
             "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
@@ -59,6 +62,111 @@ def watchos_application_test_suite():
             "MinimumOSVersion": "4.0",
             "UIDeviceFamily:0": "4",
         },
+        tags = [name],
+    )
+
+    # Test the expected values in a watchOS app's Info.plist when compiling for devices.
+    archive_contents_test(
+        name = "{}_app_plist_device_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
+        build_type = "device",
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
+            "BuildMachineOSBuild": "*",
+            "CFBundleExecutable": "app",
+            "CFBundleIdentifier": "com.google.example.watch",
+            "CFBundleName": "app",
+            "CFBundleSupportedPlatforms:0": "WatchOS*",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "*",
+            "DTPlatformName": "watchos",
+            "DTPlatformVersion": "*",
+            "DTSDKBuild": "*",
+            "DTSDKName": "watchos*",
+            "DTXcode": "*",
+            "DTXcodeBuild": "*",
+            "MinimumOSVersion": "3.0",
+            "UIDeviceFamily:0": "4",
+        },
+        tags = [name],
+    )
+
+    # Test the expected values in a watchOS extension's Info.plist when compiling for devices.
+    archive_contents_test(
+        name = "{}_extension_plist_device_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
+        build_type = "device",
+        plist_test_file = "$BUNDLE_ROOT/PlugIns/ext.appex/Info.plist",
+        plist_test_values = {
+            "BuildMachineOSBuild": "*",
+            "CFBundleExecutable": "ext",
+            # "CFBundleIdentifier": "com.google.example.ext",
+            "CFBundleName": "ext",
+            "CFBundleSupportedPlatforms:0": "WatchOS*",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "*",
+            "DTPlatformName": "watchos",
+            "DTPlatformVersion": "*",
+            "DTSDKBuild": "*",
+            "DTSDKName": "watchos*",
+            "DTXcode": "*",
+            "DTXcodeBuild": "*",
+            "MinimumOSVersion": "3.0",
+            "UIDeviceFamily:0": "4",
+        },
+        tags = [name],
+    )
+
+    # Test the expected values in a watchOS extension's Info.plist when compiling for simulators.
+    archive_contents_test(
+        name = "{}_extension_plist_simulator_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
+        build_type = "simulator",
+        plist_test_file = "$BUNDLE_ROOT/PlugIns/ext.appex/Info.plist",
+        plist_test_values = {
+            "BuildMachineOSBuild": "*",
+            "CFBundleExecutable": "ext",
+            # "CFBundleIdentifier": "com.google.example.ext",
+            "CFBundleName": "ext",
+            "CFBundleSupportedPlatforms:0": "WatchSimulator*",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "*",
+            "DTPlatformName": "watchsimulator",
+            "DTPlatformVersion": "*",
+            "DTSDKBuild": "*",
+            "DTSDKName": "watchsimulator*",
+            "DTXcode": "*",
+            "DTXcodeBuild": "*",
+            "MinimumOSVersion": "3.0",
+            "UIDeviceFamily:0": "4",
+        },
+        tags = [name],
+    )
+
+    # Tests that the provisioning profile is present when built for device.
+    archive_contents_test(
+        name = "{}_contains_provisioning_profile_test".format(name),
+        build_type = "device",
+        compilation_mode = "opt",
+        contains = [
+            "$BUNDLE_ROOT/embedded.mobileprovision",
+            "$BUNDLE_ROOT/PlugIns/ext.appex/embedded.mobileprovision",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
+        tags = [name],
+    )
+
+    # Tests that the watch application and IPA contain the WatchKit stub executable
+    # in the appropriate bundle and top-level support directories.
+    archive_contents_test(
+        name = "{}_contains_stub_executable_test".format(name),
+        build_type = "device",
+        compilation_mode = "opt",
+        contains = [
+            "$BUNDLE_ROOT/Watch/app.app/_WatchKitStub/WK",
+            "$ARCHIVE_ROOT/WatchKitSupport2/WK",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app",
         tags = [name],
     )
 

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -275,19 +275,6 @@ EOF
   expect_log 'Target "//app:watch_ext" is missing CFBundleShortVersionString.'
 }
 
-# Tests that the provisioning profile is present when built for device.
-function test_contains_provisioning_profile() {
-  # Ignore the test for simulator builds.
-  is_device_build watchos || return 0
-
-  create_minimal_watchos_application_with_companion
-  do_build watchos //app:app || fail "Should build"
-
-  # Verify that the IPA contains the provisioning profile.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Watch/watch_app.app/PlugIns/watch_ext.appex/embedded.mobileprovision"
-}
-
 # Tests that the watch application and IPA contain the WatchKit stub executable
 # in the appropriate bundle and top-level support directories.
 function test_contains_stub_executable() {


### PR DESCRIPTION
Migrate watchos_application_tests to skylark

This makes the watch targets correctly fully build(adding a provisioning profile), which makes them much easier to test.

RELNOTES: None
