### PR TITLE
Substitute PRODUCT_BUNDLE_PACKAGE_TYPE with default value

### DIFF
--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -216,6 +216,12 @@ def merge_root_infoplists(
     # Info.plists out of the box coming from Xcode.
     substitutions["DEVELOPMENT_LANGUAGE"] = "en"
 
+    # The generated Info.plists from Xcode's project templates use
+    # PRODUCT_BUNDLE_PACKAGE_TYPE as the default variable substitution for
+    # CFBundlePackageType. We substitute this to `APPL` to support
+    # Info.plists out of the box coming from Xcode 11+.
+    substitutions["PRODUCT_BUNDLE_PACKAGE_TYPE"] = "APPL"
+
     if include_executable_name:
         substitutions["EXECUTABLE_NAME"] = product_name
         forced_plists.append(struct(CFBundleExecutable = product_name))

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -347,6 +347,13 @@ replaced with the `-` character (i.e., `Foo Bar` will become `Foo-Bar`).
         <code>bundle_name</code> attribute is provided.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>PRODUCT_BUNDLE_PACKAGE_TYPE</code></td>
+      <td>
+        <p>This is currently hardcoded to <code>APPL</code> if exists. This is
+        done to support the default Info.plists come from Xcode 11+.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
I've been trying to compile a project generated with Xcode 11 with Bazel, and it's currently failing with the following error:
```
ERROR: In target "//MyProject:MyProject"; unknown variable reference "$(PRODUCT_BUNDLE_PACKAGE_TYPE)" while merging plists (key: "CFBundlePackageType", value: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)")
```

I haven't tested this change directly myself (appreciate if anyone has instructions on how to do so), but the logic is similar to the existing substitutions that are in place already. I tried to find some documentation regarding `PRODUCT_BUNDLE_PACKAGE_TYPE` and its possible values, but I couldn't find anything. The value is `APPL` for iOS and Catalyst builds, so I guess it's safe to assume it as a default value.

Should fix #643. 