### PR TITLE
[DRAFT] Fix mixed target framework issue

### DIFF
--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -82,6 +82,9 @@ framework module {module_name} {{
 def _swift_dynamic_framework_aspect_impl(target, ctx):
     """Aspect implementation for Swift dynamic framework support."""
 
+    if not ctx.rule.kind == "ios_dynamic_framework" or not ctx.rule.kind == "tvos_dynamic_framework" or not ctx.rule.kind == "watchos_dynamic_framework":
+        return []
+
     if not hasattr(ctx.rule.attr, "deps"):
         return []
 

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -61,13 +61,13 @@ def _swift_target_for_dep(dep):
                     return arg
                 if arg == "-target":
                     target_found = True
-    return ""
+    return None
 
 def _swift_arch_for_dep(dep):
     """Returns the architecture for which the dependency was built."""
     target = _swift_target_for_dep(dep)
-    if target == "":
-        return ""
+    if not target:
+        return None
     return target.split("-", 1)[0]
 
 def _modulemap_contents(module_name):
@@ -109,6 +109,8 @@ single swift_library dependency.\
     for dep in swiftdeps:
         swiftinfo = dep[SwiftInfo]
         arch = _swift_arch_for_dep(dep)
+        if not arch:
+            return []
 
         swiftmodule = None
         swiftdoc = None

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -61,11 +61,13 @@ def _swift_target_for_dep(dep):
                     return arg
                 if arg == "-target":
                     target_found = True
-    fail("error: Expected at least one Swift compilation action for target {}.".format(dep.label))
+    return ""
 
 def _swift_arch_for_dep(dep):
     """Returns the architecture for which the dependency was built."""
     target = _swift_target_for_dep(dep)
+    if target == "":
+        return ""
     return target.split("-", 1)[0]
 
 def _modulemap_contents(module_name):

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -54,6 +54,14 @@ def ios_application_test_suite(name = "ios_application"):
         tags = [name],
     )
 
+    # Tests that an app with a mixed target framework compiles
+    analysis_target_outputs_test(
+        name = "{}_mixed_target_framework_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk_with_multiple_objc_library_and_swift_library_deps",
+        expected_outputs = ["app_with_fmwk_with_multiple_objc_library_and_swift_library_deps.ipa"],
+        tags = [name],
+    )
+
     apple_verification_test(
         name = "{}_ext_and_fmwk_provisioned_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -157,6 +157,40 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_apple_dynamic_framework_import_in_framework_compiles".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_dynamic_framework_import",
+        binary_test_file = "$BUNDLE_ROOT/DynamicFrameworkImportTest",
+        macho_load_commands_contain = ["name @rpath/DynamicFrameworkImportTest.framework/DynamicFrameworkImportTest (offset 24)"],
+        contains = [
+            "$BUNDLE_ROOT/DynamicFrameworkImportTest",
+            "$BUNDLE_ROOT/Headers/DynamicFrameworkImportTest.h",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/Modules/DynamicFrameworkImportTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/DynamicFrameworkImportTest.swiftmodule/x86_64.swiftmodule",
+        ],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_apple_static_framework_import_in_framework_compiles".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_static_framework_import",
+        binary_test_file = "$BUNDLE_ROOT/StaticFrameworkImportTest",
+        macho_load_commands_contain = ["name @rpath/StaticFrameworkImportTest.framework/StaticFrameworkImportTest (offset 24)"],
+        contains = [
+            "$BUNDLE_ROOT/StaticFrameworkImportTest",
+            "$BUNDLE_ROOT/Headers/StaticFrameworkImportTest.h",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftmodule",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1683,6 +1683,9 @@ ios_unit_test(
     ],
 )
 
+# ---------------------------------------------------------------------------------------
+# Targets for iOS dynamic framework tests.
+
 swift_library(
     name = "basic_framework_lib",
     srcs = [
@@ -1931,6 +1934,70 @@ ios_static_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_common_lib",
+    ],
+)
+
+swift_library(
+    name = "basic_framework_with_dynamic_framework_import_lib",
+    srcs = [
+        "//test/starlark_tests/resources:BasicFramework.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "DynamicFrameworkImportTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//test/testdata/fmwk:iOSImportedDynamicFramework",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_dynamic_framework_import",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "DynamicFrameworkImportTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_dynamic_framework_import_lib",
+    ],
+)
+
+swift_library(
+    name = "basic_framework_with_static_framework_import_lib",
+    srcs = [
+        "//test/starlark_tests/resources:BasicFramework.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "StaticFrameworkImportTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        "//test/testdata/fmwk:iOSImportedStaticFramework",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_static_framework_import",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "StaticFrameworkImportTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_static_framework_import_lib",
     ],
 )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1107,6 +1107,24 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_fmwk_with_multiple_objc_library_and_swift_library_deps",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk_with_multiple_objc_library_and_swift_library_deps"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 ios_framework(
     name = "fmwk_no_version",
     hdrs = ["//test/starlark_tests/resources:common.h"],
@@ -1122,6 +1140,24 @@ ios_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "fmwk_with_multiple_objc_library_and_swift_library_deps",
+    bundle_id = "com.google.example.framework",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:swift_main_lib",
         "//test/starlark_tests/resources:objc_shared_lib",
     ],
 )


### PR DESCRIPTION
The swift_dyanmic_framework_aspect was really only meant to run when one of the ios_dynamic_framework, tvos_dynamic_framework, or watchos_dynamic_framework rules are run. This PR fixes this issue https://github.com/bazelbuild/rules_apple/issues/1038 and adds a test to make sure that apps built using mixed target ios_frameworks compile properly.