### PR TITLE
Preserve the codesign load commands in the output binary when stripping bitcode from Swift standard libraries.

### DIFF
--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -108,7 +108,12 @@ def _swift_dylib_action(ctx, platform_name, binary_files, output_dir):
             x.path,
         ])
 
-    if bitcode_support.bitcode_mode_string(ctx) == "none":
+    # The dylibs bundled in Swift Support need to keep the original code
+    # signature, but `bitcode_strip` also strips it out. Xcode 11.4 added a new
+    # `-keep_cs` flag to `bitcode_strip`, which allows us to strip bitcode from
+    # the dylibs without modifying their code signature.
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    if xcode_support.is_xcode_at_least_version(xcode_config, "11.4") and (bitcode_support.bitcode_mode_string(ctx) == "none"):
         swift_stdlib_tool_args.append("--strip_bitcode")
 
     apple_support.run(

--- a/tools/bitcode_strip/bitcode_strip.py
+++ b/tools/bitcode_strip/bitcode_strip.py
@@ -23,6 +23,7 @@ def invoke(input_path, output_path):
                "bitcode_strip",
                input_path,
                "-r",
+               "-keep_cs",
                "-o",
                output_path]
 


### PR DESCRIPTION
This is needed because the Swift standard libaries bundled in the
SwiftSupport directory in the .ipa file aren't resigned by the
developer's certificate --- they're originally signed by Apple and we're
not supposed to change it.

This change adds the `-keep_cs` flag to the `bitcode_strip` wrapper, and
only run it when building with Xcode 11.4 or above. This preserves the
codesign load commands when stripping bitcode from the Swift standard
libraries, thus ensures those `.dylib`s keep the original code signature
from Apple if we don't resign them.

Note that Swift standard libraries bundled under
`Payload/YourApp.app/Frameworks` are (re)signed with the developer's
certificate --- this change does not affect them.
