### PR TITLE
Fix setting DEVELOPER_DIR for test runners

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -35,7 +35,7 @@ def _get_execution_environment(ctx):
     execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        execution_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION_OVERRIDE"] = xcode_version
 
     return execution_environment
 

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -60,7 +60,7 @@ def _get_execution_environment(ctx):
     execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        execution_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION_OVERRIDE"] = xcode_version
 
     return execution_environment
 

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -33,7 +33,7 @@ def _get_execution_environment(ctx):
     execution_environment = {}
     xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
     if xcode_version:
-        execution_environment["XCODE_VERSION"] = xcode_version
+        execution_environment["XCODE_VERSION_OVERRIDE"] = xcode_version
 
     return execution_environment
 


### PR DESCRIPTION
This execution info was ignored because bazel expects XCODE_VERSION_OVERRIDE so if you had a different Xcode version selected globally bazel would use that for tests regardless of what was passed for `--xcode_version`

Also see failed CI here https://github.com/bazelbuild/rules_apple/pull/854

And https://github.com/bazelbuild/bazel/blob/e3e46e39e17f770812872175c704aed8efcab754/src/main/java/com/google/devtools/build/lib/rules/apple/AppleConfiguration.java#L47 https://github.com/bazelbuild/bazel/blob/e3e46e39e17f770812872175c704aed8efcab754/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java#L94-L98