### PR TITLE
Set execution requirements for Starlark rules that use apple_support based on the availability of the selected Xcode.

### DIFF
--- a/apple/internal/utils/legacy_actions.bzl
+++ b/apple/internal/utils/legacy_actions.bzl
@@ -60,7 +60,7 @@ def _kwargs_for_apple_platform(ctx, additional_env = None, **kwargs):
         execution_requirement_dicts.append(original_execution_requirements)
 
     # Add the execution requirements last to avoid clients overriding this value.
-    execution_requirement_dicts.append(apple_support.action_required_execution_requirements())
+    execution_requirement_dicts.append(apple_support.action_required_execution_requirements(ctx))
 
     processed_args["env"] = _add_dicts(*env_dicts)
     processed_args["execution_requirements"] = _add_dicts(*execution_requirement_dicts)

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -137,7 +137,7 @@ def _apple_verification_test_impl(ctx):
             test_env["APPLE_TEST_ENV_{}_{}".format(key, num)] = value
 
     return [
-        testing.ExecutionInfo(apple_support.action_required_execution_requirements()),
+        testing.ExecutionInfo(apple_support.action_required_execution_requirements(ctx)),
         testing.TestEnvironment(dicts.add(apple_support.action_required_env(ctx), test_env)),
         DefaultInfo(
             executable = output_script,

--- a/test/starlark_tests/rules/infoplist_contents_test.bzl
+++ b/test/starlark_tests/rules/infoplist_contents_test.bzl
@@ -68,7 +68,7 @@ def _infoplist_contents_test_impl(ctx):
     ctx.actions.write(test_script, "\n".join(test_lines), is_executable = True)
 
     return [
-        testing.ExecutionInfo(apple_support.action_required_execution_requirements()),
+        testing.ExecutionInfo(apple_support.action_required_execution_requirements(ctx)),
         testing.TestEnvironment(apple_support.action_required_env(ctx)),
         DefaultInfo(
             executable = test_script,


### PR DESCRIPTION
Set execution requirements for Starlark rules that use apple_support based on the availability of the selected Xcode.

This is part of a series of changes that set the execution requirements for actions generated by rules that require Xcodes. The dynamic scheduler will later be modified to run those actions locally/remotely accordingly, but this does not currently change behavior.

RELNOTES: None.
