### PR TITLE
Allow archive_contents_test() to test for symbols in binary files.

### DIFF
--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -32,6 +32,10 @@ def archive_contents_test(
         asset_catalog_test_file = "",
         asset_catalog_test_contains = [],
         asset_catalog_test_not_contains = [],
+        binary_test_file = "",
+        binary_test_architecture = "",
+        binary_contains_symbols = [],
+        binary_not_contains_symbols = [],
         **kwargs):
     """Macro for calling the apple_verification_test with archive_contents_test.sh.
 
@@ -64,6 +68,13 @@ def archive_contents_test(
             asset catalog specified in `asset_catalog_file`.
         asset_catalog_test_not_contains: Optional, A list of names of assets that should not appear
             in the asset catalog specified in `asset_catalog_file`.
+        binary_test_file: Optional, The binary file to test (see next three Args).
+        binary_test_architecture: Optional, The architecture to use from `binary_test_file` for
+            symbol tests (see next two Args).
+        binary_contains_symbols: Optional, A list of symbols that should appear in the binary file
+            specified in `binary_test_file`.
+        binary_not_contains_symbols: Optional, A list of symbols that should not appear in the
+            binary file specified in `binary_test_file`.
         **kwargs: Other arguments are passed through to the apple_verification_test rule.
     """
 
@@ -87,6 +98,10 @@ def archive_contents_test(
             "ASSET_CATALOG_FILE": [asset_catalog_test_file],
             "ASSET_CATALOG_CONTAINS": asset_catalog_test_contains,
             "ASSET_CATALOG_NOT_CONTAINS": asset_catalog_test_not_contains,
+            "BINARY_TEST_FILE": [binary_test_file],
+            "BINARY_TEST_ARCHITECTURE": [binary_test_architecture],
+            "BINARY_CONTAINS_SYMBOLS": binary_contains_symbols,
+            "BINARY_NOT_CONTAINS_SYMBOLS": binary_not_contains_symbols,
         },
         target_under_test = target_under_test,
         verifier_script = "verifier_scripts/archive_contents_test.sh",


### PR DESCRIPTION
Allow archive_contents_test() to test for symbols in binary files.

This enables tests to check if symbols exist in a binary file using `objdump`.

RELNOTES: None
