### PR TITLE
Fix typo in _tvos_static_framework_impl rule documentation

### DIFF
--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -271,7 +271,7 @@ def _tvos_extension_impl(ctx):
     ] + processor_result.providers
 
 def _tvos_static_framework_impl(ctx):
-    """Implementation of ios_static_framework."""
+    """Implementation of tvos_static_framework."""
 
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
     # action, when available.


### PR DESCRIPTION
While working on another PR, I noticed a small typo, likely from an earlier copy-paste in writing the tvOS rules.