### PR TITLE
Enable linkmap tests

### DIFF
--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -107,7 +107,6 @@ mutually exclusive, i.e. you can only specify one or the other for a particular
 build.
 
 -->
-<!-- Blocked on b/73547215
 
 ### linkmap Generation {#objc_generate_linkmap}
 
@@ -122,8 +121,6 @@ bazel build --objc_generate_linkmap //your/target
 By default, only the top level linkmap file is built when this flag is
 specified. If you require the linkmap file of the top level target dependencies,
 you'll need to specify the `--output_groups=+linkmaps` flag.
-
--->
 
 ### Debugging Entitlement Support {#apple.add_debugger_entitlement}
 

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -214,6 +214,19 @@ EOF
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
 }
 
+# Tests that the linkmap outputs are produced when --objc_generate_linkmap is
+# present.
+function test_linkmaps_generated() {
+  create_common_files
+  create_minimal_ios_application
+  do_build ios --objc_generate_linkmap //app:app || fail "Should build"
+
+  declare -a archs=( $(current_archs ios) )
+  for arch in "${archs[@]}"; do
+    assert_exists "test-bin/app/app_${arch}.linkmap"
+  done
+}
+
 # Tests that the IPA post-processor is executed and can modify the bundle.
 function test_ipa_post_processor() {
   create_common_files

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -595,6 +595,20 @@ function test_prebuilt_dynamic_apple_framework_import_dependency() {
       "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
+# Tests that the linkmap outputs are produced when --objc_generate_linkmap is
+# present.
+function test_linkmaps_generated() {
+  create_common_files
+  create_minimal_ios_application_with_extension
+  do_build ios --objc_generate_linkmap \
+      //app:ext || fail "Should build"
+
+  declare -a archs=( $(current_archs ios) )
+  for arch in "${archs[@]}"; do
+    assert_exists "test-bin/app/ext_${arch}.linkmap"
+  done
+}
+
 # Tests that ios_extension cannot be a depenency of objc_library.
 function test_extension_under_library() {
 cat > app/BUILD <<EOF

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -97,11 +97,7 @@ def ios_app_clip_test_suite(name = "ios_app_clip"):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
-        tags = [
-            name,
-            # OSS Blocked by b/73547215
-            "manual",  # disabled in oss
-        ],
+        tags = [name],
     )
 
     # Tests that the provisioning profile is present when built for device.

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -298,11 +298,7 @@ def ios_application_test_suite(name = "ios_application"):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
-        tags = [
-            name,
-            # OSS Blocked by b/73547215
-            "manual",  # disabled in oss
-        ],
+        tags = [name],
     )
 
     # Test that Bitcode was removed from the imported framework when building

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -146,11 +146,7 @@ def ios_extension_test_suite(name = "ios_extension"):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
-        tags = [
-            name,
-            # OSS Blocked by b/73547215
-            "manual",  # disabled in oss
-        ],
+        tags = [name],
     )
 
     # Tests that the provisioning profile is present when built for device.

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -215,11 +215,7 @@ def tvos_application_test_suite(name = "tvos_application"):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
-        tags = [
-            name,
-            # OSS Blocked by b/73547215
-            "manual",  # disabled in oss
-        ],
+        tags = [name],
     )
 
     # Tests that the provisioning profile is present when built for device.

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -169,11 +169,7 @@ def watchos_extension_test_suite(name = "watchos_extension"):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
-        tags = [
-            name,
-            # OSS Blocked by b/73547215
-            "manual",  # disabled in oss
-        ],
+        tags = [name],
     )
 
     # Tests that the provisioning profile is present when built for device.

--- a/test/tvos_application_test.sh
+++ b/test/tvos_application_test.sh
@@ -112,6 +112,19 @@ EOF
   expect_log 'Target "//app:app" is missing CFBundleShortVersionString.'
 }
 
+# Tests that the linkmap outputs are produced when --objc_generate_linkmap is
+# present.
+function test_linkmaps_generated() {
+  create_common_files
+  create_minimal_tvos_application
+  do_build tvos --objc_generate_linkmap //app:app || fail "Should build"
+
+  declare -a archs=( $(current_archs tvos) )
+  for arch in "${archs[@]}"; do
+    assert_exists "test-bin/app/app_${arch}.linkmap"
+  done
+}
+
 # Tests that failures to extract from a provisioning profile are propertly
 # reported.
 function test_provisioning_profile_extraction_failure() {

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -241,6 +241,19 @@ EOF
   expect_log 'Target "//app:watch_ext" is missing CFBundleShortVersionString.'
 }
 
+# Tests that the linkmap outputs are produced when --objc_generate_linkmap is
+# present.
+function test_linkmaps_generated() {
+  create_minimal_watchos_application_with_companion
+  do_build watchos --objc_generate_linkmap \
+      //app:watch_ext || fail "Should build"
+
+  declare -a archs=( $(current_archs watchos) )
+  for arch in "${archs[@]}"; do
+    assert_exists "test-bin/app/watch_ext_${arch}.linkmap"
+  done
+}
+
 # Tests that failures to extract from a provisioning profile are propertly
 # reported (from watchOS application profile).
 function test_provisioning_profile_extraction_failure_watch_application() {


### PR DESCRIPTION
Previously, linkmap generation didn't work because it wasn't enabled in Apple CROSSTOOL (there wasn't a feature for it). With the change in https://github.com/bazelbuild/bazel/pull/12016, this now works correctly, so we can enable these tests now.

Consequently, this also uncomments the linkmap generation documentation.