### PR TITLE
Move off deprecated SwiftInfo.module_name.

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -97,7 +97,8 @@ def _apple_resource_aspect_impl(target, ctx):
             owner = str(ctx.label)
 
     elif ctx.rule.kind == "swift_library":
-        bucketize_args["swift_module"] = target[SwiftInfo].module_name
+        module_names = [x.name for x in target[SwiftInfo].direct_modules if x.swift]
+        bucketize_args["swift_module"] = module_names[0] if module_names else None
         collect_args["res_attrs"] = ["data"]
         owner = str(ctx.label)
 

--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -114,15 +114,15 @@ swift_library dependency with no transitive swift_library dependencies.\
                 swiftinterface = module.swift.swiftinterface
                 swiftdoc = module.swift.swiftdoc
 
-            if not module_name:
-                module_name = swiftinfo.module_name
-            elif module_name != swiftinfo.module_name:
-                fail(
-                    """\
+                if not module_name:
+                    module_name = module.name
+                elif module.name and module.name != module_name:
+                    fail(
+                        """\
 error: Found multiple direct swift_library dependencies. Swift static frameworks expect a single \
 swift_library dependency with no transitive swift_library dependencies.\
 """,
-                )
+                    )
 
             arch = _swift_arch_for_dep(dep)
             swiftdocs[arch] = swiftdoc

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -188,13 +188,15 @@ def _apple_test_info_provider(deps, test_bundle, test_host):
         transitive_sources.append(test_info.sources)
         transitive_swift_modules.append(test_info.swift_modules)
 
-    # Set module_name only for test targets with a single Swift dependency.
-    # This is not used if there are multiple Swift dependencies, as it will
-    # not be possible to reduce them into a single Swift module and picking
-    # an arbitrary one is fragile.
+    # Set module_name only for test targets with a single Swift dependency that
+    # contains a single Swift module. This is not used if there are multiple
+    # Swift dependencies/modules, as it will not be possible to reduce them into
+    # a single Swift module and picking an arbitrary one is fragile.
     module_name = None
     if len(swift_infos) == 1:
-        module_name = getattr(swift_infos[0], "module_name", None)
+        module_names = [x.name for x in swift_infos[0].direct_modules if x.swift]
+        if len(module_names) == 1:
+            module_name = module_names[0]
 
     return AppleTestInfo(
         deps = depset(dep_labels),


### PR DESCRIPTION
RELNOTES: None
PiperOrigin-RevId: 344996413
(cherry picked from commit 2e319376d141895010137c0b5d1c1ca89bf09245)