### PR TITLE
Add tests for test env inheritance

### DIFF
--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -142,8 +142,8 @@ def _apple_test_rule_impl(ctx, test_type):
     # --test_env and env attribute values, but not the execution environment variables.
     test_environment = dicts.add(
         ctx.configuration.test_env,
-        ctx.attr.env,
         getattr(runner, "test_environment", {}),
+        ctx.attr.env,
     )
 
     # Environment variables for the Bazel test action itself.


### PR DESCRIPTION
Tests can come from a few places:

1. `--test_env`
2. `test_environment` on a test runner (as of https://github.com/bazelbuild/rules_apple/pull/682)
3. `env` on a test target

This validates the order of these is what we expect if the same key
appears in multiple of these places.