### PR TITLE
Use xctestrunner from source

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,6 +20,8 @@ filegroup(
         "//tools:for_bazel_tests",
         "@build_bazel_apple_support//:for_bazel_tests",
         "@build_bazel_rules_swift//:for_bazel_tests",
+        "@subpar//:subpar.bzl",
+        "@xctestrunner//:for_bazel_tests",
     ],
     visibility = ["//:__subpackages__"],
 )

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -105,7 +105,6 @@ single swift_library dependency.\
     modulemap_file = None
     for dep in swiftdeps:
         swiftinfo = dep[SwiftInfo]
-        module_name = swiftinfo.module_name
         arch = _swift_arch_for_dep(dep)
 
         swiftmodule = None
@@ -115,6 +114,7 @@ single swift_library dependency.\
                     continue
                 swiftmodule = module.swift.swiftmodule
                 swiftdoc = module.swift.swiftdoc
+                module_name = module.name
 
         swiftdocs[arch] = swiftdoc
         swiftmodules[arch] = swiftmodule

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -105,6 +105,7 @@ single swift_library dependency.\
     modulemap_file = None
     for dep in swiftdeps:
         swiftinfo = dep[SwiftInfo]
+        module_name = swiftinfo.module_name
         arch = _swift_arch_for_dep(dep)
 
         swiftmodule = None
@@ -114,7 +115,6 @@ single swift_library dependency.\
                     continue
                 swiftmodule = module.swift.swiftmodule
                 swiftdoc = module.swift.swiftdoc
-                module_name = module.name
 
         swiftdocs[arch] = swiftdoc
         swiftmodules[arch] = swiftmodule

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -14,7 +14,7 @@
 
 """Definitions for handling Bazel repositories used by the Apple rules."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _colorize(text, color):
     """Applies ANSI color codes around the given text."""
@@ -127,10 +127,23 @@ def apple_rules_dependencies(ignore_version_differences = False):
     )
 
     _maybe(
-        http_file,
+        http_archive,
+        name = "subpar",
+        urls = [
+            "https://github.com/google/subpar/archive/2.0.0.tar.gz",
+        ],
+        strip_prefix = "subpar-2.0.0",
+        sha256 = "b80297a1b8d38027a86836dbadc22f55dc3ecad56728175381aa6330705ac10f",
+        ignore_version_differences = ignore_version_differences,
+    )
+
+    _maybe(
+        http_archive,
         name = "xctestrunner",
-        executable = 1,
-        sha256 = "298846d5ad7607eba33e786149c2b642ffe39508d4a99468a8280871d902fe5d",
-        urls = ["https://github.com/google/xctestrunner/releases/download/0.2.14/ios_test_runner.par"],
+        urls = [
+            "https://github.com/google/xctestrunner/archive/64a9be0b6fa833b4b2371729c5c8cdd2c6f7775b.tar.gz",
+        ],
+        strip_prefix = "xctestrunner-64a9be0b6fa833b4b2371729c5c8cdd2c6f7775b",
+        sha256 = "c03e91efc01a1fa2f6c7764b93f5312e20c9c4fae124de2fc398871e46d4244d",
         ignore_version_differences = ignore_version_differences,
     )

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -54,9 +54,7 @@ def _ios_test_runner_impl(ctx):
             test_environment = ctx.attr.test_environment,
         ),
         DefaultInfo(
-            runfiles = ctx.runfiles(
-                files = [ctx.file._testrunner],
-            ),
+            runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,
         ),
     ]
 
@@ -101,9 +99,8 @@ into the XCTest invocation.
         ),
         "_testrunner": attr.label(
             default = Label(
-                "@xctestrunner//file",
+                "@xctestrunner//:ios_test_runner",
             ),
-            allow_single_file = True,
             executable = True,
             cfg = "host",
             doc = """

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -51,9 +51,7 @@ def _tvos_test_runner_impl(ctx):
             execution_environment = _get_execution_environment(ctx),
         ),
         DefaultInfo(
-            runfiles = ctx.runfiles(
-                files = [ctx.file._testrunner],
-            ),
+            runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,
         ),
     ]
 
@@ -92,9 +90,8 @@ By default, it is the latest supported version of the device type.'
         ),
         "_testrunner": attr.label(
             default = Label(
-                "@xctestrunner//file",
+                "@xctestrunner//:ios_test_runner",
             ),
-            allow_single_file = True,
             executable = True,
             cfg = "host",
             doc = """

--- a/test/BUILD
+++ b/test/BUILD
@@ -76,7 +76,7 @@ filegroup(
     testonly = 1,
     srcs = [
         "@bazel_skylib//:test_deps",
-        "@xctestrunner//file",
+        "@xctestrunner//:ios_test_runner",
     ],
 )
 

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -60,18 +60,6 @@ function create_new_workspace() {
   # copy and we should reference it from the original location.
   cp -rf "$EXTERNAL_DIR" ../external
 
-  # Because for xctestrunner we use the http_file rule, we need to create a
-  # similar BUILD file manually. This is not the case for bazel_skylib as it
-  # only needs an empty top level BUILD file.
-  cat > ../external/xctestrunner/file/BUILD <<EOF
-filegroup(
-    name = "file",
-    # http_file downloads files with the "downloaded" name by default.
-    srcs = ["downloaded"],
-    visibility = ["//visibility:public"],
-)
-EOF
-
   touch WORKSPACE
   cat > WORKSPACE <<EOF
 workspace(name = 'build_bazel_rules_apple_integration_tests')
@@ -87,9 +75,9 @@ new_local_repository(
 )
 
 new_local_repository(
-    name = 'xctestrunner',
+    name = "subpar",
     build_file_content = '',
-    path = '$PWD/../external/xctestrunner',
+    path = '$PWD/../external/subpar',
 )
 
 local_repository(
@@ -105,6 +93,11 @@ local_repository(
 local_repository(
     name = 'build_bazel_apple_support',
     path = '$(rlocation build_bazel_apple_support)',
+)
+
+local_repository(
+    name = 'xctestrunner',
+    path = '$(rlocation xctestrunner)',
 )
 
 # We load rules_swift dependencies into the WORKSPACE. This is safe to do


### PR DESCRIPTION
This makes iterating on xctestrunner much easier, and it allows consumers to point at a fork of xctestrunner as needed

Closes https://github.com/google/xctestrunner/issues/19, with accompanying changes in xctestrunner proper

Depends on https://github.com/google/xctestrunner/pull/27