### PR TITLE
Add support for export_symbols_lists.

### DIFF
--- a/apple/internal/exported_symbols_lists_rules.bzl
+++ b/apple/internal/exported_symbols_lists_rules.bzl
@@ -1,0 +1,38 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Actions for supporting exported symbols in link actions."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "linking_support",
+)
+
+def _exported_symbols_lists_impl(ctx):
+    return [
+        linking_support.exported_symbols_list_objc_provider(ctx.files.lists),
+    ]
+
+exported_symbols_lists = rule(
+    implementation = _exported_symbols_lists_impl,
+    attrs = {
+        "lists": attr.label_list(
+            allow_empty = False,
+            allow_files = True,
+            mandatory = True,
+            doc = "The list of files that contain exported symbols.",
+        ),
+    },
+    fragments = ["apple", "objc"],
+)

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -49,6 +49,24 @@ def _sectcreate_objc_provider(segname, sectname, file):
         link_inputs = depset([file]),
     )
 
+def _exported_symbols_list_objc_provider(files):
+    """Returns an objc provider that propagates exported symbols lists.
+
+    This function creates a new objc provider that contains the necessary linkopts
+    to add exported symbols lists
+
+    Args:
+      files: The files whose contents will be the exported symbols lists.
+
+    Returns:
+      An objc provider that propagates the appropriate linkopts.
+    """
+    linkopts = ["-Wl,-exported_symbols_list,%s" % (file.path) for file in files]
+    return apple_common.new_objc_provider(
+        linkopt = depset(linkopts, order = "topological"),
+        link_inputs = depset(files),
+    )
+
 def _register_linking_action(ctx, extra_linkopts = []):
     """Registers linking actions using the Starlark Linking API for Apple binaries.
 
@@ -90,6 +108,7 @@ def _register_linking_action(ctx, extra_linkopts = []):
     )
 
 linking_support = struct(
+    exported_symbols_list_objc_provider = _exported_symbols_list_objc_provider,
     register_linking_action = _register_linking_action,
     sectcreate_objc_provider = _sectcreate_objc_provider,
 )


### PR DESCRIPTION
Add support for export_symbols_lists.

RELNOTES:This allows the specification of exported symbols via files. Specifically meant to control ios_framework rules.
