### PR TITLE
Remove dynamic framework requirement for generated_header

### DIFF
--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -125,7 +125,7 @@ def _swift_dynamic_framework_aspect_impl(target, ctx):
             generated_header = headers.pop(0)
 
     # Make sure that all dictionaries contain at least one module before returning the provider.
-    if all([module_name, generated_header, swiftdocs, swiftmodules, modulemap_file]):
+    if all([module_name, swiftdocs, swiftmodules, modulemap_file]):
         return [
             SwiftDynamicFrameworkInfo(
                 module_name = module_name,


### PR DESCRIPTION
A swift framework doesn't need to have a generated header (and can be disabled with `--features=swift.no_generated_header`). Without this header the framework can't be consumed by Objective-C, but otherwise it's fine.
