### PR TITLE
Enable apple_rule_transition

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -118,6 +118,6 @@ _static_framework_transition = transition(
 )
 
 transition_support = struct(
-    apple_rule_transition = None,
+    apple_rule_transition = _apple_rule_transition,
     static_framework_transition = _static_framework_transition,
 )


### PR DESCRIPTION
Historically this was disabled because it used to require a flag we
didn't want to force on everyone. Now that is on by default.