### PR TITLE
Make test environment override test rule attr env and runner info

### DIFF
--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -141,9 +141,9 @@ def _apple_test_rule_impl(ctx, test_type):
     # Environment variables to be set as the %(test_env)s substitution, which includes the
     # --test_env and env attribute values, but not the execution environment variables.
     test_environment = dicts.add(
-        ctx.configuration.test_env,
         ctx.attr.env,
         getattr(runner, "test_environment", {}),
+        ctx.configuration.test_env,
     )
 
     # Environment variables for the Bazel test action itself.


### PR DESCRIPTION
Currently test rule will respect test rule's `env` attribute over manual test_env specification, this seems a bit counter-intuitive when setting test environment explicitly like `bazel test --test_env=FOO=BAR` doesn't get what you want