### PR TITLE
Fix typo in examples/BUILD comment

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,4 +1,4 @@
 licenses(["notice"])
 
-# Empty build file to define a package at examples to it is easier
+# Empty build file to define a package at examples so it is easier
 # to do builds/tests/etc.


### PR DESCRIPTION
Was looking around the repo to learn a bit about Bazel and noticed a little typo: "to it is easier to..." :point_right: "so it is easier to..."

Thank you for working on this great project 💙