### PR TITLE
Include a few directory entries for some Xcode workflows.

### DIFF
--- a/tools/bundletool/process_and_sign.sh.template
+++ b/tools/bundletool/process_and_sign.sh.template
@@ -46,11 +46,19 @@ pushd "$WORK_DIR" >/dev/null
 # Ensure that the entries in the ZIP are writable when expanded, because some
 # tools rely on the ability to unzip it, modify it, and re-sign it.
 chmod -R u+w .
-# Fix the time stamps (this only does files, not directories or symlinks).
-( TZ=UTC find . -type f -exec touch -h -t 198001010000 {} \+ )
-# Avoid zip -r and feed just the files (not symlinks) in a stable order so the
-# zip is smaller and deterministic.
-find . -type f \
+# Fix the timestamps (depth first so the directory is update after the files in
+# it so updating files doesn't update the directory).
+TZ=UTC find . -depth -exec touch -h -t 198001010000 {} \+
+# Avoid zip -r and feed the things in to zip in a deterministic order (not
+# directory order) to ensure a stable result. To keep the file smaller, only the
+# files should be needed, but it appears that atleast Xcode drag/drop install on
+# devices can fail for iPhones if there isn't an entry for the App bundles, so
+# include directories with and Info.plist or Contents/Info.plist since they will
+# also be bundles.
+(
+  find . -type f && \
+  find . -path "*/Info.plist" | sed -E 's|(/Contents)?/Info.plist$||g' \
+) \
   | sort \
   | zip -qX "-@" --compression-method "$COMPRESSION_METHOD" "$OUTPUT_BASENAME"
 popd >/dev/null


### PR DESCRIPTION
Xcode seems to check the ipa (zip) directly for some things, so keep a subset of the directory entries that seem to be bundle root directories.

RELNOTES: None
PiperOrigin-RevId: 331197271