### PR TITLE
unittest.bash: support python 3

### DIFF
--- a/test/unittest.bash
+++ b/test/unittest.bash
@@ -675,7 +675,7 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
 else
     function timestamp() {
       # OS X and FreeBSD do not have %N so python is the best we can do
-      python -c 'import time; print int(round(time.time() * 1000))'
+      python -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 


### PR DESCRIPTION
If `python` on the user's `PATH` is python 3, running the tests fails locally. In python 3, `print()` must be used like a function, not a statement.

> edit: updated to just treat `print` like a function regardless. only very-old versions of python 2 don't support it