### PR TITLE
Add watchos_static_framework implementation

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -933,9 +933,9 @@ ignored.
             "extension_safe": attr.bool(
                 default = False,
                 doc = """
-    If true, compiles and links this framework with `-application-extension`, restricting the binary to
-    use only extension-safe APIs.
-    """,
+If true, compiles and links this framework with `-application-extension`, restricting the binary to
+use only extension-safe APIs.
+""",
             ),
         })
 
@@ -945,13 +945,47 @@ ignored.
                 "frameworks": attr.label_list(
                     providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
                     doc = """
-    A list of framework targets (see
-    [`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
-    that this target depends on.
-    """,
+A list of framework targets (see
+[`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
+that this target depends on.
+""",
                     **extra_args
                 ),
             })
+    elif rule_descriptor.product_type == apple_product_type.static_framework:
+        attrs.append({
+            "hdrs": attr.label_list(
+                allow_files = [".h"],
+                doc = """
+A list of `.h` files that will be publicly exposed by this framework. These headers should have
+framework-relative imports, and if non-empty, an umbrella header named `%{bundle_name}.h` will also
+be generated that imports all of the headers listed here.
+""",
+            ),
+            "umbrella_header": attr.label(
+                allow_single_file = [".h"],
+                doc = """
+An optional single .h file to use as the umbrella header for this framework. Usually, this header
+will have the same name as this target, so that clients can load the header using the #import
+<MyFramework/MyFramework.h> format. If this attribute is not specified (the common use case), an
+umbrella header will be generated under the same name as this target.
+""",
+            ),
+            "avoid_deps": attr.label_list(
+                doc = """
+A list of library targets on which this framework depends in order to compile, but the transitive
+closure of which will not be linked into the framework's binary.
+""",
+            ),
+            "exclude_resources": attr.bool(
+                default = False,
+                doc = """
+Indicates whether resources should be excluded from the bundle. This can be used to avoid
+unnecessarily bundling resources if the static framework is being distributed in a different
+fashion, such as a Cocoapod.
+""",
+            ),
+        })
 
     return attrs
 

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -769,6 +769,17 @@ _RULE_TYPE_DESCRIPTORS = {
                 "@executable_path/Frameworks",
             ],
         ),
+        # watchos_static_framework
+        apple_product_type.static_framework: _describe_rule_type(
+            allowed_device_families = ["watch"],
+            bundle_extension = ".framework",
+            codesigning_exceptions = _CODESIGNING_EXCEPTIONS.skip_signing,
+            deps_cfg = transition_support.static_framework_transition,
+            has_infoplist = False,
+            product_type = apple_product_type.static_framework,
+            requires_bundle_id = False,
+            requires_provisioning_profile = False,
+        ),
     },
 }
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -67,10 +67,15 @@ load(
     "stub_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_static_framework_aspect.bzl",
+    "SwiftStaticFrameworkInfo",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "IosFrameworkBundleInfo",
     "WatchosApplicationBundleInfo",
     "WatchosExtensionBundleInfo",
-    "IosFrameworkBundleInfo",
+    "WatchosStaticFrameworkBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
@@ -531,7 +536,7 @@ def _watchos_extension_impl(ctx):
             bin_root_path = bin_root_path,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
-            debug_outputs_provider = debug_outputs_provider,
+            debug_outputs_provider = debug_outputs_provider, 
             dsym_info_plist_template = ctx.file._dsym_info_plist_template,
             executable_name = executable_name,
             platform_prerequisites = platform_prerequisites,
@@ -614,6 +619,106 @@ def _watchos_extension_impl(ctx):
         WatchosExtensionBundleInfo(),
     ] + processor_result.providers
 
+def _watchos_static_framework_impl(ctx):
+    """Implementation of watchos_static_framework."""
+
+    binary_target = ctx.attr.deps[0]
+    binary_artifact = binary_target[apple_common.AppleStaticLibrary].archive
+
+    actions = ctx.actions
+    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    executable_name = bundling_support.executable_name(ctx)
+    entitlements = entitlements_support.entitlements(
+        entitlements_attr = getattr(ctx.attr, "entitlements", None),
+        entitlements_file = getattr(ctx.file, "entitlements", None),
+    )
+    label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    predeclared_outputs = ctx.outputs
+    rule_descriptor = rule_support.rule_descriptor(ctx)
+    rule_executables = ctx.executable
+
+    processor_partials = [
+        partials.apple_bundle_info_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            executable_name = executable_name,
+            entitlements = entitlements,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            product_type = rule_descriptor.product_type,
+        ),
+        partials.binary_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            executable_name = executable_name,
+            label_name = label.name,
+        ),
+    ]
+
+    # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
+    # framework.
+    if SwiftStaticFrameworkInfo in binary_target:
+        processor_partials.append(
+            partials.swift_static_framework_partial(
+                actions = actions,
+                bundle_name = bundle_name,
+                label_name = label.name,
+                swift_static_framework_info = binary_target[SwiftStaticFrameworkInfo],
+            ),
+        )
+    else:
+        processor_partials.append(
+            partials.static_framework_header_modulemap_partial(
+                actions = actions,
+                binary_objc_provider = binary_target[apple_common.Objc],
+                bundle_name = bundle_name,
+                hdrs = ctx.files.hdrs,
+                label_name = label.name,
+                umbrella_header = ctx.file.umbrella_header,
+            ),
+        )
+
+    if not ctx.attr.exclude_resources:
+        rule_descriptor = rule_support.rule_descriptor(ctx)
+
+        processor_partials.append(partials.resources_partial(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            environment_plist = ctx.file._environment_plist,
+            executable_name = executable_name,
+            launch_storyboard = None,
+            platform_prerequisites = platform_prerequisites,
+            rule_attrs = ctx.attr,
+            rule_descriptor = rule_descriptor,
+            rule_executables = rule_executables,
+            rule_label = label,
+        ))
+
+    processor_result = processor.process(
+        ctx = ctx,
+        actions = actions,
+        bundle_extension = bundle_extension,
+        bundle_name = bundle_name,
+        entitlements = entitlements,
+        executable_name = executable_name,
+        partials = processor_partials,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+        provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
+        rule_descriptor = rule_descriptor,
+        rule_executables = rule_executables,
+        rule_label = label,
+    )
+
+    return [
+        DefaultInfo(files = processor_result.output_files),
+        WatchosStaticFrameworkBundleInfo(),
+    ] + processor_result.providers
+
 watchos_application = rule_factory.create_apple_bundling_rule(
     implementation = _watchos_application_impl,
     platform_type = "watchos",
@@ -633,4 +738,11 @@ watchos_dynamic_framework = rule_factory.create_apple_bundling_rule(
     platform_type = "watchos",
     product_type = apple_product_type.framework,
     doc = "Builds and bundles a watchOS dynamic framework that is consumable by Xcode.",
+)
+
+watchos_static_framework = rule_factory.create_apple_bundling_rule(
+    implementation = _watchos_static_framework_impl,
+    platform_type = "watchos",
+    product_type = apple_product_type.static_framework,
+    doc = "Builds and bundles a watchOS Static Framework.",
 )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -581,3 +581,16 @@ require that a dependency is a watchOS application extension should use this
 provider to describe that requirement.
 """,
 )
+
+WatchosStaticFrameworkBundleInfo = provider(
+    fields = [],
+    doc = """
+Denotes that a target is an watchOS static framework.
+
+This provider does not contain any fields of its own at this time but is used as
+a "marker" to indicate that a target is specifically a watchOS static framework
+bundle (and not some other Apple bundle). Rule authors who wish to require that
+a dependency is a watchOS static framework should use this provider to describe
+that requirement.
+""",
+)

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -34,6 +34,7 @@ load(
     _watchos_application = "watchos_application",
     _watchos_extension = "watchos_extension",
     _watchos_dynamic_framework = "watchos_dynamic_framework",
+    _watchos_static_framework = "watchos_static_framework",
 )
 
 def watchos_application(name, **kwargs):
@@ -115,3 +116,30 @@ watchos_build_test(
 """,
     platform_type = "watchos",
 )
+
+def watchos_static_framework(name, **kwargs):
+    # buildifier: disable=function-docstring-args
+    """Builds and bundles a watchOS static framework for third-party distribution."""
+    avoid_deps = kwargs.get("avoid_deps")
+    deps = kwargs.get("deps")
+    apple_static_library_name = "%s.apple_static_library" % name
+
+    native.apple_static_library(
+        name = apple_static_library_name,
+        deps = deps,
+        avoid_deps = avoid_deps,
+        minimum_os_version = kwargs.get("minimum_os_version"),
+        platform_type = str(apple_common.platform_type.watchos),
+        visibility = kwargs.get("visibility"),
+    )
+
+    passthrough_args = kwargs
+    passthrough_args.pop("avoid_deps", None)
+    passthrough_args.pop("deps", None)
+
+    _watchos_static_framework(
+        name = name,
+        deps = [apple_static_library_name],
+        avoid_deps = [apple_static_library_name],
+        **passthrough_args
+    )

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -33,6 +33,7 @@ load(":watchos_application_swift_tests.bzl", "watchos_application_swift_test_sui
 load(":watchos_application_tests.bzl", "watchos_application_test_suite")
 load(":watchos_dynamic_framework_tests.bzl", "watchos_dynamic_framework_test_suite")
 load(":watchos_extension_tests.bzl", "watchos_extension_test_suite")
+load(":watchos_static_framework_tests.bzl", "watchos_static_framework_test_suite")
 
 licenses(["notice"])
 
@@ -103,6 +104,8 @@ watchos_application_test_suite()
 watchos_dynamic_framework_test_suite()
 
 watchos_extension_test_suite()
+
+watchos_static_framework_test_suite()
 
 test_suite(
     name = "all_tests",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -8,6 +8,7 @@ load(
     "watchos_application",
     "watchos_dynamic_framework",
     "watchos_extension",
+    "watchos_static_framework",
 )
 load(
     "//apple:apple.bzl",
@@ -116,6 +117,20 @@ ios_application(
     watch_application = ":app",
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+# ---------------------------------------------------------------------------------------
+
+watchos_static_framework(
+    name = "static_fmwk",
+    hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    minimum_os_version = "4.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_shared_lib",
     ],
 )
 

--- a/test/starlark_tests/watchos_static_framework_tests.bzl
+++ b/test/starlark_tests/watchos_static_framework_tests.bzl
@@ -35,6 +35,7 @@ def watchos_static_framework_test_suite(name = "watchos_static_framework"):
             "$BUNDLE_ROOT/Headers/static_fmwk.h",
             "$BUNDLE_ROOT/Headers/shared.h",
             "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/static_fmwk",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/watchos_static_framework_tests.bzl
+++ b/test/starlark_tests/watchos_static_framework_tests.bzl
@@ -1,4 +1,4 @@
-# Copyright 2019 The Bazel Authors. All rights reserved.
+# Copyright 2020 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""tvos_static_framework Starlark tests."""
+"""watchos_static_framework Starlark tests."""
 
 load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
 
-def tvos_static_framework_test_suite(name = "tvos_static_framework"):
-    """Test suite for tvos_static_framework.
+def watchos_static_framework_test_suite(name = "watchos_static_framework"):
+    """Test suite for watchos_static_framework.
 
     Args:
         name: The name prefix for all the nested tests
@@ -30,7 +30,7 @@ def tvos_static_framework_test_suite(name = "tvos_static_framework"):
         name = "{}_contents_test".format(name),
         build_type = "simulator",
         compilation_mode = "opt",
-        target_under_test = "//test/starlark_tests/targets_under_test/tvos:static_fmwk",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:static_fmwk",
         contains = [
             "$BUNDLE_ROOT/Headers/static_fmwk.h",
             "$BUNDLE_ROOT/Headers/shared.h",


### PR DESCRIPTION
This is in an implementation of a new `watchos_static_framework`. We need this rule in order to build and deploy watchOS frameworks for some of our code that uses Swift.

The implementation is very much based on `tvos_static_framework`. I've tested it in our project and it produces a watchOS framework just fine!

I would also be happy to regenerate the markdown docs, but I can't find a way to do it. Pointers are welcome!