### PR TITLE
Take provisioning profile into account when processing imported dynamic frameworks

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -493,5 +493,6 @@ codesigning_support = struct(
     codesigning_args = _codesigning_args,
     codesigning_command = _codesigning_command,
     post_process_and_sign_archive_action = _post_process_and_sign_archive_action,
+    provisioning_profile = _provisioning_profile,
     sign_binary_action = _sign_binary_action,
 )

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -149,11 +149,17 @@ def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
         # Inputs of action are all the framework files, plus binaries needed for identifying the
         # current build's preferred architecture, plus a generated list of those binaries to prune
         # their dependencies so that future changes to the app/extension/framework binaries do not
-        # force this action to re-run on incremental builds.
+        # force this action to re-run on incremental builds, plus the top-level target's
+        # provisioning profile if the current build targets real devices.
+        inputs = files_by_framework[framework_basename] + framework_binaries_by_framework[framework_basename]
+
+        provisioning_profile = codesigning_support.provisioning_profile(ctx)
+        if provisioning_profile:
+            inputs.append(provisioning_profile)
+
         apple_support.run(
             ctx,
-            inputs = files_by_framework[framework_basename] +
-                     framework_binaries_by_framework[framework_basename],
+            inputs = inputs,
             tools = [ctx.executable._codesigningtool],
             executable = ctx.executable._imported_dynamic_framework_processor,
             outputs = [framework_zip],


### PR DESCRIPTION
Previously, although the `imported_dynamic_framework_processor` action
involves a code-signing step, it didn't list the provisioning profile as
one of its inputs. This made it kept using previously signed framework
binary artifacts when their contents haven't changed, even in the case
where the provisioning profile has been replaced with a new one -- for
instance, to use a new signing certificate.

This fixes the above problem by adding the provided top-level
provisioning profile to the `imported_dynamic_framework_processor`'s
input files, if the current build is a device build.

Partly fixes https://github.com/bazelbuild/rules_apple/issues/746.