### PR TITLE
Allow overriding the linker executable

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -92,6 +92,8 @@ def _register_linking_action(ctx, extra_linkopts = []):
         linkopts.extend(collections.before_each("-rpath", rpaths))
 
     linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
+    if hasattr(ctx.executable, "linker"):
+        linkopts.append("-fuse-ld=" + ctx.executable.linker.path)
 
     binary_provider_struct = apple_common.link_multi_arch_binary(
         ctx = ctx,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -269,6 +269,14 @@ This attribute is public as an implementation detail while we migrate the archit
 Do not change its value.
     """,
         ),
+        "linker": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_single_file = True,
+            doc = """
+An executable to use for linking instead of the default linker
+    """,
+        ),
         "linkopts": attr.string_list(
             doc = """
 A list of strings representing extra flags that should be passed to the linker.


### PR DESCRIPTION
since many large orgs use a custom linker via `-fuse-ld=`, and it sounds like the alternative to this is either to break hermeticity or change the toolchain, it seems like a nice option to have