### PR TITLE
Ignore .DS_Store files in the validation of single xcassets type

### DIFF
--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -18,6 +18,10 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:files.bzl",
+    "filtered_ds_store_files",
+)
 
 def _bundle_name(ctx):
     """Returns the name of the bundle.
@@ -123,6 +127,9 @@ def _ensure_single_xcassets_type(attr, files, extension, message = None):
       message: A custom error message to use, the list of found files that
           didn't match will be printed afterwards.
     """
+    # Ignore `.DS_Store` files in the validation logic, since they don't
+    # represent an xcassets type.
+    files = filtered_ds_store_files(files)
     if not message:
         message = ("Expected the xcassets directory to only contain files " +
                    "are in sub-directories with the extension %s") % extension

--- a/apple/internal/utils/files.bzl
+++ b/apple/internal/utils/files.bzl
@@ -1,0 +1,23 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support functions for files related operations."""
+
+def filtered_ds_store_files(files):
+    """Removes all `.DS_Store` files from a given list of files."""
+    return [
+        f
+        for f in files
+        if f.basename != ".DS_Store"
+    ]


### PR DESCRIPTION
`.DS_Store` doesn't represent an xcassets type -- those files don't
prevent the asset catalog compile action to execute. They can be
generated and accidentally included if the user open the `.xcassets`
directory in the Finder. This ignores all the `.DS_Store` files in the
validation logic, to avoid failing the build unnecessarily.

Fixes https://github.com/bazelbuild/rules_apple/issues/302.