### PR TITLE
Set bitcode_strip wrapper's print_output to False

### DIFF
--- a/tools/bitcode_strip/bitcode_strip.py
+++ b/tools/bitcode_strip/bitcode_strip.py
@@ -26,7 +26,11 @@ def invoke(input_path, output_path):
                "-o",
                output_path]
 
-  execute.execute_and_filter_output(
+  _, stdout, stderr = execute.execute_and_filter_output(
       xcrunargs,
-      print_output=True,
       raise_on_failure=True)
+
+  if stdout:
+    print(stdout)
+  if stderr:
+    print(stderr)


### PR DESCRIPTION
As we're not doing any post-processing of its output here. This fixes
the incompatibility with the change in
https://github.com/bazelbuild/rules_apple/pull/967.
