### PR TITLE
Added ability to manually indicate the provisioning profile that a dynamic framework should use, eliminating the need to re-sign dynamic frameworks when they are bundled into the app.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -474,7 +474,7 @@ bundle in a directory named `Settings.bundle`.
             ),
         })
 
-    if not rule_descriptor.skip_signing:
+    if rule_descriptor.codesigning_exceptions == rule_support.codesigning_exceptions.none:
         attrs.append({
             "entitlements": attr.label(
                 providers = [[], [AppleEntitlementsInfo]],

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -19,6 +19,10 @@ load(
     "apple_product_type",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "bundling_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
     "linking_support",
 )
@@ -41,6 +45,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
     "rule_factory",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "rule_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:run_support.bzl",
@@ -156,6 +164,13 @@ def _tvos_framework_impl(ctx):
 
     bundle_id = ctx.attr.bundle_id
 
+    signed_frameworks = []
+    if getattr(ctx.file, "provisioning_profile", None):
+        rule_descriptor = rule_support.rule_descriptor(ctx)
+        signed_frameworks = [
+            bundling_support.bundle_name(ctx) + rule_descriptor.bundle_extension,
+        ]
+
     processor_partials = [
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
@@ -174,6 +189,7 @@ def _tvos_framework_impl(ctx):
         partials.embedded_bundles_partial(
             frameworks = [outputs.archive(ctx)],
             embeddable_targets = ctx.attr.frameworks,
+            signed_frameworks = depset(signed_frameworks),
         ),
         partials.extension_safe_validation_partial(is_extension_safe = ctx.attr.extension_safe),
         partials.framework_headers_partial(hdrs = ctx.files.hdrs),

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -103,7 +103,9 @@ Builds and bundles an iOS application.
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
         <p>A list of framework targets (see <a href="#ios_framework"><code>ios_framework</code></a>)
-        that this application depends on.</p>
+        that this application depends on. <b>NOTE:</b> Adding a
+        <code>provisioning_profile</code> to any frameworks listed will make the
+        signing/caching more efficient.</p>
       </td>
     </tr>
     <tr>
@@ -906,8 +908,8 @@ Builds and bundles an iOS Sticker Pack extension.
 
 ```python
 ios_framework(name, bundle_id, bundle_name, extension_safe, families,
-frameworks, infoplists, ipa_post_processor, linkopts, minimum_os_version, resources,
-strings, version, deps)
+frameworks, infoplists, ipa_post_processor, linkopts, minimum_os_version,
+provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles an iOS dynamic framework. To use this framework for your
@@ -1012,6 +1014,17 @@ app and extensions, list it in the `frameworks` attributes of those
         <p>A required string indicating the minimum iOS version supported by the
         target, represented as a dotted version number (for example,
         <code>"9.0"</code>).
+      </td>
+    </tr>
+    <tr>
+      <td><code>provisioning_profile</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>The provisioning profile (<code>.mobileprovision</code> file) to use
+        when bundling the framework bundle. This value is optional and is
+        expected to match the <code>provisioning_profile</code> of the
+        <code>ios_application</code>, but it will make signing/caching more
+        efficient.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -94,7 +94,9 @@ Builds and bundles a tvOS application.
       <td>
         <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
         <p>A list of framework targets (see <a href="#tvos_framework"><code>tvos_framework</code></a>)
-        that this application depends on.</p>
+        that this application depends on. <b>NOTE:</b> Adding a
+        <code>provisioning_profile</code> to any frameworks listed will make the
+        signing/caching more efficient.</p>
       </td>
     </tr>
     <tr>
@@ -381,8 +383,8 @@ Builds and bundles a tvOS extension.
 
 ```python
 tvos_framework(name, bundle_id, bundle_name, extension_safe, frameworks,
-infoplists, ipa_post_processor, linkopts, minimum_os_version, resources, strings, version,
-deps)
+infoplists, ipa_post_processor, linkopts, minimum_os_version,
+provisioning_profile, resources, strings, version, deps)
 ```
 
 Builds and bundles a tvOS dynamic framework. To use this framework for your app
@@ -479,6 +481,17 @@ and extensions, list it in the `frameworks` attributes of those
         <p>A required string indicating the minimum tvOS version supported by
         the target, represented as a dotted version number (for example,
         <code>"10.0"</code>).
+      </td>
+    </tr>
+    <tr>
+      <td><code>provisioning_profile</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>The provisioning profile (<code>.mobileprovision</code> file) to use
+        when bundling the framework bundle. This value is optional and is
+        expected to match the <code>provisioning_profile</code> of the
+        <code>tvos_application</code>, but it will make signing/caching more
+        efficient.</p>
       </td>
     </tr>
     <tr>

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -300,6 +300,30 @@ function assert_is_codesigned() {
 }
 
 
+# Usage assert_frameworks_not_resigned_given_output <path>
+#
+# If the output file from ipa_post_processor_verify_codesigning.sh was found,
+# asserts that the frameworks in the bundle have not been resigned.
+function assert_frameworks_not_resigned_given_output() {
+  local bundle="$1"
+
+  CODESIGN_FMWKS_ORIGINAL_OUTPUT="$bundle/codesign_v_fmwks_output.txt"
+
+  if [[ -d "$CODESIGN_FMWKS_ORIGINAL_OUTPUT" ]]; then
+    CODESIGN_FMWKS_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/codesign_fmwks_output.XXXXXX")"
+
+    for fmwk in \
+        $(find "$bundle/Frameworks" -type d -maxdepth 1 -mindepth 1); do
+      /usr/bin/codesign --display --verbose=3 "$fmwk" 2>&1 | egrep "^[^Executable=]" >> "$CODESIGN_FMWKS_OUTPUT"
+    done
+
+    assert_equals "$(cat $CODESIGN_FMWKS_OUTPUT)" "$(cat $CODESIGN_FMWKS_ORIGINAL_OUTPUT)"
+
+    rm -rf "$CODESIGN_FMWKS_OUTPUT"
+  fi
+}
+
+
 # Usage: current_archs <platform>
 #
 # Prints the architectures for the given platform that were specified in the

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -55,6 +55,30 @@ def ios_application_test_suite():
     )
 
     apple_verification_test(
+        name = "{}_fmwk_in_fmwk_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk_with_fmwk",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_fmwk_in_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk_with_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_two_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_two_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
         name = "{}_entitlements_simulator_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -178,3 +178,11 @@ macos_bundle(
     tags = TARGETS_UNDER_TEST_TAGS,
     version = ":build_label_pattern_does_not_short_circuit_literal_version",
 )
+
+sh_binary(
+    name = "ipa_post_processor_verify_codesigning",
+    srcs = [
+        "ipa_post_processor_verify_codesigning.sh",
+    ],
+    tags = ["requires-darwin"],
+)

--- a/test/starlark_tests/targets_under_test/apple/ipa_post_processor_verify_codesigning.sh
+++ b/test/starlark_tests/targets_under_test/apple/ipa_post_processor_verify_codesigning.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+WORKDIR="$1"
+
+# Save all codesigning output for each framework to verify later that they are
+# not being re-signed.
+for app in \
+    $(find "$WORKDIR/Payload" -type d -maxdepth 1 -mindepth 1); do
+
+  CODESIGN_FMWKS_OUTPUT="$app/codesign_v_fmwks_output.txt"
+
+  for fmwk in \
+      $(find "$app/Frameworks" -type d -maxdepth 1 -mindepth 1); do
+    # codesign writes all output to stderr; redirect to stdout and egrep to
+    # filter problematic outputs.
+    /usr/bin/codesign --display --verbose=3 "$fmwk" 2>&1 | egrep "^[^Executable=]" >> "$CODESIGN_FMWKS_OUTPUT"
+  done
+  if [ ! -f "$CODESIGN_FMWKS_OUTPUT" ]; then
+      echo "Internal Error: Failed to create codesign output file at $CODESIGN_FMWKS_OUTPUT" >&2
+      exit 1
+  fi
+done

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -229,6 +229,77 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_two_fmwk_provisioned",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [
+        ":fmwk_with_provisioning",
+        ":second_fmwk_with_provisioning",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:ios_non_localized_assets_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_application(
+    name = "app_with_fmwk_with_fmwk_provisioned",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk_with_fmwk_with_provisioning"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:ios_non_localized_assets_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_application(
+    name = "app_with_fmwk_with_fmwk",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk_with_fmwk"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:ios_non_localized_assets_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 ios_framework(
     name = "fmwk",
     bundle_id = "com.google.example.framework",
@@ -240,6 +311,95 @@ ios_framework(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "fmwk_with_provisioning",
+    bundle_id = "com.google.example.framework",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "second_fmwk_with_provisioning",
+    bundle_id = "com.google.example.frameworktoo",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "fmwk_with_fmwk",
+    bundle_id = "com.google.example.frameworkception",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "fmwk_with_fmwk_with_provisioning",
+    bundle_id = "com.google.example.frameworkception",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk_with_provisioning"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -112,6 +112,62 @@ tvos_application(
     ],
 )
 
+tvos_application(
+    name = "app_with_two_fmwk_provisioned",
+    bundle_id = "com.google.example",
+    frameworks = [
+        ":fmwk_with_provisioning",
+        ":second_fmwk_with_provisioning",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = "9.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+tvos_application(
+    name = "app_with_fmwk_with_fmwk_provisioned",
+    bundle_id = "com.google.example",
+    frameworks = [":fmwk_with_fmwk_with_provisioning"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = "9.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+tvos_application(
+    name = "app_with_fmwk_with_fmwk",
+    bundle_id = "com.google.example",
+    frameworks = [":fmwk_with_fmwk"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 tvos_framework(
     name = "fmwk",
     bundle_id = "com.google.example.framework",
@@ -119,6 +175,75 @@ tvos_framework(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "9.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+tvos_framework(
+    name = "fmwk_with_provisioning",
+    bundle_id = "com.google.example.framework",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+tvos_framework(
+    name = "second_fmwk_with_provisioning",
+    bundle_id = "com.google.example.frameworktoo",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+tvos_framework(
+    name = "fmwk_with_fmwk",
+    bundle_id = "com.google.example.frameworkception",
+    frameworks = [":fmwk"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+tvos_framework(
+    name = "fmwk_with_fmwk_with_provisioning",
+    bundle_id = "com.google.example.frameworkception",
+    frameworks = [":fmwk_with_provisioning"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = [
         "manual",
         "notap",

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -48,6 +48,30 @@ def tvos_application_test_suite():
     )
 
     apple_verification_test(
+        name = "{}_fmwk_in_fmwk_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_fmwk_with_fmwk",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_fmwk_in_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_fmwk_with_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_two_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_two_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
         name = "{}_entitlements_simulator_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",

--- a/test/starlark_tests/verifier_scripts/codesign_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/codesign_verifier.sh
@@ -25,4 +25,7 @@ if [[ -d "$CONTENT_ROOT/Frameworks" ]]; then
       $(find "$CONTENT_ROOT/Frameworks" -type d -maxdepth 1 -mindepth 1); do
     assert_is_codesigned "$fmwk"
   done
+
+  # Assert that the frameworks have not been resigned.
+  assert_frameworks_not_resigned_given_output "$BUNDLE_ROOT"
 fi

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -63,6 +63,20 @@ def _check_output(args, inputstr=None):
   return stdout, stderr
 
 
+def _invoke_codesign(codesign_path, identity, codesign_args, full_path_to_sign):
+  cmd = [codesign_path, "-v", "--sign", identity
+        ] + codesign_args + [full_path_to_sign]
+  stdout, stderr = _check_output(cmd)
+  if stdout:
+    filtered_stdout = _filter_codesign_output(stdout)
+    if filtered_stdout:
+      print(filtered_stdout)
+  if stderr:
+    filtered_stderr = _filter_codesign_output(stderr)
+    if filtered_stderr:
+      print(filtered_stderr)
+
+
 def plist_from_bytes(byte_content):
   try:
     return plistlib.loads(byte_content)
@@ -157,11 +171,23 @@ def _filter_codesign_output(codesign_output):
 def main(argv):
   parser = argparse.ArgumentParser(description="codesign wrapper")
   parser.add_argument(
+      "--full_path_to_sign", type=str, required=True, help="full file system "
+      "path to the target to code sign"
+  )
+  parser.add_argument(
       "--mobileprovision", type=str, help="mobileprovision file")
   parser.add_argument(
       "--codesign", required=True, type=str, help="path to codesign binary")
   parser.add_argument(
       "--identity", type=str, help="specific identity to sign with")
+  parser.add_argument(
+      "--is_directory", action="store_true", help="if the target to sign is a "
+      "directory, if the directory doesn't exist this script will do nothing"
+  )
+  parser.add_argument(
+      "--signed_frameworks", type=str, nargs="*", help="a list of frameworks "
+      "that have already been signed"
+  )
   args, codesign_args = parser.parse_known_args()
   identity = args.identity
   if identity is None:
@@ -177,19 +203,38 @@ def main(argv):
       return -1
   # No identity was found, fail
   if identity is None:
-    print("ERROR: Unable to find an identity on the system matching the "\
-        "ones in %s" % args.mobileprovision, file=sys.stderr)
+    print("ERROR: Unable to find an identity on the system matching the "
+          "ones in %s" % args.mobileprovision, file=sys.stderr)
     return 1
-  stdout, stderr = _check_output([args.codesign, "-v", "--sign", identity] +
-                                 codesign_args,)
-  if stdout:
-    filtered_stdout = _filter_codesign_output(stdout)
-    if filtered_stdout:
-      print(filtered_stdout)
-  if stderr:
-    filtered_stderr = _filter_codesign_output(stderr)
-    if filtered_stderr:
-      print(filtered_stderr)
+  all_paths_to_sign = []
+  if args.is_directory:
+    if not os.path.exists(args.full_path_to_sign):
+      # TODO(b/149874635): Cleanly error here rather than no-op when the failure
+      # to find a directory is a valid error condition.
+      return 0
+    files_found = [
+        x for x in os.listdir(args.full_path_to_sign) if not x.startswith(".")
+    ]
+    # Prefix each path found through os.listdir with the full path to sign
+    # before passing to codesign.
+    all_paths_to_sign = [
+        os.path.join(args.full_path_to_sign, f) for f in files_found
+    ]
+  else:
+    all_paths_to_sign = [args.full_path_to_sign]
+  signed_frameworks = args.signed_frameworks
+  if signed_frameworks:
+    if set(signed_frameworks) - set(all_paths_to_sign):
+      print("ERROR: From the set of all paths to sign, signed frameworks were "
+            "not found: %s" % (set(signed_frameworks) - set(all_paths_to_sign)))
+      print("Set of all paths to sign contains: %s" % all_paths_to_sign)
+      return 1
+    all_paths_to_sign = [
+        p for p in all_paths_to_sign if p not in signed_frameworks
+    ]
+
+  for path_to_sign in all_paths_to_sign:
+    _invoke_codesign(args.codesign, identity, codesign_args, path_to_sign)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added ability to manually indicate the provisioning profile that a dynamic framework should use, eliminating the need to re-sign dynamic frameworks when they are bundled into the app.

RELNOTES: Added ability to manually assign a provisioning profile to an ios_framework.
