### PR TITLE
Fix swift_stdlib_tool remote-exec failure

### DIFF
--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -66,6 +66,9 @@ def _lipo_exec_files(exec_files, target_archs, strip_bitcode, source_path,
       [os.path.join(source_path, f) for f in exec_files]
   )
 
+  # Ensure directory for remote execution
+  os.makedirs(destination_path, exist_ok=True)
+
   # Copy or lipo each file as needed, from source to destination.
   for exec_file in exec_files:
     exec_file_source_path = os.path.join(source_path, exec_file)


### PR DESCRIPTION
The `destination_path` might not exist on the worker. It seems that `swift_stdlib_tool` currently works because bazel implicitly creates the directory locally when `declare_directory()` is used. To fix this we need to ensure the output directory is created in `swift_stdlib_tool`.
