### PR TITLE
Add the `stamp` attribute to all `ios_*`, `macos_*`, `tvos_*`, and `watchos_*` rules, as well as to the Starlark `apple_binary`.

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -55,6 +55,7 @@ def _apple_binary_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -110,6 +110,7 @@ def _ios_application_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -348,7 +349,10 @@ def _ios_app_clip_impl(ctx):
         "resources",
     ]
 
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -561,6 +565,7 @@ def _ios_framework_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -742,6 +747,7 @@ def _ios_extension_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -909,16 +915,16 @@ def _ios_extension_impl(ctx):
 
 def _ios_dynamic_framework_impl(ctx):
     """Experimental implementation of ios_dynamic_framework."""
-    
+
     # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
     # because of the swift_runtime_linkopts dep that comes with the swift_libray
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
-                fail(
-                    """\
+        fail(
+            """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
-                )
+        )
 
     binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
     extra_linkopts = []
@@ -928,6 +934,7 @@ def _ios_dynamic_framework_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -1337,7 +1344,10 @@ def _ios_imessage_extension_impl(ctx):
         "resources",
     ]
 
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -63,7 +63,7 @@ def _exported_symbols_list_objc_provider(files):
         link_inputs = depset(files),
     )
 
-def _register_linking_action(ctx, extra_linkopts = []):
+def _register_linking_action(ctx, *, stamp, extra_linkopts = []):
     """Registers linking actions using the Starlark Linking API for Apple binaries.
 
     This method will add the linkopts as added on the rule descriptor, in addition to any extra
@@ -71,6 +71,11 @@ def _register_linking_action(ctx, extra_linkopts = []):
 
     Args:
         ctx: The rule context.
+        stamp: Whether to include build information in the linked binary. If 1, build
+            information is always included. If 0, the default build information is always
+            excluded. If -1, the default behavior is used, which may be overridden by the
+            `--[no]stamp` flag. This should be set to 0 when generating the executable output
+            for test rules.
         extra_linkopts: Extra linkopts to add to the linking action.
 
     Returns:
@@ -97,6 +102,7 @@ def _register_linking_action(ctx, extra_linkopts = []):
     return apple_common.link_multi_arch_binary(
         ctx = ctx,
         extra_linkopts = linkopts,
+        stamp = stamp,
     )
 
 linking_support = struct(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -80,7 +80,10 @@ load(
 
 def _macos_application_impl(ctx):
     """Implementation of macos_application."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -262,7 +265,10 @@ def _macos_application_impl(ctx):
 
 def _macos_bundle_impl(ctx):
     """Implementation of macos_bundle."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -413,7 +419,11 @@ def _macos_extension_impl(ctx):
     extra_linkopts = []
     if not ctx.attr.provides_main:
         extra_linkopts.extend(["-e", "_NSExtensionMain"])
-    link_result = linking_support.register_linking_action(ctx, extra_linkopts)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -566,7 +576,11 @@ def _macos_quick_look_plugin_impl(ctx):
         "-install_name",
         "\"/Library/Frameworks/{0}.qlgenerator/{0}\"".format(ctx.attr.bundle_name),
     ]
-    link_result = linking_support.register_linking_action(ctx, extra_linkopts)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -713,7 +727,10 @@ def _macos_quick_look_plugin_impl(ctx):
 
 def _macos_kernel_extension_impl(ctx):
     """Implementation of macos_kernel_extension."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -857,7 +874,10 @@ def _macos_kernel_extension_impl(ctx):
 
 def _macos_spotlight_importer_impl(ctx):
     """Implementation of macos_spotlight_importer."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -1000,7 +1020,10 @@ def _macos_spotlight_importer_impl(ctx):
 
 def _macos_xpc_service_impl(ctx):
     """Implementation of macos_xpc_service."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -1143,7 +1166,10 @@ def _macos_xpc_service_impl(ctx):
 
 def _macos_command_line_application_impl(ctx):
     """Implementation of the macos_command_line_application rule."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -1215,7 +1241,10 @@ def _macos_command_line_application_impl(ctx):
 
 def _macos_dylib_impl(ctx):
     """Implementation of the macos_dylib rule."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -293,6 +293,8 @@ def _common_binary_linking_attrs(default_binary_type, deps_cfg, product_type):
         apple_common.objc_proto_aspect,
         swift_usage_aspect,
     ]
+
+    default_stamp = -1
     if product_type:
         deps_aspects.extend([
             apple_resource_aspect,
@@ -300,6 +302,7 @@ def _common_binary_linking_attrs(default_binary_type, deps_cfg, product_type):
         ])
         if _is_test_product_type(product_type):
             deps_aspects.append(apple_test_info_aspect)
+            default_stamp = 0
         if product_type == apple_product_type.static_framework:
             deps_aspects.append(swift_static_framework_aspect)
         if product_type == apple_product_type.framework:
@@ -341,6 +344,20 @@ A list of strings representing extra flags that should be passed to `codesign`.
 A list of strings representing extra flags that should be passed to the linker.
     """,
             ),
+            "stamp": attr.int(
+                default = default_stamp,
+                doc = """
+Enable link stamping. Whether to encode build information into the binary. Possible values:
+
+*   `stamp = 1`: Stamp the build information into the binary. Stamped binaries are only rebuilt
+    when their dependencies change. Use this if there are tests that depend on the build
+    information.
+*   `stamp = 0`: Always replace build information by constant values. This gives good build
+    result caching.
+*   `stamp = -1`: Embedding of build information is controlled by the `--[no]stamp` flag.
+""",
+                values = [-1, 0, 1],
+            ),
             "deps": attr.label_list(
                 aspects = deps_aspects,
                 cfg = deps_cfg,
@@ -348,7 +365,7 @@ A list of strings representing extra flags that should be passed to the linker.
 A list of dependencies targets that will be linked into this target's binary. Any resources, such as
 asset catalogs, that are referenced by those targets will also be transitively included in the final
 bundle.
-        """,
+""",
             ),
         },
     )

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -246,7 +246,10 @@ def _test_host_bundle_id(test_host):
 
 def _apple_test_bundle_impl(ctx, extra_providers = []):
     """Implementation for bundling XCTest bundles."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -91,7 +91,10 @@ def _tvos_application_impl(ctx):
         "resources",
     ]
 
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -289,19 +292,22 @@ def _tvos_application_impl(ctx):
 
 def _tvos_dynamic_framework_impl(ctx):
     """Experimental implementation of tvos_dynamic_framework."""
-    
+
     # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
     # because of the swift_runtime_linkopts dep that comes with the swift_libray
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
-                fail(
-                    """\
+        fail(
+            """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
-                )
+        )
 
     binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -466,7 +472,10 @@ def _tvos_dynamic_framework_impl(ctx):
 
 def _tvos_framework_impl(ctx):
     """Experimental implementation of tvos_framework."""
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 
@@ -634,7 +643,10 @@ def _tvos_extension_impl(ctx):
         "resources",
     ]
 
-    link_result = linking_support.register_linking_action(ctx)
+    link_result = linking_support.register_linking_action(
+        ctx,
+        stamp = ctx.attr.stamp,
+    )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -88,16 +88,16 @@ load(
 
 def _watchos_dynamic_framework_impl(ctx):
     """Experimental implementation of watchos_dynamic_framework."""
-    
+
     # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
     # because of the swift_runtime_linkopts dep that comes with the swift_libray
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
-                fail(
-                    """\
+        fail(
+            """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
-                )
+        )
 
     binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
     extra_linkopts = []
@@ -107,6 +107,7 @@ def _watchos_dynamic_framework_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -480,6 +481,7 @@ def _watchos_extension_impl(ctx):
     link_result = linking_support.register_linking_action(
         ctx,
         extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary
     debug_outputs_provider = link_result.debug_outputs_provider
@@ -550,7 +552,7 @@ def _watchos_extension_impl(ctx):
             bin_root_path = bin_root_path,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
-            debug_outputs_provider = debug_outputs_provider, 
+            debug_outputs_provider = debug_outputs_provider,
             dsym_info_plist_template = ctx.file._dsym_info_plist_template,
             executable_name = executable_name,
             platform_prerequisites = platform_prerequisites,


### PR DESCRIPTION
PiperOrigin-RevId: 339467642

Cherry picked from 2ddf1f71aa9a7f0b005d662cb56dc795a4facc77