### PR TITLE
Fix apple_static_framework_import with swiftinterface

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -69,12 +69,15 @@ def _swiftmodule_for_cpu(swiftmodule_files, cpu):
     #   ABC.framework/Modules/ABC.swiftmodule/<arch>.swiftmodule
     # Where <arch> will be a common arch like x86_64, arm64, etc.
     named_files = {f.basename: f for f in swiftmodule_files}
+    for extension in ("swiftinterface", "swiftmodule"):
+        module = named_files.get("{}.{}".format(cpu, extension))
+        if not module and cpu == "armv7":
+            module = named_files.get("arm.{}".format(extension))
 
-    module = named_files.get("{}.swiftmodule".format(cpu))
-    if not module and cpu == "armv7":
-        module = named_files.get("arm.swiftmodule")
+        if module:
+            return module
 
-    return module
+    return None
 
 def _classify_framework_imports(framework_imports):
     """Classify a list of framework files into bundling, header, or module_map."""


### PR DESCRIPTION
Without this when propagating a framework built with library evolution
with apple_static_framework_import it fails because the "swiftmodule"
isn't found. The naming is a bit off here like the function above, but
this now returns whichever of these files exists.