### PR TITLE
Ensure that output groups returned from `apple_common.link_multi_arch_binary` are propagated by the bundling rules.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -95,12 +95,12 @@ def _ios_application_impl(ctx):
             collections.before_each("-framework", ctx.attr.sdk_frameworks),
         )
 
-    binary_descriptor = linking_support.register_linking_action(
+    link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
     )
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -310,9 +310,15 @@ def _ios_application_impl(ctx):
             ),
         ),
         IosApplicationBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
         # Propagate the binary provider so that this target can be used as bundle_loader in test
         # rules.
-        binary_descriptor.provider,
+        link_result.binary_provider,
     ] + processor_result.providers
 
 def _ios_app_clip_impl(ctx):
@@ -324,9 +330,9 @@ def _ios_app_clip_impl(ctx):
         "resources",
     ]
 
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -510,9 +516,15 @@ def _ios_app_clip_impl(ctx):
             ),
         ),
         IosAppClipBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
         # Propagate the binary provider so that this target can be used as bundle_loader in test
         # rules.
-        binary_descriptor.provider,
+        link_result.binary_provider,
     ] + processor_result.providers
 
 def _ios_framework_impl(ctx):
@@ -523,13 +535,12 @@ def _ios_framework_impl(ctx):
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")
 
-    binary_descriptor = linking_support.register_linking_action(
+    link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
     )
-    binary_artifact = binary_descriptor.artifact
-    binary_provider = binary_descriptor.provider
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -626,7 +637,7 @@ def _ios_framework_impl(ctx):
         partials.framework_provider_partial(
             actions = actions,
             bin_root_path = bin_root_path,
-            binary_provider = binary_provider,
+            binary_provider = link_result.binary_provider,
             bundle_name = bundle_name,
             rule_label = label,
         ),
@@ -677,6 +688,12 @@ def _ios_framework_impl(ctx):
     return [
         DefaultInfo(files = processor_result.output_files),
         IosFrameworkBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _ios_extension_impl(ctx):
@@ -694,12 +711,13 @@ def _ios_extension_impl(ctx):
             collections.before_each("-framework", ctx.attr.sdk_frameworks),
         )
 
-    binary_descriptor = linking_support.register_linking_action(
+    link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
     )
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
+    output_groups = link_result.output_groups
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -847,7 +865,13 @@ def _ios_extension_impl(ctx):
         IosExtensionBundleInfo(),
         # Propagate the binary provider so that this target can be used as bundle_loader in test
         # rules.
-        binary_descriptor.provider,
+        link_result.binary_provider,
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _ios_static_framework_impl(ctx):
@@ -946,6 +970,7 @@ def _ios_static_framework_impl(ctx):
     return [
         DefaultInfo(files = processor_result.output_files),
         IosStaticFrameworkBundleInfo(),
+        OutputGroupInfo(**processor_result.output_groups),
     ] + processor_result.providers
 
 def _ios_imessage_application_impl(ctx):
@@ -1079,6 +1104,7 @@ def _ios_imessage_application_impl(ctx):
             files = processor_result.output_files,
         ),
         IosImessageApplicationBundleInfo(),
+        OutputGroupInfo(**processor_result.output_groups),
     ] + processor_result.providers
 
 def _ios_imessage_extension_impl(ctx):
@@ -1089,9 +1115,9 @@ def _ios_imessage_extension_impl(ctx):
         "resources",
     ]
 
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -1240,6 +1266,12 @@ def _ios_imessage_extension_impl(ctx):
         ),
         IosExtensionBundleInfo(),
         IosImessageExtensionBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _ios_sticker_pack_extension_impl(ctx):
@@ -1364,6 +1396,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         ),
         IosExtensionBundleInfo(),
         IosStickerPackExtensionBundleInfo(),
+        OutputGroupInfo(**processor_result.output_groups),
     ] + processor_result.providers
 
 # Rule definitions for rules that use the Starlark linking API and the new rule_factory support.

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -78,11 +78,17 @@ def _register_linking_action(ctx, extra_linkopts = []):
         extra_linkopts: Extra linkopts to add to the linking action.
 
     Returns:
-        A descriptor `struct` with the following fields:
-            * `provider`: The binary provider that represents the linked binary.
-            * `debug_outputs_provider`: The provider containing the debug symbols, if any were
-              requested.
-            * `artifact`: The final linked binary `File`.
+        The `struct` returned by `apple_common.link_multi_arch_binary`, which contains the
+        following fields:
+
+        *   `binary_provider`: A provider describing the binary that was linked. This is an
+            instance of either `AppleExecutableBinaryInfo`, `AppleDylibBinaryInfo`, or
+            `AppleLoadableBundleBinaryInfo`; all three have a `binary` field that is the linked
+            binary `File`.
+        *   `debug_outputs_provider`: An `AppleDebugOutputsInfo` provider that contains debug
+            outputs, such as linkmaps and dSYM binaries.
+        *   `output_groups`: A `dict` containing output groups that should be returned in the
+            `OutputGroupInfo` provider of the calling rule.
     """
     rule_descriptor = rule_support.rule_descriptor(ctx)
 
@@ -93,18 +99,9 @@ def _register_linking_action(ctx, extra_linkopts = []):
 
     linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
 
-    binary_provider_struct = apple_common.link_multi_arch_binary(
+    return apple_common.link_multi_arch_binary(
         ctx = ctx,
         extra_linkopts = linkopts,
-    )
-    binary_provider = binary_provider_struct.binary_provider
-    debug_outputs_provider = binary_provider_struct.debug_outputs_provider
-    binary_artifact = binary_provider.binary
-
-    return struct(
-        provider = binary_provider,
-        debug_outputs_provider = debug_outputs_provider,
-        artifact = binary_artifact,
     )
 
 linking_support = struct(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -76,9 +76,9 @@ load(
 
 def _macos_application_impl(ctx):
     """Implementation of macos_application."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     embedded_targets = ctx.attr.extensions + ctx.attr.xpc_services
 
@@ -242,14 +242,20 @@ def _macos_application_impl(ctx):
             ),
         ),
         MacosApplicationBundleInfo(),
-        binary_descriptor.provider,
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
+        link_result.binary_provider,
     ] + processor_result.providers
 
 def _macos_bundle_impl(ctx):
     """Implementation of macos_bundle."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -380,6 +386,12 @@ def _macos_bundle_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosBundleBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_extension_impl(ctx):
@@ -387,9 +399,9 @@ def _macos_extension_impl(ctx):
     extra_linkopts = []
     if not ctx.attr.provides_main:
         extra_linkopts.extend(["-e", "_NSExtensionMain"])
-    binary_descriptor = linking_support.register_linking_action(ctx, extra_linkopts)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx, extra_linkopts)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -520,7 +532,13 @@ def _macos_extension_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosExtensionBundleInfo(),
-        binary_descriptor.provider,
+        link_result.binary_provider,
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_quick_look_plugin_impl(ctx):
@@ -529,9 +547,9 @@ def _macos_quick_look_plugin_impl(ctx):
         "-install_name",
         "\"/Library/Frameworks/{0}.qlgenerator/{0}\"".format(ctx.attr.bundle_name),
     ]
-    binary_descriptor = linking_support.register_linking_action(ctx, extra_linkopts)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx, extra_linkopts)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -661,13 +679,19 @@ def _macos_quick_look_plugin_impl(ctx):
     return [
         DefaultInfo(files = processor_result.output_files),
         MacosQuickLookPluginBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_kernel_extension_impl(ctx):
     """Implementation of macos_kernel_extension."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -794,13 +818,19 @@ def _macos_kernel_extension_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosKernelExtensionBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_spotlight_importer_impl(ctx):
     """Implementation of macos_spotlight_importer."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -926,13 +956,19 @@ def _macos_spotlight_importer_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosSpotlightImporterBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_xpc_service_impl(ctx):
     """Implementation of macos_xpc_service."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -1058,17 +1094,24 @@ def _macos_xpc_service_impl(ctx):
             files = processor_result.output_files,
         ),
         MacosXPCServiceBundleInfo(),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ] + processor_result.providers
 
 def _macos_command_line_application_impl(ctx):
     """Implementation of the macos_command_line_application rule."""
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
+
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
@@ -1121,18 +1164,25 @@ def _macos_command_line_application_impl(ctx):
                 processor_result.output_files,
             ]),
         ),
-        binary_descriptor.provider,
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
+        link_result.binary_provider,
     ] + processor_result.providers
 
 def _macos_dylib_impl(ctx):
     """Implementation of the macos_dylib rule."""
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
+
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
@@ -1182,7 +1232,13 @@ def _macos_dylib_impl(ctx):
             depset([output_file]),
             processor_result.output_files,
         ])),
-        binary_descriptor.provider,
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
+        link_result.binary_provider,
     ] + processor_result.providers
 
 macos_application = rule_factory.create_apple_bundling_rule(

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -97,6 +97,49 @@ def _has_different_embedding_archive(*, platform_prerequisites, rule_descriptor)
         return False
     return rule_descriptor.bundle_locations.archive_relative != "" and rule_descriptor.expose_non_archive_relative_output
 
+def _merge_output_groups(*output_groups_list):
+    """Merges a list of output group dictionaries into a single dictionary.
+
+    In order to properly support use cases such as validation actions, which are represented as a
+    uniquely named output group, partials or other parts of the build should propagate their output
+    groups as raw dictionaries and collect them as lists of dictionaries and not wrap them into the
+    `OutputGroupInfo` provider until the very end of the rule or aspect implementation function.
+
+    In order to support this, this function merges these lists of output group dictionaries so that
+    the final dictionary contains the keys from all of the dictionaries that were given to it, and
+    furthermore, if two dictionaries in the list have the same key, the `depset`s for those keys
+    will be merged.
+
+    Args:
+        *output_groups_list: A list of dictionaries that represent output groups; that is, their
+            keys are strings (the names of the output groups) and their values are `depset`s of
+            `File`s.
+
+    Returns:
+        A new dictionary containing the union of all of the output groups.
+    """
+
+    # We collect the depsets for each key as a flat list and create a single transitive depset
+    # from all of them at the end, instead of creating a new chained depset each time we find a
+    # duplicate key. This prevents the depset depth from growing too large (even though in
+    # practice, this is unlikely for our uses of this function).
+    output_group_depsets = {}
+    for output_groups in output_groups_list:
+        for name, files in output_groups.items():
+            if name not in output_group_depsets:
+                output_group_depsets[name] = [files]
+            else:
+                output_group_depsets[name].append(files)
+
+    # We can unconditionally create a new depset here; if `depsets` has a length of 1, there is
+    # a fast-path that returns the same depset instead of constructing a new nested one.
+    merged_output_groups = {
+        name: depset(transitive = depsets)
+        for name, depsets in output_group_depsets.items()
+    }
+
+    return merged_output_groups
+
 def _root_path_from_archive(*, archive):
     """Given an archive, returns a path to a directory reference for this target's archive root."""
     return paths.replace_extension(archive.path, "_archive-root")
@@ -107,6 +150,7 @@ outputs = struct(
     binary = _binary,
     executable = _executable,
     infoplist = _infoplist,
+    merge_output_groups = _merge_output_groups,
     root_path_from_archive = _root_path_from_archive,
     has_different_embedding_archive = _has_different_embedding_archive,
 )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -93,10 +93,6 @@ load(
     "apple_support",
 )
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
@@ -643,9 +639,10 @@ def _process(
       rule_label: The label of the target being analyzed.
 
     Returns:
-      A struct with the results of the processing. The files to make outputs of
-      the rule are contained under the `output_files` field, and the providers to
-      return are contained under the `providers` field.
+      A `struct` with the results of the processing. The files to make outputs of
+      the rule are contained under the `output_files` field, the providers to
+      return are contained under the `providers` field, and a dictionary containing
+      any additional output groups is in the `output_groups` field.
     """
 
     # TODO(b/161370390): Remove the ctx kwarg passed to this call once ctx is removed from the args
@@ -690,14 +687,9 @@ def _process(
         if hasattr(partial_output, "output_groups"):
             output_group_dicts.append(partial_output.output_groups)
 
-    if output_group_dicts:
-        # TODO(kaipi): Add support for merging keys. Currently the last one wins, but because
-        # there's only one partial that supports this, it's ok.
-        merged_output_groups = dicts.add(*output_group_dicts)
-        providers.append(OutputGroupInfo(**merged_output_groups))
-
     return struct(
         output_files = depset(transitive = transitive_output_files),
+        output_groups = outputs.merge_output_groups(*output_group_dicts),
         providers = providers,
     )
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -218,9 +218,9 @@ def _test_host_bundle_id(test_host):
 
 def _apple_test_bundle_impl(ctx, extra_providers = []):
     """Implementation for bundling XCTest bundles."""
-    binary_descriptor = linking_support.register_linking_action(ctx)
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    link_result = linking_support.register_linking_action(ctx)
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     test_host_bundle_id = _test_host_bundle_id(ctx.attr.test_host)
     if ctx.attr.bundle_id:
@@ -413,6 +413,12 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
         AppleExtraOutputsInfo(files = depset(filtered_outputs)),
         DefaultInfo(files = output_files),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
+        ),
     ])
 
     return providers

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -583,7 +583,7 @@ def _tvos_extension_impl(ctx):
         TvosExtensionBundleInfo(),
         # Propagate the binary provider so that this target can be used as bundle_loader in test
         # rules.
-        binary_descriptor.provider,
+        link_result.binary_provider,
     ] + processor_result.providers
 
 def _tvos_static_framework_impl(ctx):

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -227,6 +227,7 @@ def _watchos_application_impl(ctx):
         DefaultInfo(
             files = processor_result.output_files,
         ),
+        OutputGroupInfo(**processor_result.output_groups),
         WatchosApplicationBundleInfo(),
     ] + processor_result.providers
 
@@ -264,12 +265,12 @@ def _watchos_extension_impl(ctx):
     else:
         extra_linkopts = []
 
-    binary_descriptor = linking_support.register_linking_action(
+    link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
     )
-    binary_artifact = binary_descriptor.artifact
-    debug_outputs_provider = binary_descriptor.debug_outputs_provider
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     bin_root_path = ctx.bin_dir.path
@@ -405,6 +406,12 @@ def _watchos_extension_impl(ctx):
     return [
         DefaultInfo(
             files = processor_result.output_files,
+        ),
+        OutputGroupInfo(
+            **outputs.merge_output_groups(
+                link_result.output_groups,
+                processor_result.output_groups,
+            )
         ),
         WatchosExtensionBundleInfo(),
     ] + processor_result.providers


### PR DESCRIPTION
This is important in case any of these actions are validating actions (which use a specially-named output group); we need to make sure those get merged with any output groups that the bundling rules create.

This CL also adds some logic to make sure output groups with the same name get their file sets merged, instead of simply taking the last occurrence of the name, so that output groups aren't silently lost.

PiperOrigin-RevId: 335076331