### PR TITLE
Another fix for spaces in env vars

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -96,7 +96,6 @@ if [[ -n "${TEST_ENV}" ]]; then
   # Converts the test env string to json format and addes it into launch
   # options string.
   TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) "\":\"" substr($i, d+1); }}')
-  TEST_ENV=${TEST_ENV// /\":\"}
   TEST_ENV=${TEST_ENV//$'\n'/\",\"}
   TEST_ENV="{\"${TEST_ENV}\"}"
   LAUNCH_OPTIONS_JSON_STR="\"env_vars\":${TEST_ENV}"

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -127,6 +127,8 @@ function create_ios_unit_tests() {
 - (void)testPassEnvVariable {
   XCTAssertEqual([NSProcessInfo processInfo].environment[@"SomeVariable1"], @"Its My First Variable", @"should pass");
   XCTAssertEqual([NSProcessInfo processInfo].environment[@"SomeVariable2"], @"Its My Second Variable", @"should pass");
+  XCTAssertEqual([NSProcessInfo processInfo].environment[@"REFERENCE_DIR"], @"/Project/My Tests/ReferenceImages", @"should pass");
+  XCTAssertEqual([NSProcessInfo processInfo].environment[@"IMAGE_DIR"], @"/Project/My Tests/Images", @"should pass");
 }
 
 @end
@@ -200,7 +202,9 @@ ios_unit_test(
     minimum_os_version = "9.0",
     env = {
       "SomeVariable1": "Its My First Variable",
-      "SomeVariable2": "Its My Second Variable"
+      "SomeVariable2": "Its My Second Variable",
+      "REFERENCE_DIR": "/Project/My Tests/ReferenceImages",
+      "IMAGE_DIR": "/Project/My Tests/Images"
     },
     runner = ":ios_x86_64_sim_runner",
 )


### PR DESCRIPTION
It appears that my last fix did not fully fully fix the issue with `test_env` vars containing spaces. These changes ensure all cases are covered