### PR TITLE
Add support to archive_contents_test() for regexp matching the contents of a text file.

### DIFF
--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -32,6 +32,8 @@ def archive_contents_test(
         asset_catalog_test_file = "",
         asset_catalog_test_contains = [],
         asset_catalog_test_not_contains = [],
+        text_test_file = "",
+        text_test_values = [],
         binary_test_file = "",
         binary_test_architecture = "",
         binary_contains_symbols = [],
@@ -68,6 +70,9 @@ def archive_contents_test(
             asset catalog specified in `asset_catalog_file`.
         asset_catalog_test_not_contains: Optional, A list of names of assets that should not appear
             in the asset catalog specified in `asset_catalog_file`.
+        text_test_file: Optional, The text file to test (see the next Arg).
+        text_test_values: Optional, A list of regular expressions that should be tested against
+            the contents of `text_test_file`.
         binary_test_file: Optional, The binary file to test (see next three Args).
         binary_test_architecture: Optional, The architecture to use from `binary_test_file` for
             symbol tests (see next two Args).
@@ -98,6 +103,8 @@ def archive_contents_test(
             "ASSET_CATALOG_FILE": [asset_catalog_test_file],
             "ASSET_CATALOG_CONTAINS": asset_catalog_test_contains,
             "ASSET_CATALOG_NOT_CONTAINS": asset_catalog_test_not_contains,
+            "TEXT_TEST_FILE": [text_test_file],
+            "TEXT_TEST_VALUES": text_test_values,
             "BINARY_TEST_FILE": [binary_test_file],
             "BINARY_TEST_ARCHITECTURE": [binary_test_architecture],
             "BINARY_CONTAINS_SYMBOLS": binary_contains_symbols,

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -39,6 +39,9 @@ newline=$'\n'
 #  ASSET_CATALOG_FILE: The Asset.car file to test with `ASSET_CATALOG_CONTAINS`.
 #  ASSET_CATALOG_CONTAINS: Array of asset names that should exist.
 #  ASSET_CATALOG_NOT_CONTAINS: Array of asset names that should not exist.
+#  TEXT_TEST_FILE: The text file to test with `TEXT_TEST_VALUES`.
+#  TEXT_TEST_VALUES: Array for regular expressions to test the contents of the
+#      text file with.
 #  BINARY_TEST_FILE: The file to test with `BINARY_TEST_SYMBOLS`
 #  BINARY_TEST_ARCHITECTURE: The architecture to use with `BINARY_TEST_SYMBOLS`.
 #  BINARY_CONTAINS_SYMBOLS: Array of symbols that should be present.
@@ -52,6 +55,24 @@ if [[ -n "${CONTAINS-}" ]]; then
     if [[ ! -e $expanded_path ]]; then
       fail "Archive did not contain \"$expanded_path\"" \
         "contents were:$newline$(find $ARCHIVE_ROOT)"
+    fi
+  done
+fi
+
+# Test an array of regular expressions against the contents of a text file in
+# the archive.
+
+if [[ -n "${TEXT_TEST_FILE-}" ]]; then
+  path=$(eval echo "$TEXT_TEST_FILE")
+  if [[ ! -e $path ]]; then
+    fail "Archive did not contain text file at \"$path\"" \
+      "contents were:$newline$(find $ARCHIVE_ROOT)"
+  fi
+  for test_regexp in "${TEXT_TEST_VALUES[@]}"
+  do
+    if [[ $(grep -c "$test_regexp" "$path") == 0 ]]; then
+      fail "Expected regexp \"$test_regexp\" did not match" \
+        "contents of text file at \"$path\""
     fi
   done
 fi


### PR DESCRIPTION
Add support to archive_contents_test() for regexp matching the contents of a text file.

RELNOTES: None
