### PR TITLE
Workaround actool error: "failed to open liblaunch_sim.dylib."

### DIFF
--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -235,10 +235,10 @@ def actool(_, toolargs):
   # based on the same codebase.
   #
   # Note: `actool` is problematic on all Xcode 12 builds including to 12.1. 25%
-  # of the time, it fails with the error: "failed to open # liblaunch_sim.dylib`.
+  # of the time, it fails with the error:
+  # "failed to open # liblaunch_sim.dylib"
   #
-  # This workaround adds a retry, and this works due to logic in `actool`.
-  #
+  # This workaround adds a retry it works due to logic in `actool`:
   # The first time `actool` runs, it spawns a dependent service as the current
   # user. After a failure, `actool` spawns it in a way that subsequent
   # invocations will not have the error. It only needs 1 retry.
@@ -254,7 +254,7 @@ def actool(_, toolargs):
       sys.stdout.write("%s" % stdout)
     if stderr:
       sys.stderr.write("%s" % stderr)
-      return return_code
+    return return_code
 
   return_code, _, _ = execute.execute_and_filter_output(
       xcrunargs,

--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -238,6 +238,16 @@ def actool(_, toolargs):
       trim_paths=True,
       filtering=actool_filtering,
       print_output=True)
+
+  if return_code == 0:
+      return return_code
+
+  # `actool` is problematic on Xcode 12 so retry
+  return_code, _, _ = execute.execute_and_filter_output(
+      xcrunargs,
+      trim_paths=True,
+      filtering=actool_filtering,
+      print_output=True)
   return return_code
 
 


### PR DESCRIPTION
`actool` is flaky on Xcode 11 betas, all Xcode 12 builds and it hasn't been fixed as of 12.1.  In testing a large build with multiple failures, this has fixed the issue. The error happens on ~1% of builds and it seems better to retry _inside_ of Bazel than to retry the entire build. Putting this up as RFC to get everyones appetite on fixing this in Bazel.

Note: this issue has been persisting in all of Xcode 12 builds including 12.1.