### PR TITLE
Put macos_dylib into its own output group

### DIFF
--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -1277,6 +1277,7 @@ def _macos_dylib_impl(ctx):
             **outputs.merge_output_groups(
                 link_result.output_groups,
                 processor_result.output_groups,
+                {"dylib": depset(direct = [output_file])},
             )
         ),
         link_result.binary_provider,

--- a/test/starlark_tests/macos_dylib_tests.bzl
+++ b/test/starlark_tests/macos_dylib_tests.bzl
@@ -26,6 +26,10 @@ load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
+load(
+    ":rules/output_group_test.bzl",
+    "output_group_test",
+)
 
 # buildifier: disable=unnamed-macro
 def macos_dylib_test_suite():
@@ -78,6 +82,13 @@ def macos_dylib_test_suite():
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
         expected_dsyms = ["dylib"],
+        tags = [name],
+    )
+
+    output_group_test(
+        name = "{}_output_group_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
+        expected_output_groups = ["dylib"],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/output_group_test.bzl
+++ b/test/starlark_tests/rules/output_group_test.bzl
@@ -1,0 +1,49 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark test rules for output groups."""
+
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+    "asserts",
+)
+
+def _output_group_test_impl(ctx):
+    """Implementation of the output_group_test rule."""
+    env = analysistest.begin(ctx)
+    target_under_test = ctx.attr.target_under_test
+    expected_groups = ctx.attr.expected_output_groups
+
+    for expected_group in expected_groups:
+        asserts.true(
+            env,
+            expected_group in target_under_test[OutputGroupInfo],
+            msg = "Expected output group not found\n\n\"{0}\"".format(
+                expected_group,
+            ),
+        )
+
+    return analysistest.end(env)
+
+output_group_test = analysistest.make(
+    _output_group_test_impl,
+    attrs = {
+        "expected_output_groups": attr.string_list(
+            mandatory = True,
+            doc = """List of output groups that should be present in the target.""",
+        ),
+    },
+)
+


### PR DESCRIPTION
This is what I was thinking for #911.

The default outputs remain the same (dylib + dsyms).
Now there is an additional output group `dylib` that has only the dylib, which can be retrieved by a downstream filegroup, similar to how `dsyms` already exists.
Meanwhile, the AppleBinaryInfo provider is still maintained.

What do you think?