### PR TITLE
Use angle-bracketed import in `*_static_framework`'s umbrella header

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -103,7 +103,7 @@ def _create_modulemap(
     )
     actions.write(output = output, content = content)
 
-def _create_umbrella_header(actions, output, headers):
+def _create_umbrella_header(actions, output, bundle_name, headers):
     """Creates an umbrella header that imports a list of other headers.
 
     Args:
@@ -111,7 +111,7 @@ def _create_umbrella_header(actions, output, headers):
       output: A declared `File` to which the umbrella header will be written.
       headers: A list of header files to be imported by the umbrella header.
     """
-    import_lines = ['#import "%s"' % f.basename for f in headers]
+    import_lines = ['#import <%s/%s>' % (bundle_name, f.basename) for f in headers]
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
@@ -140,6 +140,7 @@ def _static_framework_header_modulemap_partial_impl(
         _create_umbrella_header(
             actions,
             umbrella_header_file,
+            bundle_name,
             sorted(hdrs),
         )
 

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -111,7 +111,7 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
       output: A declared `File` to which the umbrella header will be written.
       headers: A list of header files to be imported by the umbrella header.
     """
-    import_lines = ['#import <%s/%s>' % (bundle_name, f.basename) for f in headers]
+    import_lines = ["#import <%s/%s>" % (bundle_name, f.basename) for f in headers]
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -109,6 +109,7 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
     Args:
       actions: The `actions` module from a rule or aspect context.
       output: A declared `File` to which the umbrella header will be written.
+      bundle_name: The name of the output bundle.
       headers: A list of header files to be imported by the umbrella header.
     """
     import_lines = ["#import <%s/%s>" % (bundle_name, f.basename) for f in headers]

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -378,6 +378,17 @@ def ios_framework_test_suite(name = "ios_framework"):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_angle_bracketed_import_in_umbrella_header".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:objc_static_framework",
+        text_test_file = "$BUNDLE_ROOT/Headers/objc_static_framework.h",
+        text_test_values = [
+            "#import <objc_static_framework/common.h>",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1917,3 +1917,16 @@ ios_application(
         "//test/starlark_tests/resources:objc_main_lib",
     ],
 )
+
+ios_static_framework(
+    name = "objc_static_framework",
+    bundle_name = "objc_static_framework",
+    minimum_os_version = "9.0",
+    tags = FIXTURE_TAGS,
+    hdrs = [
+        "//test/starlark_tests/resources:common.h",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:objc_common_lib",
+    ],
+)

--- a/test/starlark_tests/tvos_framework_tests.bzl
+++ b/test/starlark_tests/tvos_framework_tests.bzl
@@ -66,6 +66,15 @@ def tvos_framework_test_suite(name = "tvos_framework"):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_angle_bracketed_import_in_umbrella_header".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:static_fmwk",
+        text_test_file = "$BUNDLE_ROOT/Headers/static_fmwk.h",
+        text_test_values = ["#import <static_fmwk/shared.h>"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/watchos_static_framework_tests.bzl
+++ b/test/starlark_tests/watchos_static_framework_tests.bzl
@@ -40,6 +40,15 @@ def watchos_static_framework_test_suite(name = "watchos_static_framework"):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_angle_bracketed_import_in_umbrella_header".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:static_fmwk",
+        text_test_file = "$BUNDLE_ROOT/Headers/static_fmwk.h",
+        text_test_values = ["#import <static_fmwk/shared.h>"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],


### PR DESCRIPTION
Xcode 12 enables the warning flag
[`-Wquoted-include-in-framework-header`](https://reviews.llvm.org/D47157)
by default, which will fire a "double-quoted include in framework
header, expected angle-bracketed instead" warning whenever a quote
include appears in a framework header. Obj-C static frameworks built by
`*_static_framework` rules were packaging umbrella headers using the
double-quoted import style, which would trigger the warning when they
are consumed in an Xcode project.
