### PR TITLE
Fix incorrect entitlements validation of application identifier

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1170,6 +1170,9 @@ class EntitlementsTask(PlistToolTask):
       PlistToolError: For any issues found.
     """
     # com.apple.developer.team-identifier vs profile's TeamIdentifier
+    # Not verifying against profile's ApplicationIdentifierPrefix here, because
+    # it isn't always equal to the Team ID.
+    # https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-ENTITLEMENTSLIST
     src_team_id = entitlements.get('com.apple.developer.team-identifier')
     if src_team_id:
       key = 'TeamIdentifier'

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1177,7 +1177,7 @@ class EntitlementsTask(PlistToolTask):
       if src_team_id not in from_profile:
         self._report(
             ENTITLEMENTS_TEAM_ID_PROFILE_MISMATCH % (
-              self.target, src_team_id, key, from_profile)),
+              self.target, src_team_id, key, from_profile))
 
     profile_entitlements = self._profile_metadata.get('Entitlements')
 

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1169,16 +1169,15 @@ class EntitlementsTask(PlistToolTask):
     Raises:
       PlistToolError: For any issues found.
     """
-    # com.apple.developer.team-identifier vs profile's TeamIdentifier and
-    # ApplicationIdentifierPrefix
+    # com.apple.developer.team-identifier vs profile's TeamIdentifier
     src_team_id = entitlements.get('com.apple.developer.team-identifier')
     if src_team_id:
-      for key in ('TeamIdentifier', 'ApplicationIdentifierPrefix'):
-        from_profile = self._profile_metadata.get(key, [])
-        if src_team_id not in from_profile:
-          self._report(
-              ENTITLEMENTS_TEAM_ID_PROFILE_MISMATCH % (
-                self.target, src_team_id, key, from_profile))
+      key = 'TeamIdentifier'
+      from_profile = self._profile_metadata.get(key, [])
+      if src_team_id not in from_profile:
+        self._report(
+            ENTITLEMENTS_TEAM_ID_PROFILE_MISMATCH % (
+              self.target, src_team_id, key, from_profile)),
 
     profile_entitlements = self._profile_metadata.get('Entitlements')
 

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1338,22 +1338,6 @@ class PlistToolTest(unittest.TestCase):
           },
       })
 
-  def test_entitlements_profile_app_id_prefix_mismatch(self):
-    with self.assertRaisesRegex(
-        plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_TEAM_ID_PROFILE_MISMATCH % (
-            _testing_target, 'QWERTY', 'ApplicationIdentifierPrefix', "['ASDFGH']"))):
-      _plisttool_result({
-          'plists': [{'com.apple.developer.team-identifier': 'QWERTY'}],
-          'entitlements_options': {
-              'profile_metadata_file': {
-                  'TeamIdentifier': ['QWERTY'],
-                  'ApplicationIdentifierPrefix': ['ASDFGH'],
-                  'Version': 1,
-              },
-          },
-      })
-
   def test_entitlements_profile_teams_match(self):
     # This is really looking for the lack of an error being raised.
     plist1 = {'com.apple.developer.team-identifier': 'QWERTY'}


### PR DESCRIPTION
This fixes the following error that we encountered when building for
devices:

```
ERROR: BUILD.bazel:9:1: ProcessEntitlementsFiles App_entitlements.entitlements failed (Exit 1)
ERROR: In target "//:App_entitlements"; the entitlements "com.apple.developer.team-identifier" ("GFPYJQXRSN") did not match the provisioning profile's "ApplicationIdentifierPrefix" ("['BW6NM26Y25']").
```

From an Apple's Technical Note, the App ID prefix isn't always equal to
the Team ID.

> Often times the prefix is equal to the Team ID though it isn't always
the case.

https://developer.apple.com/library/archive/technotes/tn2415/_index.html#//apple_ref/doc/uid/DTS40016427-CH1-TP-INSPECTING_DISTRIBUTION_BUILD_ENTITLEMENTS_WHILE_SUBMITTING_AN_APP_IN_XCODE