### PR TITLE
Add to the existing features rather then clearing the value.

### DIFF
--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -60,15 +60,18 @@ def _apple_verification_transition_impl(settings, attr):
             "//command_line_option:tvos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "armv7k",
         })
+    existing_features = settings.get("//command_line_option:features") or []
     if attr.sanitizer != "none":
-        output_dictionary["//command_line_option:features"] = [attr.sanitizer]
+        output_dictionary["//command_line_option:features"] = existing_features + [attr.sanitizer]
     else:
-        output_dictionary["//command_line_option:features"] = []
+        output_dictionary["//command_line_option:features"] = existing_features
     return output_dictionary
 
 apple_verification_transition = transition(
     implementation = _apple_verification_transition_impl,
-    inputs = [],
+    inputs = [
+        "//command_line_option:features",
+    ],
     outputs = [
         "//command_line_option:ios_signing_cert_name",
         "//command_line_option:ios_multi_cpus",


### PR DESCRIPTION
On some tests that end up needing python tools for dependency chains, there are some
odd build failures for iOS that seem to go away if instead of clearing features the
test just add to the features instead.

PiperOrigin-RevId: 349563314
(cherry picked from commit d11ca322502bf58c44d0a403151760a9aaf4395f)