### PR TITLE
Mark the ios_framework referenced by ext_with_fmwk_provisioned as extension_safe.

### DIFF
--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -420,6 +420,7 @@ ios_framework(
 ios_framework(
     name = "fmwk_with_provisioning",
     bundle_id = "com.google.example.framework",
+    extension_safe = 1,
     families = [
         "iphone",
         "ipad",


### PR DESCRIPTION
Mark the ios_framework referenced by ext_with_fmwk_provisioned as extension_safe.

Fixes a warning that shows up when running the test suite around the importance of using extension_safe with ios_frameworks referenced by ios_extensions.

RELNOTES: None
