### PR TITLE
Allow App Extensions to be bundle loaders

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -312,6 +312,9 @@ def _ios_extension_impl(ctx):
             files = processor_result.output_files,
         ),
         IosExtensionBundleInfo(),
+        # Propagate the binary provider so that this target can be used as bundle_loader in test
+        # rules.
+        binary_target[apple_common.AppleExecutableBinary],
     ] + processor_result.providers
 
 def _ios_static_framework_impl(ctx):

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -242,6 +242,7 @@ def _macos_extension_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosExtensionBundleInfo(),
+        binary_descriptor.provider,
     ] + processor_result.providers
 
 def _macos_quick_look_plugin_impl(ctx):

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -632,7 +632,10 @@ the application bundle.
     elif rule_descriptor.product_type == apple_product_type.app_extension:
         attrs.append(_EXTENSION_PROVIDES_MAIN_ATTRS)
     elif _is_test_product_type(rule_descriptor.product_type):
-        required_providers = [[AppleBundleInfo, IosApplicationBundleInfo]]
+        required_providers = [
+            [AppleBundleInfo, IosApplicationBundleInfo],
+            [AppleBundleInfo, IosExtensionBundleInfo],
+        ]
         test_host_mandatory = False
         if rule_descriptor.product_type == apple_product_type.ui_test_bundle:
             required_providers.append([AppleBundleInfo, IosImessageApplicationBundleInfo])
@@ -723,7 +726,10 @@ set, then the default extension is determined by the application's product_type.
             "test_host": attr.label(
                 aspects = [framework_import_aspect],
                 mandatory = test_host_mandatory,
-                providers = [AppleBundleInfo, MacosApplicationBundleInfo],
+                providers = [
+                    [AppleBundleInfo, MacosApplicationBundleInfo],
+                    [AppleBundleInfo, MacosExtensionBundleInfo],
+                ],
             ),
         })
 
@@ -798,7 +804,10 @@ fashion, such as a Cocoapod.
             "test_host": attr.label(
                 aspects = [framework_import_aspect],
                 mandatory = test_host_mandatory,
-                providers = [AppleBundleInfo, TvosApplicationBundleInfo],
+                providers = [
+                    [AppleBundleInfo, TvosApplicationBundleInfo],
+                    [AppleBundleInfo, TvosExtensionBundleInfo],
+                ]
             ),
         })
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -268,6 +268,9 @@ def _tvos_extension_impl(ctx):
             files = processor_result.output_files,
         ),
         TvosExtensionBundleInfo(),
+        # Propagate the binary provider so that this target can be used as bundle_loader in test
+        # rules.
+        binary_descriptor.provider,
     ] + processor_result.providers
 
 def _tvos_static_framework_impl(ctx):

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -40,17 +40,25 @@ load("@build_bazel_rules_apple//apple:apple.bzl",
 
 objc_library(
     name = "lib",
+    hdrs = ["Foo.h"],
     srcs = ["main.m"],
 )
 EOF
 
-  cat > app/main.m <<EOF
+  cat > app/Foo.h <<EOF
 #import <Foundation/Foundation.h>
 // This dummy class is needed to generate code in the extension target,
 // which does not take main() from here, rather from an SDK.
 @interface Foo: NSObject
+- (void)doSomething;
 @end
+EOF
+
+  cat > app/main.m <<EOF
+#import <Foundation/Foundation.h>
+#import "app/Foo.h"
 @implementation Foo
+- (void)doSomething { }
 @end
 
 int main(int argc, char **argv) {
@@ -83,12 +91,12 @@ EOF
 EOF
 }
 
-# Usage: create_minimal_ios_application_with_extension [product type]
+# Usage: create_minimal_ios_application_extension [product type]
 #
-# Creates a minimal iOS application target. The optional product type is
-# the Starlark constant that should be set on the extension using the
+# Creates a minimal iOS application extension target. The optional product type
+# is the Starlark constant that should be set on the extension using the
 # `product_type` attribute.
-function create_minimal_ios_application_with_extension() {
+function create_minimal_ios_application_extension() {
   if [[ ! -f app/BUILD ]]; then
     fail "create_common_files must be called first."
   fi
@@ -96,17 +104,6 @@ function create_minimal_ios_application_with_extension() {
   product_type="${1:-}"
 
   cat >> app/BUILD <<EOF
-ios_application(
-    name = "app",
-    bundle_id = "my.bundle.id",
-    extensions = [":ext"],
-    families = ["iphone"],
-    infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    deps = [":lib"],
-)
-
 ios_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
@@ -122,6 +119,34 @@ EOF
   fi
 
   cat >> app/BUILD <<EOF
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [":lib"],
+)
+EOF
+}
+
+# Usage: create_minimal_ios_application_with_extension [product type]
+#
+# Creates a minimal iOS application target. The optional product type is
+# the Starlark constant that should be set on the extension using the
+# `product_type` attribute.
+function create_minimal_ios_application_with_extension() {
+  if [[ ! -f app/BUILD ]]; then
+    fail "create_common_files must be called first."
+  fi
+
+  product_type="${1:-}"
+
+  create_minimal_ios_application_extension "$product_type"
+
+  cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = ["Info-App.plist"],
+    minimum_os_version = "10.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -199,6 +224,48 @@ EOF
   cat > app/fmwk.framework/Headers/module.modulemap <<EOF
 This shouldn't get included
 EOF
+}
+
+# Test that the extension can be a bundle loader
+function test_bundle_loader() {
+  create_common_files
+  create_minimal_ios_application_extension
+
+  cat >> app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+     "ios_unit_test",
+)
+
+objc_library(
+    name = "unit_test_lib",
+    hdrs = ["Foo.h"],
+    srcs = ["UnitTest.m"],
+)
+
+ios_unit_test(
+    name = "unit_tests",
+    deps = [":unit_test_lib"],
+    minimum_os_version = "9.0",
+    test_host = ":ext",
+)
+EOF
+
+  cat > app/UnitTest.m <<EOF
+#import <XCTest/XCTest.h>
+#import "app/Foo.h"
+@interface UnitTest: XCTestCase
+@end
+
+@implementation UnitTest
+- (void)testAssertNil {
+  // Call something in test host to ensure bundle loading works.
+  [[[Foo alloc] init] doSomething];
+  XCTAssertNil(nil);
+}
+@end
+EOF
+
+  do_build ios //app:unit_tests || fail "Should build"
 }
 
 # Test missing the CFBundleVersion fails the build.


### PR DESCRIPTION
This is needed when using SwiftUI Previews with a WidgetKit extension.