### PR TITLE
Enable configuration transition for iOS rules.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -39,6 +39,10 @@ load(
     "swift_static_framework_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_info_aspect",
 )
@@ -956,18 +960,17 @@ def _create_apple_binary_rule(implementation, platform_type, product_type, doc):
 
     rule_attrs.extend(_get_macos_binary_attrs(rule_descriptor))
 
-    if rule_descriptor.rule_transition:
-        rule_attrs.append({
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
-        })
+    rule_attrs.append({
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    })
 
     return rule(
         implementation = implementation,
         # TODO(kaipi): Replace dicts.add with a version that errors on duplicate keys.
         attrs = dicts.add(*rule_attrs),
-        cfg = rule_descriptor.rule_transition,
+        cfg = transition_support.apple_rule_transition,
         doc = doc,
         executable = rule_descriptor.is_executable,
         fragments = ["apple", "cpp", "objc"],
@@ -1014,19 +1017,18 @@ def _create_apple_bundling_rule(implementation, platform_type, product_type, doc
     elif platform_type == "watchos":
         rule_attrs.extend(_get_watchos_attrs(rule_descriptor))
 
-    if rule_descriptor.rule_transition or rule_descriptor.force_transition_allowlist:
-        rule_attrs.append({
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
-        })
+    rule_attrs.append({
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    })
 
     archive_name = "%{name}" + rule_descriptor.archive_extension
     return rule(
         implementation = implementation,
         # TODO(kaipi): Replace dicts.add with a version that errors on duplicate keys.
         attrs = dicts.add(*rule_attrs),
-        cfg = rule_descriptor.rule_transition,
+        cfg = transition_support.apple_rule_transition,
         doc = doc,
         executable = rule_descriptor.is_executable,
         fragments = ["apple", "cpp", "objc"],

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -102,7 +102,6 @@ def _describe_rule_type(
         requires_provisioning_profile = True,
         requires_signing_for_device = True,
         rpaths = [],
-        rule_transition = None,
         skip_simulator_signing_allowed = True,
         stub_binary_path = None):
     """Creates a rule descriptor struct containing all the platform and product specific configs.
@@ -156,7 +155,6 @@ def _describe_rule_type(
         requires_signing_for_device: Whether signing is required when building for devices (as
             opposed to simulators).
         rpaths: List of rpaths to add to the linker.
-        rule_transition: Starlark transition to apply to the rule.
         skip_simulator_signing_allowed: Whether this rule is allowed to skip signing when building
             for the simulator.
         stub_binary_path: Xcode SDK root relative path to the stub binary to copy as this rule's
@@ -201,7 +199,6 @@ def _describe_rule_type(
         requires_provisioning_profile = requires_provisioning_profile,
         requires_signing_for_device = requires_signing_for_device,
         rpaths = rpaths,
-        rule_transition = rule_transition,
         skip_simulator_signing_allowed = skip_simulator_signing_allowed,
         stub_binary_path = stub_binary_path,
     )
@@ -430,7 +427,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Contents/Frameworks
                 "@executable_path/../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_command_line_application
         apple_product_type.tool: _describe_rule_type(
@@ -442,7 +438,6 @@ _RULE_TYPE_DESCRIPTORS = {
             provisioning_profile_extension = ".provisionprofile",
             requires_provisioning_profile = True,
             requires_signing_for_device = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_dylib
         apple_product_type.dylib: _describe_rule_type(
@@ -452,7 +447,6 @@ _RULE_TYPE_DESCRIPTORS = {
             deps_cfg = apple_common.multi_arch_split,
             product_type = apple_product_type.dylib,
             requires_signing_for_device = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_extension
         apple_product_type.app_extension: _describe_rule_type(
@@ -473,7 +467,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Contents/Frameworks
                 "@executable_path/../../../../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_quick_look_plugin
         apple_product_type.quicklook_plugin: _describe_rule_type(
@@ -487,7 +480,6 @@ _RULE_TYPE_DESCRIPTORS = {
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
             requires_signing_for_device = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_bundle
         apple_product_type.bundle: _describe_rule_type(
@@ -508,7 +500,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Contents/Frameworks
                 "@executable_path/../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_kernel_extension
         apple_product_type.kernel_extension: _describe_rule_type(
@@ -530,7 +521,6 @@ _RULE_TYPE_DESCRIPTORS = {
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
             requires_signing_for_device = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_spotlight_importer
         apple_product_type.spotlight_importer: _describe_rule_type(
@@ -543,7 +533,6 @@ _RULE_TYPE_DESCRIPTORS = {
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
             requires_signing_for_device = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_xpc_service
         apple_product_type.xpc_service: _describe_rule_type(
@@ -563,7 +552,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Contents/Frameworks
                 "@executable_path/../../../../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_ui_test
         apple_product_type.ui_test_bundle: _describe_rule_type(
@@ -589,7 +577,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 "@executable_path/../Frameworks",
                 "@loader_path/../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # macos_unit_test
         apple_product_type.unit_test_bundle: _describe_rule_type(
@@ -615,7 +602,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 "@executable_path/../Frameworks",
                 "@loader_path/../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
     },
     "tvos": {
@@ -640,7 +626,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Frameworks
                 "@executable_path/Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # tvos_extension
         apple_product_type.app_extension: _describe_rule_type(
@@ -662,7 +647,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Frameworks
                 "@executable_path/../../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # tvos_framework
         apple_product_type.framework: _describe_rule_type(
@@ -679,7 +663,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Frameworks
                 "@executable_path/Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # tvos_static_framework
         apple_product_type.static_framework: _describe_rule_type(
@@ -692,7 +675,6 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.static_framework,
             requires_bundle_id = False,
             requires_provisioning_profile = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # tvos_ui_test
         apple_product_type.ui_test_bundle: _describe_rule_type(
@@ -717,7 +699,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 "@loader_path/Frameworks",
             ],
             skip_simulator_signing_allowed = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
         # tvos_unit_test
         apple_product_type.unit_test_bundle: _describe_rule_type(
@@ -742,7 +723,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 "@loader_path/Frameworks",
             ],
             skip_simulator_signing_allowed = False,
-            rule_transition = transition_support.apple_rule_transition,
         ),
     },
     "watchos": {
@@ -757,7 +737,6 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.watch2_application,
             requires_deps = False,
             requires_pkginfo = True,
-            rule_transition = transition_support.apple_rule_transition,
             stub_binary_path = "Library/Application Support/WatchKit/WK",
         ),
         # watchos_extension
@@ -776,7 +755,6 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Frameworks are packaged in Application.app/Frameworks
                 "@executable_path/../../Frameworks",
             ],
-            rule_transition = transition_support.apple_rule_transition,
         ),
     },
 }

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -118,6 +118,6 @@ _static_framework_transition = transition(
 )
 
 transition_support = struct(
-    apple_rule_transition = None,
+    apple_rule_transition = _apple_rule_transition,
     static_framework_transition = _static_framework_transition,
 )


### PR DESCRIPTION
This is an NFC for macOS/tvOS/watchOS since they already had the transition applied.

RELNOTES: None.
PiperOrigin-RevId: 333561201