### PR TITLE
Capture swiftmodules in swift static framework aspect

### DIFF
--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -28,6 +28,9 @@ Dictionary of architecture to the generated swiftinterface file for that archite
         "swiftdocs": """
 Dictionary of architecture to the generated swiftdoc file for that architecture.
 """,
+        "swiftmodules": """
+Dictionary of architecture to the generated swiftmodule file for that architecture.
+""",
         "generated_header": """
 The generated Objective-C header for the single swift_library dependency.
 """,
@@ -96,6 +99,7 @@ single swift_library dependency with no transitive swift_library dependencies.\
         generated_header = None
         swiftdocs = {}
         swiftinterfaces = {}
+        swiftmodules = {}
         for dep in swiftdeps:
             swiftinfo = dep[SwiftInfo]
 
@@ -130,15 +134,17 @@ swift_library dependency with no transitive swift_library dependencies.\
 
             swiftdocs[arch] = swiftinfo.transitive_swiftdocs.to_list()[0]
             swiftinterfaces[arch] = swiftinfo.transitive_swiftinterfaces.to_list()[0]
+            swiftmodules[arch] = swiftinfo.transitive_swiftmodules.to_list()[0]
 
         # Make sure that all dictionaries contain at least one module before returning the provider.
-        if all([module_name, swiftdocs, swiftinterfaces]):
+        if all([module_name, swiftdocs, swiftinterfaces, swiftmodules]):
             return [
                 SwiftStaticFrameworkInfo(
                     module_name = module_name,
                     generated_header = generated_header,
                     swiftdocs = swiftdocs,
                     swiftinterfaces = swiftinterfaces,
+                    swiftmodules = swiftmodules,
                 ),
             ]
         else:

--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -62,6 +62,7 @@ frameworks expect a single swift_library dependency with `module_name` set to th
     generated_header = swift_static_framework_info.generated_header
     swiftdocs = swift_static_framework_info.swiftdocs
     swiftinterfaces = swift_static_framework_info.swiftinterfaces
+    swiftmodules = swift_static_framework_info.swiftmodules
 
     bundle_files = []
     modules_parent = paths.join("Modules", "{}.swiftmodule".format(expected_module_name))
@@ -74,6 +75,15 @@ frameworks expect a single swift_library dependency with `module_name` set to th
         )
         file_support.symlink(ctx, swiftinterface, bundle_interface)
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_interface])))
+
+    for arch, swiftmodule in swiftmodules.items():
+        bundle_module = intermediates.file(
+            ctx.actions,
+            ctx.label.name,
+            "{}.swiftmodule".format(arch),
+        )
+        file_support.symlink(ctx, swiftmodule, bundle_module)
+        bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_module])))
 
     for arch, swiftdoc in swiftdocs.items():
         bundle_doc = intermediates.file(ctx.actions, ctx.label.name, "{}.swiftdoc".format(arch))


### PR DESCRIPTION
When building a swift static framework in Xcode with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`, Xcode copies the `swiftinterface`, `swiftdoc`, and `swiftmodule` files for each architecture.

The bazel rules only seem to copy the `swiftinterface` and `swiftdoc` files. I'm not sure if this is intentional (perhaps I'm missing some context here).