### PR TITLE
Remove --incompatible_objc_compile_info_migration

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -449,7 +449,6 @@ function do_action() {
       # Explicitly pass these flags to ensure the external testing infrastructure
       # matches the internal one.
       "--incompatible_merge_genfiles_directory"
-      "--incompatible_objc_compile_info_migration"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then


### PR DESCRIPTION
The flag has been made to be on by default natively, and it will soon
be deleted, so remove the explicit reference.

PiperOrigin-RevId: 343894684
(cherry picked from commit 709804635c3a847b1e1e0fcb6efd981f70eceb12)