### PR TITLE
Pass the correct archive root path when codesigning for the embedding archive

### DIFF
--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -480,6 +480,7 @@ def _bundle_post_process_and_sign(ctx, partial_outputs, output_archive):
             embedding_archive_paths = _archive_paths(ctx, embedding = True)
             embedding_archive_codesigning_path = embedding_archive_paths[_LOCATION_ENUM.bundle]
             embedding_frameworks_path = embedding_archive_paths[_LOCATION_ENUM.framework]
+            embedding_archive_root_path = outputs.root_path_from_archive(archive = embedding_archive)
             unprocessed_embedded_archive = intermediates.file(
                 ctx.actions,
                 ctx.label.name,
@@ -492,7 +493,7 @@ def _bundle_post_process_and_sign(ctx, partial_outputs, output_archive):
                 embedding_frameworks_path,
                 unprocessed_embedded_archive,
                 embedding_archive,
-                output_archive_root_path,
+                embedding_archive_root_path,
                 transitive_signed_frameworks,
                 entitlements = entitlements,
             )

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -123,10 +123,7 @@ def ios_app_clip_test_suite(name = "ios_app_clip"):
         contains = [
             "$BUNDLE_ROOT/AppClips/app_clip.app/embedded.mobileprovision",
         ],
-        tags = [
-            name,
-            "manual",  # TODO: re-enable once fixed, requires bazel clean to reproduce flakiness
-        ],
+        tags = [name],
     )
 
     native.test_suite(


### PR DESCRIPTION
This happened to work due to lack of sandboxing, and racing with the non-embedded case

cc @klmcarthur who landed this code upstream