### PR TITLE
Allow .strings extension for plists

### DIFF
--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -99,7 +99,7 @@ macos_binary_infoplist = rule(
         {
             "bundle_id": attr.string(mandatory = False),
             "infoplists": attr.label_list(
-                allow_files = [".plist"],
+                allow_files = [".plist", ".strings"],
                 mandatory = False,
                 allow_empty = True,
             ),
@@ -155,7 +155,7 @@ macos_command_line_launchdplist = rule(
         rule_factory.common_tool_attributes,
         {
             "launchdplists": attr.label_list(
-                allow_files = [".plist"],
+                allow_files = [".plist", ".strings"],
                 mandatory = False,
             ),
         },

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -353,7 +353,7 @@ def _get_common_bundling_attributes(rule_descriptor):
         attrs.append({
             "infoplists": attr.label_list(
                 allow_empty = False,
-                allow_files = [".plist"],
+                allow_files = [".plist", ".strings"],
                 doc = """
 A list of .plist files that will be merged to form the Info.plist for this target. At least one file
 must be specified. Please see
@@ -869,7 +869,7 @@ required for device builds.
         # TODO(kaipi): Document this attribute.
         attrs.append({
             "launchdplists": attr.label_list(
-                allow_files = [".plist"],
+                allow_files = [".plist", ".strings"],
             ),
         })
 
@@ -881,7 +881,7 @@ this value will be embedded in an Info.plist in the application binary.
 """,
         ),
         "infoplists": attr.label_list(
-            allow_files = [".plist"],
+            allow_files = [".plist", ".strings"],
             doc = """
 A list of .plist files that will be merged to form the Info.plist that represents the application
 and is embedded into the binary. Please see


### PR DESCRIPTION
Strings files are ascii plists, so they can be combined with plists with
no extra effort. This is especially useful for providing
'InfoPlist.strings' files to the Info.plist so you don't have to
duplicate that information.