### PR TITLE
Switch linker flags to short version

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -95,11 +95,7 @@ def _register_linking_action(ctx, extra_linkopts = []):
     # Compatibility path for `apple_binary`, which does not have a product type.
     if hasattr(ctx.attr, "_product_type"):
         rule_descriptor = rule_support.rule_descriptor(ctx)
-
-        rpaths = rule_descriptor.rpaths
-        if rpaths:
-            linkopts.extend(collections.before_each("-rpath", rpaths))
-
+        linkopts.extend(["-Wl,-rpath,{}".format(rpath) for rpath in rule_descriptor.rpaths])
         linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
 
     return apple_common.link_multi_arch_binary(

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -18,10 +18,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
 )
-load(
-    "@bazel_skylib//lib:collections.bzl",
-    "collections",
-)
 
 def _sectcreate_objc_provider(segname, sectname, file):
     """Returns an objc provider that propagates a section in a linked binary.

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -513,8 +513,7 @@ _RULE_TYPE_DESCRIPTORS = {
             # for the "kernel_extension" feature, but for now it's necessary to detect kext
             # linking so CompilationSupport.java can apply the correct type of symbol stripping.
             extra_linkopts = [
-                "-Xlinker",
-                "-kext",
+                "-Wl,-kext",
             ],
             product_type = apple_product_type.kernel_extension,
             provisioning_profile_extension = ".provisionprofile",


### PR DESCRIPTION
This fixes using flags that start with `@` with https://github.com/bazelbuild/bazel/pull/12265