### PR TITLE
Create a thin binary if there's only one needed slice, otherwise create a universal binary

### DIFF
--- a/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
+++ b/tools/dynamic_framework_slicer/dynamic_framework_slicer.sh
@@ -79,9 +79,14 @@ else
         fi
     done
 
+    # Create a thin binary if there's only one needed slice, otherwise create a universal binary
     declare -a lipo_args
-    for slice in "${slices_needed[@]}"; do
-        lipo_args+=(-extract $slice)
-    done
+    if [[ "${#slices_needed[@]}" -eq 1 ]]; then
+        lipo_args+=(-thin ${slices_needed[0]})
+    else
+        for slice in "${slices_needed[@]}"; do
+            lipo_args+=(-extract $slice)
+        done
+    fi
     xcrun lipo "$IN" "${lipo_args[@]}" -output "$OUT"
 fi


### PR DESCRIPTION
This matches Xcode's produced binaries. The universal binaries are a
little larger in size compared to thin binaries.