### PR TITLE
Fix duplicate module error when the intermediates directory for ios_static_framework accidentally goes into the header search paths, when building with local strategy.

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -26,6 +26,10 @@ load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
 
 def _get_link_declarations(dylibs = [], frameworks = []):
     """Returns the module map lines that link to the given dylibs and frameworks.
@@ -158,7 +162,11 @@ def _static_framework_header_modulemap_partial_impl(
     # Create a module map if there is a need for one (that is, if there are
     # headers or if there are dylibs/frameworks that the target depends on).
     if any([sdk_dylibs, sdk_dylibs, umbrella_header_name]):
-        modulemap_file = intermediates.file(actions, label_name, "module.modulemap")
+        modulemap_file = intermediates.file(
+            actions,
+            paths.join(label_name, label_name + ".modulemaps"),
+            "module.modulemap",
+        )
         _create_modulemap(
             actions,
             modulemap_file,


### PR DESCRIPTION
This patch changes the path of the intermediate module map by placing it
under a subdirectory of the intermediate directory. Since there's no way
one could add the intermediates directory into a compile action's header
search paths, this prevents the module map from being implicitly
imported when it's produced by a previous invocation.