### PR TITLE
Implement `apple_binary` in Starlark on top of `apple_common.link_multi_arch_binary`.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -35,6 +35,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "apple_binary",
+    srcs = ["apple_binary.bzl"],
+    deps = [
+        "//apple/internal:linking_support",
+        "//apple/internal:rule_factory",
+    ],
+)
+
+bzl_library(
     name = "common",
     srcs = ["common.bzl"],
 )

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -1,0 +1,136 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark implementation of `apple_binary` to transition from native Bazel."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "linking_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+
+def _linker_flag_for_sdk_dylib(dylib):
+    """Returns a linker flag suitable for linking the given `sdk_dylib` value.
+
+    As does Bazel core, we strip a leading `lib` if it is present in the name
+    of the library.
+
+    Args:
+        dylib: The name of the library, as specified in the `sdk_dylib`
+            attribute.
+
+    Returns:
+        A linker flag used to link to the given library.
+    """
+    if dylib.startswith("lib"):
+        dylib = dylib[3:]
+    return "-l{}".format(dylib)
+
+def _apple_binary_impl(ctx):
+    extra_linkopts = [
+        _linker_flag_for_sdk_dylib(dylib)
+        for dylib in ctx.attr.sdk_dylibs
+    ] + [
+        "-Wl,-framework,{}".format(framework)
+        for framework in ctx.attr.sdk_frameworks
+    ] + [
+        "-Wl,-weak_framework,{}".format(framework)
+        for framework in ctx.attr.weak_sdk_frameworks
+    ]
+
+    link_result = linking_support.register_linking_action(
+        ctx,
+        extra_linkopts = extra_linkopts,
+    )
+    binary_artifact = link_result.binary_provider.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
+
+    return [
+        DefaultInfo(
+            files = depset([binary_artifact]),
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+                files = [binary_artifact] + ctx.files.data,
+            ),
+        ),
+        OutputGroupInfo(**link_result.output_groups),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["bundle_loader", "deps"],
+        ),
+        link_result.binary_provider,
+        link_result.debug_outputs_provider,
+    ]
+
+apple_binary = rule_factory.create_apple_binary_rule(
+    additional_attrs = {
+        "data": attr.label_list(allow_files = True),
+        "sdk_dylibs": attr.string_list(
+            allow_empty = True,
+            doc = """
+Names of SDK `.dylib` libraries to link with (e.g., `libz` or `libarchive`).
+`libc++` is included automatically if the binary has any C++ or Objective-C++
+sources in its dependency tree. When linking a binary, all libraries named in
+that binary's transitive dependency graph are used.
+""",
+        ),
+        "sdk_frameworks": attr.string_list(
+            allow_empty = True,
+            doc = """
+Names of SDK frameworks to link with (e.g., `AddressBook`, `QuartzCore`).
+`UIKit` and `Foundation` are always included, even if this attribute is
+provided and does not list them.
+
+This attribute is discouraged; in general, targets should list system
+framework dependencies in the library targets where that framework is used,
+not in the top-level bundle.
+""",
+        ),
+        "weak_sdk_frameworks": attr.string_list(
+            allow_empty = True,
+            doc = """
+Names of SDK frameworks to weakly link with (e.g., `MediaAccessibility`).
+Unlike regularly linked SDK frameworks, symbols from weakly linked
+frameworks do not cause the binary to fail to load if they are not present in
+the version of the framework available at runtime.
+
+This attribute is discouraged; in general, targets should list system
+framework dependencies in the library targets where that framework is used,
+not in the top-level bundle.
+""",
+        ),
+    },
+    doc = """
+This rule produces single- or multi-architecture ("fat") binaries targeting
+Apple platforms.
+
+The `lipo` tool is used to combine files of multiple architectures. One of
+several flags may control which architectures are included in the output,
+depending on the value of the `platform_type` attribute.
+
+NOTE: In most situations, users should prefer the platform- and
+product-type-specific rules, such as `macos_command_line_application`. This
+rule is being provided for the purpose of transitioning users from the built-in
+implementation of `apple_binary` in Bazel core so that it can be removed.
+""",
+    implementation = _apple_binary_impl,
+    implicit_outputs = {
+        # Provided for compatibility with built-in `apple_binary` only.
+        "lipobin": "%{name}_lipobin",
+    },
+)

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -90,14 +90,17 @@ def _register_linking_action(ctx, extra_linkopts = []):
         *   `output_groups`: A `dict` containing output groups that should be returned in the
             `OutputGroupInfo` provider of the calling rule.
     """
-    rule_descriptor = rule_support.rule_descriptor(ctx)
-
-    rpaths = rule_descriptor.rpaths
     linkopts = []
-    if rpaths:
-        linkopts.extend(collections.before_each("-rpath", rpaths))
 
-    linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
+    # Compatibility path for `apple_binary`, which does not have a product type.
+    if hasattr(ctx.attr, "_product_type"):
+        rule_descriptor = rule_support.rule_descriptor(ctx)
+
+        rpaths = rule_descriptor.rpaths
+        if rpaths:
+            linkopts.extend(collections.before_each("-rpath", rpaths))
+
+        linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
 
     return apple_common.link_multi_arch_binary(
         ctx = ctx,

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -1,4 +1,8 @@
 load("@rules_cc//cc:defs.bzl", "objc_library")
+load(
+    "//apple:apple_binary.bzl",
+    "apple_binary",
+)
 
 # Public only because these are used by the integration tests from generated
 # workspaces. Please no not depend on them as they can change at any time.


### PR DESCRIPTION
Using `apple_binary` directly is discouraged (users should use the platform-/product-specific rules instead), but this is provided as a transitional step so that `apple_binary` as a rule in Bazel core can be removed.

PiperOrigin-RevId: 336395942
(cherry picked from commit 8f55d10ae98bb7719e6fd8a14574408e9a794ed7)