### PR TITLE
Allow to pass a custom script to the *_test_runner rules

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -42,7 +42,7 @@ def _get_execution_environment(ctx):
 def _ios_test_runner_impl(ctx):
     """Implementation for the ios_test_runner rule."""
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(ctx),
     )
@@ -86,7 +86,7 @@ correspond to the output of `xcrun simctl list runtimes`. ' 'E.g., 11.2, 9.3.
 By default, it is the latest supported version of the device type.'
 """,
         ),
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label(
                 "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.template.sh",
             ),

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -77,7 +77,7 @@ def _macos_test_runner_impl(ctx):
     )
 
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(preprocessed_xctestrun_template),
     )
@@ -98,7 +98,7 @@ def _macos_test_runner_impl(ctx):
 macos_test_runner = rule(
     _macos_test_runner_impl,
     attrs = {
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label("@build_bazel_rules_apple//apple/testing/default_runner:macos_test_runner.template.sh"),
             allow_single_file = True,
         ),

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -40,7 +40,7 @@ def _get_execution_environment(ctx):
 def _tvos_test_runner_impl(ctx):
     """Implementation for the tvos_test_runner rule."""
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(ctx),
     )
@@ -84,7 +84,7 @@ correspond to the output of `xcrun simctl list runtimes`. ' 'E.g., 11.2, 9.1.
 By default, it is the latest supported version of the device type.'
 """,
         ),
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label(
                 "@build_bazel_rules_apple//apple/testing/default_runner:tvos_test_runner.template.sh",
             ),

--- a/test/testdata/rules/dummy_test_runner.bzl
+++ b/test/testdata/rules/dummy_test_runner.bzl
@@ -21,7 +21,7 @@ load(
 
 def _dummy_test_runner_impl(ctx):
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = {},
     )
@@ -38,7 +38,7 @@ def _dummy_test_runner_impl(ctx):
 dummy_test_runner = rule(
     _dummy_test_runner_impl,
     attrs = {
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label("@build_bazel_rules_apple//test/testdata/rules:dummy_test_runner.template"),
             allow_single_file = True,
         ),


### PR DESCRIPTION
Sometimes you want to modify the call to `xctestrunner`. 
One example: you prefer to use an existing simulator instead of creating a new one every time.