### PR TITLE
Fully escape the strings in the example.

### DIFF
--- a/doc/rules-general.md
+++ b/doc/rules-general.md
@@ -60,8 +60,8 @@ apple_bundle_version(
     build_label_pattern = "MyApp_{version}_build_{build}",
     build_version = "{version}.{build}",
     capture_groups = {
-        "version": "\d+\.\d+",
-        "build": "\d+",
+        "version": "\\d+\\.\\d+",
+        "build": "\\d+",
     },
     short_version_string = "{version}",
     fallback_build_label = "MyApp_99.99_build_99",


### PR DESCRIPTION
Fully escape the strings in the example.

Raw strings also would work, but I can't really find docs on those for Starlark, so this seems safer.

Buildifier started flagging this a while ago.