### PR TITLE
Turn off the bzl-visibility check

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -25,4 +25,6 @@ buildifier:
   version: latest
   # TODO(b/140759502): Remove native-cc from this list.
   # TODO(b/140759593): Remove native-py from this list.
-  warnings: -native-cc,-native-py
+  # Disable 'bzl-visibility' since it doesn't work properly.
+  #  https://github.com/bazelbuild/buildtools/issues/718
+  warnings: -native-cc,-native-py,-bzl-visibility


### PR DESCRIPTION
Turn off the bzl-visibility check

It was added back to the defaults: https://github.com/bazelbuild/buildtools/pull/795

But the report issue still seems to be open: https://github.com/bazelbuild/buildtools/issues/718

RELNOTES: None
