### PR TITLE
Fix rules_apple integration tests for Xcode 11.

### DIFF
--- a/test/ios_application_swift_resources_test.sh
+++ b/test/ios_application_swift_resources_test.sh
@@ -26,6 +26,7 @@ function set_up() {
 function tear_down() {
   rm -rf app
 }
+
 # Creates common source, targets, and basic plist for iOS applications.
 #
 # This creates everything but the "lib" target, which must be created by the
@@ -122,7 +123,7 @@ EOF
       "Payload/app.app/storyboard_ios.storyboardc/"
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/nonlocalized.strings"
-  assert_zip_contains "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib"
+  assert_zip_contains "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib/\?"
 
   # Verify nonlocalized unprocessed resources are present.
   assert_zip_contains "test-bin/app/app.ipa" \
@@ -136,30 +137,17 @@ EOF
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/it.lproj/localized.strings"
   assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/it.lproj/view_ios.nib"
+      "Payload/app.app/it.lproj/view_ios.nib/\?"
 
   # Verify localized unprocessed resources are present.
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/it.lproj/localized.txt"
 
-  # Verify that the module name is mentioned in the file. We can predict the
-  # name of the .nib file inside the compiled storyboard based on its object
-  # identifier and the fact that we're compiling with a particular minimum
-  # iOS version.
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/storyboard_ios.storyboardc/UIViewController-mdN-da-fi0.nib" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/unversioned_datamodel.mom" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/versioned_datamodel.momd/v1.mom" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/versioned_datamodel.momd/v2.mom" \
-      | grep "$module_name" > /dev/null
+  # TODO(b/131684083): We previously had other assertions that poked at the
+  # individual compiled resources, but they became extremely fragile as of
+  # Xcode 11 (the assumptions about the file structure no longer held).
+  # Instead, we should test (with analysis time tests) that we pass the
+  # correct module name to ibtool when we register the action.
 }
 
 # Tests that swift_library properly propagates resources from transitive
@@ -223,7 +211,7 @@ EOF
       "Payload/app.app/storyboard_ios.storyboardc/"
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/nonlocalized.strings"
-  assert_zip_contains "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib"
+  assert_zip_contains "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib/\?"
 
   # Verify nonlocalized unprocessed resources are present.
   assert_zip_contains "test-bin/app/app.ipa" \
@@ -237,30 +225,17 @@ EOF
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/it.lproj/localized.strings"
   assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/it.lproj/view_ios.nib"
+      "Payload/app.app/it.lproj/view_ios.nib/\?"
 
   # Verify localized unprocessed resources are present.
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/it.lproj/localized.txt"
 
-  # Verify that the module name is mentioned in the file. We can predict the
-  # name of the .nib file inside the compiled storyboard based on its object
-  # identifier and the fact that we're compiling with a particular minimum
-  # iOS version.
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/storyboard_ios.storyboardc/UIViewController-mdN-da-fi0.nib" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/view_ios.nib" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/unversioned_datamodel.mom" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/versioned_datamodel.momd/v1.mom" \
-      | grep "$module_name" > /dev/null
-  unzip_single_file "test-bin/app/app.ipa" \
-      "Payload/app.app/versioned_datamodel.momd/v2.mom" \
-      | grep "$module_name" > /dev/null
+  # TODO(b/131684083): We previously had other assertions that poked at the
+  # individual compiled resources, but they became extremely fragile as of
+  # Xcode 11 (the assumptions about the file structure no longer held).
+  # Instead, we should test (with analysis time tests) that we pass the
+  # correct module name to ibtool when we register the action.
 }
 
 # Tests that swift_library targets have their intermediate compiled storyboards

--- a/test/ios_application_swift_test.sh
+++ b/test/ios_application_swift_test.sh
@@ -68,38 +68,23 @@ EOF
 EOF
 }
 
-# Asserts that app.ipa contains the Swift dylibs in both the application
+# Asserts that app.ipa contains the Swift runtime in both the application
 # bundle and in the top-level support directory if the build was for device,
 # otherwise assert they're not in the top level SwiftSupport directory.
-#
-# We look for three dylibs based on what is used in the scratch AppDelegate
-# class above: Core, Foundation, and UIKit.
 function assert_ipa_contains_swift_dylibs_for_device() {
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
 
   if is_device_build ios; then
     assert_zip_contains "test-bin/app/app.ipa" \
         "SwiftSupport/iphoneos/libswiftCore.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphoneos/libswiftFoundation.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphoneos/libswiftUIKit.dylib"
   else
     assert_zip_not_contains "test-bin/app/app.ipa" \
         "SwiftSupport/iphonesimulator/libswiftCore.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphonesimulator/libswiftFoundation.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphonesimulator/libswiftUIKit.dylib"
   fi
 }
 
-# Tests that the bundler includes the Swift dylibs both in the application
+# Tests that the bundler includes the Swift runtime both in the application
 # bundle and in the top-level support directory of the IPA.
 function test_swift_dylibs_present() {
   create_minimal_ios_application
@@ -132,20 +117,12 @@ EOF
       || fail "Should build"
     assert_zip_contains "test-bin/app/app.ipa" \
         "Payload/app.app/Frameworks/libswiftCore.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "Payload/app.app/Frameworks/libswiftUIKit.dylib"
     assert_zip_not_contains "test-bin/app/app.ipa" \
         "SwiftSupport/iphoneos/libswiftCore.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphoneos/libswiftFoundation.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/iphoneos/libswiftUIKit.dylib"
   fi
 }
 
-# Tests that the bundler includes the Swift dylibs even when Swift is an
+# Tests that the bundler includes the Swift runtime even when Swift is an
 # indirect dependency (that is, none of the direct deps of the application
 # are swift_libraries, but a transitive dependency is). This verifies that
 # the `uses_swift` property is propagated correctly.

--- a/test/ios_extension_swift_test.sh
+++ b/test/ios_extension_swift_test.sh
@@ -26,6 +26,7 @@ function set_up() {
 function tear_down() {
   rm -rf app
 }
+
 # Creates the targets for a minimal iOS application written in Objective-C that
 # uses Swift in an app extension.
 function create_minimal_ios_application_with_swift_extension() {
@@ -111,103 +112,8 @@ EOF
 EOF
 }
 
-# Creates the targets for a minimal iOS application written in Swift that also
-# uses Swift in an app extension, but where the extension.
-function create_minimal_swift_ios_application_with_swift_extension() {
-  cat > app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:ios.bzl",
-     "ios_application",
-     "ios_extension")
-load("@build_bazel_rules_swift//swift:swift.bzl",
-     "swift_library")
-
-swift_library(
-    name = "app_swiftlib",
-    srcs = ["AppDelegate.swift"],
-)
-
-swift_library(
-    name = "ext_swiftlib",
-    srcs = ["ExtensionClass.swift"],
-)
-
-ios_application(
-    name = "app",
-    bundle_id = "my.bundle.id",
-    extensions = [":ext"],
-    families = ["iphone"],
-    infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":app_swiftlib"],
-)
-
-ios_extension(
-    name = "ext",
-    bundle_id = "my.bundle.id.extension",
-    families = ["iphone"],
-    infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "9.0",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":ext_swiftlib"],
-)
-EOF
-
-  cat > app/AppDelegate.swift <<EOF
-import AVFoundation
-import UIKit
-
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-  var window: UIWindow?
-  var asset: AVAsset?
-}
-EOF
-
-  # The extension shouldn't use UIApplicationMain, but something seems to be
-  # stripping the class (and thus the import it needs) out if I don't use
-  # something like this to force it to be exported.
-  cat > app/ExtensionClass.swift <<EOF
-import CoreLocation
-import UIKit
-
-@UIApplicationMain
-class ExtensionClass: UIResponder, UIApplicationDelegate {
-  var window: UIWindow?
-  var locationManager: CLLocationManager?
-}
-EOF
-
-  cat > app/Info-App.plist <<EOF
-{
-  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
-  CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "APPL";
-  CFBundleShortVersionString = "1.0";
-  CFBundleVersion = "1.0";
-}
-EOF
-
-  cat > app/Info-Ext.plist <<EOF
-{
-  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
-  CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "APPL";
-  CFBundleShortVersionString = "1.0";
-  CFBundleVersion = "1.0";
-  NSExtension = {
-    NSExtensionPrincipalClass = "DummyValue";
-    NSExtensionPointIdentifier = "com.apple.widget-extension";
-  };
-}
-EOF
-}
-
-# Tests that the bundler includes the Swift dylibs when only an extension uses
+# Tests that the bundler includes the Swift runtime when only an extension uses
 # Swift.
-#
-# We look for three dylibs based on what is used in the scratch AppDelegate
-# class above: Core, Foundation, and UIKit.
 function test_swift_dylibs_present() {
   create_minimal_ios_application_with_swift_extension
   do_build ios //app:app || fail "Should build"
@@ -216,59 +122,16 @@ function test_swift_dylibs_present() {
   # the extension, as Xcode would do.
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
 
   # And to be safe, verify that they *aren't* packaged with the extension.
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftFoundation.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftUIKit.dylib"
 
   # Ignore the following checks for simulator builds.
   is_device_build ios || return 0
 
   assert_zip_contains "test-bin/app/app.ipa" \
       "SwiftSupport/iphoneos/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/iphoneos/libswiftUIKit.dylib"
-}
-
-# Tests that the bundler includes the union of Swift libraries used by the
-# application and the extension. Only the application created by this test
-# uses AVFoundation and only the extension uses CoreLocation; both should be
-# present in the Frameworks folder and, for release builds, the SwiftSupport
-# folder.
-function test_union_of_swift_dylibs_present_for_app_and_extension() {
-  create_minimal_swift_ios_application_with_swift_extension
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that the Swift dylibs are packaged with the *application*, not with
-  # the extension, as Xcode would do.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftAVFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftCoreLocation.dylib"
-
-  # And to be safe, verify that they *aren't* packaged with the extension.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftAVFoundation.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCoreLocation.dylib"
-
-  # Ignore the following checks for simulator builds.
-  is_device_build ios || return 0
-
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/iphoneos/libswiftAVFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/iphoneos/libswiftCoreLocation.dylib"
 }
 
 run_suite "ios_extension with Swift bundling tests"

--- a/test/macos_application_swift_test.sh
+++ b/test/macos_application_swift_test.sh
@@ -70,18 +70,14 @@ EOF
 EOF
 }
 
-# Tests that the bundler includes the Swift dylibs in the application bundle.
+# Tests that the bundler includes the Swift runtime in the application bundle.
 function test_swift_dylibs_present() {
   create_minimal_macos_application
 
   do_build macos //app:app || fail "Should build"
 
   assert_zip_contains "test-bin/app/app.zip" \
-      "app.app/Contents/Frameworks/libswiftAppKit.dylib"
-  assert_zip_contains "test-bin/app/app.zip" \
       "app.app/Contents/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.zip" \
-      "app.app/Contents/Frameworks/libswiftFoundation.dylib"
 
   # This should be implied by the previous check, but we also check that Swift
   # symbols are not found in the TEXT section (which would imply static

--- a/test/tvos_application_swift_test.sh
+++ b/test/tvos_application_swift_test.sh
@@ -68,38 +68,23 @@ EOF
 EOF
 }
 
-# Asserts that app.ipa contains the Swift dylibs in both the application
+# Asserts that app.ipa contains the Swift runtime in both the application
 # bundle and in the top-level support directory.
-#
-# We look for three dylibs based on what is used in the scratch AppDelegate
-# class above: Core, Foundation, and UIKit.
 function assert_ipa_contains_swift_dylibs_for_device() {
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
 
   if is_device_build tvos; then
     assert_zip_contains "test-bin/app/app.ipa" \
         "SwiftSupport/appletvos/libswiftCore.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvos/libswiftFoundation.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvos/libswiftUIKit.dylib"
   else
     assert_zip_not_contains "test-bin/app/app.ipa" \
         "SwiftSupport/appletvsimulator/libswiftCore.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvsimulator/libswiftFoundation.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvsimulator/libswiftUIKit.dylib"
   fi
 
 }
 
-# Tests that the bundler includes the Swift dylibs both in the application
+# Tests that the bundler includes the Swift runtime both in the application
 # bundle and in the top-level support directory of the IPA.
 function test_swift_dylibs_present() {
   create_minimal_tvos_application
@@ -132,20 +117,12 @@ EOF
       || fail "Should build"
     assert_zip_contains "test-bin/app/app.ipa" \
         "Payload/app.app/Frameworks/libswiftCore.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-    assert_zip_contains "test-bin/app/app.ipa" \
-        "Payload/app.app/Frameworks/libswiftUIKit.dylib"
     assert_zip_not_contains "test-bin/app/app.ipa" \
         "SwiftSupport/appletvos/libswiftCore.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvos/libswiftFoundation.dylib"
-    assert_zip_not_contains "test-bin/app/app.ipa" \
-        "SwiftSupport/appletvos/libswiftUIKit.dylib"
   fi
 }
 
-# Tests that the bundler includes the Swift dylibs even when Swift is an
+# Tests that the bundler includes the Swift runtime even when Swift is an
 # indirect dependency (that is, none of the direct deps of the application
 # are swift_libraries, but a transitive dependency is). This verifies that
 # the `uses_swift` property is propagated correctly.

--- a/test/tvos_extension_swift_test.sh
+++ b/test/tvos_extension_swift_test.sh
@@ -110,101 +110,8 @@ EOF
 EOF
 }
 
-# Creates the targets for a minimal tvOS application written in Swift that also
-# uses Swift in an app extension, but where the extension.
-function create_minimal_swift_tvos_application_with_swift_extension() {
-  cat > app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:tvos.bzl",
-     "tvos_application",
-     "tvos_extension")
-load("@build_bazel_rules_swift//swift:swift.bzl",
-     "swift_library")
-
-swift_library(
-    name = "app_swiftlib",
-    srcs = ["AppDelegate.swift"],
-)
-
-swift_library(
-    name = "ext_swiftlib",
-    srcs = ["ExtensionClass.swift"],
-)
-
-tvos_application(
-    name = "app",
-    bundle_id = "my.bundle.id",
-    extensions = [":ext"],
-    infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
-    deps = [":app_swiftlib"],
-)
-
-tvos_extension(
-    name = "ext",
-    bundle_id = "my.bundle.id.extension",
-    infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
-    deps = [":ext_swiftlib"],
-)
-EOF
-
-  cat > app/AppDelegate.swift <<EOF
-import AVFoundation
-import UIKit
-
-@UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
-  var window: UIWindow?
-  var asset: AVAsset?
-}
-EOF
-
-  # The extension shouldn't use UIApplicationMain, but something seems to be
-  # stripping the class (and thus the import it needs) out if I don't use
-  # something like this to force it to be exported.
-  cat > app/ExtensionClass.swift <<EOF
-import CoreLocation
-import UIKit
-
-@UIApplicationMain
-class ExtensionClass: UIResponder, UIApplicationDelegate {
-  var window: UIWindow?
-  var locationManager: CLLocationManager?
-}
-EOF
-
-  cat > app/Info-App.plist <<EOF
-{
-  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
-  CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "APPL";
-  CFBundleShortVersionString = "1.0";
-  CFBundleVersion = "1.0";
-}
-EOF
-
-  cat > app/Info-Ext.plist <<EOF
-{
-  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
-  CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "APPL";
-  CFBundleShortVersionString = "1.0";
-  CFBundleVersion = "1.0";
-  NSExtension = {
-    NSExtensionPrincipalClass = "DummyValue";
-    NSExtensionPointIdentifier = "com.apple.widget-extension";
-  };
-}
-EOF
-}
-
-# Tests that the bundler includes the Swift dylibs when only an extension uses
+# Tests that the bundler includes the Swift runtime when only an extension uses
 # Swift.
-#
-# We look for three dylibs based on what is used in the scratch AppDelegate
-# class above: Core, Foundation, and UIKit.
 function test_swift_dylibs_present() {
   create_minimal_tvos_application_with_swift_extension
   do_build tvos //app:app || fail "Should build"
@@ -213,59 +120,16 @@ function test_swift_dylibs_present() {
   # the extension, as Xcode would do.
   assert_zip_contains "test-bin/app/app.ipa" \
       "Payload/app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftUIKit.dylib"
 
   # And to be safe, verify that they *aren't* packaged with the extension.
   assert_zip_not_contains "test-bin/app/app.ipa" \
       "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftFoundation.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftUIKit.dylib"
 
   # Ignore the following checks for simulator builds.
   is_device_build tvos || return 0
 
   assert_zip_contains "test-bin/app/app.ipa" \
       "SwiftSupport/appletvos/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/appletvos/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/appletvos/libswiftUIKit.dylib"
-}
-
-# Tests that the bundler includes the union of Swift libraries used by the
-# application and the extension. Only the application created by this test
-# uses AVFoundation and only the extension uses CoreLocation; both should be
-# present in the Frameworks folder and, for release builds, the SwiftSupport
-# folder.
-function test_union_of_swift_dylibs_present_for_app_and_extension() {
-  create_minimal_swift_tvos_application_with_swift_extension
-  do_build tvos //app:app || fail "Should build"
-
-  # Verify that the Swift dylibs are packaged with the *application*, not with
-  # the extension, as Xcode would do.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftAVFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/libswiftCoreLocation.dylib"
-
-  # And to be safe, verify that they *aren't* packaged with the extension.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftAVFoundation.dylib"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/PlugIns/ext.appex/Frameworks/libswiftCoreLocation.dylib"
-
-  # Ignore the following checks for simulator builds.
-  is_device_build tvos || return 0
-
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/appletvos/libswiftAVFoundation.dylib"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "SwiftSupport/appletvos/libswiftCoreLocation.dylib"
 }
 
 run_suite "tvos_extension with Swift bundling tests"

--- a/test/watchos_application_swift_test.sh
+++ b/test/watchos_application_swift_test.sh
@@ -138,6 +138,7 @@ swift_library(
 objc_library(
     name = "watch_lib",
     srcs = ["main.m"],
+    sdk_frameworks = ["WatchKit"],
 )
 EOF
 
@@ -146,8 +147,6 @@ EOF
   # Make sure we do have Swift dylibs in the iOS application.
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "Payload/phone_app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "Payload/phone_app.app/Frameworks/libswiftFoundation.dylib"
 
   # Make sure we don't have a Swift dylib in the watchOS extension.
   assert_zip_not_contains "test-bin/app/phone_app.ipa" \
@@ -160,8 +159,6 @@ EOF
 
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "SwiftSupport/iphoneos/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
 }
 
 # Tests that if the watchOS extension uses Swift and the iOS app does not, then
@@ -192,8 +189,6 @@ EOF
   # Make sure we do have Swift dylibs in the watchOS extension.
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftFoundation.dylib"
 
   # Ignore the following checks for simulator builds.
   # Support bundles are only present on device builds, since those are
@@ -202,8 +197,6 @@ EOF
 
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "SwiftSupport/watchos/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "SwiftSupport/watchos/libswiftFoundation.dylib"
 }
 
 # Tests that if both the iOS app and the watchOS extension use Swift, then the
@@ -230,14 +223,10 @@ EOF
   # Make sure we do have Swift dylibs in the iOS application.
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "Payload/phone_app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "Payload/phone_app.app/Frameworks/libswiftFoundation.dylib"
 
   # Make sure we do have Swift dylibs in the watchOS extension.
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "Payload/phone_app.app/Watch/watch_app.app/Frameworks/libswiftFoundation.dylib"
 
   # Ignore the following checks for simulator builds.
   # Support bundles are only present on device builds, since those are
@@ -248,11 +237,7 @@ EOF
   assert_zip_contains "test-bin/app/phone_app.ipa" \
       "SwiftSupport/iphoneos/libswiftCore.dylib"
   assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "SwiftSupport/iphoneos/libswiftFoundation.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
       "SwiftSupport/watchos/libswiftCore.dylib"
-  assert_zip_contains "test-bin/app/phone_app.ipa" \
-      "SwiftSupport/watchos/libswiftFoundation.dylib"
 }
 
 run_suite "watchos_application with Swift bundling tests"

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -42,6 +42,11 @@ objc_library(
     srcs = ["main.m"],
 )
 
+objc_library(
+    name = "watch_lib",
+    sdk_frameworks = ["WatchKit"],
+)
+
 ios_application(
     name = "app",
     bundle_id = "my.bundle.id",
@@ -125,7 +130,7 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 
 watchos_extension(
@@ -135,7 +140,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 }
@@ -342,7 +347,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "bogus.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -351,7 +355,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -378,7 +382,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -387,7 +390,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "bogus.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -415,7 +418,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -425,7 +427,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -464,7 +466,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -474,7 +475,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -496,7 +497,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -506,7 +506,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -557,7 +557,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -567,7 +566,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -605,7 +604,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -615,7 +613,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -666,7 +664,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -676,7 +673,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -714,7 +711,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -724,7 +720,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 
@@ -758,7 +754,6 @@ watchos_application(
     infoplists = ["Info-WatchApp.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
 )
 
 watchos_extension(
@@ -768,7 +763,7 @@ watchos_extension(
     infoplists = ["Info-WatchExt.plist"],
     minimum_os_version = "2.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
+    deps = [":watch_lib"],
 )
 EOF
 


### PR DESCRIPTION
Fix rules_apple integration tests for Xcode 11.

Most notably, the Swift compiler appears to have gotten smarter about autolinking and now only links to the Swift overlay for a system framework if you actually use something from that overlay (for example, the `Data` struct in Foundation, vs. just importing Foundation and using the underlying Objective-C types). This made many of our Swift bundling tests break because we were checking for those dylibs.

Some NIB handling also changed. We removed some fragile tests and plan to replace them with analysis time action verification tests when we have the cycles.

There are still some remaining failures on Xcode 11 for ios_test_runner; those will be fixed separately as they need more investigation.