### PR TITLE
Remove redundant extra_binaries arg from the framework_import partial.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -64,7 +64,6 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
@@ -128,7 +127,6 @@ def _ios_application_impl(ctx):
         ),
         partials.framework_import_partial(
             targets = ctx.attr.deps + ctx.attr.extensions + ctx.attr.frameworks,
-            extra_binaries = [x[AppleBundleInfo].binary for x in ctx.attr.extensions],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -47,7 +47,7 @@ load(
     "paths",
 )
 
-def _framework_import_partial_impl(ctx, targets, targets_to_avoid, extra_binaries):
+def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
     """Implementation for the framework import file processing partial."""
     _ignored = [ctx]
 
@@ -171,7 +171,7 @@ def _framework_import_partial_impl(ctx, targets, targets_to_avoid, extra_binarie
         signed_frameworks = depset(signed_frameworks_list),
     )
 
-def framework_import_partial(targets, targets_to_avoid = [], extra_binaries = []):
+def framework_import_partial(targets, targets_to_avoid = []):
     """Constructor for the framework import file processing partial.
 
     This partial propagates framework import file bundle locations. The files are collected through
@@ -181,8 +181,6 @@ def framework_import_partial(targets, targets_to_avoid = [], extra_binaries = []
         targets: The list of targets through which to collect the framework import files.
         targets_to_avoid: The list of targets that may already be bundling some of the frameworks,
             to be used when deduplicating frameworks already bundled.
-        extra_binaries: Extra binaries to consider when collecting which archs should be
-            preserved in the imported dynamic frameworks.
 
     Returns:
         A partial that returns the bundle location of the framework import files.
@@ -191,5 +189,4 @@ def framework_import_partial(targets, targets_to_avoid = [], extra_binaries = []
         _framework_import_partial_impl,
         targets = targets,
         targets_to_avoid = targets_to_avoid,
-        extra_binaries = extra_binaries,
     )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -60,7 +60,6 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
     "TvosApplicationBundleInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
@@ -110,7 +109,6 @@ def _tvos_application_impl(ctx):
         ),
         partials.framework_import_partial(
             targets = ctx.attr.deps + embeddable_targets,
-            extra_binaries = [x[AppleBundleInfo].binary for x in ctx.attr.extensions],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,


### PR DESCRIPTION
Remove redundant extra_binaries arg from the framework_import partial.

RELNOTES: None.
