### PR TITLE
Add swiftmodule files to ios_static_framework

### DIFF
--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -25,6 +25,9 @@ SwiftStaticFrameworkInfo = provider(
         "swiftinterfaces": """
 Dictionary of architecture to the generated swiftinterface file for that architecture.
 """,
+        "swiftmodules": """
+Dictionary of architecture to the generated swiftmodule file for that architecture.
+""",
         "swiftdocs": """
 Dictionary of architecture to the generated swiftdoc file for that architecture.
 """,
@@ -95,6 +98,7 @@ single swift_library dependency with no transitive swift_library dependencies.\
         module_name = None
         generated_header = None
         swiftdocs = {}
+        swiftmodules = {}
         swiftinterfaces = {}
         for dep in swiftdeps:
             swiftinfo = dep[SwiftInfo]
@@ -129,15 +133,17 @@ swift_library dependency with no transitive swift_library dependencies.\
                     generated_header = swiftinfo.transitive_generated_headers.to_list()[0]
 
             swiftdocs[arch] = swiftinfo.transitive_swiftdocs.to_list()[0]
+            swiftmodules[arch] = swiftinfo.transitive_swiftmodules.to_list()[0]
             swiftinterfaces[arch] = swiftinfo.transitive_swiftinterfaces.to_list()[0]
 
         # Make sure that all dictionaries contain at least one module before returning the provider.
-        if all([module_name, swiftdocs, swiftinterfaces]):
+        if all([module_name, swiftdocs, swiftmodules, swiftinterfaces]):
             return [
                 SwiftStaticFrameworkInfo(
                     module_name = module_name,
                     generated_header = generated_header,
                     swiftdocs = swiftdocs,
+                    swiftmodules = swiftmodules,
                     swiftinterfaces = swiftinterfaces,
                 ),
             ]

--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -61,6 +61,7 @@ frameworks expect a single swift_library dependency with `module_name` set to th
 
     generated_header = swift_static_framework_info.generated_header
     swiftdocs = swift_static_framework_info.swiftdocs
+    swiftmodules = swift_static_framework_info.swiftmodules
     swiftinterfaces = swift_static_framework_info.swiftinterfaces
 
     bundle_files = []
@@ -74,6 +75,11 @@ frameworks expect a single swift_library dependency with `module_name` set to th
         )
         file_support.symlink(ctx, swiftinterface, bundle_interface)
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_interface])))
+
+    for arch, swiftmodule in swiftmodules.items():
+        bundle_module = intermediates.file(ctx.actions, ctx.label.name, "{}.swiftmodule".format(arch))
+        file_support.symlink(ctx, swiftmodule, bundle_module)
+        bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_module])))
 
     for arch, swiftdoc in swiftdocs.items():
         bundle_doc = intermediates.file(ctx.actions, ctx.label.name, "{}.swiftdoc".format(arch))


### PR DESCRIPTION
As far as I can tell even with swiftinterface files these are still
required. Xcode still adds them to the framework when using the library
evolution flags and without them you get build errors when including the
framework with just the swiftinterface.