### PR TITLE
Move off SwiftInfo.transitive_swift*

### DIFF
--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -111,7 +111,7 @@ error: Found transitive swift_library dependencies. Swift static frameworks expe
 swift_library dependency with no transitive swift_library dependencies.\
 """,
                     )
-                swiftinterface = module.swift.swiftmodule
+                swiftinterface = module.swift.swiftinterface
                 swiftdoc = module.swift.swiftdoc
 
             if not module_name:

--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -99,13 +99,20 @@ single swift_library dependency with no transitive swift_library dependencies.\
         for dep in swiftdeps:
             swiftinfo = dep[SwiftInfo]
 
-            if len(swiftinfo.transitive_swiftinterfaces.to_list()) > 1:
-                fail(
-                    """\
+            swiftinterface = None
+            swiftdoc = None
+            for module in swiftinfo.transitive_modules.to_list():
+                if not module.swift:
+                    continue
+                if swiftinterface:
+                    fail(
+                        """\
 error: Found transitive swift_library dependencies. Swift static frameworks expect a single \
 swift_library dependency with no transitive swift_library dependencies.\
 """,
-                )
+                    )
+                swiftinterface = module.swift.swiftmodule
+                swiftdoc = module.swift.swiftdoc
 
             if not module_name:
                 module_name = swiftinfo.module_name
@@ -128,8 +135,8 @@ swift_library dependency with no transitive swift_library dependencies.\
                     # just take any of them.
                     generated_header = swiftinfo.transitive_generated_headers.to_list()[0]
 
-            swiftdocs[arch] = swiftinfo.transitive_swiftdocs.to_list()[0]
-            swiftinterfaces[arch] = swiftinfo.transitive_swiftinterfaces.to_list()[0]
+            swiftdocs[arch] = swiftdoc
+            swiftinterfaces[arch] = swiftinterface
 
         # Make sure that all dictionaries contain at least one module before returning the provider.
         if all([module_name, swiftdocs, swiftinterfaces]):

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -124,9 +124,13 @@ def _apple_test_info_aspect_impl(target, ctx):
         includes.append(cc_info.compilation_context.quote_includes)
         includes.append(cc_info.compilation_context.system_includes)
 
-    if (SwiftInfo in target and
-        hasattr(target[SwiftInfo], "transitive_swiftmodules")):
-        swift_modules.append(target[SwiftInfo].transitive_swiftmodules)
+    if SwiftInfo in target:
+        module_swiftmodules = [
+            module.swift.swiftmodule
+            for module in target[SwiftInfo].transitive_modules.to_list()
+            if module.swift
+        ]
+        swift_modules.append(depset(module_swiftmodules))
 
     # Collect sources from the current target. Note that we do not propagate
     # sources transitively as we intentionally only show test sources from the


### PR DESCRIPTION
The fields were deprecated a while ago and are now being removed.

RELNOTES: None
PiperOrigin-RevId: 344258779
(cherry picked from commit 15f48024ed209408bf7300fc3b00dab88838961f)