### PR TITLE
Allow spaces in unit test env variables

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -95,8 +95,7 @@ TEST_ENV="%(test_env)s"
 if [[ -n "${TEST_ENV}" ]]; then
   # Converts the test env string to json format and addes it into launch
   # options string.
-  TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) " " substr($i, d+1); }}')
-  TEST_ENV=${TEST_ENV// /\":\"}
+  TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) "\":\"" substr($i, d+1); }}')
   TEST_ENV=${TEST_ENV//$'\n'/\",\"}
   TEST_ENV="{\"${TEST_ENV}\"}"
   LAUNCH_OPTIONS_JSON_STR="\"env_vars\":${TEST_ENV}"

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -124,6 +124,10 @@ function create_ios_unit_tests() {
   XCTAssertEqual(1, 1, @"should pass");
 }
 
+- (void)testPassEnvVariable {
+  XCTAssertEqual([NSProcessInfo processInfo].environment[@"SomeVariable"], @"Its My Variable", @"should pass");
+}
+
 @end
 EOF
 
@@ -193,6 +197,9 @@ ios_unit_test(
     infoplists = ["PassUnitTest-Info.plist"],
     deps = [":pass_unit_test_lib"],
     minimum_os_version = "9.0",
+    env = {
+      "SomeVariable": "Its My Variable"
+    },
     runner = ":ios_x86_64_sim_runner",
 )
 


### PR DESCRIPTION
Allows for spaces to exist in test env variables

Fixes #937