### PR TITLE
Explicitly set a transition for `_dummy_lib`.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -126,6 +126,7 @@ _COMMON_BINARY_RULE_ATTRS = dicts.add(
         # Needed for the J2ObjC processing code that already exists in the implementation of
         # apple_common.link_multi_arch_binary.
         "_dummy_lib": attr.label(
+            cfg = apple_common.multi_arch_split,
             default = Label("@bazel_tools//tools/objc:dummy_lib"),
         ),
         "_googlemac_proto_compiler": attr.label(


### PR DESCRIPTION
PiperOrigin-RevId: 345342550
(cherry picked from commit d029d3b9ff4c454fb88ef89deeb4bd928f0cba77)