### PR TITLE
Remove the failure that prevents apple_dynamic_framework_import from working

### DIFF
--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -61,13 +61,13 @@ def _swift_target_for_dep(dep):
                     return arg
                 if arg == "-target":
                     target_found = True
-    return ""
+    return None
 
 def _swift_arch_for_dep(dep):
     """Returns the architecture for which the dependency was built."""
     target = _swift_target_for_dep(dep)
-    if target == "":
-        return ""
+    if not target:
+        return None
     return target.split("-", 1)[0]
 
 def _modulemap_contents(module_name):
@@ -109,6 +109,8 @@ single swift_library dependency.\
     for dep in swiftdeps:
         swiftinfo = dep[SwiftInfo]
         arch = _swift_arch_for_dep(dep)
+        if not arch:
+            return []
 
         swiftmodule = None
         swiftdoc = None

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -61,11 +61,13 @@ def _swift_target_for_dep(dep):
                     return arg
                 if arg == "-target":
                     target_found = True
-    fail("error: Expected at least one Swift compilation action for target {}.".format(dep.label))
+    return ""
 
 def _swift_arch_for_dep(dep):
     """Returns the architecture for which the dependency was built."""
     target = _swift_target_for_dep(dep)
+    if target == "":
+        return ""
     return target.split("-", 1)[0]
 
 def _modulemap_contents(module_name):

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -157,6 +157,40 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_apple_dynamic_framework_import_in_framework_compiles".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_dynamic_framework_import",
+        binary_test_file = "$BUNDLE_ROOT/DynamicFrameworkImportTest",
+        macho_load_commands_contain = ["name @rpath/DynamicFrameworkImportTest.framework/DynamicFrameworkImportTest (offset 24)"],
+        contains = [
+            "$BUNDLE_ROOT/DynamicFrameworkImportTest",
+            "$BUNDLE_ROOT/Headers/DynamicFrameworkImportTest.h",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/Modules/DynamicFrameworkImportTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/DynamicFrameworkImportTest.swiftmodule/x86_64.swiftmodule",
+        ],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_apple_static_framework_import_in_framework_compiles".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_static_framework_import",
+        binary_test_file = "$BUNDLE_ROOT/StaticFrameworkImportTest",
+        macho_load_commands_contain = ["name @rpath/StaticFrameworkImportTest.framework/StaticFrameworkImportTest (offset 24)"],
+        contains = [
+            "$BUNDLE_ROOT/StaticFrameworkImportTest",
+            "$BUNDLE_ROOT/Headers/StaticFrameworkImportTest.h",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftmodule",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1683,6 +1683,9 @@ ios_unit_test(
     ],
 )
 
+# ---------------------------------------------------------------------------------------
+# Targets for iOS dynamic framework tests.
+
 swift_library(
     name = "basic_framework_lib",
     srcs = [
@@ -1931,6 +1934,70 @@ ios_static_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_common_lib",
+    ],
+)
+
+swift_library(
+    name = "basic_framework_with_dynamic_framework_import_lib",
+    srcs = [
+        "//test/starlark_tests/resources:BasicFramework.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "DynamicFrameworkImportTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//test/testdata/fmwk:iOSImportedDynamicFramework",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_dynamic_framework_import",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "DynamicFrameworkImportTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_dynamic_framework_import_lib",
+    ],
+)
+
+swift_library(
+    name = "basic_framework_with_static_framework_import_lib",
+    srcs = [
+        "//test/starlark_tests/resources:BasicFramework.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "StaticFrameworkImportTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//test/testdata/fmwk:iOSImportedStaticFramework",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_static_framework_import",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "StaticFrameworkImportTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_static_framework_import_lib",
     ],
 )
 


### PR DESCRIPTION
As noted by this issue https://github.com/bazelbuild/rules_apple/issues/1033, this commit https://github.com/bazelbuild/rules_apple/commit/572aee29236aa6aa850484d5706b79aa2a098219 seems to have broken static/dynamic import because of a failure in the swift_dynamic_framework_aspect. This PR removes that failure since the apple_dynamic_framework_import rule shouldn't fail in this case.