### PR TITLE
Minimize the action and tweak where it runs.

### DIFF
--- a/tools/bundletool/process_and_sign.sh.template
+++ b/tools/bundletool/process_and_sign.sh.template
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eu
 
+# NOTES:
+# 1. This can run on Linux or Mac depending on what work it needs to do.
+# 2. This script is passed arguments but they are *NOT* used, the arguments
+#    are there to allow action logging to have some visibility into what the
+#    actions running the script is doing each time.
+
 # The path where the archive should be created, including the name of the
 # archive itself.
 readonly OUTPUT_PATH=%output_path%


### PR DESCRIPTION
- If there is nothing to do, just copy the archive over without requiring
  macOS/the Xcode enviornment.
  - There is a potential behavior change here, if the input archive
    was compressed, but the action wasn't going to compress, then the
    output is now compressed.
- If only doing the compression, also, don't require macOS.
- Add arguments to the script to allow log visibility into the work that is
  being done.

RELNOTES: None
PiperOrigin-RevId: 329546005