### PR TITLE
Fix issue where the default minimum OS is returned in platform_prerequisites as type DottedVersion when it should be of type String.

### DIFF
--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -125,7 +125,8 @@ def _platform_prerequisites(
     if explicit_minimum_os:
         minimum_os = explicit_minimum_os
     else:
-        minimum_os = xcode_version_config.minimum_os_for_platform_type(platform_type_attr)
+        # TODO(b/38006810): Use the SDK version instead of the flag value as a soft default.
+        minimum_os = str(xcode_version_config.minimum_os_for_platform_type(platform_type_attr))
 
     sdk_version = xcode_version_config.sdk_version_for_platform(platform)
 


### PR DESCRIPTION
PiperOrigin-RevId: 337347290
(cherry picked from commit 46a5f891c8b22c167dea40f14f73a8230c00a8b2)