### PR TITLE
Strip bitcode from imported dynamic frameworks and Swift standard libraries when building without bitcode

### DIFF
--- a/apple/internal/bitcode_support.bzl
+++ b/apple/internal/bitcode_support.bzl
@@ -1,0 +1,38 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bitcode support."""
+
+def _bitcode_mode_string(ctx):
+    """Returns a string representing the current Bitcode mode."""
+
+    bitcode_mode = ctx.fragments.apple.bitcode_mode
+    if not bitcode_mode:
+        fail("Internal error: Can't figure out bitcode_mode from apple " +
+             "fragment")
+
+    bitcode_mode_string = str(bitcode_mode)
+    bitcode_modes = ["embedded", "embedded_markers", "none"]
+    if bitcode_mode_string in bitcode_modes:
+        return bitcode_mode_string
+
+    fail("Internal error: expected bitcode_mode to be one of: " +
+         "{}, but got '{}'".format(
+             bitcode_modes,
+             bitcode_mode_string,
+         ))
+
+bitcode_support = struct(
+    bitcode_mode_string = _bitcode_mode_string,
+)

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -23,6 +23,10 @@ load(
     "AppleFrameworkImportInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:bitcode_support.bzl",
+    "bitcode_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
@@ -130,6 +134,9 @@ def _framework_import_partial_impl(ctx, targets, targets_to_avoid):
 
         for build_arch in build_archs_found:
             args.add("--slice", build_arch)
+
+        if bitcode_support.bitcode_mode_string(ctx) == "none":
+            args.add("--strip_bitcode")
 
         args.add("--output_zip", framework_zip.path)
 

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -23,6 +23,10 @@ load(
     "xcode_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:bitcode_support.bzl",
+    "bitcode_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -103,6 +107,9 @@ def _swift_dylib_action(ctx, platform_name, binary_files, output_dir):
             "--binary",
             x.path,
         ])
+
+    if bitcode_support.bitcode_mode_string(ctx) == "none":
+        swift_stdlib_tool_args.append("--strip_bitcode")
 
     apple_support.run(
         ctx,

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -273,6 +273,28 @@ def ios_application_test_suite(name = "ios_application"):
         ],
     )
 
+    # Test that Bitcode was removed from the imported framework when building
+    # with Bitcode disabled.
+    archive_contents_test(
+        name = "{}_imported_dynamic_framework_bitcode_strip_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_dynamic_fmwk_with_bitcode",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/iOSDynamicFrameworkWithBitcode.framework/iOSDynamicFrameworkWithBitcode",
+        macho_load_commands_not_contain = ["__LLVM"],
+        tags = [name],
+    )
+
+    # Test that Bitcode was removed from the Swift standard libraries when building
+    # with Bitcode disabled.
+    archive_contents_test(
+        name = "{}_swift_stdlibs_bitcode_strip_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_swift_dep",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
+        macho_load_commands_not_contain = ["__LLVM"],
+        tags = [name],
+    )
+
     # Tests that the provisioning profile is present when built for device.
     archive_contents_test(
         name = "{}_contains_provisioning_profile_test".format(name),

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -409,6 +409,49 @@ ios_framework(
 )
 
 ios_application(
+    name = "app_with_imported_dynamic_fmwk_with_bitcode",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+        "//test/testdata/frameworks:iOSImportedDynamicFrameworkWithBitcode",
+    ],
+)
+
+ios_application(
+    name = "app_with_swift_dep",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:swift_main_lib",
+    ],
+)
+
+ios_application(
     name = "app_with_inner_and_outer_static_fmwk",
     bundle_id = "com.google.example",
     families = ["iphone"],

--- a/test/testdata/frameworks/BUILD
+++ b/test/testdata/frameworks/BUILD
@@ -20,6 +20,11 @@ apple_dynamic_framework_import(
     framework_imports = [":iOSDynamicFramework"],
 )
 
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithBitcode",
+    framework_imports = [":iOSDynamicFrameworkWithBitcode"],
+)
+
 apple_static_framework_import(
     name = "iOSImportedStaticFramework",
     framework_imports = [":iOSStaticFramework"],
@@ -66,6 +71,15 @@ generate_import_framework(
     name = "iOSDynamicFramework",
     archs = ["x86_64"],
     libtype = "dynamic",
+    minimum_os_version = "11.0",
+    sdk = "iphonesimulator",
+)
+
+generate_import_framework(
+    name = "iOSDynamicFrameworkWithBitcode",
+    archs = ["x86_64"],
+    libtype = "dynamic",
+    embed_bitcode = True,
     minimum_os_version = "11.0",
     sdk = "iphonesimulator",
 )

--- a/test/testdata/frameworks/generate_framework.bzl
+++ b/test/testdata/frameworks/generate_framework.bzl
@@ -24,6 +24,8 @@ def _generate_import_framework_impl(ctx):
     args.add("--sdk", ctx.attr.sdk)
     args.add("--minimum_os_version", ctx.attr.minimum_os_version)
     args.add("--libtype", ctx.attr.libtype)
+    if ctx.attr.embed_bitcode:
+        args.add("--embed_bitcode")
     for arch in ctx.attr.archs:
         args.add("--arch", arch)
 
@@ -103,6 +105,12 @@ Minimum version of the OS corresponding to the SDK that this binary will support
             doc = """
 Possible values are `dynamic` or `static`.
 Determines if the framework will be built as a dynamic framework or a static framework.
+""",
+        ),
+        "embed_bitcode": attr.bool(
+            default = False,
+            doc = """
+Set to `True` to generate and embed bitcode in the final framework binary.
 """,
         ),
         "_generate_framework": attr.label(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,6 +12,7 @@ filegroup(
     name = "for_bazel_tests",
     testonly = 1,
     srcs = glob(["**"]) + [
+        "//tools/bitcode_strip:for_bazel_tests",
         "//tools/bundletool:for_bazel_tests",
         "//tools/clangrttool:for_bazel_tests",
         "//tools/codesigningtool:for_bazel_tests",

--- a/tools/bitcode_strip/BUILD
+++ b/tools/bitcode_strip/BUILD
@@ -1,18 +1,14 @@
 licenses(["notice"])
 
-py_binary(
-    name = "imported_dynamic_framework_processor",
-    srcs = ["imported_dynamic_framework_processor.py"],
+py_library(
+    name = "bitcode_strip",
+    srcs = ["bitcode_strip.py"],
     srcs_version = "PY2AND3",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
     visibility = ["//visibility:public"],
-    deps = [
-        "//tools/bitcode_strip",
-        "//tools/codesigningtool:codesigningtool_lib",
-        "//tools/wrapper_common:lipo",
-    ],
+    deps = ["//tools/wrapper_common:execute"],
 )
 
 # Consumed by bazel tests.

--- a/tools/bitcode_strip/README
+++ b/tools/bitcode_strip/README
@@ -1,0 +1,3 @@
+bitcode_strip removes the bitcode segment in a Mach-O file.
+
+bitcode_strip only runs on Darwin.

--- a/tools/bitcode_strip/bitcode_strip.py
+++ b/tools/bitcode_strip/bitcode_strip.py
@@ -1,0 +1,32 @@
+# Lint as: python2, python3
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from build_bazel_rules_apple.tools.wrapper_common import execute
+
+
+def invoke(input_path, output_path):
+  """Wraps bitcode_strip with the given input and output."""
+  xcrunargs = ["xcrun",
+               "bitcode_strip",
+               input_path,
+               "-r",
+               "-o",
+               output_path]
+
+  execute.execute_and_filter_output(
+      xcrunargs,
+      print_output=True,
+      raise_on_failure=True)

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -19,6 +19,7 @@ import shutil
 import sys
 import time
 
+from build_bazel_rules_apple.tools.bitcode_strip import bitcode_strip
 from build_bazel_rules_apple.tools.codesigningtool import codesigningtool
 from build_bazel_rules_apple.tools.wrapper_common import lipo
 
@@ -97,6 +98,10 @@ def main():
       "expected to represent the target architectures"
   )
   parser.add_argument(
+      "--strip_bitcode", action="store_true", default=False, help="strip "
+      "bitcode from the imported frameworks."
+  )
+  parser.add_argument(
       "--framework_file", type=str, action="append", help="path to a file "
       "scoped to one of the imported frameworks, distinct from the binary files"
   )
@@ -143,6 +148,12 @@ def main():
                                             slices_needed)
     if status_code:
       return 1
+
+    # Strip bitcode from the output framework binary
+    if args.strip_bitcode:
+      output_binary = os.path.join(args.temp_path,
+                                   os.path.basename(framework_binary))
+      bitcode_strip.invoke(output_binary, output_binary)
 
   if args.framework_file:
     for framework_file in args.framework_file:

--- a/tools/swift_stdlib_tool/BUILD
+++ b/tools/swift_stdlib_tool/BUILD
@@ -9,6 +9,7 @@ py_binary(
     # not used by other things.
     visibility = ["//visibility:public"],
     deps = [
+        "//tools/bitcode_strip",
         "//tools/wrapper_common:execute",
         "//tools/wrapper_common:lipo",
     ],


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_apple/issues/327.