### PR TITLE
Suppress function-docstring-args in specific places.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,10 +23,6 @@ tasks:
 
 buildifier:
   version: latest
-  # Function doc string requirements are a little hard to follow, they did get
-  # split into multiple warnings, so there is now just one left that causes
-  # warnings. For the history of some of the issues, see:
-  #  https://github.com/bazelbuild/buildtools/issues/576
   # TODO(b/140759502): Remove native-cc from this list.
   # TODO(b/140759593): Remove native-py from this list.
-  warnings: -function-docstring-args,-native-cc,-native-py
+  warnings: -native-cc,-native-py

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -74,6 +74,7 @@ def ios_extension(name, **kwargs):
     )
 
 def ios_framework(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds and bundles an iOS dynamic framework."""
     linkopts = kwargs.get("linkopts", [])
 
@@ -106,6 +107,7 @@ def ios_framework(name, **kwargs):
     )
 
 def ios_static_framework(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds and bundles an iOS static framework for third-party distribution."""
     avoid_deps = kwargs.get("avoid_deps")
     deps = kwargs.get("deps")

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -48,6 +48,7 @@ load(
 )
 
 def macos_application(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Packages a macOS application."""
     binary_args = dict(kwargs)
     features = binary_args.pop("features", [])
@@ -66,6 +67,7 @@ def macos_application(name, **kwargs):
     )
 
 def macos_bundle(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Packages a macOS loadable bundle."""
     binary_args = dict(kwargs)
     features = binary_args.pop("features", [])
@@ -98,6 +100,7 @@ def macos_quick_look_plugin(name, **kwargs):
     )
 
 def macos_kernel_extension(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Packages a macOS Kernel Extension."""
     binary_args = dict(kwargs)
     features = binary_args.pop("features", [])
@@ -144,6 +147,7 @@ def macos_xpc_service(name, **kwargs):
     )
 
 def macos_command_line_application(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds a macOS command line application."""
 
     # Xcode will happily apply entitlements during code signing for a command line
@@ -205,6 +209,7 @@ def macos_command_line_application(name, **kwargs):
     )
 
 def macos_dylib(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds a macOS dylib."""
 
     # Xcode will happily apply entitlements during code signing for a dylib even
@@ -256,6 +261,7 @@ def macos_dylib(name, **kwargs):
     )
 
 def macos_extension(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Packages a macOS Extension Bundle."""
     binary_args = dict(kwargs)
 

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -38,6 +38,7 @@ apple_resource_group = _apple_resource_group
 # TODO(b/124103649): Create a proper rule when ObjC compilation is available in Starlark.
 # TODO(rdar/48851150): Add support for Swift once the generator supports public interfaces.
 def apple_core_ml_library(name, mlmodel, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Macro to orchestrate an objc_library with generated sources for mlmodel files."""
 
     # List of allowed attributes for the apple_core_ml_library rule. Do not want to expose the

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -66,6 +66,7 @@ def tvos_extension(name, **kwargs):
     )
 
 def tvos_framework(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds and bundles a tvOS dynamic framework."""
 
     # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
@@ -92,6 +93,7 @@ def tvos_framework(name, **kwargs):
     )
 
 def tvos_static_framework(name, **kwargs):
+    # buildifier: disable=function-docstring-args
     """Builds and bundles a tvOS static framework for third-party distribution."""
     avoid_deps = kwargs.get("avoid_deps")
     deps = kwargs.get("deps")


### PR DESCRIPTION
Suppress function-docstring-args in specific places.

If a function is over a computed complexity, buildifier requires a comment, if
the args aren't documented, that then triggers a warning for getting the args
documented. For these cases were we don't really care about the args because
things are pass thru to the real rule, just suppress the warning. Then then
enabled the real arg validation warnings so in the cases we do document args,
they will be correct/complete.

RELNOTES: None
