### PR TITLE
Generate and include the symbols files in the IPA file

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -120,6 +120,7 @@ def _ios_application_impl(ctx):
         partials.debug_symbols_partial(
             debug_dependencies = embeddable_targets,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
+            package_symbols = True,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -79,6 +79,7 @@ def _macos_application_impl(ctx):
         partials.debug_symbols_partial(
             debug_dependencies = embedded_targets + ctx.attr.additional_contents.keys(),
             debug_outputs_provider = debug_outputs_provider,
+            package_symbols = True,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -102,6 +102,7 @@ def _tvos_application_impl(ctx):
         partials.debug_symbols_partial(
             debug_dependencies = embeddable_targets,
             debug_outputs_provider = debug_outputs_provider,
+            package_symbols = True,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -176,6 +176,14 @@ can pass `--define=apple.propagate_embedded_extra_outputs=(yes|true|1)` to
 bazel build --define=apple.propagate_embedded_extra_outputs=yes //your/target
 ```
 
+### Include symbols in ipas
+
+Including symbols in the final ipa is necessary if you want to allow Apple to
+symbolicate crash logs from App Store Connect and provide to you directly in
+the Xcode's Organizer window. If you want to include symbols in your ipa for
+App Store builds, you can pass `--apple_generate_dsym` and
+`--define=apple.package_symbols=yes` to `bazel build`.
+
 ### Disable `SwiftSupport` in ipas
 
 The SwiftSupport directory in a final ipa is only necessary if you're shipping

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -667,6 +667,50 @@ function assert_ipa_contains_bitcode_maps() {
   done
 }
 
+# Usage: assert_ipa_contains_symbols <archive> <binary_path>
+#
+# Asserts that the IPA at `archive` contains symbols of the binary at `path`
+# for each architecture being built.
+#
+# To support legacy shell tests and newer Starlark tests, this function can take
+# the `archive` and `binary_path` arguments in two forms:
+#
+# - If `archive` is a directory, then `binary_path` is assumed to be the
+#   path to the binary relative to `archive`.
+# - If `archive` is a file, it is assumed to be an .ipa or .zip archive and
+#   `binary_path` is treated as the relative path to the binary inside that
+#   archive.
+function assert_ipa_contains_symbols() {
+  local archive_zip_or_dir="$1" ; shift
+
+  for binary in "$@" ; do
+    if [[ -d "$archive_zip_or_dir" ]] ; then
+      assert_exists "$archive_zip_or_dir/$binary"
+      ln -s "$archive_zip_or_dir/$binary" "$TEST_TMPDIR"/tmp_bin
+    else
+      assert_zip_contains "$archive_zip_or_dir" "$binary"
+      unzip_single_file "$archive_zip_or_dir" "$binary" > "$TEST_TMPDIR"/tmp_bin
+    fi
+
+    # Verify that there is a .symbols file for each UUID in the DWARF info.
+    dwarfdump -u "$TEST_TMPDIR"/tmp_bin | while read line ; do
+      local -a uuid_and_arch=(
+        $(echo "$line" | sed -e 's/UUID: \([^ ]*\) (\([^)]*\)).*/\1 \2/') )
+      local uuid=${uuid_and_arch[0]}
+
+      if [[ -d "$archive_zip_or_dir" ]] ; then
+        echo "$archive_zip_or_dir/Symbols/${uuid}.symbols"
+        assert_exists "$archive_zip_or_dir/Symbols/${uuid}.symbols"
+      else
+        assert_zip_contains "$archive_zip_or_dir" \
+          "Symbols/${uuid}.symbols"
+      fi
+    done
+
+    rm "$TEST_TMPDIR"/tmp_bin
+  done
+}
+
 # Usage: assert_plist_is_binary <archive> <path_in_archive>
 #
 # Asserts that the IPA/zip at `archive` contains a binary plist file at

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -683,4 +683,16 @@ function test_tree_artifacts_and_disable_simulator_codesigning() {
       --define=apple.codesign_simulator_bundles=no || fail "Should build"
 }
 
+# Tests that symbols files are included in the ipa when builds with
+# --apple_generate_dsym and --define=apple.package_symbols=yes.
+function test_ipa_contains_symbols() {
+  create_common_files
+  create_minimal_ios_application
+  do_build ios //app:app \
+      --apple_generate_dsym \
+      --define=apple.package_symbols=yes || fail "Should build"
+
+  assert_ipa_contains_symbols "test-bin/app/app.ipa" "Payload/app.app/app"
+}
+
 run_suite "ios_application bundling tests"

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -156,4 +156,17 @@ function test_pkginfo_contents() {
       "app.app/Contents/PkgInfo")"
 }
 
+# Tests that symbols files are included in the ipa when builds with
+# --apple_generate_dsym and --define=apple.package_symbols=yes.
+function test_ipa_contains_symbols() {
+  create_common_files
+  create_minimal_macos_application
+  do_build macos //app:app \
+      --apple_generate_dsym \
+      --define=apple.package_symbols=yes || fail "Should build"
+
+  assert_ipa_contains_symbols "test-bin/app/app.zip" \
+      "app.app/Contents/MacOS/app"
+}
+
 run_suite "macos_application bundling tests"

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -138,6 +138,20 @@ def ios_application_test_suite(name = "ios_application"):
         tags = [name],
     )
 
+    apple_verification_test(
+        name = "{}_package_symbols_test".format(name),
+        build_type = "simulator",
+        env = {
+            "BINARY_PATHS": ["Payload/app.app/app"],
+        },
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        verifier_script = "verifier_scripts/symbols_verifier.sh",
+        tags = [
+            name,
+            "manual",  # can't use Starlark transition on --define now
+        ],
+    )
+
     archive_contents_test(
         name = "{}_custom_executable_name_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/verifier_scripts/symbols_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/symbols_verifier.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# This function lives in apple_shell_testutils.sh, which is sourced before this
+# line is executed.
+assert_ipa_contains_symbols \
+    "$ARCHIVE_ROOT" "${BINARY_PATHS[@]}"

--- a/test/tvos_application_test.sh
+++ b/test/tvos_application_test.sh
@@ -138,4 +138,16 @@ EOF
   expect_log 'While processing target "//app:app_entitlements", failed to extract from the provisioning profile "app/bogus.mobileprovision".'
 }
 
+# Tests that symbols files are included in the ipa when builds with
+# --apple_generate_dsym and --define=apple.package_symbols=yes.
+function test_ipa_contains_symbols() {
+  create_common_files
+  create_minimal_tvos_application
+  do_build tvos //app:app \
+      --apple_generate_dsym \
+      --define=apple.package_symbols=yes || fail "Should build"
+
+  assert_ipa_contains_symbols "test-bin/app/app.ipa" "Payload/app.app/app"
+}
+
 run_suite "tvos_application bundling tests"


### PR DESCRIPTION
Xcode's export action for App Store has an option "Upload your app’s
symbols to receive symbolicated reports from Apple" that:

> Allows Apple to symbolicate crash logs and provide other diagnostic
information. The symbol information is extracted from the debugging
symbols (dSYM files) including in the archive, and is limited to
function and methods (including inline functions), names and paths of
source code files (for navigation), and line number information (for
navigation).

(from https://help.apple.com/xcode/mac/current/#/devde46df08a)

This patch adds a new define named `apple.package_symbols` that supports
the same functionality. When you build your app with
`--apple_generate_dsym` and
`--define=apple.package_symbols=(yes|true|1)`, `.symbols` files will be
generated and packaged within the final IPA file.

Note that this does not generate and package symbols from imported
frameworks yet, because there's currently no API that allows importing
dSYMs provided along with the imported frameworks.

RELNOTES: Added support for packaging symbols files in the produced
IPAs. Pass `--apple_generate_dsym` and
`--define=apple.package_symbols=(yes|true|1)` to your build to enable
this feature. Including symbols in your IPA allows Apple to symbolicate
crash logs and provide other diagnostic information in Xcode's
Organizer.

Fixes https://github.com/bazelbuild/rules_apple/issues/545.
Fixes https://github.com/bazelbuild/rules_apple/issues/709.