### PR TITLE
Support processing Metal files

### DIFF
--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -325,6 +325,7 @@ def _resources_partial_impl(
         "asset_catalogs": (resources_support.asset_catalogs, False),
         "datamodels": (resources_support.datamodels, True),
         "infoplists": (resources_support.infoplists, False),
+        "metals": (resources_support.metals, False),
         "mlmodels": (resources_support.mlmodels, False),
         "plists": (resources_support.plists_and_strings, False),
         "pngs": (resources_support.pngs, False),

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -222,6 +222,40 @@ def _infoplists(ctx, parent_dir, files):
     else:
         return struct(files = [], infoplists = files.to_list())
 
+def _metals(ctx, parent_dir, files, output_filename = "default.metallib"):
+    """Processes metal files.
+
+    The metal files will be compiled into a Metal library named `default.metallib`.
+
+    Args:
+        ctx: The target's context.
+        parent_dir: The path under which the library should be placed.
+        files: The metal files to process.
+        output_filename: The output .metallib filename.
+
+    Returns:
+        A struct containing a `files` field with tuples as described in processor.bzl.
+    """
+    metallib_path = paths.join(parent_dir or "", output_filename)
+    metallib_file = intermediates.file(
+        ctx.actions,
+        ctx.label.name,
+        metallib_path,
+    )
+    resource_actions.compile_metals(
+        ctx,
+        files.to_list(),
+        metallib_file,
+    )
+
+    return struct(
+        files = [(
+            processor.location.resource,
+            parent_dir,
+            depset(direct = [metallib_file])
+        )],
+    )
+
 def _mlmodels(ctx, parent_dir, files):
     """Processes mlmodel files."""
 
@@ -435,6 +469,7 @@ resources_support = struct(
     asset_catalogs = _asset_catalogs,
     datamodels = _datamodels,
     infoplists = _infoplists,
+    metals = _metals,
     mlmodels = _mlmodels,
     noop = _noop,
     plists_and_strings = _plists_and_strings,

--- a/apple/internal/resource_actions.bzl
+++ b/apple/internal/resource_actions.bzl
@@ -30,6 +30,10 @@ load(
     _link_storyboards = "link_storyboards",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/resource_actions:metals.bzl",
+    _compile_metals = "compile_metals",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:mlmodel.bzl",
     _compile_mlmodel = "compile_mlmodel",
     _generate_objc_mlmodel_sources = "generate_objc_mlmodel_sources",
@@ -58,6 +62,7 @@ resource_actions = struct(
     compile_asset_catalog = _compile_asset_catalog,
     compile_datamodels = _compile_datamodels,
     compile_mappingmodel = _compile_mappingmodel,
+    compile_metals = _compile_metals,
     compile_mlmodel = _compile_mlmodel,
     compile_plist = _compile_plist,
     compile_storyboard = _compile_storyboard,

--- a/apple/internal/resource_actions/metals.bzl
+++ b/apple/internal/resource_actions/metals.bzl
@@ -1,0 +1,104 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metal related actions."""
+
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+
+def _metal_apple_target_triple(ctx):
+    """Returns a Metal target triple string for an Apple platform.
+
+    Args:
+        ctx: The target's context.
+    Returns:
+        A target triple string describing the platform.
+    """
+    platform = ctx.fragments.apple.single_arch_platform
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    target_os_version = xcode_config.minimum_os_for_platform_type(
+        platform.platform_type,
+    )
+
+    platform_string = str(platform.platform_type)
+    if platform_string == "macos":
+        platform_string = "macosx"
+
+    environment = "" if platform.is_device else "-simulator"
+
+    return "air64-apple-{platform}{version}{environment}".format(
+        environment = environment,
+        platform = platform_string,
+        version = target_os_version,
+    )
+
+def compile_metals(ctx, input_files, output_file):
+    """Creates actions that compile .metal files into a single .metallib file.
+
+    Args:
+        ctx: The target's rule context.
+        input_files: The input metal files.
+        output_file: The output metallib file.
+    """
+    air_files = []
+    target = _metal_apple_target_triple(ctx)
+
+    if not input_files:
+        fail("Input .metal files can't be empty")
+
+    # Compile each .metal file into a single .air file
+    for input_metal in input_files:
+        air_file = ctx.actions.declare_file(
+            paths.replace_extension(input_metal.basename, ".air"),
+        )
+        air_files.append(air_file)
+
+        args = ctx.actions.args()
+        args.add("metal")
+        args.add("-c")
+        args.add("-target", target)
+        args.add("-ffast-math")
+        args.add("-o", air_file)
+        args.add(input_metal)
+
+        apple_support.run(
+            ctx,
+            executable = "/usr/bin/xcrun",
+            inputs = [input_metal],
+            outputs = [air_file],
+            arguments = [args],
+            mnemonic = "MetalCompile",
+        )
+
+    # Compile .air files into a single .metallib file, which stores the Metal
+    # library
+    args = ctx.actions.args()
+    args.add("metallib")
+    args.add("-o", output_file)
+    args.add_all(air_files)
+
+    apple_support.run(
+        ctx,
+        executable = "/usr/bin/xcrun",
+        inputs = air_files,
+        outputs = [output_file],
+        arguments = [args],
+        mnemonic = "MetallibCompile",
+    )

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -198,6 +198,8 @@ def _bucketize_data(
             bucket_name = "pngs"
         elif resource_short_path.endswith(".plist"):
             bucket_name = "plists"
+        elif resource_short_path.endswith(".metal"):
+            bucket_name = "metals"
         elif resource_short_path.endswith(".mlmodel"):
             bucket_name = "mlmodels"
         else:

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -142,6 +142,8 @@ AppleResourceInfo = provider(
         "infoplists": """Plist files to be merged and processed. Plist files that should not be
 merged into the root Info.plist should be propagated in `plists`. Because of this, infoplists should
 only be bucketed with the `bucketize_typed` method.""",
+        "metals": """Metal Shading Language source files to be compiled into a single .metallib file
+and bundled at the top level.""",
         "mlmodels": "Core ML model files that should be processed and bundled at the top level.",
         "plists": "Resource Plist files that should not be merged into Info.plist",
         "pngs": "PNG images which are not bundled in an .xcassets folder.",

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -205,6 +205,7 @@ def ios_application_resources_test_suite(name = "ios_application_resources"):
         },
         contains = [
             "$BUNDLE_ROOT/bundle_library_ios.bundle/basic.bundle/basic_bundle.txt",
+            "$BUNDLE_ROOT/bundle_library_ios.bundle/default.metallib",
             "$BUNDLE_ROOT/bundle_library_ios.bundle/it.lproj/localized.strings",
             "$BUNDLE_ROOT/bundle_library_ios.bundle/it.lproj/localized.txt",
             "$BUNDLE_ROOT/bundle_library_ios.bundle/it.lproj/storyboard_ios.storyboardc/",

--- a/test/starlark_tests/macos_application_resources_tests.bzl
+++ b/test/starlark_tests/macos_application_resources_tests.bzl
@@ -129,6 +129,7 @@ def macos_application_resources_test_suite():
         },
         contains = [
             "$RESOURCE_ROOT/bundle_library_apple.bundle/basic.bundle/basic_bundle.txt",
+            "$RESOURCE_ROOT/bundle_library_apple.bundle/default.metallib",
             "$RESOURCE_ROOT/bundle_library_apple.bundle/it.lproj/localized.strings",
             "$RESOURCE_ROOT/bundle_library_apple.bundle/it.lproj/localized.txt",
             "$RESOURCE_ROOT/bundle_library_apple.bundle/mapping_model.cdm",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -227,6 +227,11 @@ filegroup(
 )
 
 filegroup(
+    name = "metal_files",
+    srcs = glob(["*.metal"]),
+)
+
+filegroup(
     name = "localized_generic_resources",
     srcs = glob(["*.lproj/*.txt"]),
 )
@@ -350,6 +355,7 @@ apple_resource_bundle(
         ":localized_strings",
         ":localized_xibs_ios",
         ":mapping_model",
+        ":metal_files",
         ":unversioned_datamodel",
         ":versioned_datamodel",
     ],
@@ -383,6 +389,7 @@ apple_resource_bundle(
         ":localized_plists",
         ":localized_strings",
         ":mapping_model",
+        ":metal_files",
         ":unversioned_datamodel",
         ":versioned_datamodel",
     ],

--- a/test/starlark_tests/resources/sample1.metal
+++ b/test/starlark_tests/resources/sample1.metal
@@ -1,0 +1,3 @@
+#include <metal_stdlib>
+
+using namespace metal;

--- a/test/starlark_tests/resources/sample2.metal
+++ b/test/starlark_tests/resources/sample2.metal
@@ -1,0 +1,3 @@
+#include <metal_stdlib>
+
+using namespace metal;


### PR DESCRIPTION
This adds support for processing Metal files when they're included in a
`apple_resource_bundle` target. This currently does not support
specifying the output filename of the compiled .metallib -- the Metal
files are always compiled to a single `default.metallib` now. 

Resolves #696