### PR TITLE
Suggested fix to address running macos_kernel_extension tests with Xcode 12.

### DIFF
--- a/test/starlark_tests/resources/kext_resources/BUILD
+++ b/test/starlark_tests/resources/kext_resources/BUILD
@@ -24,7 +24,6 @@ cc_library(
     copts = [
         "-mkernel",
         "-fapple-kext",
-        "-isystem__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/PrivateHeaders",
         "-isystem__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/Headers",
     ],
     tags = [

--- a/test/starlark_tests/resources/kext_resources/BUILD
+++ b/test/starlark_tests/resources/kext_resources/BUILD
@@ -24,8 +24,8 @@ cc_library(
     copts = [
         "-mkernel",
         "-fapple-kext",
-        "-I__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/PrivateHeaders",
-        "-I__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/Headers",
+        "-isystem__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/PrivateHeaders",
+        "-isystem__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Kernel.framework/Headers",
     ],
     tags = [
         "manual",


### PR DESCRIPTION
PiperOrigin-RevId: 336678536