### PR TITLE
Support custom executable name for rules that create executables.

### DIFF
--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -67,6 +67,25 @@ def _bundle_name_with_extension(ctx):
     """
     return _bundle_name(ctx) + _bundle_extension(ctx)
 
+def _executable_name(ctx):
+    """Returns the executable name of the bundle.
+
+    The executable of the bundle is the value of the `executable_name`
+    attribute if it was given; if not, then the name of the `bundle_name`
+    attribute if it was given; if not, then the name of the target will be used
+    instead.
+
+    Args:
+      ctx: The Starlark context.
+
+    Returns:
+      The executable name.
+    """
+    executable_name = getattr(ctx.attr, "executable_name", None)
+    if not executable_name:
+        executable_name = _bundle_name(ctx)
+    return executable_name
+
 def _validate_bundle_id(bundle_id):
     """Ensure the value is a valid bundle it or fail the build.
 
@@ -201,5 +220,6 @@ bundling_support = struct(
     bundle_name_with_extension = _bundle_name_with_extension,
     ensure_path_format = _ensure_path_format,
     ensure_single_xcassets_type = _ensure_single_xcassets_type,
+    executable_name = _executable_name,
     validate_bundle_id = _validate_bundle_id,
 )

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -59,7 +59,7 @@ def _binary(ctx):
     return intermediates.file(
         ctx.actions,
         ctx.label.name,
-        bundling_support.bundle_name(ctx),
+        bundling_support.executable_name(ctx),
     )
 
 def _executable(ctx):

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -60,6 +60,7 @@ def _apple_bundle_info_partial_impl(ctx, bundle_id):
                 bundle_id = bundle_id,
                 bundle_name = bundling_support.bundle_name(ctx),
                 bundle_extension = bundling_support.bundle_extension(ctx),
+                executable_name = bundling_support.executable_name(ctx),
                 entitlements = getattr(ctx.attr, "entitlements", None),
                 infoplist = infoplist,
                 minimum_os_version = platform_support.minimum_os(ctx),

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -206,6 +206,7 @@ def merge_root_infoplists(
     info_plist_options = {}
 
     bundle_name = bundling_support.bundle_name_with_extension(ctx)
+    executable_name = bundling_support.executable_name(ctx)
     product_name = paths.replace_extension(bundle_name, "")
 
     # Values for string replacement substitutions to perform in the merged
@@ -227,8 +228,8 @@ def merge_root_infoplists(
     substitutions["DEVELOPMENT_LANGUAGE"] = "en"
 
     if include_executable_name:
-        substitutions["EXECUTABLE_NAME"] = product_name
-        forced_plists.append(struct(CFBundleExecutable = product_name))
+        substitutions["EXECUTABLE_NAME"] = executable_name
+        forced_plists.append(struct(CFBundleExecutable = executable_name))
 
     if bundle_id:
         substitutions["PRODUCT_BUNDLE_IDENTIFIER"] = bundle_id

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -384,6 +384,14 @@ The desired name of the bundle (without the extension). If this attribute is not
 of the target will be used instead.
 """,
         ),
+        "executable_name": attr.string(
+            mandatory = False,
+            doc = """
+The desired name of the executable, if the bundle has an executable. If this attribute is not set,
+then the name of the `bundle_name` attribute will be used if it is set; if not, then the name of
+the target will be used instead.
+""",
+        ),
         # TODO(b/36512239): Rename to "bundle_post_processor".
         "ipa_post_processor": attr.label(
             allow_files = True,

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -53,6 +53,9 @@ the binary directly at analysis time; for example, for code coverage.
         "bundle_name": """
 `string`. The name of the bundle, without the extension.
 """,
+        "executable_name": """
+`string`. The name of the executable that was bundled.
+""",
         "entitlements": "`File`. Entitlements file used to codesign, if any.",
         "extension_safe": """
 Boolean. True if the target propagating this provider was

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -316,10 +316,10 @@ replaced with the `-` character (i.e., `Foo Bar` will become `Foo-Bar`).
     <tr>
       <td><code>EXECUTABLE_NAME</code></td>
       <td>
-        <p>This is an alias for the same value as <code>PRODUCT_NAME</code>.
-        This is done to match some developer expectations from Xcode. It is
-        only available on rules that create executables, not on those that
-        create resource-only bundles.</p>
+        <p>The value of the rule's <code>executable_name</code> attribute if it
+        was given; if not, then the name of the <code>bundle_name</code>
+        attribute if it was given; if not, then the <code>name</code>of the
+        target.</p>
       </td>
     </tr>
     <tr>

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -139,6 +139,15 @@ def ios_application_test_suite(name = "ios_application"):
     )
 
     archive_contents_test(
+        name = "{}_custom_executable_name_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_custom_executable_name",
+        contains = ["$BUNDLE_ROOT/app.exe"],
+        not_contains = ["$BUNDLE_ROOT/app_with_custom_executable_name"],
+        tags = [name],
+    )
+
+    archive_contents_test(
         name = "{}_dbg_resources_simulator_test".format(name),
         build_type = "simulator",
         compilation_mode = "dbg",
@@ -220,6 +229,15 @@ def ios_application_test_suite(name = "ios_application"):
             "DTXcodeBuild": "*",
             "MinimumOSVersion": "8.0",
             "UIDeviceFamily:0": "1",
+        },
+        tags = [name],
+    )
+
+    infoplist_contents_test(
+        name = "{}_custom_executable_name_plist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_custom_executable_name",
+        expected_values = {
+            "CFBundleExecutable": "app.exe",
         },
         tags = [name],
     )

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -110,12 +110,15 @@ def _apple_verification_test_impl(ctx):
             archive_relative_binary = paths.join(
                 archive_relative_contents,
                 "MacOS",
-                bundle_info.bundle_name,
+                bundle_info.executable_name,
             )
             archive_relative_resources = paths.join(archive_relative_contents, "Resources")
         else:
             archive_relative_contents = archive_relative_bundle
-            archive_relative_binary = paths.join(archive_relative_bundle, bundle_info.bundle_name)
+            archive_relative_binary = paths.join(
+                archive_relative_bundle,
+                bundle_info.executable_name,
+            )
             archive_relative_resources = archive_relative_bundle
 
         archive_short_path = archive.short_path

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -117,6 +117,7 @@ ios_application(
 ios_application(
     name = "app_with_custom_executable_name",
     bundle_id = "com.google.example",
+    bundle_name = "custom_bundle_name",
     executable_name = "app.exe",
     families = ["iphone"],
     infoplists = [

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -115,6 +115,24 @@ ios_application(
 )
 
 ios_application(
+    name = "app_with_custom_executable_name",
+    bundle_id = "com.google.example",
+    executable_name = "app.exe",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_application(
     name = "app_with_structured_resources_in_resources_folder",
     bundle_id = "com.google.example",
     families = [


### PR DESCRIPTION
This adds a new attribute `executable_name` to rules that create
executables that allows specifying custom executable name in the final
bundle. This is an optional attribute that, if not specified, will get the
value of `bundle_name` or `name` in this order.

This new attribute can be useful, for example, when building a target
with multiple configurations, that it allows you to specify different
executable names for different configurations, while still keeping the
archive bundle name and dSYM bundle name unchanged.

Resolves https://github.com/bazelbuild/rules_apple/issues/762.