### PR TITLE
Export the template since the test directly uses it.

### DIFF
--- a/test/testdata/rules/BUILD
+++ b/test/testdata/rules/BUILD
@@ -12,3 +12,7 @@ filegroup(
         "dummy_test_runner.template",
     ],
 )
+
+exports_files([
+    "dummy_test_runner.template",
+])


### PR DESCRIPTION
Export the template since the test directly uses it.

RELNOTES: None
