### PR TITLE
Use default when "None" is passed for test runner

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -182,7 +182,7 @@ def ios_imessage_extension(name, **kwargs):
 _DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner"
 
 def ios_unit_test(name, **kwargs):
-    runner = kwargs.pop("runner") or _DEFAULT_TEST_RUNNER
+    runner = kwargs.pop("runner", None) or _DEFAULT_TEST_RUNNER
     apple_test_assembler.assemble(
         name = name,
         bundle_rule = _ios_internal_unit_test_bundle,
@@ -194,7 +194,7 @@ def ios_unit_test(name, **kwargs):
     )
 
 def ios_ui_test(name, **kwargs):
-    runner = kwargs.pop("runner") or _DEFAULT_TEST_RUNNER
+    runner = kwargs.pop("runner", None) or _DEFAULT_TEST_RUNNER
     apple_test_assembler.assemble(
         name = name,
         bundle_rule = _ios_internal_ui_test_bundle,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -182,7 +182,7 @@ def ios_imessage_extension(name, **kwargs):
 _DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner"
 
 def ios_unit_test(name, **kwargs):
-    runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
+    runner = kwargs.pop("runner") or _DEFAULT_TEST_RUNNER
     apple_test_assembler.assemble(
         name = name,
         bundle_rule = _ios_internal_unit_test_bundle,
@@ -194,7 +194,7 @@ def ios_unit_test(name, **kwargs):
     )
 
 def ios_ui_test(name, **kwargs):
-    runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)
+    runner = kwargs.pop("runner") or _DEFAULT_TEST_RUNNER
     apple_test_assembler.assemble(
         name = name,
         bundle_rule = _ios_internal_ui_test_bundle,


### PR DESCRIPTION
In some build systems, like tensorflow's, they have some convenience
macros that set the test runner. In some cases they choose to not
override the runner and therefore return None. This was previously not
handled because the None was passed through and eventually fails.