### PR TITLE
Remove plist and strings handling at the rule implementation level for settings bundles.

### DIFF
--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -225,7 +225,6 @@ bzl_library(
         "//apple:providers",
         "//apple/internal:processor",
         "//apple/internal:resources",
-        "//apple/internal/partials/support:resources_support",
         "//apple/internal/utils:bundle_paths",
         "@bazel_skylib//lib:partial",
     ],

--- a/apple/internal/partials/settings_bundle.bzl
+++ b/apple/internal/partials/settings_bundle.bzl
@@ -15,10 +15,6 @@
 """Partial implementation for processing the settings bundle for iOS apps."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/partials/support:resources_support.bzl",
-    "resources_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
 )
@@ -59,21 +55,7 @@ def _settings_bundle_partial_impl(
         for parent_dir, _, files in getattr(provider, field):
             bundle_name = bundle_paths.farthest_parent(parent_dir, "bundle")
             parent_dir = parent_dir.replace(bundle_name, "Settings.bundle")
-
-            if field in ["plists", "strings"]:
-                # TODO(b/176548747): This might already be dead code as the workflow appears to be
-                # handled by the resource aspect. Confirm this in follow up work.
-                compiled_files = resources_support.plists_and_strings(
-                    actions = actions,
-                    files = files,
-                    force_binary = True,
-                    parent_dir = parent_dir,
-                    platform_prerequisites = platform_prerequisites,
-                    rule_label = rule_label,
-                )
-                bundle_files.extend(compiled_files.files)
-            else:
-                bundle_files.append((processor.location.resource, parent_dir, files))
+            bundle_files.append((processor.location.resource, parent_dir, files))
 
     return struct(bundle_files = bundle_files)
 


### PR DESCRIPTION
PiperOrigin-RevId: 350244630
(cherry picked from commit 83d81ea39b90f8a76c7e0f9f1131697f5cab51d5)