### PR TITLE
Add ability to import user-provided dSYM to apple_dynamic_framework_import

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,6 +12,16 @@ x_defaults:
     - "test/..."
     - "examples/..."
 
+  # Tests that need extra flags
+  # 1. Test that .symbols files are generated and bundled in .ipa file
+  package_symbols: &package_symbols
+    platform: macos
+    test_flags:
+    - "--apple_generate_dsym"
+    - "--define=apple.package_symbols=true"
+    test_targets:
+    - "test/starlark_tests:ios_application_package_symbols_test"
+
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
 tasks:
@@ -33,6 +43,11 @@ tasks:
     # has landed on them breaking this project.
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
+
+  macos_latest_package_symbols:
+    name: "Symbols Tests with Latest Bazel"
+    bazel: latest
+    <<: *package_symbols
 
 buildifier:
   version: latest

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -169,12 +169,13 @@ def _transitive_framework_imports(deps):
         if hasattr(dep[AppleFrameworkImportInfo], "framework_imports")
     ]
 
-def _framework_import_info(transitive_sets, arch_found):
+def _framework_import_info(transitive_sets, arch_found, dsyms = []):
     """Returns AppleFrameworkImportInfo containing transitive framework imports and build archs."""
     provider_fields = {}
     if transitive_sets:
         provider_fields["framework_imports"] = depset(transitive = transitive_sets)
     provider_fields["build_archs"] = depset([arch_found])
+    provider_fields["dsym_imports"] = depset(dsyms)
     return AppleFrameworkImportInfo(**provider_fields)
 
 def _is_debugging(ctx):
@@ -243,7 +244,13 @@ def _apple_dynamic_framework_import_impl(ctx):
     transitive_sets = _transitive_framework_imports(ctx.attr.deps)
     if bundling_imports:
         transitive_sets.append(depset(bundling_imports))
-    providers.append(_framework_import_info(transitive_sets, ctx.fragments.apple.single_arch_cpu))
+    providers.append(
+        _framework_import_info(
+            transitive_sets,
+            ctx.fragments.apple.single_arch_cpu,
+            ctx.files.dsym_imports,
+        ),
+    )
 
     framework_groups = _grouped_framework_files(framework_imports)
     framework_dirs_set = depset(framework_groups.keys())
@@ -353,6 +360,12 @@ target.
             providers = [
                 [apple_common.Objc, AppleFrameworkImportInfo],
             ],
+        ),
+        "dsym_imports": attr.label_list(
+            allow_files = True,
+            doc = """
+The list of files under a .dSYM directory, that is the imported framework's dSYM bundle.
+""",
         ),
     },
     doc = """

--- a/apple/internal/aspects/framework_import_aspect.bzl
+++ b/apple/internal/aspects/framework_import_aspect.bzl
@@ -30,6 +30,7 @@ def _framework_import_aspect_impl(target, ctx):
     if AppleFrameworkImportInfo in target:
         return []
 
+    transitive_dsyms = []
     transitive_sets = []
     build_archs = []
     for attribute in _FRAMEWORK_IMPORT_ASPECT_ATTRS:
@@ -37,6 +38,8 @@ def _framework_import_aspect_impl(target, ctx):
             continue
         for dep_target in getattr(ctx.rule.attr, attribute):
             if AppleFrameworkImportInfo in dep_target:
+                if hasattr(dep_target[AppleFrameworkImportInfo], "dsym_imports"):
+                    transitive_dsyms.append(dep_target[AppleFrameworkImportInfo].dsym_imports)
                 if hasattr(dep_target[AppleFrameworkImportInfo], "framework_imports"):
                     transitive_sets.append(dep_target[AppleFrameworkImportInfo].framework_imports)
                 build_archs.append(dep_target[AppleFrameworkImportInfo].build_archs)
@@ -45,6 +48,7 @@ def _framework_import_aspect_impl(target, ctx):
         return []
 
     return [AppleFrameworkImportInfo(
+        dsym_imports = depset(transitive = transitive_dsyms),
         framework_imports = depset(transitive = transitive_sets),
         build_archs = depset(transitive = build_archs),
     )]

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -200,6 +200,7 @@ def _ios_application_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             label_name = label.name,
+            package_symbols = True,
             platform_prerequisites = platform_prerequisites,
             rule_executables = rule_executables,
             targets = ctx.attr.deps + ctx.attr.extensions + ctx.attr.frameworks,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -92,13 +92,12 @@ def _framework_import_partial_impl(
             files_to_bundle = [x for x in files_to_bundle if x not in avoid_files]
 
     # Collect the architectures that we are using for the build.
-    build_archs_found_dict = dict()
-    for x in targets:
-        if not AppleFrameworkImportInfo in x:
-            continue
-        for build_arch in x[AppleFrameworkImportInfo].build_archs.to_list():
-            build_archs_found_dict[build_arch] = None
-    build_archs_found = build_archs_found_dict.keys()
+    build_archs_found = [
+        build_arch
+        for x in targets
+        if AppleFrameworkImportInfo in x
+        for build_arch in x[AppleFrameworkImportInfo].build_archs.to_list()
+    ]
 
     # Start assembling our partial's outputs.
     bundle_zips = []

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -143,6 +143,11 @@ AppleFrameworkImportInfo = provider(
 Depset of Files that represent framework imports that need to be bundled in the top level
 application bundle under the Frameworks directory.
 """,
+        "dsym_imports": """
+Depset of Files that represent dSYM imports that need to be processed to
+provide .symbols files for packaging into the .ipa file if requested in the
+build with --define=apple.package_symbols=(yes|true|1).
+""",
         "build_archs": """
 Depset of strings that represent binary architectures reported from the current build.
 """,

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -170,6 +170,7 @@ def ios_application_test_suite(name = "ios_application"):
             "BINARY_PATHS": [
                 "Payload/app_with_imported_dynamic_fmwk_with_dsym.app/app_with_imported_dynamic_fmwk_with_dsym",
                 "Payload/app_with_imported_dynamic_fmwk_with_dsym.app/Frameworks/iOSDynamicFramework.framework/iOSDynamicFramework",
+                "Payload/app_with_imported_dynamic_fmwk_with_dsym.app/Frameworks/iOSDynamicFrameworkWithDebugInfo.framework/iOSDynamicFrameworkWithDebugInfo",
             ],
         },
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_dynamic_fmwk_with_dsym",

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -167,9 +167,12 @@ def ios_application_test_suite(name = "ios_application"):
         name = "{}_package_symbols_test".format(name),
         build_type = "simulator",
         env = {
-            "BINARY_PATHS": ["Payload/app.app/app"],
+            "BINARY_PATHS": [
+                "Payload/app_with_imported_dynamic_fmwk_with_dsym.app/app_with_imported_dynamic_fmwk_with_dsym",
+                "Payload/app_with_imported_dynamic_fmwk_with_dsym.app/Frameworks/iOSDynamicFramework.framework/iOSDynamicFramework",
+            ],
         },
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_dynamic_fmwk_with_dsym",
         verifier_script = "verifier_scripts/symbols_verifier.sh",
         tags = [
             name,

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -434,6 +434,28 @@ ios_application(
 )
 
 ios_application(
+    name = "app_with_imported_dynamic_fmwk_with_dsym",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+        "//test/testdata/frameworks:iOSImportedDynamicFrameworkWithDsym",
+    ],
+)
+
+ios_application(
     name = "app_with_swift_dep",
     bundle_id = "com.google.example",
     families = [

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -451,6 +451,7 @@ ios_application(
     ],
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
+        "//test/testdata/frameworks:iOSImportedDynamicFrameworkWithDebugInfo",
         "//test/testdata/frameworks:iOSImportedDynamicFrameworkWithDsym",
     ],
 )

--- a/test/testdata/frameworks/BUILD
+++ b/test/testdata/frameworks/BUILD
@@ -30,6 +30,11 @@ apple_dynamic_framework_import(
 )
 
 apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithDebugInfo",
+    framework_imports = [":iOSDynamicFrameworkWithDebugInfo"],
+)
+
+apple_dynamic_framework_import(
     name = "iOSImportedDynamicFrameworkWithDsym",
     dsym_imports = [":iOSDynamicFrameworkDsym"],
     framework_imports = [":iOSDynamicFramework"],
@@ -81,6 +86,15 @@ py_binary(
 generate_import_framework(
     name = "iOSDynamicFramework",
     archs = ["x86_64"],
+    libtype = "dynamic",
+    minimum_os_version = "11.0",
+    sdk = "iphonesimulator",
+)
+
+generate_import_framework(
+    name = "iOSDynamicFrameworkWithDebugInfo",
+    archs = ["x86_64"],
+    embed_debug_info = True,
     libtype = "dynamic",
     minimum_os_version = "11.0",
     sdk = "iphonesimulator",

--- a/test/testdata/frameworks/BUILD
+++ b/test/testdata/frameworks/BUILD
@@ -8,6 +8,10 @@ load(
     "//test/testdata/frameworks:generate_framework.bzl",
     "generate_import_framework",
 )
+load(
+    "//test/testdata/frameworks:generate_framework_dsym.bzl",
+    "generate_import_framework_dsym",
+)
 
 # Public only because these are used by the integration tests from generated
 # workspaces. Please no not depend on them as they can change at any time.
@@ -23,6 +27,12 @@ apple_dynamic_framework_import(
 apple_dynamic_framework_import(
     name = "iOSImportedDynamicFrameworkWithBitcode",
     framework_imports = [":iOSDynamicFrameworkWithBitcode"],
+)
+
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithDsym",
+    dsym_imports = [":iOSDynamicFrameworkDsym"],
+    framework_imports = [":iOSDynamicFramework"],
 )
 
 apple_static_framework_import(
@@ -57,6 +67,7 @@ filegroup(
         "BUILD",
         "generate_framework.bzl",
         "generate_framework.py",
+        "generate_framework_dsym.bzl",
     ],
 )
 
@@ -73,6 +84,11 @@ generate_import_framework(
     libtype = "dynamic",
     minimum_os_version = "11.0",
     sdk = "iphonesimulator",
+)
+
+generate_import_framework_dsym(
+    name = "iOSDynamicFrameworkDsym",
+    framework_imports = [":iOSDynamicFramework"],
 )
 
 generate_import_framework(

--- a/test/testdata/frameworks/generate_framework.bzl
+++ b/test/testdata/frameworks/generate_framework.bzl
@@ -26,6 +26,8 @@ def _generate_import_framework_impl(ctx):
     args.add("--libtype", ctx.attr.libtype)
     if ctx.attr.embed_bitcode:
         args.add("--embed_bitcode")
+    if ctx.attr.embed_debug_info:
+        args.add("--embed_debug_info")
     for arch in ctx.attr.archs:
         args.add("--arch", arch)
 
@@ -111,6 +113,13 @@ Determines if the framework will be built as a dynamic framework or a static fra
             default = False,
             doc = """
 Set to `True` to generate and embed bitcode in the final framework binary.
+""",
+        ),
+        "embed_debug_info": attr.bool(
+            default = False,
+            doc = """
+Set to `True` to generate and embed debug information in the framework
+binary.
 """,
         ),
         "_generate_framework": attr.label(

--- a/test/testdata/frameworks/generate_framework.py
+++ b/test/testdata/frameworks/generate_framework.py
@@ -45,7 +45,7 @@ def _version_arg_for_sdk(sdk, minimum_os_version):
 
 
 def _build_library_binary(archs, sdk, minimum_os_version, embed_bitcode,
-                          source_file, output_path):
+                          embed_debug_info, source_file, output_path):
   """Builds the library binary from a source file, writes to output_path."""
   output_lib = os.path.join(os.path.dirname(output_path),
                             os.path.basename(source_file) + ".o")
@@ -57,6 +57,9 @@ def _build_library_binary(archs, sdk, minimum_os_version, embed_bitcode,
 
   if embed_bitcode:
     library_cmd.append("-fembed-bitcode")
+
+  if embed_debug_info:
+    library_cmd.append("-g")
 
   # Append archs.
   for arch in archs:
@@ -105,10 +108,12 @@ def _generate_dynamic_cmd(name, sdk, minimum_os_version, framework_path, archs):
 
 
 def _build_framework_binary(name, sdk, minimum_os_version, framework_path,
-                            libtype, embed_bitcode, archs, source_file):
+                            libtype, embed_bitcode, embed_debug_info, archs,
+                            source_file):
   """Builds the framework binary from a source file, saves to framework_path."""
   output_lib = _build_library_binary(archs, sdk, minimum_os_version,
-                                     embed_bitcode, source_file, framework_path)
+                                     embed_bitcode, embed_debug_info,
+                                     source_file, framework_path)
 
   # Delete any existing framework files, if they are already there.
   if os.path.exists(framework_path):
@@ -253,6 +258,10 @@ def main():
       "bitcode in the final framework binary"
   )
   parser.add_argument(
+      "--embed_debug_info", action="store_true", default=False, help="embed "
+      "debug information in the framework binary"
+  )
+  parser.add_argument(
       "--framework_path", type=str, required=True, help="path to create the "
       "framework's contents in"
   )
@@ -275,7 +284,8 @@ def main():
                                         args.minimum_os_version,
                                         args.framework_path,
                                         args.libtype, args.embed_bitcode,
-                                        args.arch, args.source_file)
+                                        args.embed_debug_info, args.arch,
+                                        args.source_file)
   if status_code:
     return status_code
 

--- a/test/testdata/frameworks/generate_framework_dsym.bzl
+++ b/test/testdata/frameworks/generate_framework_dsym.bzl
@@ -1,0 +1,132 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules to generate dSYM bundle from given framework for testing."""
+
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
+)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _dsym_info_plist_content(framework_name):
+    return """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.xcode.dsym.{}.framework.dSYM</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>dSYM</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+  </dict>
+</plist>
+""".format(framework_name)
+
+def _get_framework_binary_file(framework_imports, framework_binary_path):
+    for framework_import in framework_imports:
+        if framework_import.path == framework_binary_path:
+            return framework_import
+
+    fail("Framework must contain a binary named after the framework")
+
+def _generate_import_framework_dsym_impl(ctx):
+    framework_imports = ctx.files.framework_imports
+    framework_groups = group_files_by_directory(
+        framework_imports,
+        ["framework"],
+        attr = "framework_imports",
+    )
+
+    framework_dir = framework_groups.keys()[0]
+    framework_dir_name = paths.basename(framework_dir)
+    framework_name = paths.split_extension(framework_dir_name)[0]
+    framework_binary_path = paths.join(framework_dir, framework_name)
+
+    framework_binary = _get_framework_binary_file(
+        framework_imports,
+        framework_binary_path,
+    )
+    inputs = [framework_binary]
+
+    dsym_dir_name = framework_dir_name + ".dSYM"
+
+    # Generate dSYM bundle's DWARF binary
+    dsym_binary_file = ctx.actions.declare_file(
+        paths.join(
+            dsym_dir_name,
+            "Contents",
+            "Resources",
+            "DWARF",
+            framework_name,
+        ),
+    )
+    args = ctx.actions.args()
+    args.add("dsymutil")
+    args.add("--flat")
+    args.add("--out", dsym_binary_file)
+    args.add(framework_binary)
+    apple_support.run(
+        ctx,
+        inputs = inputs,
+        outputs = [dsym_binary_file],
+        executable = "/usr/bin/xcrun",
+        arguments = [args],
+        mnemonic = "GenerateImportedAppleFrameworkDsym",
+    )
+
+    # Write dSYM bundle's Info.plist
+    dsym_info_plist = ctx.actions.declare_file(
+        paths.join(dsym_dir_name, "Contents", "Info.plist")
+    )
+    ctx.actions.write(
+        content = _dsym_info_plist_content(framework_name),
+        output = dsym_info_plist,
+    )
+
+    outputs = [dsym_binary_file, dsym_info_plist]
+
+    return [
+        DefaultInfo(files = depset(outputs)),
+    ]
+
+generate_import_framework_dsym = rule(
+    implementation = _generate_import_framework_dsym_impl,
+    attrs = dicts.add(apple_support.action_required_attrs(), {
+        "framework_imports": attr.label_list(
+            allow_files = True,
+            doc = "The list of files under a `.framework` directory.",
+        ),
+    }),
+    fragments = ["apple"],
+    doc = """
+Generates a dSYM bundle from given framework for testing. NOTE: The generated
+dSYM's DWARF binary doesn't actually contain any debug symbol.
+""",
+)


### PR DESCRIPTION
This adds a new `dsym_imports` attribute to
`apple_dynamic_framework_import` rule, that will allow users to import
the dSYM bundle of the imported framework. This is currently only used
for generating and packaging `.symbols` files into the `.ipa` file for
submitting to the App Store.

Closes https://github.com/bazelbuild/rules_apple/issues/892.