### PR TITLE
Add support for App Clips

### DIFF
--- a/apple/internal/apple_product_type.bzl
+++ b/apple/internal/apple_product_type.bzl
@@ -85,6 +85,7 @@ type of rule being created and thus its descriptor to control behaviors.
 #   have the extension `.xpc`.
 apple_product_type = struct(
     application = "com.apple.product-type.application",
+    app_clip = "com.apple.product-type.application.on-demand-install-capable",
     app_extension = "com.apple.product-type.app-extension",
     bundle = "com.apple.product-type.bundle",
     dylib = "com.apple.product-type.library.dynamic",

--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -74,6 +74,7 @@ def _create_swift_runtime_linkopts_target(
 def _add_entitlements_and_swift_linkopts(
         name,
         platform_type,
+        product_type,
         include_entitlements = True,
         is_stub = False,
         link_swift_statically = False,
@@ -93,6 +94,7 @@ def _add_entitlements_and_swift_linkopts(
       name: The name of the bundle target, from which the targets' names
           will be derived.
       platform_type: The platform type of the bundle.
+      product_type: The product type of the bundle.
       include_entitlements: True/False, indicates whether to include an entitlements target.
           Defaults to True.
       is_stub: True/False, indicates whether the function is being called for a bundle that uses a
@@ -121,6 +123,7 @@ def _add_entitlements_and_swift_linkopts(
             bundle_id = bundling_args.get("bundle_id"),
             entitlements = entitlements_value,
             platform_type = platform_type,
+            product_type = product_type,
             provisioning_profile = provisioning_profile,
             tags = tags,
             testonly = testonly,
@@ -270,6 +273,7 @@ def _create_binary(
             bundle_id = kwargs.get("bundle_id"),
             entitlements = entitlements_value,
             platform_type = platform_type,
+            product_type = product_type,
             provisioning_profile = provisioning_profile,
             testonly = testonly,
             validation_mode = kwargs.get("entitlements_validation"),

--- a/apple/internal/partials/embedded_bundles.bzl
+++ b/apple/internal/partials/embedded_bundles.bzl
@@ -32,6 +32,9 @@ _AppleEmbeddableInfo = provider(
 Private provider used to propagate the different embeddable bundles that a
 top-level bundling rule will need to package.""",
     fields = {
+        "app_clips": """
+A depset with the zipped archives of bundles that need to be expanded into the
+AppClips section of the packaging bundle.""",
         "frameworks": """
 A depset with the zipped archives of bundles that need to be expanded into the
 Frameworks section of the packaging bundle.""",
@@ -67,6 +70,7 @@ def _embedded_bundles_partial_impl(
 
     # Map of embedded bundle type to their final location in the top-level bundle.
     bundle_type_to_location = {
+        "app_clips": processor.location.app_clip,
         "frameworks": processor.location.framework,
         "plugins": processor.location.plugin,
         "watch_bundles": processor.location.watch,
@@ -157,6 +161,7 @@ def _embedded_bundles_partial_impl(
     )
 
 def embedded_bundles_partial(
+        app_clips = [],
         bundle_embedded_bundles = False,
         embeddable_targets = [],
         frameworks = [],
@@ -172,6 +177,8 @@ def embedded_bundles_partial(
     ios_application.
 
     Args:
+        app_clips: List of plugin bundles that should be propagated downstream for a top level
+            target to bundle inside `AppClips`.
         bundle_embedded_bundles: If True, this target will embed all transitive embeddable_bundles
             _only_ propagated through the targets given in embeddable_targets. If False, the
             embeddable bundles will be propagated downstream for a top level target to bundle them.
@@ -193,6 +200,7 @@ def embedded_bundles_partial(
     """
     return partial.make(
         _embedded_bundles_partial_impl,
+        app_clips = app_clips,
         bundle_embedded_bundles = bundle_embedded_bundles,
         embeddable_targets = embeddable_targets,
         frameworks = frameworks,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -61,6 +61,7 @@ load(
     "AppleResourceBundleInfo",
     "AppleTestRunnerInfo",
     "IosApplicationBundleInfo",
+    "IosAppClipBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
     "IosImessageApplicationBundleInfo",
@@ -606,6 +607,12 @@ fashion, such as a Cocoapod.
         })
     elif rule_descriptor.product_type == apple_product_type.application:
         attrs.append({
+            "app_clips": attr.label_list(
+                providers = [[AppleBundleInfo, IosAppClipBundleInfo]],
+                doc = """
+A list of iOS app clips to include in the final application bundle.
+""",
+            ),
             "extensions": attr.label_list(
                 providers = [[AppleBundleInfo, IosExtensionBundleInfo]],
                 doc = """
@@ -626,6 +633,18 @@ Info.plist under the key `UILaunchStoryboardName`.
                 doc = """
 A `watchos_application` target that represents an Apple Watch application that should be embedded in
 the application bundle.
+""",
+            ),
+        })
+    elif rule_descriptor.product_type == apple_product_type.app_clip:
+        attrs.append({
+            "launch_storyboard": attr.label(
+                allow_single_file = [".storyboard", ".xib"],
+                doc = """
+The `.storyboard` or `.xib` file that should be used as the launch screen for the application. The
+provided file will be compiled into the appropriate format (`.storyboardc` or `.nib`) and placed in
+the root of the final bundle. The generated file will also be registered in the bundle's
+Info.plist under the key `UILaunchStoryboardName`.
 """,
             ),
         })
@@ -650,7 +669,8 @@ the application bundle.
     # _common_binary_linking_attrs().
     if rule_descriptor.requires_deps:
         extra_args = {}
-        if rule_descriptor.product_type == apple_product_type.application:
+        if (rule_descriptor.product_type == apple_product_type.application or
+            rule_descriptor.product_type == apple_product_type.app_clip):
             extra_args["aspects"] = [framework_import_aspect]
 
         attrs.append({

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -46,6 +46,7 @@ _CODESIGNING_EXCEPTIONS = struct(
 def _describe_bundle_locations(
         archive_relative = "",
         bundle_relative_contents = "",
+        contents_relative_app_clips = "AppClips",
         contents_relative_binary = "",
         contents_relative_frameworks = "Frameworks",
         contents_relative_plugins = "PlugIns",
@@ -56,6 +57,7 @@ def _describe_bundle_locations(
     return struct(
         archive_relative = archive_relative,
         bundle_relative_contents = bundle_relative_contents,
+        contents_relative_app_clips = contents_relative_app_clips,
         contents_relative_binary = contents_relative_binary,
         contents_relative_frameworks = contents_relative_frameworks,
         contents_relative_plugins = contents_relative_plugins,
@@ -220,6 +222,27 @@ _RULE_TYPE_DESCRIPTORS = {
             rpaths = [
                 # Application binaries live in Application.app/Application
                 # Frameworks are packaged in Application.app/Frameworks
+                "@executable_path/Frameworks",
+            ],
+        ),
+        # ios_app_clip
+        apple_product_type.app_clip: _describe_rule_type(
+            allowed_device_families = ["iphone", "ipad"],
+            allows_locale_trimming = True,
+            app_icon_parent_extension = ".xcassets",
+            app_icon_extension = ".appiconset",
+            archive_extension = ".ipa",
+            bundle_extension = ".app",
+            bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
+            has_launch_images = True,
+            has_settings_bundle = True,
+            is_executable = True,
+            mandatory_families = True,
+            product_type = apple_product_type.app_clip,
+            requires_pkginfo = True,
+            rpaths = [
+                # Application binaries live in AppClip.app/Application
+                # Frameworks are packaged in AppClip.app/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -15,6 +15,10 @@
 """Helper methods for assembling the test targets."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -98,6 +102,7 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         test_bundle_name,
         bundle_name = name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.unit_test_bundle,
         is_test = True,
         include_entitlements = False,
         testonly = True,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -40,6 +40,7 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
     _ios_application = "ios_application",
+    _ios_app_clip = "ios_app_clip",
     _ios_extension = "ios_extension",
     _ios_framework = "ios_framework",
     _ios_imessage_application = "ios_imessage_application",
@@ -58,6 +59,20 @@ def ios_application(name, **kwargs):
     )
 
     _ios_application(
+        name = name,
+        **bundling_args
+    )
+
+def ios_app_clip(name, **kwargs):
+    """Builds and bundles an iOS app clip."""
+    bundling_args = binary_support.create_binary(
+        name,
+        str(apple_common.platform_type.ios),
+        apple_product_type.app_clip,
+        **kwargs
+    )
+
+    _ios_app_clip(
         name = name,
         **bundling_args
     )
@@ -144,6 +159,7 @@ def ios_imessage_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_application,
         is_stub = True,
         **kwargs
     )
@@ -159,6 +175,7 @@ def ios_sticker_pack_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_sticker_pack_extension,
         is_stub = True,
         **kwargs
     )
@@ -174,6 +191,7 @@ def ios_imessage_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_extension,
         **kwargs
     )
 

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -30,6 +30,10 @@ load(
     _macos_unit_test = "macos_unit_test",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -61,6 +65,7 @@ def macos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.application,
         features = features,
         **binary_args
     )
@@ -80,6 +85,7 @@ def macos_bundle(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.bundle,
         features = features,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -98,6 +104,7 @@ def macos_quick_look_plugin(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.quicklook_plugin,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -118,6 +125,7 @@ def macos_kernel_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.kernel_extension,
         features = features,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -133,6 +141,7 @@ def macos_spotlight_importer(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.spotlight_importer,
         **kwargs
     )
 
@@ -148,6 +157,7 @@ def macos_xpc_service(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.xpc_service,
         **binary_args
     )
 
@@ -207,6 +217,7 @@ def macos_command_line_application(name, **kwargs):
     cmd_line_app_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.tool,
         link_swift_statically = True,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
@@ -260,6 +271,7 @@ def macos_dylib(name, **kwargs):
     dylib_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.dylib,
         link_swift_statically = True,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
@@ -283,6 +295,7 @@ def macos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.app_extension,
         features = features,
         **binary_args
     )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -266,6 +266,17 @@ requirement.
 """,
 )
 
+IosAppClipBundleInfo = provider(
+    doc = """
+Denotes that a target is an iOS app clip.
+
+This provider does not contain any fields of its own at this time but is used as
+a "marker" to indicate that a target is specifically an iOS app clip bundle (and
+not some other Apple bundle). Rule authors who wish to require that a dependency
+is an iOS app clip should use this provider to describe that requirement.
+""",
+)
+
 IosExtensionBundleInfo = provider(
     doc = """
 Denotes that a target is an iOS application extension.

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -30,6 +30,10 @@ load(
     _tvos_unit_test = "tvos_unit_test",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -46,6 +50,7 @@ def tvos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.application,
         **kwargs
     )
 
@@ -60,6 +65,7 @@ def tvos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.app_extension,
         **kwargs
     )
 
@@ -85,6 +91,7 @@ def tvos_framework(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.framework,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
     )

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -19,6 +19,10 @@ load(
     "apple_build_test_rule",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -37,6 +41,7 @@ def watchos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.watchos),
+        product_type = apple_product_type.application,
         is_stub = True,
         **kwargs
     )
@@ -51,6 +56,7 @@ def watchos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.watchos),
+        product_type = apple_product_type.app_extension,
         **kwargs
     )
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -25,6 +25,7 @@ extensions, and frameworks) and for running unit tests and UI tests.
       <td valign="top"><code>@build_bazel_rules_apple//apple:ios.bzl</code></td>
       <td valign="top">
         <code><a href="rules-ios.md#ios_application">ios_application</a></code><br/>
+        <code><a href="rules-ios.md#ios_app_clip">ios_app_clip</a></code><br/>
         <code><a href="rules-ios.md#ios_imessage_application">ios_imessage_application</a></code><br/>
         <code><a href="rules-ios.md#ios_extension">ios_extension</a></code><br/>
         <code><a href="rules-ios.md#ios_imessage_extension">ios_imessage_extension</a></code><br/>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -240,6 +240,230 @@ Builds and bundles an iOS application.
   </tbody>
 </table>
 
+<a name="ios_app_clip"></a>
+## ios_app_clip
+
+```python
+ios_app_clip_(name, app_icons, bundle_id, bundle_name, entitlements,
+entitlements_validation, families, frameworks, infoplists,
+ipa_post_processor, launch_images, launch_storyboard, linkopts,
+minimum_os_version, provisioning_profile, resources, settings_bundle, strings, version,
+deps)
+```
+
+Builds and bundles an iOS app clip.
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#name">Name</a>, required</code></p>
+        <p>A unique name for the target.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>app_icons</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>Files that comprise the app icons for the app clip. Each file must
+        have a containing directory named <code>*.xcassets/*.appiconset</code>
+        and there may be only one such <code>.appiconset</code> directory in
+        the list.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_id</code></td>
+      <td>
+        <p><code>String; required</code></p>
+        <p>The bundle ID (reverse-DNS path followed by app name) of the app
+        clip.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>bundle_name</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>The desired name of the bundle (without the <code>.app</code>
+        extension). If this attribute is not set, then the <code>name</code> of
+        the target will be used instead.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>entitlements</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>The entitlements file required for device builds of the app clip.
+        If absent, the default entitlements from the provisioning profile will
+        be used.</p>
+        <p>The following variables are substituted in the entitlements file:
+        <code>$(CFBundleIdentifier)</code> with the bundle ID of the app clip
+        and <code>$(AppIdentifierPrefix)</code> with the value of the
+        <code>ApplicationIdentifierPrefix</code> key from the target's
+        provisioning profile.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>entitlements_validation</code></td>
+      <td>
+        <p><code>String; optional; default is
+        entitlements_validation_mode.loose</code></p>
+        <p>An
+        <code><a href="types.md#entitlements-validation-mode">entitlements_validation_mode</a></code>
+        to control the validation of the requested entitlements against the
+        provisioning profile to ensure they are supported.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>families</code></td>
+      <td>
+        <p><code>List of strings; required</code></p>
+        <p>A list of device families supported by this app clip. Valid values
+        are <code>iphone</code> and <code>ipad</code>; at least one must be specified.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>frameworks</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of framework targets (see <a href="#ios_framework"><code>ios_framework</code></a>)
+        that this app clip depends on. <b>NOTE:</b> Adding a
+        <code>provisioning_profile</code> to any frameworks listed will make the
+        signing/caching more efficient.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>infoplists</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; required</code></p>
+        <p>A list of <code>.plist</code> files that will be merged to form the
+        <code>Info.plist</code> that represents the app clip. At least one
+        file must be specified. Please see <a href="common_info.md#infoplist-handling">Info.plist Handling</a>
+        for what is supported.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>ipa_post_processor</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>A tool that edits this target's bundle output after it is assembled
+        but before it is signed. The tool is invoked with a single command-line
+        argument that denotes the path to a directory containing the unzipped
+        contents of the  bundle (that is, the <code>Payload</code> directory will
+        be present in this directory).</p>
+        <p>Any changes made by the tool must be made in this directory, and
+        the tool's execution must be hermetic given these inputs to ensure that
+        the result can be safely cached.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>launch_images</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>Files that comprise the launch images for the app clip. Each file
+        must have a containing directory named<code>*.xcassets/*.launchimage</code> and
+        there may be only one such <code>.launchimage</code> directory in the list.</p>
+        <p>It is recommended that you use a <code>launch_storyboard</code> instead.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>launch_storyboard</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>The <code>.storyboard</code> or <code>.xib</code> file that should
+        be used as the launch screen for the app clip. The provided file will
+        be compiled into the appropriate format (<code>.storyboardc</code> or
+        <code>.nib</code>) and placed in the root of the final bundle. The
+        generated file will also be registered in the bundle's <code>Info.plist</code>
+        under the key <code>UILaunchStoryboardName</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>linkopts</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>A list of strings representing extra flags that should be passed to
+        the linker.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>minimum_os_version</code></td>
+      <td>
+        <p><code>String; required</code></p>
+        <p>A required string indicating the minimum iOS version supported by the
+        target, represented as a dotted version number (for example,
+        <code>"9.0"</code>).
+      </td>
+    </tr>
+    <tr>
+      <td><code>provisioning_profile</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>The provisioning profile (<code>.mobileprovision</code> file) to use
+        when bundling the app clip. This value is optional for simulator
+        builds as the simulator doesn't fully enforce entitlements, but is
+        <strong>required for device builds.</strong></p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of associated resource bundles or files that will be bundled into the final bundle.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>settings_bundle</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A resource bundle target that contains the files that make up
+        the app clip's settings bundle. These files will be copied into the
+        root of the final app clip bundle in a directory named
+        <code>Settings.bundle</code>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>strings</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of <code>.strings</code> files, often localizable. These files
+        are converted to binary plists (if they are not already) and placed in the
+        root of the final app clip bundle, unless a file's immediate containing
+        directory is named <code>*.lproj</code>, in which case it will be placed
+        under a directory with the same name in the bundle.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>version</code></td>
+      <td>
+        <p><code><a href="https://bazel.build/versions/master/docs/build-ref.html#labels">Label</a>; optional</code></p>
+        <p>An <code>apple_bundle_version</code> target that represents the version
+        for this target. See
+        <a href="rules-general.md?cl=head#apple_bundle_version"><code>apple_bundle_version</code></a>.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <p><code>List of <a href="https://bazel.build/versions/master/docs/build-ref.html#labels">labels</a>; optional</code></p>
+        <p>A list of dependencies targets to link into the binary. Any
+        resources, such as asset catalogs, that are referenced by those targets
+        will also be transitively included in the final app clip.</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <a name="ios_imessage_application"></a>
 ## ios_imessage_application
 

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -99,6 +99,7 @@ def _apple_verification_test_impl(ctx):
             "tvos",
         ] and bundle_info.product_type in [
             apple_product_type.application,
+            apple_product_type.app_clip,
             apple_product_type.messages_application,
         ]:
             archive_relative_bundle = paths.join("Payload", bundle_with_extension)


### PR DESCRIPTION
Resolves #821.

The "com.apple.developer.parent-application-identifiers" entitlement isn't automatically added, though it probably could be (https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_parent-application-identifiers).

I haven't added tests yet, because I want to make sure this is the desired approach.