### PR TITLE
Fix output paths colliding for different target with same bundle name

### DIFF
--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -23,6 +23,10 @@ load(
     "bundling_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "rule_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
@@ -38,10 +42,10 @@ load(
 def _archive(ctx):
     """Returns a file reference for this target's archive."""
     if is_experimental_tree_artifact_enabled(ctx):
-        bundle_name_with_extension = (
-            bundling_support.bundle_name(ctx) + bundling_support.bundle_extension(ctx)
-        )
-        return ctx.actions.declare_directory(bundle_name_with_extension)
+        archive_relative_path = rule_support.rule_descriptor(ctx).bundle_locations.archive_relative
+        root_path = ctx.attr.name.split('.__internal__.')[0] + "_archive-root"
+        return ctx.actions.declare_directory(
+            paths.join(root_path, archive_relative_path, bundling_support.bundle_name_with_extension(ctx)))
 
     # TODO(kaipi): Look into removing this rule implicit output and just return it using
     # DefaultInfo.

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -103,7 +103,7 @@ def _bundle_dsym_files(ctx, debug_provider, bundle_name, bundle_extension = ""):
       outputs from the target.
     """
     bundle_name_with_extension = bundle_name + bundle_extension
-    dsym_bundle_name = bundle_name_with_extension + ".dSYM"
+    dsym_bundle_name = paths.join(ctx.attr.name.split('.__internal__.')[0] + "_dsyms", bundle_name_with_extension + ".dSYM")
 
     outputs = []
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -668,15 +668,15 @@ function test_all_dsyms_propagated() {
       --output_groups=+dsyms \
       //app:app || fail "Should build"
 
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-  assert_exists "test-bin/app/ext.appex.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/app/app_dsyms/app.app.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/app/ext_dsyms/ext.appex.dSYM/Contents/Info.plist"
 
   declare -a archs=( $(current_archs ios) )
   for arch in "${archs[@]}"; do
     assert_exists \
-        "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
+        "test-bin/app/app_dsyms/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
     assert_exists \
-        "test-bin/app/ext.appex.dSYM/Contents/Resources/DWARF/ext_${arch}"
+        "test-bin/app/ext_dsyms/ext.appex.dSYM/Contents/Resources/DWARF/ext_${arch}"
   done
 }
 

--- a/test/macos_command_line_application_test.sh
+++ b/test/macos_command_line_application_test.sh
@@ -196,12 +196,12 @@ EOF
       //app:app || fail "Should build"
 
   # Make sure that a dSYM bundle was generated.
-  assert_exists "test-bin/app/app.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/app/app_dsyms/app.dSYM/Contents/Info.plist"
 
   declare -a archs=( $(current_archs macos) )
   for arch in "${archs[@]}"; do
     assert_exists \
-        "test-bin/app/app.dSYM/Contents/Resources/DWARF/app_${arch}"
+        "test-bin/app/app_dsyms/app.dSYM/Contents/Resources/DWARF/app_${arch}"
   done
 }
 

--- a/test/macos_dylib_test.sh
+++ b/test/macos_dylib_test.sh
@@ -121,12 +121,12 @@ EOF
       //dylib:dylib || fail "Should build"
 
   # Make sure that a dSYM bundle was generated.
-  assert_exists "test-bin/dylib/dylib.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/dylib/dylib_dsyms/dylib.dSYM/Contents/Info.plist"
 
   declare -a archs=( $(current_archs macos) )
   for arch in "${archs[@]}"; do
     assert_exists \
-        "test-bin/dylib/dylib.dSYM/Contents/Resources/DWARF/dylib_${arch}"
+        "test-bin/dylib/dylib_dsyms/dylib.dSYM/Contents/Resources/DWARF/dylib_${arch}"
   done
 }
 

--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -45,18 +45,20 @@ def _dsyms_test_impl(ctx):
     }
 
     package = target_under_test.label.package
+    name = target_under_test.label.name
 
     expected_infoplists = [
-        "{0}/{1}.dSYM/Contents/Info.plist".format(package, x)
+        "{0}/{2}_dsyms/{1}.dSYM/Contents/Info.plist".format(package, x, name)
         for x in ctx.attr.expected_dsyms
     ]
 
     expected_binaries = [
-        "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}_{3}".format(
+        "{0}/{4}_dsyms/{1}.dSYM/Contents/Resources/DWARF/{2}_{3}".format(
             package,
             x,
             paths.split_extension(x)[0],
             architecture,
+            name,
         )
         for x in ctx.attr.expected_dsyms
     ]


### PR DESCRIPTION
Bundles are created in `bazel-bin/<package>/<bundle_name>.<app/appex>`. Two targets in the same package that use the same bundle name will see their outputs colliding and Bazel failing. A similar collision occurs with dSYM paths.
These changes replace the current paths with:
   - `bazel-bin/<package>/<target name>_archive_root/Payload/<bundle_name>.<app/appex>`
   - `bazel-bin/<package>/<target name>_dsyms/<bundle_name>.<app/appex>.dSYMS`