### PR TITLE
Make dSYM binary the same name with the bundle name

### DIFF
--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -693,13 +693,10 @@ function test_all_dsyms_propagated() {
   assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
   assert_exists "test-bin/app/ext.appex.dSYM/Contents/Info.plist"
 
-  declare -a archs=( $(current_archs ios) )
-  for arch in "${archs[@]}"; do
-    assert_exists \
-        "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app_${arch}"
-    assert_exists \
-        "test-bin/app/ext.appex.dSYM/Contents/Resources/DWARF/ext_${arch}"
-  done
+  assert_exists \
+      "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app"
+  assert_exists \
+      "test-bin/app/ext.appex.dSYM/Contents/Resources/DWARF/ext"
 }
 
 run_suite "ios_extension bundling tests"

--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -15,11 +15,6 @@
 """Starlark test rules for debug symbols."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfo",
-    "AppleBundleInfo",
-)
-load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
@@ -34,19 +29,6 @@ def _dsyms_test_impl(ctx):
     env = analysistest.begin(ctx)
     target_under_test = ctx.attr.target_under_test[0]
 
-    if AppleBundleInfo in target_under_test:
-        platform_type = target_under_test[AppleBundleInfo].platform_type
-        if platform_type == "watchos":
-            architecture = "i386"
-        else:
-            architecture = "x86_64"
-    elif AppleBinaryInfo in target_under_test:
-        # AppleBinaryInfo does not supply a platform_type. In this case, assume x86_64.
-        architecture = "x86_64"
-    else:
-        fail(("Target %s does not provide AppleBundleInfo or AppleBinaryInfo") %
-             target_under_test.label)
-
     outputs = {
         x.short_path: None
         for x in target_under_test[OutputGroupInfo]["dsyms"].to_list()
@@ -60,11 +42,10 @@ def _dsyms_test_impl(ctx):
     ]
 
     expected_binaries = [
-        "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}_{3}".format(
+        "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}".format(
             package,
             x,
             paths.split_extension(x)[0],
-            architecture,
         )
         for x in ctx.attr.expected_dsyms
     ]


### PR DESCRIPTION
Previously dSYM binaries were created separately for each arch
being built, with the binary name appended with the arch name (for
example, `MyApp.app.dSYM/Contents/Resources/DWARF/MyApp_arm64`). This
was slightly different with Xcode's convention, where it creates a
single universal binary for each dSYM bundle and names the binary after
the bundle name. Some crash analytics services rely on this convention
to symbolicate the crash logs.

This patch changes the debug symbols processing to match Xcode's
convention.