### PR TITLE
bzl-visibility is no longer in the defaults.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,8 +29,6 @@ buildifier:
   #  https://github.com/bazelbuild/buildtools/issues/576
   # Disable 'print' warnings as there is no way to issue a warning from
   # Starlark.
-  # Disable 'bzl-visibility' since it doesn't work properly.
-  #  https://github.com/bazelbuild/buildtools/issues/718
   # TODO(b/140759502): Remove native-cc from this list.
   # TODO(b/140759593): Remove native-py from this list.
-  warnings: -function-docstring-args,-print,-bzl-visibility,-native-cc,-native-py
+  warnings: -function-docstring-args,-print,-native-cc,-native-py


### PR DESCRIPTION
bzl-visibility is no longer in the defaults.

Looking at the issue mentioned, it doesn't sound like it can be made to
generally work, so it got removed from the default set in
bazelbuild/buildtools#721

RELNOTES: None
