### PR TITLE
Add support for passing extra options to resource tools

### DIFF
--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -19,6 +19,10 @@ load(
     "xcode_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:legacy_actions.bzl",
     "legacy_actions",
 )
@@ -205,6 +209,13 @@ def compile_asset_catalog(ctx, asset_files, output_dir, output_plist):
             "--output-partial-info-plist",
             xctoolrunner.prefixed_path(output_plist.path),
         ])
+
+    user_defined_args = defines.list_value(
+        ctx,
+        define_name = "apple.actool_opts",
+        default = [],
+    )
+    args.extend(user_defined_args)
 
     xcassets = group_files_by_directory(
         asset_files,

--- a/apple/internal/resource_actions/datamodel.bzl
+++ b/apple/internal/resource_actions/datamodel.bzl
@@ -15,6 +15,10 @@
 """Datamodel related actions."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:legacy_actions.bzl",
     "legacy_actions",
 )
@@ -48,9 +52,19 @@ def compile_datamodels(ctx, datamodel_path, module_name, input_files, output_fil
         min_os,
         "--module",
         module_name,
+    ]
+
+    user_defined_args = defines.list_value(
+        ctx,
+        define_name = "apple.momc_opts",
+        default = [],
+    )
+    args.extend(user_defined_args)
+
+    args.extend([
         xctoolrunner.prefixed_path(datamodel_path),
         xctoolrunner.prefixed_path(output_file.path),
-    ]
+    ])
 
     legacy_actions.run(
         ctx,
@@ -75,6 +89,13 @@ def compile_mappingmodel(ctx, mappingmodel_path, input_files, output_file):
         xctoolrunner.prefixed_path(mappingmodel_path),
         xctoolrunner.prefixed_path(output_file.path),
     ]
+
+    user_defined_args = defines.list_value(
+        ctx,
+        define_name = "apple.mapc_opts",
+        default = [],
+    )
+    args.extend(user_defined_args)
 
     legacy_actions.run(
         ctx,

--- a/apple/internal/resource_actions/ibtool.bzl
+++ b/apple/internal/resource_actions/ibtool.bzl
@@ -15,6 +15,10 @@
 """IBTool related actions."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:legacy_actions.bzl",
     "legacy_actions",
 )
@@ -80,8 +84,18 @@ def compile_storyboard(ctx, swift_module, input_file, output_dir):
     args.extend([
         "--module",
         swift_module,
-        xctoolrunner.prefixed_path(input_file.path),
     ])
+
+    user_defined_args = defines.list_value(
+        ctx,
+        define_name = "apple.ibtool_opts",
+        default = [],
+    )
+    args.extend(user_defined_args)
+
+    args.append(
+        xctoolrunner.prefixed_path(input_file.path),
+    )
 
     legacy_actions.run(
         ctx,

--- a/apple/internal/resource_actions/mlmodel.bzl
+++ b/apple/internal/resource_actions/mlmodel.bzl
@@ -19,6 +19,10 @@ load(
     "apple_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
     "xctoolrunner",
 )
@@ -40,6 +44,13 @@ def compile_mlmodel(ctx, input_file, output_bundle, output_plist):
         "--output-partial-info-plist",
         xctoolrunner.prefixed_path(output_plist.path),
     ]
+
+    user_defined_args = defines.list_value(
+        ctx,
+        define_name = "apple.coreml_opts",
+        default = [],
+    )
+    args.extend(user_defined_args)
 
     apple_support.run(
         ctx,

--- a/apple/internal/utils/defines.bzl
+++ b/apple/internal/utils/defines.bzl
@@ -38,6 +38,29 @@ def _bool_value(ctx, define_name, default):
         ))
     return default
 
+def _list_value(ctx, define_name, default):
+    """Returns a list of string value given a define on ctx.
+
+    Args:
+      ctx: A Starlark context.
+      define_name: The name of the define to look up.
+      default: The value to return if the define isn't found.
+
+    Returns:
+      List of string or the default value if the define wasn't found.
+    """
+    value = ctx.var.get(define_name, None)
+    if value != None:
+        values = []
+        # Handle cases where multiple spaces are passed as separators, that end
+        # up being split into empty strings
+        for v in value.split(" "):
+            if v != "":
+                values.append(v)
+        return values
+    return default
+
 defines = struct(
     bool_value = _bool_value,
+    list_value = _list_value,
 )


### PR DESCRIPTION
This adds the following define names:

- `apple.actool_opts`
- `apple.ibtool_opts`
- `apple.momc_opts`
- `apple.mapc_opts`
- `apple.coreml_opts`

that will allow users to pass extra options to the relevant tools.

For example, to apply space optimization for asset catalog compilation,
pass the following option to the build command:

```
--define=apple.actool_opts="--optimization space"
```

Resolves https://github.com/bazelbuild/rules_apple/issues/732.
Resolves https://github.com/bazelbuild/rules_apple/issues/852.