### PR TITLE
Exclude Swift modules in the transitive closure of `avoid_deps` when verifying that an `{ios,tvos}_static_framework` contains only a single Swift module.

### DIFF
--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -44,6 +44,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "@bazel_skylib//lib:sets",
         "@build_bazel_rules_swift//swift",
     ],
 )

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -8,6 +8,7 @@ load(":ios_extension_tests.bzl", "ios_extension_test_suite")
 load(":ios_framework_tests.bzl", "ios_framework_test_suite")
 load(":ios_dynamic_framework_tests.bzl", "ios_dynamic_framework_test_suite")
 load(":ios_imessage_application_tests.bzl", "ios_imessage_application_test_suite")
+load(":ios_static_framework_tests.bzl", "ios_static_framework_test_suite")
 load(":ios_sticker_pack_extension_tests.bzl", "ios_sticker_pack_extension_test_suite")
 load(":ios_ui_test_tests.bzl", "ios_ui_test_test_suite")
 load(":ios_unit_test_tests.bzl", "ios_unit_test_test_suite")
@@ -54,6 +55,8 @@ ios_framework_test_suite()
 ios_dynamic_framework_test_suite()
 
 ios_imessage_application_test_suite()
+
+ios_static_framework_test_suite()
 
 ios_sticker_pack_extension_test_suite()
 

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -1,0 +1,54 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ios_static_framework Starlark tests."""
+
+load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+)
+
+def ios_static_framework_test_suite():
+    """Test suite for ios_static_framework."""
+    name = "ios_static_framework"
+
+    # Test that it's permitted for a static framework to have multiple
+    # `swift_library` dependencies if only one module remains after excluding
+    # the transitive closure of `avoid_deps`. Likewise, make sure that the
+    # symbols from the avoided deps aren't linked in. (In a situation like
+    # this, the user must provide those dependencies separately if they are
+    # needed.)
+    archive_contents_test(
+        name = "{}_swift_avoid_deps_test".format(name),
+        build_type = "simulator",
+        compilation_mode = "opt",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:static_fmwk_with_swift_and_avoid_deps",
+        contains = [
+            "$BUNDLE_ROOT/Modules/StaticFmwkUpperLib.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/StaticFmwkUpperLib.swiftmodule/x86_64.swiftinterface",
+        ],
+        binary_test_file = "$BUNDLE_ROOT/StaticFmwkUpperLib",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_$s18StaticFmwkUpperLib5DummyVMf"],
+        binary_not_contains_symbols = [
+            "_$s18StaticFmwkLowerLib5DummyVMf",
+            "_$s19StaticFmwkLowestLib5DummyVMf",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -19,9 +19,12 @@ load(
     "archive_contents_test",
 )
 
-def ios_static_framework_test_suite():
-    """Test suite for ios_static_framework."""
-    name = "ios_static_framework"
+def ios_static_framework_test_suite(name = "ios_static_framework"):
+    """Test suite for ios_static_framework.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # Test that it's permitted for a static framework to have multiple
     # `swift_library` dependencies if only one module remains after excluding

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -12,7 +12,10 @@ load(
     "ios_ui_test",
     "ios_unit_test",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
 load("//test/testdata/rules:substitution.bzl", "substitution")
 load("//test/starlark_tests:common.bzl", "FIXTURE_TAGS")
 
@@ -1929,4 +1932,45 @@ ios_static_framework(
     deps = [
         "//test/starlark_tests/resources:objc_common_lib",
     ],
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for iOS static framework tests.
+
+ios_static_framework(
+    name = "static_fmwk_with_swift_and_avoid_deps",
+    avoid_deps = [":StaticFmwkLowerLib"],
+    bundle_name = "StaticFmwkUpperLib",
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [":StaticFmwkUpperLib"],
+)
+
+genrule(
+    name = "dummy_swift_src",
+    outs = ["Dummy.swift"],
+    cmd = "echo 'public struct Dummy {}' > $@",
+)
+
+swift_library(
+    name = "StaticFmwkUpperLib",
+    srcs = ["Dummy.swift"],
+    module_name = "StaticFmwkUpperLib",
+    tags = FIXTURE_TAGS,
+    deps = [":StaticFmwkLowerLib"],
+)
+
+swift_library(
+    name = "StaticFmwkLowerLib",
+    srcs = ["Dummy.swift"],
+    module_name = "StaticFmwkLowerLib",
+    tags = FIXTURE_TAGS,
+    deps = [":StaticFmwkLowestLib"],
+)
+
+swift_library(
+    name = "StaticFmwkLowestLib",
+    srcs = ["Dummy.swift"],
+    module_name = "StaticFmwkLowestLib",
+    tags = FIXTURE_TAGS,
 )


### PR DESCRIPTION
This allows users to build multiple static frameworks that have Swift modules that depend on each other, as long as the end user includes all of the frameworks in their search paths when they build.

PiperOrigin-RevId: 350785087
(cherry picked from commit 8c2494e616bc6ee2fbd2676ef9b0d47a11e7fe7e)