### PR TITLE
Validate for all case-variants of invalid top-level directories in bundles

### DIFF
--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -128,7 +128,11 @@ def _invalid_top_level_directories_for_platform(*, platform_type):
     # codesigning for some reason. With this, we validate that there are no
     # Resources folder going to be created in the bundle, with a message that
     # better explains which files are incorrectly placed.
-    return ["Resources"]
+    #
+    # Since the build may be running on a case-insensitive file-system, which
+    # is the default for macOS, this just lists the lowercased ones, so that we
+    # can check for all other case variants.
+    return ["resources"]
 
 def _is_parent_dir_valid(*, invalid_top_level_dirs, parent_dir):
     """Validates that the files to bundle are not placed in invalid locations.
@@ -148,7 +152,8 @@ def _is_parent_dir_valid(*, invalid_top_level_dirs, parent_dir):
     if not parent_dir:
         return True
     for invalid_dir in invalid_top_level_dirs:
-        if parent_dir == invalid_dir or parent_dir.startswith(invalid_dir + "/"):
+        lowercased_parent_dir = parent_dir.lower()
+        if lowercased_parent_dir == invalid_dir or lowercased_parent_dir.startswith(invalid_dir + "/"):
             return False
     return True
 
@@ -312,7 +317,7 @@ def _bundle_partial_outputs_files(
             if (invalid_top_level_dirs and not parent_dir_is_valid):
                 file_paths = "\n".join([f.path for f in files.to_list()])
                 fail(("Error: For %s bundles, the following top level " +
-                      "directories are invalid: %s, check input files:\n%s") %
+                      "directories are invalid (case-insensitive): %s, check input files:\n%s") %
                      (platform_type, ", ".join(invalid_top_level_dirs), file_paths))
 
             sources = files.to_list()
@@ -342,7 +347,7 @@ def _bundle_partial_outputs_files(
             )
             if invalid_top_level_dirs and not parent_dir_is_valid:
                 fail(("Error: For %s bundles, the following top level " +
-                      "directories are invalid: %s") %
+                      "directories are invalid (case-insensitive): %s, check input files:\n%s") %
                      (platform_type, ", ".join(invalid_top_level_dirs)))
 
             sources = zip_files.to_list()

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -87,7 +87,7 @@ def ios_application_resources_test_suite(name = "ios_application_resources"):
     analysis_failure_message_test(
         name = "{}_invalid_top_level_directory_fail_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_structured_resources_in_resources_folder",
-        expected_error = "For ios bundles, the following top level directories are invalid: Resources",
+        expected_error = "For ios bundles, the following top level directories are invalid (case-insensitive): resources",
         tags = [name],
     )
 


### PR DESCRIPTION
Previously, we only checked for the non-existent top level `Resources`
folder, but not other variants like `resources`. If the developer uses
any of those names, the validation would pass and then fail in the
codesign action.

Since the build may be running on a case-insensitive file-system, which
is the default file-system for macOS, the validation should check for
all the case variants of invalid directory names.

Fixes https://github.com/bazelbuild/rules_apple/issues/1019.