### PR TITLE
Add -application_extension flag in framework link

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -239,6 +239,8 @@ def _create_binary(
     linkopts = kwargs.pop("linkopts", [])
     linkopts = linkopts + collections.before_each("-rpath", rule_descriptor.rpaths)
     linkopts = linkopts + rule_descriptor.extra_linkopts
+    if extension_safe:
+        linkopts = linkopts + ["-application_extension"]
 
     minimum_os_version = kwargs.get("minimum_os_version")
     provisioning_profile = kwargs.get("provisioning_profile")


### PR DESCRIPTION
This causes the linker to validate that any dynamic libraries linked against
are safe for use in application extensions.

Without the flag, the framework won't link.