### PR TITLE
Fix mixed target framework issue

### DIFF
--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -92,14 +92,6 @@ def _swift_dynamic_framework_aspect_impl(target, ctx):
     if not swiftdeps:
         return []
 
-    if len(swiftdeps) != len(ctx.rule.attr.deps):
-        fail(
-            """\
-error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-single swift_library dependency.\
-""",
-        )
-
     # Collect all relevant artifacts for Swift dynamic framework generation.
     module_name = None
     generated_header = None

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -916,8 +916,7 @@ def _ios_dynamic_framework_impl(ctx):
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
                 fail(
                     """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
                 )
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -296,8 +296,7 @@ def _tvos_dynamic_framework_impl(ctx):
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
                 fail(
                     """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
                 )
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -81,10 +81,25 @@ load(
     "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
 )
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 
 def _watchos_dynamic_framework_impl(ctx):
     """Experimental implementation of watchos_dynamic_framework."""
     
+    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
+    # because of the swift_runtime_linkopts dep that comes with the swift_libray
+    swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
+    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
+                fail(
+                    """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
+                )
+
     binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
     extra_linkopts = []
     if ctx.attr.extension_safe:

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -95,8 +95,7 @@ def _watchos_dynamic_framework_impl(ctx):
     if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
                 fail(
                     """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
                 )
 

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -54,6 +54,14 @@ def ios_application_test_suite(name = "ios_application"):
         tags = [name],
     )
 
+    # Tests that an app with a mixed target framework compiles
+    analysis_target_outputs_test(
+        name = "{}_mixed_target_framework_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_fmwk_with_multiple_objc_library_and_swift_library_deps",
+        expected_outputs = ["app_with_fmwk_with_multiple_objc_library_and_swift_library_deps.ipa"],
+        tags = [name],
+    )
+
     apple_verification_test(
         name = "{}_ext_and_fmwk_provisioned_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -199,8 +199,7 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:dynamic_fmwk_with_multiple_dependencies",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )
@@ -209,8 +208,7 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
         name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:dynamic_fmwk_with_objc_library",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -15,6 +15,10 @@
 """ios_dynamic_framework Starlark tests."""
 
 load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -188,6 +192,26 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
             "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftdoc",
             "$BUNDLE_ROOT/Modules/StaticFrameworkImportTest.swiftmodule/x86_64.swiftmodule",
         ],
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:dynamic_fmwk_with_multiple_dependencies",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:dynamic_fmwk_with_objc_library",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1107,6 +1107,24 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_fmwk_with_multiple_objc_library_and_swift_library_deps",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":fmwk_with_multiple_objc_library_and_swift_library_deps"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 ios_framework(
     name = "fmwk_no_version",
     hdrs = ["//test/starlark_tests/resources:common.h"],
@@ -1122,6 +1140,24 @@ ios_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
+ios_framework(
+    name = "fmwk_with_multiple_objc_library_and_swift_library_deps",
+    bundle_id = "com.google.example.framework",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:swift_shared_lib",
         "//test/starlark_tests/resources:objc_shared_lib",
     ],
 )
@@ -1889,7 +1925,25 @@ ios_application(
 )
 
 ios_dynamic_framework(
-    name = "dynamic_fmwk_with_imported_fmwk",
+    name = "dynamic_fmwk_with_multiple_dependencies",
+    bundle_id = "com.google.example.framework",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_lib",
+        ":basic_framework_with_direct_dependency_lib",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "dynamic_fmwk_with_objc_library",
     bundle_id = "com.google.example.framework",
     families = [
         "iphone",
@@ -1902,25 +1956,6 @@ ios_dynamic_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_lib_with_resources",
-        "//test/testdata/fmwk:iOSImportedDynamicFramework",
-    ],
-)
-
-ios_application(
-    name = "app_with_inner_and_outer_dynamic_framework",
-    bundle_id = "com.google.example",
-    families = ["iphone"],
-    frameworks = [
-        ":dynamic_fmwk_with_imported_fmwk",
-    ],
-    infoplists = [
-        "//test/starlark_tests/resources:Info.plist",
-    ],
-    minimum_os_version = "11.0",
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = FIXTURE_TAGS,
-    deps = [
-        "//test/starlark_tests/resources:objc_main_lib",
     ],
 )
 

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -477,3 +477,30 @@ tvos_dynamic_framework(
         ":basic_framework_with_transitive_dependency_lib",
     ],
 )
+
+tvos_dynamic_framework(
+    name = "dynamic_fmwk_with_multiple_dependencies",
+    bundle_id = "com.google.example.framework",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "14.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_lib",
+        ":basic_framework_with_direct_dependency_lib",
+    ],
+)
+
+tvos_dynamic_framework(
+    name = "dynamic_fmwk_with_objc_library",
+    bundle_id = "com.google.example.framework",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "14.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_lib_with_resources",
+    ],
+)

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -408,3 +408,30 @@ watchos_dynamic_framework(
         ":basic_framework_with_transitive_dependency_lib",
     ],
 )
+
+watchos_dynamic_framework(
+    name = "dynamic_fmwk_with_multiple_dependencies",
+    bundle_id = "com.google.example.framework",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "6.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_lib",
+        ":basic_framework_with_direct_dependency_lib",
+    ],
+)
+
+watchos_dynamic_framework(
+    name = "dynamic_fmwk_with_objc_library",
+    bundle_id = "com.google.example.framework",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "6.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_lib_with_resources",
+    ],
+)

--- a/test/starlark_tests/tvos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/tvos_dynamic_framework_tests.bzl
@@ -112,8 +112,7 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
         name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:dynamic_fmwk_with_multiple_dependencies",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )
@@ -122,8 +121,7 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
         name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:dynamic_fmwk_with_objc_library",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )

--- a/test/starlark_tests/tvos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/tvos_dynamic_framework_tests.bzl
@@ -15,6 +15,10 @@
 """tvos_dynamic_framework Starlark tests."""
 
 load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -101,6 +105,26 @@ def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftdoc",
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:dynamic_fmwk_with_multiple_dependencies",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:dynamic_fmwk_with_objc_library",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/watchos_dynamic_framework_tests.bzl
@@ -15,6 +15,10 @@
 """watchos_dynamic_framework Starlark tests."""
 
 load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -96,6 +100,26 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/i386.swiftdoc",
             "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/i386.swiftmodule"
         ],
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:dynamic_fmwk_with_multiple_dependencies",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:dynamic_fmwk_with_objc_library",
+        expected_error = """\
+    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
+    single swift_library dependency.\
+    """,
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/watchos_dynamic_framework_tests.bzl
@@ -107,8 +107,7 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
         name = "{}_multiple_deps_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:dynamic_fmwk_with_multiple_dependencies",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )
@@ -117,8 +116,7 @@ def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
         name = "{}_non_swiftlib_dep_in_dynamic_framework_fail".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:dynamic_fmwk_with_objc_library",
         expected_error = """\
-    error: Found a mix of swift_library and other rule dependencies. Swift dynamic frameworks expect a \
-    single swift_library dependency.\
+    error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         tags = [name],
     )


### PR DESCRIPTION
The ios_dynamic_framework, tvos_dynamic_framework, or watchos_dynamic_framework rules have the restriction that they should only accept one swiftlib target as a dependency. These rules also do not support mixed target frameworks, so a check was put in the swift_dyanmic_framework_aspect to make sure these conditions are true. These restrictions are not in place for ios_framework targets and since the swift_dyanmic_framework_aspect is run for all targets with a product type of framework, the check was causing this issue #1038.

The swift_dyanmic_framework_aspect was really only meant to run when one of the ios_dynamic_framework, tvos_dynamic_framework, or watchos_dynamic_framework rules are run. This PR moves the check out of the aspect and into each respective dynamic framework rules. Because this check is not in the aspect anymore, the mixed target case is no longer covered, but fixing the ios_framework rule was more important for the time being.