### PR TITLE
Add support for App Clips to rules.

### DIFF
--- a/apple/internal/apple_product_type.bzl
+++ b/apple/internal/apple_product_type.bzl
@@ -85,6 +85,7 @@ type of rule being created and thus its descriptor to control behaviors.
 #   have the extension `.xpc`.
 apple_product_type = struct(
     application = "com.apple.product-type.application",
+    app_clip = "com.apple.product-type.application.on-demand-install-capable",
     app_extension = "com.apple.product-type.app-extension",
     bundle = "com.apple.product-type.bundle",
     dylib = "com.apple.product-type.library.dynamic",

--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -74,6 +74,7 @@ def _create_swift_runtime_linkopts_target(
 def _add_entitlements_and_swift_linkopts(
         name,
         platform_type,
+        product_type,
         include_entitlements = True,
         is_stub = False,
         link_swift_statically = False,
@@ -93,6 +94,7 @@ def _add_entitlements_and_swift_linkopts(
       name: The name of the bundle target, from which the targets' names
           will be derived.
       platform_type: The platform type of the bundle.
+      product_type: The product type of the bundle.
       include_entitlements: True/False, indicates whether to include an entitlements target.
           Defaults to True.
       is_stub: True/False, indicates whether the function is being called for a bundle that uses a
@@ -121,6 +123,7 @@ def _add_entitlements_and_swift_linkopts(
             bundle_id = bundling_args.get("bundle_id"),
             entitlements = entitlements_value,
             platform_type = platform_type,
+            product_type = product_type,
             provisioning_profile = provisioning_profile,
             tags = tags,
             testonly = testonly,
@@ -270,6 +273,7 @@ def _create_binary(
             bundle_id = kwargs.get("bundle_id"),
             entitlements = entitlements_value,
             platform_type = platform_type,
+            product_type = product_type,
             provisioning_profile = provisioning_profile,
             testonly = testonly,
             validation_mode = kwargs.get("entitlements_validation"),

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -429,7 +429,7 @@ def _post_process_and_sign_archive_action(
     process_and_sign_template = intermediates.file(
         ctx.actions,
         ctx.label.name,
-        "process-and-sign.sh",
+        "process-and-sign-%s.sh" % hash(output_archive.path),
     )
     ctx.actions.expand_template(
         template = ctx.file._process_and_sign_template,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -64,6 +64,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "IosAppClipBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
@@ -94,7 +95,7 @@ def _ios_application_impl(ctx):
 
     bundle_id = ctx.attr.bundle_id
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
-    embeddable_targets = ctx.attr.frameworks + ctx.attr.extensions
+    embeddable_targets = ctx.attr.frameworks + ctx.attr.extensions + ctx.attr.app_clips
     if ctx.attr.watch_application:
         embeddable_targets.append(ctx.attr.watch_application)
 
@@ -194,6 +195,101 @@ def _ios_application_impl(ctx):
         binary_target[apple_common.AppleExecutableBinary],
     ] + processor_result.providers
 
+def _ios_app_clip_impl(ctx):
+    """Experimental implementation of ios_app_clip."""
+    top_level_attrs = [
+        "app_icons",
+        "launch_storyboard",
+        "strings",
+        "resources",
+    ]
+
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+
+    # TODO: Replace the debug_outputs_provider with the provider returned from the linking
+    # action, when available.
+    # TODO: Extract this into a common location to be reused and refactored later when we
+    # add linking support directly into the rule.
+    binary_target = ctx.attr.deps[0]
+    binary_artifact = binary_target[apple_common.AppleExecutableBinary].binary
+
+    bundle_id = ctx.attr.bundle_id
+    embeddable_targets = ctx.attr.frameworks
+    rule_descriptor = rule_support.rule_descriptor(ctx)
+
+    processor_partials = [
+        partials.app_assets_validation_partial(
+            app_icons = ctx.files.app_icons,
+            platform_prerequisites = platform_prerequisites,
+            product_type = ctx.attr._product_type,
+        ),
+        partials.apple_bundle_info_partial(bundle_id = bundle_id),
+        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.bitcode_symbols_partial(
+            actions = ctx.actions,
+            binary_artifact = binary_artifact,
+            debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
+            dependency_targets = embeddable_targets,
+            label_name = ctx.label.name,
+            package_bitcode = True,
+            platform_prerequisites = platform_prerequisites,
+        ),
+        partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
+        partials.debug_symbols_partial(
+            debug_dependencies = embeddable_targets,
+            debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
+        ),
+        partials.embedded_bundles_partial(
+            app_clips = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            bundle_embedded_bundles = True,
+            embeddable_targets = embeddable_targets,
+        ),
+        partials.framework_import_partial(
+            targets = ctx.attr.deps + ctx.attr.frameworks,
+        ),
+        partials.resources_partial(
+            bundle_id = bundle_id,
+            plist_attrs = ["infoplists"],
+            targets_to_avoid = ctx.attr.frameworks,
+            top_level_attrs = top_level_attrs,
+        ),
+        partials.swift_dylibs_partial(
+            binary_artifact = binary_artifact,
+            dependency_targets = embeddable_targets,
+            bundle_dylibs = True,
+            package_swift_support_if_needed = True,
+        ),
+    ]
+
+    if platform_support.is_device_build(ctx):
+        processor_partials.append(
+            partials.provisioning_profile_partial(profile_artifact = ctx.file.provisioning_profile),
+        )
+
+    processor_result = processor.process(ctx, processor_partials)
+
+    executable = outputs.executable(ctx)
+    run_support.register_simulator_executable(ctx, executable)
+
+    return [
+        # TODO(b/121155041): Should we do the same for ios_framework?
+        coverage_common.instrumented_files_info(ctx, dependency_attributes = ["deps"]),
+        DefaultInfo(
+            executable = executable,
+            files = processor_result.output_files,
+            runfiles = ctx.runfiles(
+                files = [
+                    outputs.archive(ctx),
+                    ctx.file._std_redirect_dylib,
+                ],
+            ),
+        ),
+        IosAppClipBundleInfo(),
+        # Propagate the binary provider so that this target can be used as bundle_loader in test
+        # rules.
+        binary_target[apple_common.AppleExecutableBinary],
+    ] + processor_result.providers
+
 def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
     # TODO(kaipi): Add support for packaging headers.
@@ -210,8 +306,8 @@ def _ios_framework_impl(ctx):
     bundle_id = ctx.attr.bundle_id
 
     signed_frameworks = []
+    rule_descriptor = rule_support.rule_descriptor(ctx)
     if getattr(ctx.file, "provisioning_profile", None):
-        rule_descriptor = rule_support.rule_descriptor(ctx)
         signed_frameworks = [
             bundling_support.bundle_name(ctx) + rule_descriptor.bundle_extension,
         ]
@@ -235,7 +331,7 @@ def _ios_framework_impl(ctx):
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
         ),
         partials.embedded_bundles_partial(
-            frameworks = [outputs.archive(ctx)],
+            frameworks = [outputs.archive_for_embedding(ctx, rule_descriptor)],
             embeddable_targets = ctx.attr.frameworks,
             signed_frameworks = depset(signed_frameworks),
         ),
@@ -281,6 +377,7 @@ def _ios_extension_impl(ctx):
     binary_artifact = binary_target[apple_common.AppleExecutableBinary].binary
 
     bundle_id = ctx.attr.bundle_id
+    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -304,7 +401,7 @@ def _ios_extension_impl(ctx):
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
         ),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive(ctx)],
+            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = True),
@@ -460,6 +557,7 @@ def _ios_imessage_extension_impl(ctx):
     debug_outputs_provider = binary_descriptor.debug_outputs_provider
 
     bundle_id = ctx.attr.bundle_id
+    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     processor_partials = [
         # TODO(kaipi): Refactor this partial into a more generic interface to account for
@@ -485,7 +583,7 @@ def _ios_imessage_extension_impl(ctx):
             debug_outputs_provider = debug_outputs_provider,
         ),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive(ctx)],
+            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = True),
@@ -545,7 +643,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         partials.apple_bundle_info_partial(bundle_id = bundle_id),
         partials.binary_partial(binary_artifact = binary_artifact),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive(ctx)],
+            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,
@@ -579,6 +677,13 @@ ios_application = rule_factory.create_apple_bundling_rule(
     platform_type = "ios",
     product_type = apple_product_type.application,
     doc = "Builds and bundles an iOS Application.",
+)
+
+ios_app_clip = rule_factory.create_apple_bundling_rule(
+    implementation = _ios_app_clip_impl,
+    platform_type = "ios",
+    product_type = apple_product_type.app_clip,
+    doc = "Builds and bundles an iOS App Clip.",
 )
 
 ios_extension = rule_factory.create_apple_bundling_rule(

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -47,6 +47,13 @@ def _archive(ctx):
     # DefaultInfo.
     return ctx.outputs.archive
 
+def _archive_for_embedding(ctx, rule_descriptor):
+    """Returns a files reference for this target's archive, when embedded in another target."""
+    if _has_different_embedding_archive(ctx, rule_descriptor):
+        return ctx.actions.declare_file("%s.embedding.zip" % ctx.label.name)
+    else:
+        return _archive(ctx)
+
 def _archive_root_path(ctx):
     """Returns the path to a directory reference for this target's archive root."""
 
@@ -70,10 +77,19 @@ def _infoplist(ctx):
     """Returns a file reference for this target's Info.plist file."""
     return intermediates.file(ctx.actions, ctx.label.name, "Info.plist")
 
+def _has_different_embedding_archive(ctx, rule_descriptor):
+    """Returns True if this target exposes a different archive when embedded in another target."""
+    if is_experimental_tree_artifact_enabled(ctx):
+        return False
+
+    return rule_descriptor.bundle_locations.archive_relative != "" and rule_descriptor.expose_non_archive_relative_output
+
 outputs = struct(
     archive = _archive,
+    archive_for_embedding = _archive_for_embedding,
     archive_root_path = _archive_root_path,
     binary = _binary,
     executable = _executable,
     infoplist = _infoplist,
+    has_different_embedding_archive = _has_different_embedding_archive,
 )

--- a/apple/internal/partials/embedded_bundles.bzl
+++ b/apple/internal/partials/embedded_bundles.bzl
@@ -32,6 +32,9 @@ _AppleEmbeddableInfo = provider(
 Private provider used to propagate the different embeddable bundles that a
 top-level bundling rule will need to package.""",
     fields = {
+        "app_clips": """
+A depset with the zipped archives of bundles that need to be expanded into the
+AppClips section of the packaging bundle.""",
         "frameworks": """
 A depset with the zipped archives of bundles that need to be expanded into the
 Frameworks section of the packaging bundle.""",
@@ -67,6 +70,7 @@ def _embedded_bundles_partial_impl(
 
     # Map of embedded bundle type to their final location in the top-level bundle.
     bundle_type_to_location = {
+        "app_clips": processor.location.app_clip,
         "frameworks": processor.location.framework,
         "plugins": processor.location.plugin,
         "watch_bundles": processor.location.watch,
@@ -157,6 +161,7 @@ def _embedded_bundles_partial_impl(
     )
 
 def embedded_bundles_partial(
+        app_clips = [],
         bundle_embedded_bundles = False,
         embeddable_targets = [],
         frameworks = [],
@@ -172,6 +177,8 @@ def embedded_bundles_partial(
     ios_application.
 
     Args:
+        app_clips: List of plugin bundles that should be propagated downstream for a top level
+            target to bundle inside `AppClips`.
         bundle_embedded_bundles: If True, this target will embed all transitive embeddable_bundles
             _only_ propagated through the targets given in embeddable_targets. If False, the
             embeddable bundles will be propagated downstream for a top level target to bundle them.
@@ -193,6 +200,7 @@ def embedded_bundles_partial(
     """
     return partial.make(
         _embedded_bundles_partial_impl,
+        app_clips = app_clips,
         bundle_embedded_bundles = bundle_embedded_bundles,
         embeddable_targets = embeddable_targets,
         frameworks = frameworks,

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -247,6 +247,7 @@ def _bundle_partial_outputs_files(
       output_file: The file where the final zipped bundle should be created.
       codesigning_command: When building tree artifact outputs, the command to codesign the output
           bundle.
+      embedding: Whether outputs are being bundled to be embedded.
       extra_input_files: Extra files to include in the bundling action.
     """
     rule_descriptor = rule_support.rule_descriptor(ctx)

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -60,6 +60,7 @@ load(
     "AppleBundleVersionInfo",
     "AppleResourceBundleInfo",
     "AppleTestRunnerInfo",
+    "IosAppClipBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
     "IosFrameworkBundleInfo",
@@ -595,6 +596,12 @@ fashion, such as a Cocoapod.
         })
     elif rule_descriptor.product_type == apple_product_type.application:
         attrs.append({
+            "app_clips": attr.label_list(
+                providers = [[AppleBundleInfo, IosAppClipBundleInfo]],
+                doc = """
+A list of iOS app clips to include in the final application bundle.
+""",
+            ),
             "extensions": attr.label_list(
                 providers = [[AppleBundleInfo, IosExtensionBundleInfo]],
                 doc = """
@@ -615,6 +622,18 @@ Info.plist under the key `UILaunchStoryboardName`.
                 doc = """
 A `watchos_application` target that represents an Apple Watch application that should be embedded in
 the application bundle.
+""",
+            ),
+        })
+    elif rule_descriptor.product_type == apple_product_type.app_clip:
+        attrs.append({
+            "launch_storyboard": attr.label(
+                allow_single_file = [".storyboard", ".xib"],
+                doc = """
+The `.storyboard` or `.xib` file that should be used as the launch screen for the app clip. The
+provided file will be compiled into the appropriate format (`.storyboardc` or `.nib`) and placed in
+the root of the final bundle. The generated file will also be registered in the bundle's
+Info.plist under the key `UILaunchStoryboardName`.
 """,
             ),
         })
@@ -642,7 +661,8 @@ the application bundle.
     # _common_binary_linking_attrs().
     if rule_descriptor.requires_deps:
         extra_args = {}
-        if rule_descriptor.product_type == apple_product_type.application:
+        if (rule_descriptor.product_type == apple_product_type.application or
+            rule_descriptor.product_type == apple_product_type.app_clip):
             extra_args["aspects"] = [framework_import_aspect]
 
         attrs.append({

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -50,6 +50,7 @@ _CODESIGNING_EXCEPTIONS = struct(
 def _describe_bundle_locations(
         archive_relative = "",
         bundle_relative_contents = "",
+        contents_relative_app_clips = "AppClips",
         contents_relative_binary = "",
         contents_relative_frameworks = "Frameworks",
         contents_relative_plugins = "PlugIns",
@@ -60,6 +61,7 @@ def _describe_bundle_locations(
     return struct(
         archive_relative = archive_relative,
         bundle_relative_contents = bundle_relative_contents,
+        contents_relative_app_clips = contents_relative_app_clips,
         contents_relative_binary = contents_relative_binary,
         contents_relative_frameworks = contents_relative_frameworks,
         contents_relative_plugins = contents_relative_plugins,
@@ -85,6 +87,7 @@ def _describe_rule_type(
         default_test_runner = None,
         deps_cfg = None,
         extra_linkopts = [],
+        expose_non_archive_relative_output = False,
         force_transition_allowlist = False,
         has_infoplist = True,
         has_launch_images = False,
@@ -130,6 +133,9 @@ def _describe_rule_type(
         deps_cfg: The configuration for the deps attribute. This should be None for rules that use
             the apple_binary intermediate target, and apple_common.multi_arch_split for the rules
             that use the Starlark linking API.
+        expose_non_archive_relative_output: Whether or not to expose an output archive that ignores
+            the `archive_relative` bundle location, to permit embedding within another target. Has no
+            effect if `archive_relative` is empty.
         extra_linkopts: Extra options to pass to the linker.
         force_transition_allowlist: Whether to force a dependency on the transition allowlist.
         has_infoplist: Whether the rule should place an Info.plist file at the root of the bundle.
@@ -179,6 +185,7 @@ def _describe_rule_type(
         default_infoplist = default_infoplist,
         default_test_runner = default_test_runner,
         deps_cfg = deps_cfg,
+        expose_non_archive_relative_output = expose_non_archive_relative_output,
         extra_linkopts = extra_linkopts,
         force_transition_allowlist = force_transition_allowlist,
         has_infoplist = has_infoplist,
@@ -228,6 +235,26 @@ _RULE_TYPE_DESCRIPTORS = {
             rpaths = [
                 # Application binaries live in Application.app/Application
                 # Frameworks are packaged in Application.app/Frameworks
+                "@executable_path/Frameworks",
+            ],
+        ),
+        # ios_app_clip
+        apple_product_type.app_clip: _describe_rule_type(
+            allowed_device_families = ["iphone", "ipad"],
+            allows_locale_trimming = True,
+            app_icon_parent_extension = ".xcassets",
+            app_icon_extension = ".appiconset",
+            archive_extension = ".ipa",
+            bundle_extension = ".app",
+            bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
+            expose_non_archive_relative_output = True,
+            is_executable = True,
+            mandatory_families = True,
+            product_type = apple_product_type.app_clip,
+            requires_pkginfo = True,
+            rpaths = [
+                # AppClip binary located at AppClip.app/AppClip
+                # Frameworks are packaged in AppClip.app/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -246,6 +246,7 @@ _RULE_TYPE_DESCRIPTORS = {
             app_icon_extension = ".appiconset",
             archive_extension = ".ipa",
             bundle_extension = ".app",
+            bundle_package_type = bundle_package_type.application,
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
             expose_non_archive_relative_output = True,
             is_executable = True,

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -15,6 +15,10 @@
 """Helper methods for assembling the test targets."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -98,6 +102,7 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         test_bundle_name,
         bundle_name = name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.unit_test_bundle,
         is_test = True,
         include_entitlements = False,
         testonly = True,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -39,6 +39,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
+    _ios_app_clip = "ios_app_clip",
     _ios_application = "ios_application",
     _ios_extension = "ios_extension",
     _ios_framework = "ios_framework",
@@ -58,6 +59,20 @@ def ios_application(name, **kwargs):
     )
 
     _ios_application(
+        name = name,
+        **bundling_args
+    )
+
+def ios_app_clip(name, **kwargs):
+    """Builds and bundles an iOS app clip."""
+    bundling_args = binary_support.create_binary(
+        name,
+        str(apple_common.platform_type.ios),
+        apple_product_type.app_clip,
+        **kwargs
+    )
+
+    _ios_app_clip(
         name = name,
         **bundling_args
     )
@@ -144,6 +159,7 @@ def ios_imessage_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_application,
         is_stub = True,
         **kwargs
     )
@@ -159,6 +175,7 @@ def ios_sticker_pack_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_sticker_pack_extension,
         is_stub = True,
         **kwargs
     )
@@ -174,6 +191,7 @@ def ios_imessage_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.ios),
+        product_type = apple_product_type.messages_extension,
         **kwargs
     )
 

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -30,6 +30,10 @@ load(
     _macos_unit_test = "macos_unit_test",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -61,6 +65,7 @@ def macos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.application,
         features = features,
         **binary_args
     )
@@ -80,6 +85,7 @@ def macos_bundle(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.bundle,
         features = features,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -98,6 +104,7 @@ def macos_quick_look_plugin(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.quicklook_plugin,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -118,6 +125,7 @@ def macos_kernel_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.kernel_extension,
         features = features,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
@@ -133,6 +141,7 @@ def macos_spotlight_importer(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.spotlight_importer,
         **kwargs
     )
 
@@ -148,6 +157,7 @@ def macos_xpc_service(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.xpc_service,
         **binary_args
     )
 
@@ -207,6 +217,7 @@ def macos_command_line_application(name, **kwargs):
     cmd_line_app_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.tool,
         link_swift_statically = True,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
@@ -260,6 +271,7 @@ def macos_dylib(name, **kwargs):
     dylib_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.dylib,
         link_swift_statically = True,
         include_entitlements = False,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
@@ -283,6 +295,7 @@ def macos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.macos),
+        product_type = apple_product_type.app_extension,
         features = features,
         **binary_args
     )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -266,6 +266,17 @@ requirement.
 """,
 )
 
+IosAppClipBundleInfo = provider(
+    doc = """
+Denotes that a target is an iOS app clip.
+
+This provider does not contain any fields of its own at this time but is used as
+a "marker" to indicate that a target is specifically an iOS app clip bundle (and
+not some other Apple bundle). Rule authors who wish to require that a dependency
+is an iOS app clip should use this provider to describe that requirement.
+""",
+)
+
 IosExtensionBundleInfo = provider(
     doc = """
 Denotes that a target is an iOS application extension.

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -30,6 +30,10 @@ load(
     _tvos_unit_test = "tvos_unit_test",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -46,6 +50,7 @@ def tvos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.application,
         **kwargs
     )
 
@@ -60,6 +65,7 @@ def tvos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.app_extension,
         **kwargs
     )
 
@@ -85,6 +91,7 @@ def tvos_framework(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.tvos),
+        product_type = apple_product_type.framework,
         exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
         **binary_args
     )

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -19,6 +19,10 @@ load(
     "apple_build_test_rule",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:binary_support.bzl",
     "binary_support",
 )
@@ -37,6 +41,7 @@ def watchos_application(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.watchos),
+        product_type = apple_product_type.application,
         is_stub = True,
         **kwargs
     )
@@ -51,6 +56,7 @@ def watchos_extension(name, **kwargs):
     bundling_args = binary_support.add_entitlements_and_swift_linkopts(
         name,
         platform_type = str(apple_common.platform_type.watchos),
+        product_type = apple_product_type.app_extension,
         **kwargs
     )
 

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -3,6 +3,7 @@ load(":apple_bundle_version_tests.bzl", "apple_bundle_version_test_suite")
 load(":dtrace_compile_tests.bzl", "dtrace_compile_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
+load(":ios_app_clip_tests.bzl", "ios_app_clip_test_suite")
 load(":ios_extension_tests.bzl", "ios_extension_test_suite")
 load(":ios_framework_tests.bzl", "ios_framework_test_suite")
 load(":ios_imessage_application_tests.bzl", "ios_imessage_application_test_suite")
@@ -39,6 +40,8 @@ dtrace_compile_test_suite()
 ios_application_resources_test_suite()
 
 ios_application_test_suite()
+
+ios_app_clip_test_suite()
 
 ios_extension_test_suite()
 

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -1,0 +1,129 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ios_app_clip Starlark tests."""
+
+load(
+    ":rules/apple_verification_test.bzl",
+    "apple_verification_test",
+)
+load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+    "bitcode_symbol_map_test",
+)
+load(
+    ":rules/linkmap_test.bzl",
+    "linkmap_test",
+)
+
+def ios_app_clip_test_suite():
+    """Test suite for ios_app_clip."""
+    name = "ios_app_clip"
+
+    # Tests that app clip is codesigned when built as a standalone app
+    apple_verification_test(
+        name = "{}_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        verifier_script = "verifier_scripts/app_clip_codesign_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that app clip entitlements are added when built for simulator.
+    apple_verification_test(
+        name = "{}_app_clip_entitlements_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        verifier_script = "verifier_scripts/app_clip_entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that app clip entitlements are added when built for device.
+    apple_verification_test(
+        name = "{}_app_clip_entitlements_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        verifier_script = "verifier_scripts/app_clip_entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that entitlements are present when specified and built for simulator.
+    apple_verification_test(
+        name = "{}_entitlements_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that entitlements are present when specified and built for device.
+    apple_verification_test(
+        name = "{}_entitlements_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that the archive contains Bitcode symbol maps when Bitcode is
+    # enabled.
+    bitcode_symbol_map_test(
+        name = "{}_archive_contains_bitcode_symbol_maps_test".format(name),
+        binary_paths = [
+            "Payload/app_with_app_clip.app/app_with_app_clip",
+            "Payload/app_with_app_clip.app/AppClips/app_clip.app/app_clip",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_app_clip",
+        tags = [name],
+    )
+
+    # Tests that the linkmap outputs are produced when `--objc_generate_linkmap`
+    # is present.
+    linkmap_test(
+        name = "{}_linkmap_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        tags = [
+            name,
+            # OSS Blocked by b/73547215
+            "manual",  # disabled in oss
+        ],
+    )
+
+    # Tests that the provisioning profile is present when built for device.
+    archive_contents_test(
+        name = "{}_contains_provisioning_profile_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        contains = [
+            "$BUNDLE_ROOT/embedded.mobileprovision",
+        ],
+        tags = [name],
+    )
+
+    # Tests that the provisioning profile is present when built for device and embedded in an app.
+    archive_contents_test(
+        name = "{}_embedding_provisioning_profile_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_app_clip",
+        contains = [
+            "$BUNDLE_ROOT/AppClips/app_clip.app/embedded.mobileprovision",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -28,9 +28,12 @@ load(
     "linkmap_test",
 )
 
-def ios_app_clip_test_suite():
-    """Test suite for ios_app_clip."""
-    name = "ios_app_clip"
+def ios_app_clip_test_suite(name = "ios_app_clip"):
+    """Test suite for ios_app_clip.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # Tests that app clip is codesigned when built as a standalone app
     apple_verification_test(

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -99,6 +99,7 @@ def _apple_verification_test_impl(ctx):
             "tvos",
         ] and bundle_info.product_type in [
             apple_product_type.application,
+            apple_product_type.app_clip,
             apple_product_type.messages_application,
         ]:
             archive_relative_bundle = paths.join("Payload", bundle_with_extension)

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
+    "ios_app_clip",
     "ios_application",
     "ios_extension",
     "ios_framework",
@@ -584,6 +585,47 @@ objc_library(
         "//test/starlark_tests/resources:main.m",
     ],
     deps = [":fmwk_8_0_minimum_lib"],
+)
+
+# ---------------------------------------------------------------------------------------
+
+ios_application(
+    name = "app_with_app_clip",
+    app_clips = [":app_clip"],
+    bundle_id = "com.google.example",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "14.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_app_clip(
+    name = "app_clip",
+    bundle_id = "com.google.example.clip",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "14.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
 )
 
 # ---------------------------------------------------------------------------------------

--- a/test/starlark_tests/verifier_scripts/app_clip_codesign_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_codesign_verifier.sh
@@ -19,17 +19,6 @@ set -eu
 # Assert that the bundle itself is signed.
 assert_is_codesigned "$BUNDLE_ROOT"
 
-# If it has any frameworks, assert that they are signed as well.
-if [[ -d "$CONTENT_ROOT/Frameworks" ]]; then
-  for fmwk in \
-      $(find "$CONTENT_ROOT/Frameworks" -type d -maxdepth 1 -mindepth 1); do
-    assert_is_codesigned "$fmwk"
-  done
-
-  # Assert that the frameworks have not been resigned.
-  assert_frameworks_not_resigned_given_output "$BUNDLE_ROOT"
-fi
-
 # If it has any App Clips, assert that they are signed as well.
 if [[ -d "$CONTENT_ROOT/AppClips" ]]; then
   for clip in \

--- a/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+TEMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/codesign_output.XXXXXX")"
+
+if [[ "$BUILD_TYPE" == "simulator" ]]; then
+  xcrun llvm-objdump -macho -section=__TEXT,__entitlements "$BINARY" | \
+      sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
+      -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
+elif [[ "$BUILD_TYPE" == "device" ]]; then
+  codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+else
+  fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
+fi
+
+# This key marks the application as an app clip.
+assert_contains "<key>com.apple.developer.on-demand-install-capable</key>" \
+    "$TEMP_OUTPUT"
+
+rm -rf "$TEMP_OUTPUT"


### PR DESCRIPTION
This change adds a new ios_app_clip rule, and enables embedding app clips in ios_application rules through a new app_clips property.

Additional changes are made to codesigning to support multiple code signed archives as outputs for any given target, to support an app clip having both a signed .ipa and a signed embeddable archive for use when embedding in an application target.

Unit tests changes include verification of embedding and verification that both embedded and standalone app clips are correctly signed and possess app clip entitlement.

Based on: PR #838 by brentleyjones

RELNOTES: None
PiperOrigin-RevId: 332074165