### PR TITLE
Disable flaky app clip test

### DIFF
--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -123,7 +123,10 @@ def ios_app_clip_test_suite(name = "ios_app_clip"):
         contains = [
             "$BUNDLE_ROOT/AppClips/app_clip.app/embedded.mobileprovision",
         ],
-        tags = [name],
+        tags = [
+            name,
+            "manual",  # TODO: re-enable once fixed, requires bazel clean to reproduce flakiness
+        ],
     )
 
     native.test_suite(


### PR DESCRIPTION
This fails if you run it after running a clean. I haven't been able to
figure out why and don't want to block other changes