### PR TITLE
Fix swift_stdlib_tool for Python 2

### DIFF
--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -67,7 +67,8 @@ def _lipo_exec_files(exec_files, target_archs, strip_bitcode, source_path,
   )
 
   # Ensure directory for remote execution
-  os.makedirs(destination_path, exist_ok=True)
+  if not os.path.exists(destination_path):
+    os.makedirs(destination_path)
 
   # Copy or lipo each file as needed, from source to destination.
   for exec_file in exec_files:


### PR DESCRIPTION
My previous change only worked in Python 3.5+.
