### PR TITLE
Make AppleFrameworkImportInfo public

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -43,23 +43,14 @@ load(
     "group_files_by_directory",
 )
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleFrameworkImportInfo",
+)
+load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftToolchainInfo",
     "SwiftUsageInfo",
     "swift_common",
-)
-
-AppleFrameworkImportInfo = provider(
-    doc = "Provider that propagates information about framework import targets.",
-    fields = {
-        "framework_imports": """
-Depset of Files that represent framework imports that need to be bundled in the top level
-application bundle under the Frameworks directory.
-""",
-        "build_archs": """
-Depset of strings that represent binary architectures reported from the current build.
-""",
-    },
 )
 
 def _is_swiftmodule(path):

--- a/apple/internal/aspects/framework_import_aspect.bzl
+++ b/apple/internal/aspects/framework_import_aspect.bzl
@@ -15,7 +15,7 @@
 """Implementation of the aspect that propagates framework import files."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
+    "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkImportInfo",
 )
 

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -19,7 +19,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
+    "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkImportInfo",
 )
 load(

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -136,6 +136,19 @@ to ensure that they are explicitly produced as outputs of the build.
     },
 )
 
+AppleFrameworkImportInfo = provider(
+    doc = "Provider that propagates information about framework import targets.",
+    fields = {
+        "framework_imports": """
+Depset of Files that represent framework imports that need to be bundled in the top level
+application bundle under the Frameworks directory.
+""",
+        "build_archs": """
+Depset of strings that represent binary architectures reported from the current build.
+""",
+    },
+)
+
 AppleResourceInfo = provider(
     doc = "Provider that propagates buckets of resources that are differentiated by type.",
     # @unsorted-dict-items


### PR DESCRIPTION
This provider is used by the framework import rules to propagate the
files they import. This is useful for users to write custom rules that
can be depended on by the framework import rules.