### PR TITLE
Converted two partials to the new ctx-less format. Addressed run_support to remove ctx in the process.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -213,10 +213,12 @@ bzl_library(
     ],
     deps = [
         ":apple_product_type",
+        ":bundling_support",
         ":codesigning_support",
         ":linking_support",
         ":outputs",
         ":partials",
+        ":platform_support",
         ":processor",
         ":rule_factory",
         ":run_support",
@@ -276,6 +278,7 @@ bzl_library(
     ],
     deps = [
         ":rule_support",
+        ":swift_support",
     ],
 )
 
@@ -379,9 +382,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        ":bundling_support",
         ":outputs",
-        ":platform_support",
     ],
 )
 
@@ -444,6 +445,7 @@ bzl_library(
     ],
     deps = [
         ":apple_product_type",
+        ":bundling_support",
         ":linking_support",
         ":outputs",
         ":partials",

--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -19,6 +19,22 @@ load(
     "rule_support",
 )
 
+# TODO(b/161370390): Move all instances of bundle_name, bundle_extension, and
+# bundle_name_with_extension to use this macro instead, from the rule declarations and nowhere else.
+#
+# Eliminate bundle_name, bundle_extension and bundle_name_from_extension and move the implementation
+# of bundle_name and bundle_extension into this macro once that is done.
+def _bundle_full_name_from_rule_ctx(ctx):
+    """Returns a tuple containing information on the bundle file name from a rule context.
+
+    Args:
+      ctx: The Starlark context for a rule.
+
+    Returns:
+      A tuple representing the default bundle file name and extension for that rule context.
+    """
+    return (_bundle_name(ctx), _bundle_extension(ctx))
+
 def _bundle_name(ctx):
     """Returns the name of the bundle.
 
@@ -215,6 +231,7 @@ def _ensure_path_format(attr, files, path_fragments_list, message = None):
 
 # Define the loadable module that lists the exported symbols in this file.
 bundling_support = struct(
+    bundle_full_name_from_rule_ctx = _bundle_full_name_from_rule_ctx,
     bundle_name = _bundle_name,
     bundle_extension = _bundle_extension,
     bundle_name_with_extension = _bundle_name_with_extension,

--- a/apple/internal/experimental.bzl
+++ b/apple/internal/experimental.bzl
@@ -19,6 +19,11 @@ load(
     "defines",
 )
 
-def is_experimental_tree_artifact_enabled(ctx):
+def is_experimental_tree_artifact_enabled(ctx = None, *, config_vars = None):
     """Returns whether tree artifact outputs experiment is enabled."""
-    return defines.bool_value(ctx, "apple.experimental.tree_artifact_outputs", False)
+    return defines.bool_value(
+        ctx = ctx,
+        config_vars = config_vars,
+        define_name = "apple.experimental.tree_artifact_outputs",
+        default = False,
+    )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -84,18 +84,20 @@ def _ios_application_impl(ctx):
         "resources",
     ]
 
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-
-    # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
-    # action, when available.
-    # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
-    # add linking support directly into the rule.
     binary_target = ctx.attr.deps[0]
     binary_artifact = binary_target[apple_common.AppleExecutableBinary].binary
 
+    actions = ctx.actions
     bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = ctx.attr.frameworks + ctx.attr.extensions + ctx.attr.app_clips
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
+
     if ctx.attr.watch_application:
         embeddable_targets.append(ctx.attr.watch_application)
 
@@ -113,14 +115,29 @@ def _ios_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.bitcode_symbols_partial(
-            actions = ctx.actions,
+            actions = actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = embeddable_targets,
-            label_name = ctx.label.name,
+            label_name = label.name,
             package_bitcode = True,
             platform_prerequisites = platform_prerequisites,
         ),
@@ -173,8 +190,27 @@ def _ios_application_impl(ctx):
 
     processor_result = processor.process(ctx, processor_partials)
 
-    executable = outputs.executable(ctx)
-    run_support.register_simulator_executable(ctx, executable)
+    executable = outputs.executable(
+        actions = actions,
+        label_name = label.name,
+    )
+    run_support.register_simulator_executable(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        file = ctx.file,
+        output = executable,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
+
+    archive = outputs.archive(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     return [
         # TODO(b/121155041): Should we do the same for ios_framework and ios_extension?
@@ -183,10 +219,7 @@ def _ios_application_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [
-                    outputs.archive(ctx),
-                    ctx.file._std_redirect_dylib,
-                ],
+                files = [archive, ctx.file._std_redirect_dylib],
             ),
         ),
         IosApplicationBundleInfo(),
@@ -204,18 +237,30 @@ def _ios_app_clip_impl(ctx):
         "resources",
     ]
 
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-
-    # TODO: Replace the debug_outputs_provider with the provider returned from the linking
-    # action, when available.
-    # TODO: Extract this into a common location to be reused and refactored later when we
-    # add linking support directly into the rule.
     binary_target = ctx.attr.deps[0]
     binary_artifact = binary_target[apple_common.AppleExecutableBinary].binary
 
+    actions = ctx.actions
     bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     embeddable_targets = ctx.attr.frameworks
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    embeddable_targets = ctx.attr.frameworks
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
     rule_descriptor = rule_support.rule_descriptor(ctx)
+
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -223,14 +268,29 @@ def _ios_app_clip_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.bitcode_symbols_partial(
-            actions = ctx.actions,
+            actions = actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = embeddable_targets,
-            label_name = ctx.label.name,
+            label_name = label.name,
             package_bitcode = True,
             platform_prerequisites = platform_prerequisites,
         ),
@@ -240,7 +300,7 @@ def _ios_app_clip_impl(ctx):
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
         ),
         partials.embedded_bundles_partial(
-            app_clips = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            app_clips = [archive_for_embedding],
             bundle_embedded_bundles = True,
             embeddable_targets = embeddable_targets,
         ),
@@ -268,8 +328,28 @@ def _ios_app_clip_impl(ctx):
 
     processor_result = processor.process(ctx, processor_partials)
 
-    executable = outputs.executable(ctx)
-    run_support.register_simulator_executable(ctx, executable)
+    executable = outputs.executable(
+        actions = actions,
+        label_name = label.name,
+    )
+
+    run_support.register_simulator_executable(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        file = ctx.file,
+        output = executable,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
+
+    archive = outputs.archive(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     return [
         # TODO(b/121155041): Should we do the same for ios_framework?
@@ -278,10 +358,7 @@ def _ios_app_clip_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [
-                    outputs.archive(ctx),
-                    ctx.file._std_redirect_dylib,
-                ],
+                files = [archive, ctx.file._std_redirect_dylib],
             ),
         ),
         IosAppClipBundleInfo(),
@@ -294,33 +371,59 @@ def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
     # TODO(kaipi): Add support for packaging headers.
 
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-
-    # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
-    # action, when available.
-    # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
-    # add linking support directly into the rule.
     binary_target = ctx.attr.deps[0]
     binary_artifact = binary_target[apple_common.AppleDylibBinary].binary
 
+    actions = ctx.actions
     bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
+    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     signed_frameworks = []
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     if getattr(ctx.file, "provisioning_profile", None):
         signed_frameworks = [
-            bundling_support.bundle_name(ctx) + rule_descriptor.bundle_extension,
+            bundle_name + rule_descriptor.bundle_extension,
         ]
 
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_name = bundle_name,
+        bundle_extension = bundle_extension,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
+
     processor_partials = [
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.bitcode_symbols_partial(
-            actions = ctx.actions,
+            actions = actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = ctx.attr.frameworks,
-            label_name = ctx.label.name,
+            label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
         # TODO(kaipi): Check if clang_rt dylibs are needed in Frameworks, or if
@@ -331,7 +434,7 @@ def _ios_framework_impl(ctx):
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
         ),
         partials.embedded_bundles_partial(
-            frameworks = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            frameworks = [archive_for_embedding],
             embeddable_targets = ctx.attr.frameworks,
             signed_frameworks = depset(signed_frameworks),
         ),
@@ -367,17 +470,28 @@ def _ios_extension_impl(ctx):
         "strings",
     ]
 
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-
-    # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
-    # action, when available.
-    # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
-    # add linking support directly into the rule.
     binary_target = ctx.attr.deps[0]
     binary_artifact = binary_target[apple_common.AppleExecutableBinary].binary
 
+    actions = ctx.actions
     bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
     rule_descriptor = rule_support.rule_descriptor(ctx)
+
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -385,14 +499,29 @@ def _ios_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.bitcode_symbols_partial(
-            actions = ctx.actions,
+            actions = actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
             dependency_targets = ctx.attr.frameworks,
-            label_name = ctx.label.name,
+            label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -401,7 +530,7 @@ def _ios_extension_impl(ctx):
             debug_outputs_provider = binary_target[apple_common.AppleDebugOutputs],
         ),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            plugins = [archive_for_embedding],
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = True),
@@ -437,16 +566,34 @@ def _ios_extension_impl(ctx):
 def _ios_static_framework_impl(ctx):
     """Experimental implementation of ios_static_framework."""
 
-    # TODO(kaipi): Replace the debug_outputs_provider with the provider returned from the linking
-    # action, when available.
-    # TODO(kaipi): Extract this into a common location to be reused and refactored later when we
-    # add linking support directly into the rule.
     binary_target = ctx.attr.deps[0]
     binary_artifact = binary_target[apple_common.AppleStaticLibrary].archive
 
+    actions = ctx.actions
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
+
     processor_partials = [
-        partials.apple_bundle_info_partial(),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
     ]
 
     # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
@@ -484,18 +631,22 @@ def _ios_imessage_application_impl(ctx):
         "resources",
     ]
 
-    rule_descriptor = rule_support.rule_descriptor(ctx)
+    actions = ctx.actions
+    bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_verification_targets = [struct(target = ctx.attr.extension)]
+    embeddable_targets = [ctx.attr.extension]
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
+    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     binary_artifact = stub_support.create_stub_binary(
         ctx,
         xcode_stub_path = rule_descriptor.stub_binary_path,
     )
-
-    bundle_id = ctx.attr.bundle_id
-
-    bundle_verification_targets = [struct(target = ctx.attr.extension)]
-    embeddable_targets = [ctx.attr.extension]
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -503,8 +654,23 @@ def _ios_imessage_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
             embeddable_targets = embeddable_targets,
@@ -550,14 +716,29 @@ def _ios_imessage_extension_impl(ctx):
         "resources",
     ]
 
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-
     binary_descriptor = linking_support.register_linking_action(ctx)
     binary_artifact = binary_descriptor.artifact
     debug_outputs_provider = binary_descriptor.debug_outputs_provider
 
+    actions = ctx.actions
     bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
     rule_descriptor = rule_support.rule_descriptor(ctx)
+
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     processor_partials = [
         # TODO(kaipi): Refactor this partial into a more generic interface to account for
@@ -567,14 +748,29 @@ def _ios_imessage_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.bitcode_symbols_partial(
-            actions = ctx.actions,
+            actions = actions,
             binary_artifact = binary_artifact,
             debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
-            label_name = ctx.label.name,
+            label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -583,7 +779,7 @@ def _ios_imessage_extension_impl(ctx):
             debug_outputs_provider = debug_outputs_provider,
         ),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            plugins = [archive_for_embedding],
             embeddable_targets = ctx.attr.frameworks,
         ),
         partials.extension_safe_validation_partial(is_extension_safe = True),
@@ -622,15 +818,30 @@ def _ios_sticker_pack_extension_impl(ctx):
         "resources",
     ]
 
-    rule_descriptor = rule_support.rule_descriptor(ctx)
+    actions = ctx.actions
+    bundle_id = ctx.attr.bundle_id
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    entitlements = getattr(ctx.attr, "entitlements", None)
+    label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    product_type = ctx.attr._product_type
+    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     binary_artifact = stub_support.create_stub_binary(
         ctx,
         xcode_stub_path = rule_descriptor.stub_binary_path,
     )
 
-    bundle_id = ctx.attr.bundle_id
+    archive_for_embedding = outputs.archive_for_embedding(
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        label_name = label.name,
+        rule_descriptor = rule_descriptor,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
 
     processor_partials = [
         # TODO(kaipi): Refactor this partial into a more generic interface to account for
@@ -640,10 +851,25 @@ def _ios_sticker_pack_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             product_type = ctx.attr._product_type,
         ),
-        partials.apple_bundle_info_partial(bundle_id = bundle_id),
-        partials.binary_partial(binary_artifact = binary_artifact),
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_id = bundle_id,
+            bundle_name = bundle_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
+            label_name = label.name,
+        ),
         partials.embedded_bundles_partial(
-            plugins = [outputs.archive_for_embedding(ctx, rule_descriptor)],
+            plugins = [archive_for_embedding],
         ),
         partials.resources_partial(
             bundle_id = bundle_id,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -93,6 +93,7 @@ def _ios_application_impl(ctx):
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = ctx.attr.frameworks + ctx.attr.extensions + ctx.attr.app_clips
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -120,6 +121,7 @@ def _ios_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -129,7 +131,7 @@ def _ios_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -208,6 +210,7 @@ def _ios_application_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
     )
@@ -247,6 +250,7 @@ def _ios_app_clip_impl(ctx):
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     embeddable_targets = ctx.attr.frameworks
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     predeclared_outputs = ctx.outputs
     product_type = ctx.attr._product_type
@@ -256,6 +260,7 @@ def _ios_app_clip_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label.name,
         rule_descriptor = rule_descriptor,
         platform_prerequisites = platform_prerequisites,
@@ -273,6 +278,7 @@ def _ios_app_clip_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -282,7 +288,7 @@ def _ios_app_clip_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -347,6 +353,7 @@ def _ios_app_clip_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
     )
@@ -378,6 +385,7 @@ def _ios_framework_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -394,6 +402,7 @@ def _ios_framework_impl(ctx):
         actions = actions,
         bundle_name = bundle_name,
         bundle_extension = bundle_extension,
+        executable_name = executable_name,
         label_name = label.name,
         rule_descriptor = rule_descriptor,
         platform_prerequisites = platform_prerequisites,
@@ -406,6 +415,7 @@ def _ios_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -415,7 +425,7 @@ def _ios_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -477,6 +487,7 @@ def _ios_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -487,6 +498,7 @@ def _ios_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label.name,
         rule_descriptor = rule_descriptor,
         platform_prerequisites = platform_prerequisites,
@@ -504,6 +516,7 @@ def _ios_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -513,7 +526,7 @@ def _ios_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -572,6 +585,7 @@ def _ios_static_framework_impl(ctx):
     actions = ctx.actions
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -582,6 +596,7 @@ def _ios_static_framework_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -591,7 +606,7 @@ def _ios_static_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
     ]
@@ -637,6 +652,7 @@ def _ios_imessage_application_impl(ctx):
     bundle_verification_targets = [struct(target = ctx.attr.extension)]
     embeddable_targets = [ctx.attr.extension]
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -659,6 +675,7 @@ def _ios_imessage_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -668,7 +685,7 @@ def _ios_imessage_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.embedded_bundles_partial(
@@ -724,6 +741,7 @@ def _ios_imessage_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -734,6 +752,7 @@ def _ios_imessage_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label.name,
         rule_descriptor = rule_descriptor,
         platform_prerequisites = platform_prerequisites,
@@ -753,6 +772,7 @@ def _ios_imessage_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -762,7 +782,7 @@ def _ios_imessage_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -822,6 +842,7 @@ def _ios_sticker_pack_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -837,6 +858,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label.name,
         rule_descriptor = rule_descriptor,
         platform_prerequisites = platform_prerequisites,
@@ -856,6 +878,7 @@ def _ios_sticker_pack_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -865,7 +888,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.embedded_bundles_partial(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -79,6 +79,7 @@ def _macos_application_impl(ctx):
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     bundle_verification_targets = [struct(target = ext) for ext in embedded_targets]
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -90,6 +91,7 @@ def _macos_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -99,7 +101,7 @@ def _macos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -188,6 +190,7 @@ def _macos_bundle_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -207,6 +210,7 @@ def _macos_bundle_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -216,7 +220,7 @@ def _macos_bundle_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -273,6 +277,7 @@ def _macos_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -292,6 +297,7 @@ def _macos_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -301,7 +307,7 @@ def _macos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -358,6 +364,7 @@ def _macos_quick_look_plugin_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -377,6 +384,7 @@ def _macos_quick_look_plugin_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -386,7 +394,7 @@ def _macos_quick_look_plugin_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         # TODO(kaipi): Check if clang_rt dylibs are needed in Quick Look plugins, or if
@@ -439,6 +447,7 @@ def _macos_kernel_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -458,6 +467,7 @@ def _macos_kernel_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -467,7 +477,7 @@ def _macos_kernel_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -517,6 +527,7 @@ def _macos_spotlight_importer_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -536,6 +547,7 @@ def _macos_spotlight_importer_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -545,7 +557,7 @@ def _macos_spotlight_importer_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),
@@ -594,6 +606,7 @@ def _macos_xpc_service_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -612,6 +625,7 @@ def _macos_xpc_service_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             bundle_id = bundle_id,
             entitlements = entitlements,
             label_name = label.name,
@@ -622,7 +636,7 @@ def _macos_xpc_service_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -41,6 +41,7 @@ def _archive(
         actions = None,
         bundle_extension = None,
         bundle_name = None,
+        executable_name = None,
         platform_prerequisites = None,
         predeclared_outputs = None):
     """Returns a file reference for this target's archive."""
@@ -78,6 +79,7 @@ def _archive_for_embedding(
         actions = None,
         bundle_name = None,
         bundle_extension = None,
+        executable_name = None,
         label_name = None,
         platform_prerequisites = None,
         predeclared_outputs = None):
@@ -128,7 +130,7 @@ def _archive_root_path(
 
     return _root_path_from_archive(archive = archive)
 
-def _binary(ctx = None, *, actions = None, bundle_name = None, label_name = None):
+def _binary(ctx = None, *, actions = None, executable_name = None, label_name = None):
     """Returns a file reference for the binary that will be packaged into this target's archive. """
     if not actions:
         actions = ctx.actions
@@ -136,10 +138,10 @@ def _binary(ctx = None, *, actions = None, bundle_name = None, label_name = None
     if not label_name:
         label_name = ctx.label.name
 
-    if not bundle_name:
-        bundle_name = bundling_support.executable_name(ctx)
+    if not executable_name:
+        executable_name = bundling_support.executable_name(ctx)
 
-    return intermediates.file(actions, label_name, bundle_name)
+    return intermediates.file(actions, label_name, executable_name)
 
 def _executable(ctx = None, *, actions = None, label_name = None):
     """Returns a file reference for the executable that would be invoked with `bazel run`."""

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -35,54 +35,149 @@ load(
     "paths",
 )
 
-def _archive(ctx):
+def _archive(
+        ctx = None,
+        *,
+        actions = None,
+        bundle_extension = None,
+        bundle_name = None,
+        platform_prerequisites = None,
+        predeclared_outputs = None):
     """Returns a file reference for this target's archive."""
-    if is_experimental_tree_artifact_enabled(ctx):
+    if not actions:
+        actions = ctx.actions
+
+    if bundle_name != None and bundle_extension != None:
+        bundle_name_with_extension = bundle_name + bundle_extension
+    else:
         bundle_name_with_extension = (
             bundling_support.bundle_name(ctx) + bundling_support.bundle_extension(ctx)
         )
-        return ctx.actions.declare_directory(bundle_name_with_extension)
+
+    if platform_prerequisites != None:
+        tree_artifact_enabled = is_experimental_tree_artifact_enabled(
+            config_vars = platform_prerequisites.config_vars,
+        )
+    else:
+        tree_artifact_enabled = is_experimental_tree_artifact_enabled(ctx = ctx)
+
+    if not predeclared_outputs:
+        predeclared_outputs = ctx.outputs
+
+    if tree_artifact_enabled:
+        return actions.declare_directory(bundle_name_with_extension)
 
     # TODO(kaipi): Look into removing this rule implicit output and just return it using
     # DefaultInfo.
-    return ctx.outputs.archive
+    return predeclared_outputs.archive
 
-def _archive_for_embedding(ctx, rule_descriptor):
+def _archive_for_embedding(
+        ctx = None,
+        rule_descriptor = None,
+        *,
+        actions = None,
+        bundle_name = None,
+        bundle_extension = None,
+        label_name = None,
+        platform_prerequisites = None,
+        predeclared_outputs = None):
     """Returns a files reference for this target's archive, when embedded in another target."""
-    if _has_different_embedding_archive(ctx, rule_descriptor):
-        return ctx.actions.declare_file("%s.embedding.zip" % ctx.label.name)
-    else:
-        return _archive(ctx)
+    if not actions:
+        actions = ctx.actions
 
-def _archive_root_path(ctx):
-    """Returns the path to a directory reference for this target's archive root."""
+    if not label_name:
+        label_name = ctx.label.name
 
-    # TODO(b/65366691): Migrate this to an actual tree artifact.
-    archive_root_name = paths.replace_extension(_archive(ctx).path, "_archive-root")
-    return archive_root_name
-
-def _binary(ctx):
-    """Returns a file reference for the binary that will be packaged into this target's archive. """
-    return intermediates.file(
-        ctx.actions,
-        ctx.label.name,
-        bundling_support.executable_name(ctx),
+    has_different_embedding_archive = _has_different_embedding_archive(
+        ctx = ctx,
+        platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
     )
 
-def _executable(ctx):
+    if has_different_embedding_archive:
+        return actions.declare_file("%s.embedding.zip" % label_name)
+    else:
+        return _archive(
+            ctx = ctx,
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+        )
+
+# TODO(b/161370390): Migrate all uses of this to root_path_from_archive.
+def _archive_root_path(
+        ctx = None,
+        *,
+        actions = None,
+        bundle_name = None,
+        bundle_extension = None,
+        platform_prerequisites = None,
+        predeclared_outputs = None):
+    """Returns the path to a directory reference for this target's archive root."""
+
+    archive = _archive(
+        ctx = ctx,
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+    )
+
+    return _root_path_from_archive(archive = archive)
+
+def _binary(ctx = None, *, actions = None, bundle_name = None, label_name = None):
+    """Returns a file reference for the binary that will be packaged into this target's archive. """
+    if not actions:
+        actions = ctx.actions
+
+    if not label_name:
+        label_name = ctx.label.name
+
+    if not bundle_name:
+        bundle_name = bundling_support.executable_name(ctx)
+
+    return intermediates.file(actions, label_name, bundle_name)
+
+def _executable(ctx = None, *, actions = None, label_name = None):
     """Returns a file reference for the executable that would be invoked with `bazel run`."""
-    return ctx.actions.declare_file(ctx.label.name)
+    if not actions:
+        actions = ctx.actions
 
-def _infoplist(ctx):
+    if not label_name:
+        label_name = ctx.label.name
+
+    return actions.declare_file(label_name)
+
+def _infoplist(ctx = None, *, actions = None, label_name = None):
     """Returns a file reference for this target's Info.plist file."""
-    return intermediates.file(ctx.actions, ctx.label.name, "Info.plist")
+    if not actions:
+        actions = ctx.actions
 
-def _has_different_embedding_archive(ctx, rule_descriptor):
+    if not label_name:
+        label_name = ctx.label.name
+
+    return intermediates.file(actions, label_name, "Info.plist")
+
+def _has_different_embedding_archive(ctx, rule_descriptor, *, platform_prerequisites = None):
     """Returns True if this target exposes a different archive when embedded in another target."""
-    if is_experimental_tree_artifact_enabled(ctx):
+    if platform_prerequisites != None:
+        tree_artifact_enabled = is_experimental_tree_artifact_enabled(
+            config_vars = platform_prerequisites.config_vars,
+        )
+    else:
+        tree_artifact_enabled = is_experimental_tree_artifact_enabled(ctx = ctx)
+
+    if tree_artifact_enabled:
         return False
 
     return rule_descriptor.bundle_locations.archive_relative != "" and rule_descriptor.expose_non_archive_relative_output
+
+def _root_path_from_archive(*, archive):
+    """Given an archive, returns a path to a directory reference for this target's archive root."""
+    return paths.replace_extension(archive.path, "_archive-root")
 
 outputs = struct(
     archive = _archive,
@@ -91,5 +186,6 @@ outputs = struct(
     binary = _binary,
     executable = _executable,
     infoplist = _infoplist,
+    root_path_from_archive = _root_path_from_archive,
     has_different_embedding_archive = _has_different_embedding_archive,
 )

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -29,10 +29,7 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
-        "//apple/internal:bundling_support",
         "//apple/internal:outputs",
-        "//apple/internal:platform_support",
-        "//apple/internal:swift_support",
         "@bazel_skylib//lib:partial",
     ],
 )

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -54,7 +54,7 @@ def _apple_bundle_info_partial_impl(
 
     binary = outputs.binary(
         actions = actions,
-        bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label_name,
     )
 
@@ -75,7 +75,7 @@ def _apple_bundle_info_partial_impl(
                 bundle_id = bundle_id,
                 bundle_name = bundle_name,
                 bundle_extension = bundle_extension,
-                executable_name = executable_name
+                executable_name = executable_name,
                 entitlements = entitlements,
                 infoplist = infoplist,
                 minimum_os_version = platform_prerequisites.minimum_os,
@@ -92,6 +92,7 @@ def apple_bundle_info_partial(
         bundle_id = None,
         bundle_extension,
         bundle_name,
+        executable_name,
         entitlements,
         label_name,
         platform_prerequisites,

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -27,12 +27,17 @@ load(
     "partial",
 )
 
-def _binary_partial_impl(ctx, binary_artifact):
+# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
+def _binary_partial_impl(ctx, actions, binary_artifact, bundle_name, label_name):
     """Implementation for the binary processing partial."""
 
     # Create intermediate file with proper name for the binary.
-    output_binary = outputs.binary(ctx)
-    ctx.actions.symlink(target_file = binary_artifact, output = output_binary)
+    output_binary = outputs.binary(
+        actions = actions,
+        bundle_name = bundle_name,
+        label_name = label_name,
+    )
+    actions.symlink(target_file = binary_artifact, output = output_binary)
 
     return struct(
         bundle_files = [
@@ -40,18 +45,24 @@ def _binary_partial_impl(ctx, binary_artifact):
         ],
     )
 
-def binary_partial(binary_artifact):
+def binary_partial(actions, binary_artifact, bundle_name, label_name):
     """Constructor for the binary processing partial.
 
     This partial propagates the bundle location for the main binary artifact for the target.
 
     Args:
+      actions: The actions provider from ctx.actions.
       binary_artifact: The main binary artifact for this target.
+      bundle_name: The name of the output bundle.
+      label_name: Name of the target being built.
 
     Returns:
       A partial that returns the bundle location of the binary artifact.
     """
     return partial.make(
         _binary_partial_impl,
+        actions = actions,
         binary_artifact = binary_artifact,
+        bundle_name = bundle_name,
+        label_name = label_name,
     )

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -28,13 +28,13 @@ load(
 )
 
 # TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
-def _binary_partial_impl(ctx, actions, binary_artifact, bundle_name, label_name):
+def _binary_partial_impl(ctx, actions, binary_artifact, executable_name, label_name):
     """Implementation for the binary processing partial."""
 
     # Create intermediate file with proper name for the binary.
     output_binary = outputs.binary(
         actions = actions,
-        bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label_name,
     )
     actions.symlink(target_file = binary_artifact, output = output_binary)
@@ -45,7 +45,7 @@ def _binary_partial_impl(ctx, actions, binary_artifact, bundle_name, label_name)
         ],
     )
 
-def binary_partial(actions, binary_artifact, bundle_name, label_name):
+def binary_partial(actions, binary_artifact, executable_name, label_name):
     """Constructor for the binary processing partial.
 
     This partial propagates the bundle location for the main binary artifact for the target.
@@ -53,7 +53,7 @@ def binary_partial(actions, binary_artifact, bundle_name, label_name):
     Args:
       actions: The actions provider from ctx.actions.
       binary_artifact: The main binary artifact for this target.
-      bundle_name: The name of the output bundle.
+      executable_name: The name of the output executable.
       label_name: Name of the target being built.
 
     Returns:
@@ -63,6 +63,6 @@ def binary_partial(actions, binary_artifact, bundle_name, label_name):
         _binary_partial_impl,
         actions = actions,
         binary_artifact = binary_artifact,
-        bundle_name = bundle_name,
+        executable_name = executable_name,
         label_name = label_name,
     )

--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -27,6 +27,7 @@ bzl_library(
     deps = [
         "//apple:providers",
         "//apple/internal:apple_product_type",
+        "//apple/internal:bundling_support",
         "//apple/internal:experimental",
         "//apple/internal:linking_support",
         "//apple/internal:outputs",

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -229,6 +229,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     config_vars = ctx.var
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -255,6 +256,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -264,7 +266,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.clang_rt_dylibs_partial(binary_artifact = binary_artifact),

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -85,6 +85,7 @@ def _tvos_application_impl(ctx):
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = ctx.attr.extensions + ctx.attr.frameworks
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -103,6 +104,7 @@ def _tvos_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -112,7 +114,7 @@ def _tvos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -207,6 +209,7 @@ def _tvos_framework_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -233,6 +236,7 @@ def _tvos_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -242,7 +246,7 @@ def _tvos_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -304,6 +308,7 @@ def _tvos_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -322,6 +327,7 @@ def _tvos_extension_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             bundle_id = bundle_id,
             entitlements = entitlements,
             label_name = label.name,
@@ -332,7 +338,7 @@ def _tvos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -391,6 +397,7 @@ def _tvos_static_framework_impl(ctx):
     actions = ctx.actions
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -401,6 +408,7 @@ def _tvos_static_framework_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             entitlements = entitlements,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -410,7 +418,7 @@ def _tvos_static_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
     ]

--- a/apple/internal/utils/defines.bzl
+++ b/apple/internal/utils/defines.bzl
@@ -14,20 +14,24 @@
 
 """Support functions for common --define operations."""
 
-def _bool_value(ctx, define_name, default):
+def _bool_value(ctx, define_name, default, *, config_vars = None):
     """Looks up a define on ctx for a boolean value.
 
     Will also report an error if the value is not a supported value.
 
     Args:
-      ctx: A Starlark context.
+      ctx: A Starlark context. Deprecated.
       define_name: The name of the define to look up.
       default: The value to return if the define isn't found.
+      config_vars: A dictionary (String to String) of configuration variables. Can be from ctx.var.
 
     Returns:
       True/False or the default value if the define wasn't found.
     """
-    value = ctx.var.get(define_name, None)
+    if not config_vars:
+        config_vars = ctx.var
+
+    value = config_vars.get(define_name, None)
     if value != None:
         if value.lower() in ("true", "yes", "1"):
             return True

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -77,6 +77,7 @@ def _watchos_application_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -112,6 +113,7 @@ def _watchos_application_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             bundle_id = bundle_id,
             entitlements = entitlements,
             label_name = label.name,
@@ -122,7 +124,7 @@ def _watchos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = label.name,
         ),
         partials.bitcode_symbols_partial(
@@ -211,6 +213,7 @@ def _watchos_extension_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     entitlements = getattr(ctx.attr, "entitlements", None)
+    executable_name = bundling_support.executable_name(ctx)
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -229,6 +232,7 @@ def _watchos_extension_impl(ctx):
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            executable_name = executable_name,
             bundle_id = bundle_id,
             entitlements = entitlements,
             label_name = label.name,
@@ -239,7 +243,7 @@ def _watchos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            bundle_name = bundle_name,
+            executable_name = executable_name,
             label_name = ctx.label.name,
         ),
         partials.bitcode_symbols_partial(


### PR DESCRIPTION
Add executable_name parameters where applicable to fix compatibility
with the open-source branch

Also remove binary_partial's bundle_name parameter, since it was only
used to declare the executable filename, which is now handled by
the executable_name parameter.