### PR TITLE
Ignore missing executable_names

### DIFF
--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -264,7 +264,7 @@ def merge_root_infoplists(
     # Info.plists out of the box coming from Xcode.
     substitutions["DEVELOPMENT_LANGUAGE"] = "en"
 
-    if include_executable_name:
+    if include_executable_name and executable_name:
         substitutions["EXECUTABLE_NAME"] = executable_name
         forced_plists.append(struct(CFBundleExecutable = executable_name))
 


### PR DESCRIPTION
For some plists like those in resource bundles executable names should
not be included. In this case this can be called with
`include_executable_name = True` since that's the default, but
`executable_name = None`. In this case we can ignore this since that's
not a valid value.