### PR TITLE
Migrate the remaining `ios_*` rules (except `ios_static_framework`) to `apple_common.link_multi_arch_binary`.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -41,12 +41,10 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        ":apple_product_type",
         ":entitlement_rules",
         ":exported_symbols_lists_rules",
         ":rule_support",
         ":swift_support",
-        "@bazel_skylib//lib:collections",
     ],
 )
 
@@ -173,6 +171,7 @@ bzl_library(
         ":stub_support",
         "//apple:providers",
         "//apple/internal/aspects:swift_static_framework_aspect",
+        "@bazel_skylib//lib:collections",
     ],
 )
 

--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -15,10 +15,6 @@
 """Binary creation support functions."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
-    "apple_product_type",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:entitlement_rules.bzl",
     "entitlements",
 )
@@ -27,16 +23,8 @@ load(
     "exported_symbols_lists",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
-    "rule_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
     "swift_runtime_linkopts",
-)
-load(
-    "@bazel_skylib//lib:collections.bzl",
-    "collections",
 )
 
 def _create_swift_runtime_linkopts_target(
@@ -193,141 +181,7 @@ def _add_exported_symbols_lists(name, exported_symbols_lists_value):
 
     return exported_symbols_list_deps
 
-def _create_binary(
-        name,
-        platform_type,
-        product_type,
-        binary_type = "executable",
-        bundle_loader = None,
-        extension_safe = False,
-        link_swift_statically = False,
-        sdk_frameworks = [],
-        suppress_entitlements = False,
-        target_name_template = "%s.__internal__.apple_binary",
-        **kwargs):
-    """Creates a binary target for a bundle by linking user code.
-
-    This function also wraps the entitlements handling logic. It returns a
-    modified copy of the given keyword arguments that has `binary` and
-    `entitlements` attributes added if necessary and removes other
-    binary-specific options (such as `linkopts`).
-
-    Args:
-      name: The name of the bundle target, from which the binary target's name
-          will be derived.
-      platform_type: The platform type for which the binary should be built.
-      product_type: The product type of the bundle for which the binary will be built.
-      binary_type: The type of binary to create. Can be "executable",
-          "loadable_bundle" or "dylib".
-      bundle_loader: Label to an apple_binary target that will act as the
-          bundle_loader for this apple_binary. Can only be set if binary_type is
-          "loadable_bundle".
-      extension_safe: If true, compiles and links this framework with
-          '-application-extension', restricting the binary to use only
-          extension-safe APIs. False by default.
-      link_swift_statically: True/False, indicates whether the static versions of
-          the Swift standard libraries should be used during linking.
-      sdk_frameworks: Additional SDK frameworks that should be linked with the
-          final binary.
-      suppress_entitlements: True/False, indicates that the entitlements() should
-          be suppressed.
-      target_name_template: A string that will be used to derive the name of the
-          `apple_binary` target. This string must contain a single `%s`, which
-          will be replaced by the name of the bundle target.
-      **kwargs: The arguments that were passed into the top-level macro.
-
-    Returns:
-      A modified copy of `**kwargs` that should be passed to the bundling rule.
-    """
-    bundling_args = dict(kwargs)
-
-    rule_descriptor = rule_support.rule_descriptor_no_ctx(platform_type, product_type)
-
-    linkopts = kwargs.pop("linkopts", [])
-    linkopts = linkopts + collections.before_each("-rpath", rule_descriptor.rpaths)
-    linkopts = linkopts + rule_descriptor.extra_linkopts
-    if extension_safe:
-        linkopts = linkopts + ["-application_extension"]
-
-    # Special case for `ios_extension` until it is migrated to the Starlark linking
-    # API. Note that we use `kwargs.get` instead of `pop` so that the attribute
-    # remains in the dictionary to be passed to the bundling rule; this ensures that
-    # analysis fails if the user tries to pass the attribute to a rule that doesn't
-    # support it.
-    provides_main = kwargs.get("provides_main", False)
-    if product_type == apple_product_type.app_extension and not provides_main:
-        linkopts.extend(["-e", "_NSExtensionMain"])
-
-    minimum_os_version = kwargs.get("minimum_os_version")
-    provisioning_profile = kwargs.get("provisioning_profile")
-    tags = bundling_args.get("tags", None)
-    testonly = bundling_args.get("testonly", None)
-
-    if suppress_entitlements:
-        entitlements_deps = []
-    else:
-        entitlements_value = bundling_args.pop("entitlements", None)
-        entitlements_name = "%s_entitlements" % name
-        entitlements(
-            name = entitlements_name,
-            bundle_id = kwargs.get("bundle_id"),
-            entitlements = entitlements_value,
-            platform_type = platform_type,
-            product_type = product_type,
-            provisioning_profile = provisioning_profile,
-            testonly = testonly,
-            validation_mode = kwargs.get("entitlements_validation"),
-        )
-        bundling_args["entitlements"] = ":" + entitlements_name
-        entitlements_deps = [":" + entitlements_name]
-
-    exported_symbols_list_deps = _add_exported_symbols_lists(
-        name,
-        bundling_args.pop("exported_symbols_lists", None),
-    )
-
-    # Remove the deps so that we only pass them to the binary, not to the
-    # bundling rule.
-    deps = bundling_args.pop("deps", [])
-
-    # Propagate the linker flags that dynamically link the Swift runtime, if
-    # Swift was used. If it wasn't, this target propagates no linkopts.
-    swift_linkopts_deps = [
-        _create_swift_runtime_linkopts_target(
-            name,
-            deps,
-            link_swift_statically,
-            is_test = testonly or False,
-            tags = tags,
-            testonly = testonly,
-        ),
-    ]
-
-    # Link the executable from any library deps provided. Pass the entitlements
-    # target as an extra dependency to the binary rule to pick up the extra
-    # linkopts (if any) propagated by it.
-    apple_binary_name = target_name_template % name
-    native.apple_binary(
-        name = apple_binary_name,
-        binary_type = binary_type,
-        bundle_loader = bundle_loader,
-        dylibs = kwargs.get("frameworks"),
-        features = kwargs.get("features"),
-        linkopts = linkopts,
-        minimum_os_version = minimum_os_version,
-        platform_type = platform_type,
-        sdk_frameworks = sdk_frameworks,
-        deps = deps + entitlements_deps + exported_symbols_list_deps + swift_linkopts_deps,
-        tags = ["manual", "notap"] + kwargs.get("tags", []),
-        testonly = testonly,
-        visibility = kwargs.get("visibility"),
-    )
-    bundling_args["deps"] = [":" + apple_binary_name]
-
-    return bundling_args
-
 # Define the loadable module that lists the exported symbols in this file.
 binary_support = struct(
     add_entitlements_and_swift_linkopts = _add_entitlements_and_swift_linkopts,
-    create_binary = _create_binary,
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -388,9 +388,16 @@ def _ios_app_clip_impl(ctx):
 
 def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
-    # TODO(kaipi): Add support for packaging headers.
 
-    binary_descriptor = linking_support.register_linking_action(ctx)
+    # TODO(kaipi): Add support for packaging headers.
+    extra_linkopts = []
+    if ctx.attr.extension_safe:
+        extra_linkopts.append("-fapplication-extension")
+
+    binary_descriptor = linking_support.register_linking_action(
+        ctx,
+        extra_linkopts = extra_linkopts,
+    )
     binary_artifact = binary_descriptor.artifact
     binary_provider = binary_descriptor.provider
     debug_outputs_provider = binary_descriptor.debug_outputs_provider

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -597,7 +597,7 @@ def _ios_extension_impl(ctx):
         IosExtensionBundleInfo(),
         # Propagate the binary provider so that this target can be used as bundle_loader in test
         # rules.
-        binary_target[apple_common.AppleExecutableBinary],
+        binary_descriptor.provider,
     ] + processor_result.providers
 
 def _ios_static_framework_impl(ctx):

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -681,6 +681,27 @@ that this target depends on.
             ),
         })
 
+    # TODO(b/XXXXXXXX): `sdk_frameworks` was never documented on `ios_application` but it leaked
+    # through due to the old macro passing it to the underlying `apple_binary`. Support this
+    # temporarily for a limited set of product types until we can migrate teams off the attribute,
+    # once explicit build targets are used to propagate linking information for system frameworks.
+    if (rule_descriptor.product_type == apple_product_type.application or
+        rule_descriptor.product_type == apple_product_type.app_extension):
+        attrs.append({
+            "sdk_frameworks": attr.string_list(
+                allow_empty = True,
+                doc = """
+Names of SDK frameworks to link with (e.g., `AddressBook`, `QuartzCore`).
+`UIKit` and `Foundation` are always included, even if this attribute is
+provided and does not list them.
+
+This attribute is discouraged; in general, targets should list system
+framework dependencies in the library targets where that framework is used,
+not in the top-level bundle.
+""",
+            ),
+        })
+
     return attrs
 
 def _get_macos_attrs(rule_descriptor):

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -223,6 +223,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
             bundle_package_type = bundle_package_type.application,
+            deps_cfg = apple_common.multi_arch_split,
             has_launch_images = True,
             has_settings_bundle = True,
             is_executable = True,
@@ -245,6 +246,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_package_type = bundle_package_type.application,
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
+            deps_cfg = apple_common.multi_arch_split,
             expose_non_archive_relative_output = True,
             is_executable = True,
             mandatory_families = True,
@@ -264,10 +266,9 @@ _RULE_TYPE_DESCRIPTORS = {
             app_icon_extension = ".appiconset",
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
+            deps_cfg = apple_common.multi_arch_split,
             extra_linkopts = [
-                # Migrate to -fapplication-extension, like the other rules, once ios_extension is
-                # migrated to a proper rule and not a macro with an apple_binary.
-                "-application_extension",
+                "-fapplication-extension",
             ],
             mandatory_families = True,
             product_type = apple_product_type.app_extension,
@@ -280,9 +281,11 @@ _RULE_TYPE_DESCRIPTORS = {
         # ios_framework
         apple_product_type.framework: _describe_rule_type(
             allowed_device_families = ["iphone", "ipad"],
+            binary_type = "dylib",
             bundle_extension = ".framework",
             bundle_package_type = bundle_package_type.framework,
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.sign_with_provisioning_profile,
+            deps_cfg = apple_common.multi_arch_split,
             mandatory_families = True,
             product_type = apple_product_type.framework,
             rpaths = [


### PR DESCRIPTION
After this change, no Apple rules use `apple_binary` directly. Instead, they call its functionality through the Starlark API that Bazel core exposes. The `{ios,tvos}_static_framework` rules still use `apple_static_library` since there is no Starlark-callable API equivalent of that yet.

PiperOrigin-RevId: 334189971