### PR TITLE
Docs update to indicate the exact effect of adding a provisioning_profile to an ios_framework.

### DIFF
--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -1024,7 +1024,8 @@ app and extensions, list it in the `frameworks` attributes of those
         when bundling the framework bundle. This value is optional and is
         expected to match the <code>provisioning_profile</code> of the
         <code>ios_application</code>, but it will make signing/caching more
-        efficient.</p>
+        efficient. <strong>NOTE</strong>: This will codesign the framework when
+        it is built standalone.</p>
       </td>
     </tr>
     <tr>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -491,7 +491,8 @@ and extensions, list it in the `frameworks` attributes of those
         when bundling the framework bundle. This value is optional and is
         expected to match the <code>provisioning_profile</code> of the
         <code>tvos_application</code>, but it will make signing/caching more
-        efficient.</p>
+        efficient. <strong>NOTE</strong>: This will codesign the framework when
+        it is built standalone.</p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Docs update to indicate the exact effect of adding a provisioning_profile to an ios_framework.

RELNOTES: None
