### PR TITLE
Fix swiftinterface only framework debugging warning

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -305,9 +305,8 @@ def _apple_static_framework_import_impl(ctx):
         if _is_debugging(ctx):
             cpu = ctx.fragments.apple.single_arch_cpu
             swiftmodule = _swiftmodule_for_cpu(swiftmodule_imports, cpu)
-            if not swiftmodule:
-                fail("ERROR: Missing imported swiftmodule for {}".format(cpu))
-            objc_provider_fields.update(_ensure_swiftmodule_is_embedded(swiftmodule))
+            if swiftmodule:
+                objc_provider_fields.update(_ensure_swiftmodule_is_embedded(swiftmodule))
 
     providers.append(_objc_provider_with_dependencies(ctx, objc_provider_fields))
     providers.append(_cc_info_with_dependencies(ctx, header_imports))

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -69,15 +69,12 @@ def _swiftmodule_for_cpu(swiftmodule_files, cpu):
     #   ABC.framework/Modules/ABC.swiftmodule/<arch>.swiftmodule
     # Where <arch> will be a common arch like x86_64, arm64, etc.
     named_files = {f.basename: f for f in swiftmodule_files}
-    for extension in ("swiftinterface", "swiftmodule"):
-        module = named_files.get("{}.{}".format(cpu, extension))
-        if not module and cpu == "armv7":
-            module = named_files.get("arm.{}".format(extension))
 
-        if module:
-            return module
+    module = named_files.get("{}.swiftmodule".format(cpu))
+    if not module and cpu == "armv7":
+        module = named_files.get("arm.swiftmodule")
 
-    return None
+    return module
 
 def _classify_framework_imports(framework_imports):
     """Classify a list of framework files into bundling, header, or module_map."""


### PR DESCRIPTION
This is a second approach to 3d4a8f0089db8f2b7c15cd649bbd71ca572909f1 (which this reverts).

Here are the possible cases:

1. You're importing a pre-compiled Swift framework with just a swiftmodule file built from your current compiler version
   Before: Debugging worked fine
   After: Debugging works fine

1. You're importing a pre-compiled Swift framework with just a swiftmodule file built from a different compiler version than your current one
   Before: Compilation failed
   After: Compilation fails

1. You're importing a pre-compiled Swift framework with a swiftmodule and swiftinterface file built from your current compiler version
   Before: The swiftinterface was passed to the linker with `add_ast_path`, lldb produced a warning when debugging (but seemingly had no effect on debugging fidelity)
   After: The swiftmodule file is passed to the linker with `add_ast_path`, debugging info is improved

1. You're importing a pre-compiled Swift framework with a swiftmodule and swiftinterface file built from a different compiler version than your current one
   Before: The swiftinterface was passed to the linker with `add_ast_path`, lldb produced a warning when debugging (but seemingly had no effect on debugging fidelity)
   After: The swiftmodule file is passed to the linker with `add_ast_path`, lldb produces a warning about how the swiftmodule was built with a different version of the compiler, but seemingly has no effect on debugging fidelity

1. You're importing a pre-compiled Swift framework with just a swiftinterface file built from any compiler version (barring any swift issues that could cause compilation to fail). This is the type of framework the `ios_static_framework` rule produces
   Before: The swiftinterface was passed to the linker with `add_ast_path`, lldb produced a warning when debugging (but seemingly had no effect on debugging fidelity). Before the reverted commit here, this case would error.
   After: No `add_ast_path` is passed to the linker for the imported framework, but debugging fidelity seems ok