### PR TITLE
Properly escape spaces when compiling plists

### DIFF
--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -87,9 +87,9 @@ def compile_plist(ctx, input_file, output_file):
     # execute the version of plutil that takes the file directly. If the file is
     # empty, it will echo an new line and then pipe it into plutil. We do this
     # to handle empty files as plutil doesn't handle them very well.
-    plutil_command = "plutil -convert binary1 -o %s --" % output_file.path
-    complete_command = ("if [[ -s {in_file} ]] ; then {plutil_command} {in_file} ; " +
-                        "elif [[ -f {in_file} ]] ; then echo | {plutil_command} - ; " +
+    plutil_command = "plutil -convert binary1 -o '%s' --" % output_file.path
+    complete_command = ("if [[ -s '{in_file}' ]] ; then {plutil_command} '{in_file}' ; " +
+                        "elif [[ -f '{in_file}' ]] ; then echo | {plutil_command} - ; " +
                         "else exit 1 ; " +
                         "fi").format(
         in_file = input_file.path,

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -42,6 +42,10 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
+load(
+    "@bazel_skylib//lib:shell.bzl",
+    "shell",
+)
 
 def plisttool_action(ctx, inputs, outputs, control_file, mnemonic = None):
     """Registers an action that invokes `plisttool`.
@@ -87,12 +91,12 @@ def compile_plist(ctx, input_file, output_file):
     # execute the version of plutil that takes the file directly. If the file is
     # empty, it will echo an new line and then pipe it into plutil. We do this
     # to handle empty files as plutil doesn't handle them very well.
-    plutil_command = "plutil -convert binary1 -o '%s' --" % output_file.path
-    complete_command = ("if [[ -s '{in_file}' ]] ; then {plutil_command} '{in_file}' ; " +
-                        "elif [[ -f '{in_file}' ]] ; then echo | {plutil_command} - ; " +
+    plutil_command = "plutil -convert binary1 -o %s --" % shell.quote(output_file.path)
+    complete_command = ("if [[ -s {in_file} ]] ; then {plutil_command} {in_file} ; " +
+                        "elif [[ -f {in_file} ]] ; then echo | {plutil_command} - ; " +
                         "else exit 1 ; " +
                         "fi").format(
-        in_file = input_file.path,
+        in_file = shell.quote(input_file.path),
         plutil_command = plutil_command,
     )
     apple_support.run_shell(


### PR DESCRIPTION
We just hit this recently when we started to build everything (the app) with `opt` mode, when the plist files are actually compiled. (Those aren't `Info.plist`s)