### PR TITLE
Remove the resource aspect from the list of aspects applied to deps for standalone apple_binary targets.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -286,11 +286,13 @@ true.
 def _common_binary_linking_attrs(default_binary_type, deps_cfg, product_type):
     deps_aspects = [
         apple_common.objc_proto_aspect,
-        apple_resource_aspect,
-        framework_import_aspect,
         swift_usage_aspect,
     ]
     if product_type:
+        deps_aspects.extend([
+            apple_resource_aspect,
+            framework_import_aspect,
+        ])
         if _is_test_product_type(product_type):
             deps_aspects.append(apple_test_info_aspect)
         if product_type == apple_product_type.static_framework:


### PR DESCRIPTION
PiperOrigin-RevId: 343089051
(cherry picked from commit 1101d29a32864b29026d8e05540a2ac57413f482)