### PR TITLE
Validate the test rule configuration.

### DIFF
--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -43,11 +43,11 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
-    
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework",
@@ -84,7 +84,7 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
@@ -102,7 +102,7 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -35,7 +35,6 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework",
         binary_test_file = "$BUNDLE_ROOT/BasicFramework",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/BasicFramework.framework/BasicFramework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/BasicFramework",
@@ -76,7 +75,6 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_direct_dependency",
         binary_test_file = "$BUNDLE_ROOT/DirectDependencyTest",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/DirectDependencyTest.framework/DirectDependencyTest (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/DirectDependencyTest",
@@ -94,7 +92,6 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_transitive_dependency",
         binary_test_file = "$BUNDLE_ROOT/TransitiveDependencyTest",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/TransitiveDependencyTest.framework/TransitiveDependencyTest (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/TransitiveDependencyTest",

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -59,7 +59,6 @@ def ios_framework_test_suite(name = "ios_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:fmwk",
         binary_test_file = "$BUNDLE_ROOT/fmwk",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/fmwk.framework/fmwk (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/fmwk",

--- a/test/starlark_tests/macos_application_resources_tests.bzl
+++ b/test/starlark_tests/macos_application_resources_tests.bzl
@@ -68,7 +68,6 @@ def macos_application_resources_test_suite():
             "$RESOURCE_ROOT/it.lproj/localized.strings",
             "$RESOURCE_ROOT/it.lproj/localized.plist",
         ],
-        plist_test_file = "$CONTENT_ROOT/Info.plist",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         tags = [name],
     )

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -124,6 +124,8 @@ def archive_contents_test(
             fail("Need binary_test_file to check the binary for symbols")
         if any([macho_load_commands_contain, macho_load_commands_not_contain]):
             fail("Need binary_test_file to check macho load commands")
+        if any([codesign_info_contains, codesign_info_not_contains]):
+            fail("Need binary_test_file to check codesign info")
 
     if not any([
         contains,

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -116,10 +116,9 @@ def archive_contents_test(
         elif binary_test_architecture and not any([
             binary_contains_symbols,
             binary_not_contains_symbols,
-            macho_load_commands_contain,
-            macho_load_commands_not_contain,
         ]):
-            fail("Need to check symbols or macho load commands when providing a binary and arch")
+            fail("Need binary_contains_symbols and/or binary_not_contains_symbols when checking " +
+                 "for symbols")
     else:
         if any([binary_contains_symbols, binary_not_contains_symbols, binary_test_architecture]):
             fail("Need binary_test_file to check the binary for symbols")

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -116,9 +116,10 @@ def archive_contents_test(
         elif binary_test_architecture and not any([
             binary_contains_symbols,
             binary_not_contains_symbols,
+            macho_load_commands_contain,
+            macho_load_commands_not_contain,
         ]):
-            fail("Need binary_contains_symbols and/or binary_not_contains_symbols when checking " +
-                 "for symbols")
+            fail("Need to check symbols or macho load commands when providing a binary and arch")
     else:
         if any([binary_contains_symbols, binary_not_contains_symbols, binary_test_architecture]):
             fail("Need binary_test_file to check the binary for symbols")

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -94,6 +94,48 @@ def archive_contents_test(
             appear in the binary file specified in `binary_test_file`.
         **kwargs: Other arguments are passed through to the apple_verification_test rule.
     """
+    if any([plist_test_file, plist_test_values]) and not all([plist_test_file, plist_test_values]):
+        fail("Need both plist_test_file and plist_test_values")
+
+    got_asset_catalog_tests = any([asset_catalog_test_contains, asset_catalog_test_not_contains])
+    if any([asset_catalog_test_file, got_asset_catalog_tests]) and not all([
+        asset_catalog_test_file,
+        got_asset_catalog_tests,
+    ]):
+        fail("Need asset_catalog_test_file along with " +
+             "asset_catalog_test_contains and/or asset_catalog_test_not_contains")
+
+    if any([text_test_file, text_test_values]) and not all([text_test_file, text_test_values]):
+        fail("Need both text_test_file and text_test_values")
+
+    if binary_test_file:
+        if any([binary_contains_symbols, binary_not_contains_symbols]) and (
+            not binary_test_architecture
+        ):
+            fail("Need binary_test_architecture when checking symbols")
+        elif binary_test_architecture and not any([
+            binary_contains_symbols,
+            binary_not_contains_symbols,
+        ]):
+            fail("Need binary_contains_symbols and/or binary_not_contains_symbols when checking " +
+                 "for symbols")
+    else:
+        if any([binary_contains_symbols, binary_not_contains_symbols, binary_test_architecture]):
+            fail("Need binary_test_file to check the binary for symbols")
+        if any([macho_load_commands_contain, macho_load_commands_not_contain]):
+            fail("Need binary_test_file to check macho load commands")
+
+    if not any([
+        contains,
+        not_contains,
+        is_binary_plist,
+        is_not_binary_plist,
+        plist_test_file,
+        asset_catalog_test_file,
+        text_test_file,
+        binary_test_file,
+    ]):
+        fail("There are no tests for the archive")
 
     # Concatenate the keys and values of the test values so they can be passed as env vars.
     plist_test_values_list = []
@@ -165,6 +207,14 @@ def binary_contents_test(
             Defaults to `__info_plist`.
         **kwargs: Other arguments are passed through to the apple_verification_test rule.
     """
+    if any([binary_contains_symbols, binary_not_contains_symbols]) and not binary_test_architecture:
+        fail("Need binary_test_architecture when checking symbols")
+    elif binary_test_architecture and not any([binary_contains_symbols, binary_not_contains_symbols]):
+        fail("Need binary_contains_symbols and/or binary_not_contains_symbols when checking an " +
+             "architecture")
+
+    if not any([binary_test_file, embedded_plist_test_values]):
+        fail("There are no tests for the binary")
 
     # Concatenate the keys and values of the test values so they can be passed as env vars.
     plist_test_values_list = []

--- a/test/starlark_tests/tvos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/tvos_dynamic_framework_tests.bzl
@@ -35,7 +35,6 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:basic_framework",
         binary_test_file = "$BUNDLE_ROOT/BasicFramework",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/BasicFramework.framework/BasicFramework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/BasicFramework",
@@ -43,11 +42,11 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
-    
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:basic_framework",
@@ -76,7 +75,6 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:basic_framework_with_direct_dependency",
         binary_test_file = "$BUNDLE_ROOT/DirectDependencyTest",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/DirectDependencyTest.framework/DirectDependencyTest (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/DirectDependencyTest",
@@ -84,7 +82,7 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
@@ -94,7 +92,6 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:basic_framework_with_transitive_dependency",
         binary_test_file = "$BUNDLE_ROOT/TransitiveDependencyTest",
-        binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["name @rpath/TransitiveDependencyTest.framework/TransitiveDependencyTest (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/TransitiveDependencyTest",
@@ -102,7 +99,7 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule"
+            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -165,6 +165,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${CODESIGN_INFO_CONTAINS-}" ]]; then
       for test_codesign_info in "${CODESIGN_INFO_CONTAINS[@]}"
       do
+        something_tested=true
         codesign_info_found=false
         if grep -sq "$test_codesign_info" "$codesign_output"; then
           codesign_info_found=true
@@ -181,6 +182,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${CODESIGN_INFO_NOT_CONTAINS-}" ]]; then
       for test_codesign_info in "${CODESIGN_INFO_NOT_CONTAINS[@]}"
       do
+        something_tested=true
         codesign_info_found=false
         if grep -sq "$test_codesign_info" "$codesign_output"; then
           codesign_info_found=true

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -55,10 +55,13 @@ newline=$'\n'
 #  MACHO_LOAD_COMMANDS_NOT_CONTAIN: Array of Mach-O load commands that should
 #      not be present.
 
+something_tested=false
+
 # Test that the archive contains the specified files in the CONTAIN env var.
 if [[ -n "${CONTAINS-}" ]]; then
   for path in "${CONTAINS[@]}"
   do
+    something_tested=true
     expanded_path=$(eval echo "$path")
     if [[ ! -e $expanded_path ]]; then
       fail "Archive did not contain \"$expanded_path\"" \
@@ -77,11 +80,17 @@ if [[ -n "${TEXT_TEST_FILE-}" ]]; then
   fi
   for test_regexp in "${TEXT_TEST_VALUES[@]}"
   do
+    something_tested=true
     if [[ $(grep -c "$test_regexp" "$path") == 0 ]]; then
       fail "Expected regexp \"$test_regexp\" did not match" \
         "contents of text file at \"$path\""
     fi
   done
+else
+  if [[ -n "${TEXT_TEST_VALUES-}" ]]; then
+      fail "Rule Misconfigured: Supposed to look for values in a file," \
+        "but no file was set to check: ${TEXT_TEST_VALUES[@]}"
+  fi
 fi
 
 # Test that the archive contains and does not contain the specified symbols.
@@ -103,6 +112,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_CONTAINS_SYMBOLS[@]}"
       do
+        something_tested=true
         symbol_found=false
         for actual_symbol in "${actual_symbols[@]}"
         do
@@ -121,6 +131,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${BINARY_NOT_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
       do
+        something_tested=true
         symbol_found=false
         for actual_symbol in "${actual_symbols[@]}"
         do
@@ -134,6 +145,15 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
               "in the binary were:$newline${actual_symbols[@]}"
         fi
       done
+    fi
+  else
+    if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
+      fail "Rule Misconfigured: Supposed to look for symbols," \
+        "but no arch was set to check: ${BINARY_CONTAINS_SYMBOLS[@]}"
+    fi
+    if [[ -n "${BINARY_NOT_CONTAINS_SYMBOLS-}" ]]; then
+      fail "Rule Misconfigured: Supposed to look for missing symbols," \
+        "but no arch was set to check: ${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
     fi
   fi
 
@@ -183,6 +203,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${MACHO_LOAD_COMMANDS_CONTAIN-}" ]]; then
       for test_symbol in "${MACHO_LOAD_COMMANDS_CONTAIN[@]}"
       do
+        something_tested=true
         symbol_found=false
         for actual_symbol in "${actual_symbols[@]}"
         do
@@ -202,6 +223,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${MACHO_LOAD_COMMANDS_NOT_CONTAIN-}" ]]; then
       for test_symbol in "${MACHO_LOAD_COMMANDS_NOT_CONTAIN[@]}"
       do
+        something_tested=true
         symbol_found=false
         for actual_symbol in "${actual_symbols[@]}"
         do
@@ -218,12 +240,34 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
       done
     fi
   fi
+else
+  if [[ -n "${BINARY_TEST_ARCHITECTURE-}" ]]; then
+    fail "Rule Misconfigured: Binary arch was set," \
+      "but no binary was set to check: ${BINARY_TEST_ARCHITECTURE}"
+  fi
+  if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
+    fail "Rule Misconfigured: Supposed to look for symbols," \
+      "but no binary was set to check: ${BINARY_CONTAINS_SYMBOLS[@]}"
+  fi
+  if [[ -n "${BINARY_NOT_CONTAINS_SYMBOLS-}" ]]; then
+    fail "Rule Misconfigured: Supposed to look for missing symbols," \
+      "but no binary was set to check: ${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
+  fi
+  if [[ -n "${MACHO_LOAD_COMMANDS_CONTAIN-}" ]]; then
+    fail "Rule Misconfigured: Supposed to look for macho load commands," \
+      "but no binary was set to check: ${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
+  fi
+  if [[ -n "${MACHO_LOAD_COMMANDS_NOT_CONTAIN-}" ]]; then
+    fail "Rule Misconfigured: Supposed to look for missing macho load commands," \
+      "but no binary was set to check: ${MACHO_LOAD_COMMANDS_NOT_CONTAIN[@]}"
+  fi
 fi
 
 # Test that the archive doesn't contains the specified files in NOT_CONTAINS.
 if [[ -n "${NOT_CONTAINS-}" ]]; then
   for path in "${NOT_CONTAINS[@]}"
   do
+    something_tested=true
     expanded_path=$(eval echo "$path")
     if [[ -e $expanded_path ]]; then
       fail "Archive did contain \"$expanded_path\""
@@ -235,6 +279,7 @@ fi
 if [[ -n "${IS_BINARY_PLIST-}" ]]; then
   for path in "${IS_BINARY_PLIST[@]}"
   do
+    something_tested=true
     expanded_path=$(eval echo "$path")
     if [[ ! -e $expanded_path ]]; then
       fail "Archive did not contain plist \"$expanded_path\"" \
@@ -250,6 +295,7 @@ fi
 if [[ -n "${IS_NOT_BINARY_PLIST-}" ]]; then
   for path in "${IS_NOT_BINARY_PLIST[@]}"
   do
+    something_tested=true
     expanded_path=$(eval echo "$path")
     if [[ ! -e $expanded_path ]]; then
       fail "Archive did not contain plist \"$expanded_path\"" \
@@ -273,6 +319,7 @@ if [[ -n "${PLIST_TEST_VALUES-}" ]]; then
   fi
   for test_values in "${PLIST_TEST_VALUES[@]}"
   do
+    something_tested=true
     # Keys and expected-values are in the format "KEY VALUE".
     IFS=' ' read -r key expected_value <<< "$test_values"
     value="$(/usr/libexec/PlistBuddy -c "Print $key" $path 2>/dev/null || true)"
@@ -303,6 +350,7 @@ if [[ -n "${ASSET_CATALOG_FILE-}" ]]; then
   if [[ -n "${ASSET_CATALOG_CONTAINS-}" ]]; then
     for expected_name in "${ASSET_CATALOG_CONTAINS[@]}"
     do
+      something_tested=true
       name_found=false
       # Loop over the known asset names. `while read` loops loop over lines.
       while read -r actual_name
@@ -322,6 +370,7 @@ if [[ -n "${ASSET_CATALOG_FILE-}" ]]; then
   if [[ -n "${ASSET_CATALOG_NOT_CONTAINS-}" ]]; then
     for unexpected_name in "${ASSET_CATALOG_NOT_CONTAINS[@]}"
     do
+      something_tested=true
       name_found=false
       # Loop over the known asset names. `while read` loops loop over lines.
       while read -r actual_name
@@ -336,4 +385,8 @@ if [[ -n "${ASSET_CATALOG_FILE-}" ]]; then
       fi
     done
   fi
+fi
+
+if [[ "$something_tested" = false ]]; then
+  fail "Rule Misconfigured: Nothing was configured to be tested in archive: \"$path\""
 fi

--- a/test/starlark_tests/watchos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/watchos_dynamic_framework_tests.bzl
@@ -34,8 +34,6 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
         name = "{}_archive_contents_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:basic_framework",
-        binary_test_file = "$BUNDLE_ROOT/BasicFramework",
-        binary_test_architecture = "i386",
         contains = [
             "$BUNDLE_ROOT/BasicFramework",
             "$BUNDLE_ROOT/Headers/BasicFramework.h",
@@ -74,8 +72,6 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
         name = "{}_direct_dependency_archive_contents_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:basic_framework_with_direct_dependency",
-        binary_test_file = "$BUNDLE_ROOT/DirectDependencyTest",
-        binary_test_architecture = "i386",
         contains = [
             "$BUNDLE_ROOT/DirectDependencyTest",
             "$BUNDLE_ROOT/Headers/DirectDependencyTest.h",
@@ -92,8 +88,6 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
         name = "{}_transitive_dependency_archive_contents_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:basic_framework_with_transitive_dependency",
-        binary_test_file = "$BUNDLE_ROOT/TransitiveDependencyTest",
-        binary_test_architecture = "i386",
         contains = [
             "$BUNDLE_ROOT/TransitiveDependencyTest",
             "$BUNDLE_ROOT/Headers/TransitiveDependencyTest.h",


### PR DESCRIPTION
- Ensure paired arguments are set as needed.
- Ensure something is tested on the the validation rules.
- Add a second layer check within the backing scripts to catch if they are
  reused and not configured correctly.
- Update a few tests that were passing parts of the flags, so not really doing
  validations.

PiperOrigin-RevId: 349460772
(cherry picked from commit 12496040ddb4ddba994ddd2a009e0ff5ede88878)