### PR TITLE
Use -Wl so linkopts only use a single argument

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -34,10 +34,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
     "swift_runtime_linkopts",
 )
-load(
-    "@bazel_skylib//lib:collections.bzl",
-    "collections",
-)
 
 def _create_swift_runtime_linkopts_target(
         name,
@@ -244,7 +240,7 @@ def _create_binary(
     rule_descriptor = rule_support.rule_descriptor_no_ctx(platform_type, product_type)
 
     linkopts = kwargs.pop("linkopts", [])
-    linkopts = linkopts + collections.before_each("-rpath", rule_descriptor.rpaths)
+    linkopts = linkopts + ["-Wl,-rpath,{}".format(rpath) for rpath in rule_descriptor.rpaths]
     linkopts = linkopts + rule_descriptor.extra_linkopts
     if extension_safe:
         linkopts = linkopts + ["-application_extension"]

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -18,10 +18,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
 )
-load(
-    "@bazel_skylib//lib:collections.bzl",
-    "collections",
-)
 
 def _sectcreate_objc_provider(segname, sectname, file):
     """Returns an objc provider that propagates a section in a linked binary.
@@ -89,7 +85,7 @@ def _register_linking_action(ctx, extra_linkopts = []):
     rpaths = rule_descriptor.rpaths
     linkopts = []
     if rpaths:
-        linkopts.extend(collections.before_each("-rpath", rpaths))
+        linkopts.extend(["-Wl,-rpath,{}".format(rpath) for rpath in rpaths])
 
     linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
 

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -509,10 +509,7 @@ _RULE_TYPE_DESCRIPTORS = {
             # stripping is better-handled. It's redundant with an option added in the CROSSTOOL
             # for the "kernel_extension" feature, but for now it's necessary to detect kext
             # linking so CompilationSupport.java can apply the correct type of symbol stripping.
-            extra_linkopts = [
-                "-Xlinker",
-                "-kext",
-            ],
+            extra_linkopts = ["-Wl,-kext"],
             product_type = apple_product_type.kernel_extension,
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,


### PR DESCRIPTION
This ensures they wont be incorrectly de-duplicated if put into a NestedSet