### PR TITLE
Set utime for directories as well as files before making zips

### DIFF
--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -27,8 +27,8 @@ def _zip_framework(framework_temp_path, output_zip_path):
   """Saves the framework as a zip file for caching."""
   zip_epoch_timestamp = 946684800  # 2000-01-01 00:00
   if os.path.exists(framework_temp_path):
-    for root, _, files in os.walk(framework_temp_path):
-      for file_name in files:
+    for root, dirs, files in os.walk(framework_temp_path):
+      for file_name in dirs + files:
         file_path = os.path.join(root, file_name)
         timestamp = zip_epoch_timestamp + time.timezone
         os.utime(file_path, (timestamp, timestamp))

--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -257,8 +257,8 @@ def _zip_directory(directory, output):
   # Set the timestamp of all files within "tmpdir" to the Zip Epoch:
   # 2000-01-01 00:00. They are adjusted for timezone since Python "zipfile"
   # checks the local timestamps of the files.
-  for root, _, files in os.walk(directory):
-    for f in files:
+  for root, dirs, files in os.walk(directory):
+    for f in dirs + files:
       filepath = os.path.join(root, f)
       timestamp = zip_epoch_timestamp + time.timezone
       os.utime(filepath, (timestamp, timestamp))


### PR DESCRIPTION
Zip archives contain utime/mtime for directories as well as files, so to make the zips completely deterministic (in addition to their contents), the directory utimes need to be deterministic as well

Note this will only impact the zips themselves, the output of any actions that unzip the zips should be unaffected