### PR TITLE
Sign simulator bundles with com.apple.security.get-task-allow

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -118,12 +118,16 @@ def _codesign_args_for_path(
             maybe_quote(identity),
         ])
 
+    # The entitlements rule ensures that entitlements_file is None or a file
+    # containing only "com.apple.security.get-task-allow" when building for the
+    # simulator.
+    if path_to_sign.use_entitlements and entitlements_file:
+        cmd_codesigning.extend([
+            "--entitlements",
+            maybe_quote(entitlements_file.path),
+        ])
+
     if is_device:
-        if path_to_sign.use_entitlements and entitlements_file:
-            cmd_codesigning.extend([
-                "--entitlements",
-                maybe_quote(entitlements_file.path),
-            ])
         cmd_codesigning.append("--force")
     else:
         cmd_codesigning.extend([

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -283,10 +283,16 @@ EOF
 BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS BOGUS
 EOF
 
-  ! do_build watchos //app:app || fail "Should fail"
-  # The fact that multiple things are tried is left as an impl detail and
-  # only the final message is looked for.
-  expect_log 'While processing target "//app:watch_app_entitlements", failed to extract from the provisioning profile "app/bogus.mobileprovision".'
+  if is_device_build watchos ; then
+    ! do_build watchos //app:app || fail "Should fail"
+    # The fact that multiple things are tried is left as an impl detail and
+    # only the final message is looked for.
+    expect_log 'While processing target "//app:watch_app_entitlements", failed to extract from the provisioning profile "app/bogus.mobileprovision".'
+  else
+    # For simulator builds, entitlements are added as a Mach-O section in
+    # the binary, so the build shouldn't fail.
+    do_build watchos //app:app || fail "Should build"
+  fi
 }
 
 # Tests that failures to extract from a provisioning profile are propertly


### PR DESCRIPTION
This is needed for Accessibility Inspector to work.