### PR TITLE
Add apple.skip_codesign_simulator_bundles

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -255,6 +255,7 @@ def _signing_command_lines(
 def _should_sign_simulator_bundles(
         *,
         config_vars,
+        features,
         rule_descriptor):
     """Check if a main bundle should be codesigned.
 
@@ -267,6 +268,13 @@ def _should_sign_simulator_bundles(
       True/False for if the bundle should be signed.
 
     """
+    if "apple.codesign_simulator_bundles" in config_vars:
+        # buildifier: disable=print
+        print("warning: --define apple.codesign_simulator_bundles is deprecated, please switch to --features=apple.skip_codesign_simulator_bundles")
+
+    if "apple.skip_codesign_simulator_bundles" in features:
+        return False
+
     if not rule_descriptor.skip_simulator_signing_allowed:
         return True
 
@@ -325,6 +333,7 @@ def _codesigning_args(
     is_device = platform_prerequisites.platform.is_device
     should_sign_sim_bundles = _should_sign_simulator_bundles(
         config_vars = platform_prerequisites.config_vars,
+        features = platform_prerequisites.features,
         rule_descriptor = rule_descriptor,
     )
     if not is_framework and not is_device and not should_sign_sim_bundles:
@@ -406,6 +415,7 @@ def _codesigning_command(
         )
     should_sign_sim_bundles = _should_sign_simulator_bundles(
         config_vars = platform_prerequisites.config_vars,
+        features = platform_prerequisites.features,
         rule_descriptor = rule_descriptor,
     )
     if platform_prerequisites.platform.is_device or should_sign_sim_bundles:

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -252,15 +252,32 @@ def _signing_command_lines(
         commands.append(" ".join(codesign_command))
     return "\n".join(commands)
 
+def _should_sign_simulator_frameworks(
+        *,
+        config_vars,
+        features,
+        rule_descriptor):
+    """Check if simulator bound framework bundles should be codesigned.
+
+    Args:
+
+    Returns:
+      True/False for if the framework should be signed.
+    """
+    if "apple.skip_codesign_simulator_bundles" in features:
+        return False
+
+    # To preserve existing functionality, where Frameworks/* bundles are always
+    # signed, we only skip them with the new flag. This check will go away when
+    # `apple.codesign_simulator_bundles` goes away.
+    return True
+
 def _should_sign_simulator_bundles(
         *,
         config_vars,
         features,
         rule_descriptor):
     """Check if a main bundle should be codesigned.
-
-    The Frameworks/* bundles should *always* be signed, this is just for
-    the other bundles.
 
     Args:
 
@@ -336,6 +353,8 @@ def _codesigning_args(
         features = platform_prerequisites.features,
         rule_descriptor = rule_descriptor,
     )
+
+    # We need to re-sign imported frameworks
     if not is_framework and not is_device and not should_sign_sim_bundles:
         return []
 
@@ -398,7 +417,12 @@ def _codesigning_command(
     # The command returned by this function is executed as part of a bundling shell script.
     # Each directory to be signed must be prefixed by $WORK_DIR, which is the variable in that
     # script that contains the path to the directory where the bundle is being built.
-    if frameworks_path:
+    should_sign_sim_frameworks = _should_sign_simulator_frameworks(
+        config_vars = platform_prerequisites.config_vars,
+        features = platform_prerequisites.features,
+        rule_descriptor = rule_descriptor,
+    )
+    if frameworks_path and should_sign_sim_frameworks:
         framework_root = paths.join("$WORK_DIR", frameworks_path) + "/"
         full_signed_frameworks = []
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -180,7 +180,7 @@ the build to Apple. If you want to disable bundling SwiftSupport in your ipa for
 other device or enterprise builds, you can pass
 `--define=apple.package_swift_support=no` to `bazel build`
 
-### Codesign Bundles for the Simulator {#apple.codesign_simulator_bundles}
+### Codesign Bundles for the Simulator {#apple.skip_codesign_simulator_bundles}
 
 The simulators are far more lax about a lot of things compared to working on
 real devices. One of these areas is the codesigning of bundles (applications,
@@ -196,7 +196,7 @@ to work.
 
 By default, the rules will do what Xcode would otherwise do and *will* sign the
 main bundle (with an adhoc signature) when targeting the Simulator. However,
-this `--define` can be used to opt out of this if you are more concerned with
+this feature can be used to opt out of this if you are more concerned with
 build speed vs. potential correctness.
 
 Remember, at any time, Apple could do a macOS point release and/or an Xcode
@@ -204,17 +204,22 @@ release that changes this and opting out of could mean your binary doesn't run
 under the simulator.
 
 The rules support direct control over this signing via
-`--define=apple.codesign_simulator_bundles=(yes|true|1|no|false|0)`.
+`--features=apple.skip_codesign_simulator_bundles`.
 
 Disable the signing of simulator bundles:
 
 ```shell
-bazel build --define=apple.codesign_simulator_bundles=no //your/target
+bazel build --features=apple.skip_codesign_simulator_bundles //your/target
 ```
 
-One exception is XCTest bundles, those do need to be signed for the simulators
-to load them. The above `--define` does not change the behavior around signing
-of these bundles as a result.
+More likely you'll want to do this on a per-target basis such as with:
+
+```bzl
+ios_unit_test(
+    ...
+    features = ["apple.skip_codesign_simulator_bundles"],
+)
+```
 
 ### Localization Handling
 

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -709,7 +709,7 @@ function test_tree_artifacts_and_disable_simulator_codesigning() {
   create_minimal_ios_application
   do_build ios //app:app \
       --define=apple.experimental.tree_artifact_outputs=yes \
-      --define=apple.codesign_simulator_bundles=no || fail "Should build"
+      --features=apple.skip_codesign_simulator_bundles || fail "Should build"
 }
 
 run_suite "ios_application bundling tests"


### PR DESCRIPTION
This is a replacement for `apple.codesign_simulator_bundles` that uses
the newer `features` system. This has the benefit of being able to set
it on specific targets, and disable it for others. This way if you have
some targets that require signing, you can use:

```
features = ["-apple.skip_codesign_simulator_bundles"],
```

On those will still passing
`--features=apple.skip_codesign_simulator_bundles` if that works for
you.

Once the old option is removed there will be no filtering for when to
use this, so you can use it on whatever target types you want, and like
before it's up to you to manage the tradeoff between performance and
correctness.

Fixes https://github.com/bazelbuild/rules_apple/issues/710