### PR TITLE
Pass extra test_args through to xctestrunner

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -23,6 +23,7 @@ basename_without_extension() {
   echo "${filename%.*}"
 }
 
+custom_xctestrunner_args=()
 simulator_id=""
 while [[ $# -gt 0 ]]; do
   arg="$1"
@@ -31,8 +32,7 @@ while [[ $# -gt 0 ]]; do
       simulator_id="${arg##*=}"
       ;;
     *)
-      echo "error: unsupported --test_arg: '$1'"
-      exit 1
+      custom_xctestrunner_args+=("$arg")
       ;;
   esac
   shift
@@ -136,7 +136,8 @@ fi
 
 cmd=("%(testrunner_binary)s"
   "${runner_flags[@]}"
-  "${target_flags[@]}")
+  "${target_flags[@]}"
+  "${custom_xctestrunner_args[@]}")
 "${cmd[@]}" 2>&1
 status=$?
 exit ${status}

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -444,12 +444,13 @@ function test_ios_unit_simulator_id() {
   expect_log "Executed 3 tests, with 0 failures"
 }
 
-function test_ios_unit_simulator_id() {
+function test_ios_unit_other_arg() {
   create_sim_runners
   create_ios_unit_tests
   ! do_ios_test //ios:PassingUnitTest --test_arg=invalid_arg || fail "should fail"
 
-  expect_log "error: unsupported --test_arg: 'invalid_arg'"
+  # Error comes from xctestrunner
+  expect_log "downloaded: error: unrecognized arguments: invalid_arg"
 }
 
 function test_ios_unit_test_with_multi_equal_env() {


### PR DESCRIPTION
This fixes a regression from
https://github.com/bazelbuild/rules_apple/pull/653 where all args were
passed through to xctestrunner. This handles the 1 arg we care about in
the test runner now, and passes through the rest