### PR TITLE
Fix invalid bash in test

### DIFF
--- a/test/ios_framework_import_test.sh
+++ b/test/ios_framework_import_test.sh
@@ -254,8 +254,9 @@ EOF
 
     do_build ios --compilation_mode=dbg //app:app || fail "Should build"
 
-    local symbols=$(
-        unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/app"
+    local symbols
+    symbols=$(
+        unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/app" \
             | nm -aj - | grep .swiftmodule
     )
 


### PR DESCRIPTION
This wasn't failing the test because declaring and assigning at the same
time hides return values.