### PR TITLE
Downgrade error to warning, when a signed framework is not found in the set of all paths to sign.

### DIFF
--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -47,6 +47,26 @@ def ios_application_test_suite():
     )
 
     apple_verification_test(
+        name = "{}_ext_and_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_ext_and_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_ext_and_fmwk_provisioned_codesign_asan_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_ext_and_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        sanitizer = "asan",
+        tags = [
+            name,
+            "manual",  # disabled in oss
+        ],
+    )
+
+    apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk",

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -40,6 +40,26 @@ def ios_extension_test_suite():
     )
 
     apple_verification_test(
+        name = "{}_fmwk_provisioned_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_with_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_fmwk_provisioned_codesign_asan_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_with_fmwk_provisioned",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        sanitizer = "asan",
+        tags = [
+            name,
+            "manual",  # disabled in oss
+        ],
+    )
+
+    apple_verification_test(
         name = "{}_entitlements_simulator_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -162,6 +162,31 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_ext_and_fmwk_provisioned",
+    bundle_id = "com.google.example",
+    extensions = [":ext_with_fmwk_provisioned"],
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [
+        ":fmwk_with_provisioning",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 ios_extension(
     name = "ext",
     bundle_id = "com.google.example.ext",
@@ -196,6 +221,31 @@ ios_extension(
         "//test/starlark_tests/resources:Another.plist",
     ],
     minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_extension(
+    name = "ext_with_fmwk_provisioned",
+    bundle_id = "com.google.example.ext",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [
+        ":fmwk_with_provisioning",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = [
         "manual",
         "notap",

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -225,10 +225,9 @@ def main(argv):
   signed_frameworks = args.signed_frameworks
   if signed_frameworks:
     if set(signed_frameworks) - set(all_paths_to_sign):
-      print("ERROR: From the set of all paths to sign, signed frameworks were "
+      print("WARNING: From the set of all paths to sign, signed frameworks "
             "not found: %s" % (set(signed_frameworks) - set(all_paths_to_sign)))
       print("Set of all paths to sign contains: %s" % all_paths_to_sign)
-      return 1
     all_paths_to_sign = [
         p for p in all_paths_to_sign if p not in signed_frameworks
     ]


### PR DESCRIPTION
Downgrade error to warning, when a signed framework is not found in the set of all paths to sign.

RELNOTES=Addressed error when clang_rt support libraries were added to an ios_extension referencing an ios_framework, and the ios_framework has a provisioning_profile.
