### PR TITLE
Add bundle_package_type bzl library

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -48,6 +48,15 @@ bzl_library(
     ],
 )
 
+
+bzl_library(
+    name = "bundle_package_type",
+    srcs = ["bundle_package_type.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+)
+
 bzl_library(
     name = "bundling_support",
     srcs = ["bundling_support.bzl"],
@@ -382,6 +391,7 @@ bzl_library(
     ],
     deps = [
         ":apple_product_type",
+        ":bundle_package_type",
         ":transition_support",
     ],
 )


### PR DESCRIPTION
I encountered a failure related to the `bundle_package_type.bzl` import not being found when trying to run stardoc in some of our rules. I tested this locally and it seems to fix. I assume this was forgot in #891.
