### PR TITLE
Created a macro to replace the wrapper macros used to determine platform features from ctx in the Apple BUILD Rules today.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -83,6 +83,8 @@ def _ios_application_impl(ctx):
         "resources",
     ]
 
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
     # action, when available.
     # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
@@ -107,14 +109,19 @@ def _ios_application_impl(ctx):
         partials.app_assets_validation_partial(
             app_icons = ctx.files.app_icons,
             launch_images = ctx.files.launch_images,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = embeddable_targets,
+            label_name = ctx.label.name,
             package_bitcode = True,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
         partials.debug_symbols_partial(
@@ -191,6 +198,8 @@ def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
     # TODO(kaipi): Add support for packaging headers.
 
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
     # action, when available.
     # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
@@ -211,9 +220,12 @@ def _ios_framework_impl(ctx):
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = ctx.attr.frameworks,
+            label_name = ctx.label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         # TODO(kaipi): Check if clang_rt dylibs are needed in Frameworks, or if
         # the can be skipped.
@@ -259,6 +271,8 @@ def _ios_extension_impl(ctx):
         "strings",
     ]
 
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
     # action, when available.
     # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
@@ -271,13 +285,18 @@ def _ios_extension_impl(ctx):
     processor_partials = [
         partials.app_assets_validation_partial(
             app_icons = ctx.files.app_icons,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = ctx.attr.frameworks,
+            label_name = ctx.label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
         partials.debug_symbols_partial(
@@ -362,13 +381,14 @@ def _ios_static_framework_impl(ctx):
 
 def _ios_imessage_application_impl(ctx):
     """Experimental implementation of ios_imessage_application."""
-    rule_descriptor = rule_support.rule_descriptor(ctx)
-
     top_level_attrs = [
         "app_icons",
         "strings",
         "resources",
     ]
+
+    rule_descriptor = rule_support.rule_descriptor(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
 
     binary_artifact = stub_support.create_stub_binary(
         ctx,
@@ -383,6 +403,8 @@ def _ios_imessage_application_impl(ctx):
     processor_partials = [
         partials.app_assets_validation_partial(
             app_icons = ctx.files.app_icons,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
@@ -431,6 +453,8 @@ def _ios_imessage_extension_impl(ctx):
         "resources",
     ]
 
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     binary_descriptor = linking_support.register_linking_action(ctx)
     binary_artifact = binary_descriptor.artifact
     debug_outputs_provider = binary_descriptor.debug_outputs_provider
@@ -442,13 +466,18 @@ def _ios_imessage_extension_impl(ctx):
         # sticker_assets as a top level attribute.
         partials.app_assets_validation_partial(
             app_icons = ctx.files.app_icons,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
+            label_name = ctx.label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
         partials.debug_symbols_partial(
@@ -489,13 +518,14 @@ def _ios_imessage_extension_impl(ctx):
 
 def _ios_sticker_pack_extension_impl(ctx):
     """Experimental implementation of ios_sticker_pack_extension."""
-    rule_descriptor = rule_support.rule_descriptor(ctx)
-
     top_level_attrs = [
         "sticker_assets",
         "strings",
         "resources",
     ]
+
+    rule_descriptor = rule_support.rule_descriptor(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
 
     binary_artifact = stub_support.create_stub_binary(
         ctx,
@@ -509,6 +539,8 @@ def _ios_sticker_pack_extension_impl(ctx):
         # sticker_assets as a top level attribute.
         partials.app_assets_validation_partial(
             app_icons = ctx.files.sticker_assets,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -51,26 +51,33 @@ def _families(ctx):
     rule_descriptor = rule_support.rule_descriptor(ctx)
     return getattr(ctx.attr, "families", rule_descriptor.allowed_device_families)
 
-def _ui_device_family_plist_value(ctx):
+def _ui_device_family_plist_value(ctx = None, *, platform_prerequisites = None):
     """Returns the value to use for `UIDeviceFamily` in an info.plist.
 
     This function returns the array of value to use or None if there should be
     no plist entry (currently, only macOS doesn't use UIDeviceFamily).
 
     Args:
-      ctx: The Starlark context.
+      ctx: The Starlark context. Deprecated.
+      platform_prerequisites: The platform prerequisites.
 
     Returns:
       A list of integers to use for the `UIDeviceFamily` in an Info.plist
       or None if the key should not be added to the Info.plist.
     """
-    families = []
-    for f in _families(ctx):
+    family_ids = []
+
+    if platform_prerequisites:
+        families = platform_prerequisites.families
+    else:
+        families = _families(ctx)
+
+    for f in families:
         number = _DEVICE_FAMILY_VALUES[f]
         if number:
-            families.append(number)
-    if families:
-        return families
+            family_ids.append(number)
+    if family_ids:
+        return family_ids
     return None
 
 def _is_device_build(ctx):
@@ -84,6 +91,67 @@ def _is_device_build(ctx):
     """
     platform = _platform(ctx)
     return platform.is_device
+
+def _platform_prerequisites(
+        *,
+        apple_fragment,
+        device_families,
+        explicit_minimum_os = None,
+        platform_type_string,
+        xcode_version_config):
+    """Returns a struct containing information on the platform being targeted.
+
+    Args:
+      apple_fragment: An Apple fragment (ctx.fragments.apple).
+      device_families: The list of device families that apply to the target being built.
+      explicit_minimum_os: A dotted version string indicating minimum OS desired. Optional.
+      platform_type_string: The platform type for the current target as a string.
+      xcode_version_config: The `apple_common.XcodeVersionConfig` provider from the current context.
+
+    Returns:
+      A struct representing the collected platform information.
+    """
+    platform_type_attr = getattr(apple_common.platform_type, platform_type_string)
+    platform = apple_fragment.multi_arch_platform(platform_type_attr)
+
+    if explicit_minimum_os:
+        minimum_os = explicit_minimum_os
+    else:
+        minimum_os = xcode_version_config.minimum_os_for_platform_type(platform_type_attr)
+
+    sdk_version = xcode_version_config.sdk_version_for_platform(platform)
+
+    return struct(
+        apple_fragment = apple_fragment,
+        device_families = device_families,
+        minimum_os = minimum_os,
+        platform = platform,
+        platform_type = platform_type_attr,
+        sdk_version = sdk_version,
+        xcode_version_config = xcode_version_config,
+    )
+
+def _platform_prerequisites_from_rule_ctx(ctx):
+    """Returns a struct containing information on the platform being targeted from a rule context.
+
+    Args:
+      ctx: The Starlark context for a rule.
+
+    Returns:
+      A struct representing the default collected platform information for that rule context.
+    """
+    device_families = getattr(ctx.attr, "families", None)
+    if not device_families:
+        rule_descriptor = rule_support.rule_descriptor(ctx)
+        device_families = rule_descriptor.allowed_device_families
+
+    return _platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        device_families = device_families,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        platform_type_string = ctx.attr.platform_type,
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
 
 def _minimum_os(ctx):
     """Returns the minimum OS version required for the current target.
@@ -149,6 +217,8 @@ platform_support = struct(
     minimum_os = _minimum_os,
     platform = _platform,
     platform_and_sdk_version = _platform_and_sdk_version,
+    platform_prerequisites = _platform_prerequisites,
+    platform_prerequisites_from_rule_ctx = _platform_prerequisites_from_rule_ctx,
     platform_type = _platform_type,
     ui_device_family_plist_value = _ui_device_family_plist_value,
 )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -472,7 +472,10 @@ def _process(ctx, partials, bundle_post_process_and_sign = True):
       the rule are contained under the `output_files` field, and the providers to
       return are contained under the `providers` field.
     """
-    partial_outputs = [partial.call(p, ctx) for p in partials]
+
+    # TODO(b/161370390): Remove the ctx kwarg passed to this call once ctx is removed from the args
+    # of all of the partials.
+    partial_outputs = [partial.call(p, ctx = ctx) for p in partials]
 
     if bundle_post_process_and_sign:
         output_archive = outputs.archive(ctx)

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -68,13 +68,14 @@ load(
 
 def _tvos_application_impl(ctx):
     """Experimental implementation of tvos_application."""
-
     top_level_attrs = [
         "app_icons",
         "launch_images",
         "strings",
         "resources",
     ]
+
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
 
     binary_descriptor = linking_support.register_linking_action(ctx)
     binary_artifact = binary_descriptor.artifact
@@ -89,14 +90,19 @@ def _tvos_application_impl(ctx):
         partials.app_assets_validation_partial(
             app_icons = ctx.files.app_icons,
             launch_images = ctx.files.launch_images,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
         ),
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = debug_outputs_provider,
             dependency_targets = embeddable_targets,
+            label_name = ctx.label.name,
             package_bitcode = True,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
         partials.debug_symbols_partial(
@@ -156,6 +162,8 @@ def _tvos_application_impl(ctx):
 
 def _tvos_framework_impl(ctx):
     """Experimental implementation of tvos_framework."""
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     binary_descriptor = linking_support.register_linking_action(ctx)
     binary_artifact = binary_descriptor.artifact
     binary_provider = binary_descriptor.provider
@@ -174,9 +182,12 @@ def _tvos_framework_impl(ctx):
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
+            label_name = ctx.label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         # TODO(kaipi): Check if clang_rt dylibs are needed in Frameworks, or if
         # the can be skipped.
@@ -221,6 +232,8 @@ def _tvos_extension_impl(ctx):
         "resources",
     ]
 
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
     binary_descriptor = linking_support.register_linking_action(ctx)
     binary_artifact = binary_descriptor.artifact
     debug_outputs_provider = binary_descriptor.debug_outputs_provider
@@ -231,9 +244,12 @@ def _tvos_extension_impl(ctx):
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.bitcode_symbols_partial(
+            actions = ctx.actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
+            label_name = ctx.label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
         partials.debug_symbols_partial(
@@ -276,6 +292,8 @@ def _tvos_extension_impl(ctx):
 
 def _tvos_static_framework_impl(ctx):
     """Implementation of tvos_static_framework."""
+
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
 
     # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
     # action, when available.


### PR DESCRIPTION
Migrated app_assets_validation partial and bitcode_symbols partial to use that new macro instead of ctx, passing the rest of the inputs through as arguments that were previously obtained through directly accessing ctx.

PiperOrigin-RevId: 330988093