### PR TITLE
Stop passing extension_safe to apple_binary

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -308,7 +308,6 @@ def _create_binary(
         binary_type = binary_type,
         bundle_loader = bundle_loader,
         dylibs = kwargs.get("frameworks"),
-        extension_safe = extension_safe,
         features = kwargs.get("features"),
         linkopts = linkopts,
         minimum_os_version = minimum_os_version,


### PR DESCRIPTION
This attribute has been unused in bazel for years

https://github.com/bazelbuild/bazel/pull/11914