### PR TITLE
Handle test environment values that contain = in ios_test_runner

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -95,8 +95,9 @@ TEST_ENV="%(test_env)s"
 if [[ -n "${TEST_ENV}" ]]; then
   # Converts the test env string to json format and addes it into launch
   # options string.
-  TEST_ENV=${TEST_ENV//=/\":\"}
-  TEST_ENV=${TEST_ENV//,/\",\"}
+  TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) " " substr($i, d+1); }}')
+  TEST_ENV=${TEST_ENV// /\":\"}
+  TEST_ENV=${TEST_ENV//$'\n'/\",\"}
   TEST_ENV="{\"${TEST_ENV}\"}"
   LAUNCH_OPTIONS_JSON_STR="\"env_vars\":${TEST_ENV}"
 fi

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -436,4 +436,12 @@ function test_ios_unit_simulator_id() {
   expect_log "error: unsupported --test_arg: 'invalid_arg'"
 }
 
+function test_ios_unit_test_with_multi_equal_env() {
+  create_sim_runners
+  create_ios_unit_envtest ENV_KEY1 ENV_VALUE2=ENV_VALUE3
+  do_ios_test --test_env=ENV_KEY1=ENV_VALUE2=ENV_VALUE3 //ios:EnvUnitTest || fail "should pass"
+
+  expect_log "Test Suite 'EnvUnitTest' passed"
+}
+
 run_suite "ios_unit_test with iOS test runner bundling tests"


### PR DESCRIPTION
The existing implementation doesn't correctly handle environment variables like `TSAN_OPTIONS=halt_on_error=1` because the "=" in the value is treated as if it were another key-value pair. The updated logic accounts for this by matching only on the first occurrence of "=" for each env var.