### PR TITLE
Introduce product_tags

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -46,12 +46,18 @@ load(
 
 def ios_application(name, **kwargs):
     """Builds and bundles an iOS application."""
+    product_tags = kwargs.pop("product_tags", [])
+
     bundling_args = binary_support.create_binary(
         name,
         str(apple_common.platform_type.ios),
         apple_product_type.application,
         **kwargs
     )
+
+    if product_tags or "tags" in bundling_args:
+        tags = bundling_args.pop("tags", [])
+        kwargs["tags"] = tags + product_tags
 
     _ios_application(
         name = name,


### PR DESCRIPTION
This is a proposal to solve a problem we hit with how tags are propagated in rules_apple, and use of `bazel query`.

We'd like to have tags that apply only to core top level rules, for example `ios_application`, etc. However tags are propagated to the bundles as well. One way to solve this is have some separate tags parameter ("`product_tags`") that is not visible to bundle rules, and passed only to the core rules.

The current motivation is to query targets by tags, and then build them. As is, those results include products, and the underlying binaries and bundles. Passing these to `bazel build` results in bundles for example being built with twice, for different transition configurations. This is slower to build and uses more disk space.