### PR TITLE
Disable --incompatible_run_shell_command_string for now to fix incompatibility with Bazel at HEAD.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,3 +28,8 @@ build --nocheck_visibility
 # here forever.
 build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
 build --strategy=SwiftCompile=local
+
+# Disable this for now because apple_support currently relies on a workaround
+# that needs to be able to pass a sequence of strings to actions.run_shell's
+# 'command'.
+build --incompatible_run_shell_command_string=false

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -450,6 +450,10 @@ function do_action() {
       # matches the internal one.
       "--incompatible_merge_genfiles_directory"
       "--incompatible_objc_compile_info_migration"
+      # Disable this for now because apple_support currently relies on a
+      # workaround that needs to be able to pass a sequence of strings to
+      # actions.run_shell's 'command'.
+      "--incompatible_run_shell_command_string=false"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then


### PR DESCRIPTION
Disable this for now because apple_support currently relies on a
workaround that needs to be able to pass a sequence of strings to
actions.run_shell's 'command'.
