### PR TITLE
Fix error message formatting by specifying params

### DIFF
--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -53,7 +53,7 @@ def _swift_static_framework_partial_impl(ctx, swift_static_framework_info):
 error: Found swift_library with module name {actual} but expected {expected}. Swift static \
 frameworks expect a single swift_library dependency with `module_name` set to the same \
 `bundle_name` as the static framework target.\
-""")
+""".format(actual = swift_static_framework_info.module_name, expected = expected_module_name))
 
     generated_header = swift_static_framework_info.generated_header
     swiftdocs = swift_static_framework_info.swiftdocs


### PR DESCRIPTION
Noticed since `bazel build --nobuild ...` was failing