### PR TITLE
Add _lcov_merger attribute to test rules

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -226,6 +226,11 @@ AppleTestRunnerInfo provider.
         default = Label("@bazel_tools//tools/objc:mcov"),
         allow_single_file = True,
     ),
+    "_lcov_merger": attr.label(
+        cfg = "host",
+        executable = True,
+        default = Label("@bazel_tools//tools/test:lcov_merger"),
+    ),
 }
 
 def _common_binary_linking_attrs(rule_descriptor):


### PR DESCRIPTION
This is required to use `--combined_report=lcov` with `bazel coverage`