### PR TITLE
Add arm64_32 as a valid architecture

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -17,6 +17,7 @@ licenses(["notice"])
         "tvos_arm64",
         "watchos_i386",
         "watchos_armv7k",
+        "watchos_arm64_32",
     ]
 ]
 


### PR DESCRIPTION
Not sure if there are more required changes, but I'd first like to see if this makes sense to add. I was trying to conditionally workaround an issue in one on my `BUILD` files using `select()` but couldn't because `arm64_32` is not listed as a valid architecture.