### PR TITLE
Remove duplicate --compress-pngs flag from actool wrapper

### DIFF
--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -213,7 +213,6 @@ def actool(_, toolargs):
                "--errors",
                "--warnings",
                "--notices",
-               "--compress-pngs",
                "--output-format",
                "human-readable-text"]
 


### PR DESCRIPTION
This is already specified in apple/internal/resource_actions/actool.bzl.