### PR TITLE
Use last_green, not last_downstream_green for buildkite.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -17,7 +17,7 @@ x_defaults:
 tasks:
   macos_last_green:
     name: "Last Green Bazel"
-    bazel: last_downstream_green
+    bazel: last_green
     <<: *common
 
 


### PR DESCRIPTION
Use last_green, not last_downstream_green for buildkite.

Difference documented at:
  https://github.com/bazelbuild/bazelisk/blob/master/README.md#how-does-bazelisk-know-which-bazel-version-to-run-and-where-to-get-it-from

RELNOTES: None
