### PR TITLE
Final cleanups around the direct use of ctx in rules bundling macros.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -71,7 +71,7 @@ def _swiftmodule_for_cpu(swiftmodule_files, cpu):
 
     return module
 
-def _classify_framework_imports(ctx, framework_imports):
+def _classify_framework_imports(config_vars, framework_imports):
     """Classify a list of framework files into bundling, header, or module_map."""
 
     bundling_imports = []
@@ -91,7 +91,11 @@ def _classify_framework_imports(ctx, framework_imports):
             # statements for imported framework by adding module map to
             # header_imports so that they are included in Obj-C compilation but
             # they aren't processed in any way.
-            if defines.bool_value(ctx, "apple.incompatible.objc_framework_propagate_modulemap", False):
+            if defines.bool_value(
+                config_vars = config_vars,
+                define_name = "apple.incompatible.objc_framework_propagate_modulemap",
+                default = False,
+            ):
                 header_imports.append(file)
             module_map_imports.append(file)
             continue
@@ -238,7 +242,7 @@ def _apple_dynamic_framework_import_impl(ctx):
 
     framework_imports = ctx.files.framework_imports
     bundling_imports, header_imports, module_map_imports = (
-        _classify_framework_imports(ctx, framework_imports)
+        _classify_framework_imports(ctx.var, framework_imports)
     )
 
     transitive_sets = _transitive_framework_imports(ctx.attr.deps)
@@ -278,7 +282,7 @@ def _apple_static_framework_import_impl(ctx):
     providers = []
 
     framework_imports = ctx.files.framework_imports
-    _, header_imports, module_map_imports = _classify_framework_imports(ctx, framework_imports)
+    _, header_imports, module_map_imports = _classify_framework_imports(ctx.var, framework_imports)
 
     transitive_sets = _transitive_framework_imports(ctx.attr.deps)
     providers.append(_framework_import_info(transitive_sets, ctx.fragments.apple.single_arch_cpu))

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -272,7 +272,6 @@ def _should_sign_simulator_bundles(
 
     # Default is to sign.
     return defines.bool_value(
-        ctx = None,
         config_vars = config_vars,
         define_name = "apple.codesign_simulator_bundles",
         default = True,
@@ -493,7 +492,6 @@ def _post_process_and_sign_archive_action(
     # For debug builds, zip without compression, which will speed up the build.
     config_vars = platform_prerequisites.config_vars
     compression_requested = defines.bool_value(
-        ctx = None,
         config_vars = config_vars,
         define_name = "apple.compress_ipa",
         default = False,

--- a/apple/internal/entitlement_rules.bzl
+++ b/apple/internal/entitlement_rules.bzl
@@ -66,12 +66,12 @@ during code signing. May be `None` if there are no entitlements.
     },
 )
 
-def _tool_validation_mode(rules_mode, is_device):
+def _tool_validation_mode(*, is_device, rules_mode):
     """Returns the tools validation_mode to use.
 
     Args:
-      rules_mode: The validation_mode attribute of the rule.
       is_device: True if this is a device build, False otherwise.
+      rules_mode: The validation_mode attribute of the rule.
 
     Returns:
       The value to use the for the validation_mode in the entitlement
@@ -94,24 +94,25 @@ def _tool_validation_mode(rules_mode, is_device):
 
     return value
 
-def _new_entitlements_artifact(ctx, extension):
+def _new_entitlements_artifact(*, actions, extension, label_name):
     """Returns a new file artifact for entitlements.
 
     This function creates a new file in an "entitlements" directory in the
     target's location whose name is the target's name with the given extension.
 
     Args:
-      ctx: The Starlark context.
+      actions: The actions provider from `ctx.actions`.
       extension: The file extension (including the leading dot).
+      label_name: The name of the target.
 
     Returns:
       The requested file object.
     """
-    return ctx.actions.declare_file(
-        "entitlements/%s%s" % (ctx.label.name, extension),
+    return actions.declare_file(
+        "entitlements/%s%s" % (label_name, extension),
     )
 
-def _include_debug_entitlements(ctx):
+def _include_debug_entitlements(*, platform_prerequisites):
     """Returns a value indicating whether debug entitlements should be used.
 
     Debug entitlements are used if the --device_debug_entitlements command-line
@@ -120,82 +121,104 @@ def _include_debug_entitlements(ctx):
     Debug entitlements are also not used on macOS.
 
     Args:
-      ctx: The Starlark context.
+      platform_prerequisites: Struct containing information on the platform being targeted.
 
     Returns:
       True if the debug entitlements should be included, otherwise False.
     """
-    if platform_support.platform_type(ctx) == apple_common.platform_type.macos:
+    if platform_prerequisites.platform_type == apple_common.platform_type.macos:
         return False
     add_debugger_entitlement = defines.bool_value(
-        ctx,
-        "apple.add_debugger_entitlement",
-        None,
+        config_vars = platform_prerequisites.config_vars,
+        default = None,
+        define_name = "apple.add_debugger_entitlement",
     )
     if add_debugger_entitlement != None:
         return add_debugger_entitlement
-    if not ctx.fragments.objc.uses_device_debug_entitlements:
+    if not platform_prerequisites.objc_fragment.uses_device_debug_entitlements:
         return False
     return True
 
-def _include_app_clip_entitlements(ctx):
+def _include_app_clip_entitlements(*, product_type):
     """Returns a value indicating whether app clip entitlements should be used.
 
     Args:
-      ctx: The Starlark context.
+      product_type: The product type identifier used to describe the current bundle type.
 
     Returns:
       True if the app clip entitlements should be included, otherwise False.
     """
-    return ctx.attr.product_type == apple_product_type.app_clip
+    return product_type == apple_product_type.app_clip
 
-def _extract_signing_info(ctx):
+def _extract_signing_info(
+        *,
+        actions,
+        entitlements,
+        platform_prerequisites,
+        provisioning_profile,
+        provisioning_profile_tool,
+        rule_label):
     """Inspects the current context and extracts the signing information.
 
     Args:
-      ctx: The Starlark context.
+      actions: The actions provider from `ctx.actions`.
+      entitlements: The entitlements file to sign with. Can be `None` if one was not provided.
+      platform_prerequisites: Struct containing information on the platform being targeted.
+      provisioning_profile: File for the provisioning profile.
+      provisioning_profile_tool: A tool used to extract info from a provisioning profile.
+      rule_label: The label of the target being analyzed.
 
     Returns:
       A `struct` with two items: the entitlements file to use, a
       profile_metadata file.
     """
-    entitlements = ctx.file.entitlements
     profile_metadata = None
 
-    provisioning_profile = ctx.file.provisioning_profile
     if provisioning_profile:
-        profile_metadata = _new_entitlements_artifact(ctx, ".profile_metadata")
+        profile_metadata = _new_entitlements_artifact(
+            actions = actions,
+            extension = ".profile_metadata",
+            label_name = rule_label.name,
+        )
         outputs = [profile_metadata]
         control = {
             "profile_metadata": profile_metadata.path,
             "provisioning_profile": provisioning_profile.path,
-            "target": str(ctx.label),
+            "target": str(rule_label),
         }
         if not entitlements:
             # No entitlements, extract the default one from the profile.
-            entitlements = _new_entitlements_artifact(ctx, ".extracted_entitlements")
+            entitlements = _new_entitlements_artifact(
+                actions = actions,
+                extension = ".extracted_entitlements",
+                label_name = rule_label.name,
+            )
             control["entitlements"] = entitlements.path
             outputs.append(entitlements)
 
         control_file = _new_entitlements_artifact(
-            ctx,
-            "provisioning_profile_tool-control",
+            actions = actions,
+            extension = "provisioning_profile_tool-control",
+            label_name = rule_label.name,
         )
-        ctx.actions.write(
+        actions.write(
             output = control_file,
             content = struct(**control).to_json(),
         )
 
         apple_support.run(
-            ctx,
-            inputs = [control_file, provisioning_profile],
-            outputs = outputs,
-            executable = ctx.executable._provisioning_profile_tool,
+            actions = actions,
+            apple_fragment = platform_prerequisites.apple_fragment,
             arguments = [control_file.path],
-            mnemonic = "ExtractFromProvisioningProfile",
+            executable = provisioning_profile_tool,
             # Since the tools spawns openssl and/or security tool, it doesn't
             # support being sandboxed.
             execution_requirements = {"no-sandbox": "1"},
+            inputs = [control_file, provisioning_profile],
+            mnemonic = "ExtractFromProvisioningProfile",
+            outputs = outputs,
+            xcode_config = platform_prerequisites.xcode_version_config,
+            xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
         )
 
     return struct(
@@ -259,15 +282,22 @@ def _entitlements_impl(ctx):
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 
-    signing_info = _extract_signing_info(ctx)
+    signing_info = _extract_signing_info(
+        actions = actions,
+        entitlements = ctx.file.entitlements,
+        platform_prerequisites = platform_prerequisites,
+        provisioning_profile = ctx.file.provisioning_profile,
+        provisioning_profile_tool = ctx.executable._provisioning_profile_tool,
+        rule_label = ctx.label,
+    )
     plists = []
     forced_plists = []
     if signing_info.entitlements:
         plists.append(signing_info.entitlements)
-    if _include_debug_entitlements(ctx):
+    if _include_debug_entitlements(platform_prerequisites = platform_prerequisites):
         get_task_allow = {"get-task-allow": True}
         forced_plists.append(struct(**get_task_allow))
-    if _include_app_clip_entitlements(ctx):
+    if _include_app_clip_entitlements(product_type = ctx.attr.product_type):
         app_clip = {"com.apple.developer.on-demand-install-capable": True}
         forced_plists.append(struct(**app_clip))
 
@@ -283,7 +313,6 @@ def _entitlements_impl(ctx):
     final_entitlements = ctx.actions.declare_file(
         "%s.entitlements" % ctx.label.name,
     )
-    is_device = platform_support.is_device_build(ctx)
 
     entitlements_options = {
         "bundle_id": bundle_id,
@@ -292,8 +321,8 @@ def _entitlements_impl(ctx):
         inputs.append(signing_info.profile_metadata)
         entitlements_options["profile_metadata_file"] = signing_info.profile_metadata.path
         entitlements_options["validation_mode"] = _tool_validation_mode(
-            ctx.attr.validation_mode,
-            is_device,
+            is_device = platform_prerequisites.platform.is_device,
+            rules_mode = ctx.attr.validation_mode,
         )
 
     control = struct(
@@ -304,7 +333,11 @@ def _entitlements_impl(ctx):
         target = str(ctx.label),
         variable_substitutions = struct(CFBundleIdentifier = ctx.attr.bundle_id),
     )
-    control_file = _new_entitlements_artifact(ctx, "plisttool-control")
+    control_file = _new_entitlements_artifact(
+        actions = actions,
+        extension = "plisttool-control",
+        label_name = ctx.label.name,
+    )
     ctx.actions.write(
         output = control_file,
         content = control.to_json(),
@@ -322,7 +355,7 @@ def _entitlements_impl(ctx):
 
     # Only propagate linkopts for simulator builds to embed the entitlements into
     # the binary; for device builds, the entitlements are applied during signing.
-    if not is_device:
+    if not platform_prerequisites.platform.is_device:
         simulator_entitlements = None
         if _include_debug_entitlements(ctx):
             simulator_entitlements = ctx.actions.declare_file(

--- a/apple/internal/entitlement_rules.bzl
+++ b/apple/internal/entitlement_rules.bzl
@@ -357,7 +357,7 @@ def _entitlements_impl(ctx):
     # the binary; for device builds, the entitlements are applied during signing.
     if not platform_prerequisites.platform.is_device:
         simulator_entitlements = None
-        if _include_debug_entitlements(ctx):
+        if _include_debug_entitlements(platform_prerequisites = platform_prerequisites):
             simulator_entitlements = ctx.actions.declare_file(
                 "%s.simulator.entitlements" % ctx.label.name,
             )
@@ -367,7 +367,11 @@ def _entitlements_impl(ctx):
                 output = simulator_entitlements.path,
                 target = str(ctx.label),
             )
-            simulator_control_file = _new_entitlements_artifact(ctx, "simulator-plisttool-control")
+            simulator_control_file = _new_entitlements_artifact(
+                actions = actions,
+                extension = "simulator-plisttool-control",
+                label_name = ctx.label.name,
+            )
             ctx.actions.write(
                 output = simulator_control_file,
                 content = simulator_control.to_json(),

--- a/apple/internal/experimental.bzl
+++ b/apple/internal/experimental.bzl
@@ -22,9 +22,7 @@ load(
 def is_experimental_tree_artifact_enabled(*, config_vars):
     """Returns whether tree artifact outputs experiment is enabled."""
 
-    # TODO(b/161370390): Remove ctx from all invocations of defines.bool_value.
     return defines.bool_value(
-        ctx = None,
         config_vars = config_vars,
         define_name = "apple.experimental.tree_artifact_outputs",
         default = False,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1243,7 +1243,9 @@ def _ios_imessage_application_impl(ctx):
     rule_executables = ctx.executable
 
     binary_artifact = stub_support.create_stub_binary(
-        ctx,
+        actions = actions,
+        platform_prerequisites = platform_prerequisites,
+        rule_label = label,
         xcode_stub_path = rule_descriptor.stub_binary_path,
     )
 
@@ -1553,7 +1555,9 @@ def _ios_sticker_pack_extension_impl(ctx):
     rule_executables = ctx.executable
 
     binary_artifact = stub_support.create_stub_binary(
-        ctx,
+        actions = actions,
+        platform_prerequisites = platform_prerequisites,
+        rule_label = label,
         xcode_stub_path = rule_descriptor.stub_binary_path,
     )
 

--- a/apple/internal/partials/app_assets_validation.bzl
+++ b/apple/internal/partials/app_assets_validation.bzl
@@ -27,10 +27,8 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _app_assets_validation_partial_impl(
         *,
-        ctx,
         app_icons,
         launch_images,
         platform_prerequisites,

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -27,10 +27,8 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _apple_bundle_info_partial_impl(
         *,
-        ctx,
         actions,
         bundle_id,
         bundle_extension,

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -27,8 +27,7 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
-def _binary_partial_impl(ctx, actions, binary_artifact, executable_name, label_name):
+def _binary_partial_impl(*, actions, binary_artifact, executable_name, label_name):
     """Implementation for the binary processing partial."""
 
     # Create intermediate file with proper name for the binary.

--- a/apple/internal/partials/bitcode_symbols.bzl
+++ b/apple/internal/partials/bitcode_symbols.bzl
@@ -38,10 +38,8 @@ _AppleBitcodeInfo = provider(
     },
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _bitcode_symbols_partial_impl(
         *,
-        ctx,
         actions,
         binary_artifact,
         debug_outputs_provider,

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -47,10 +47,8 @@ def _should_package_clang_runtime(*, features):
             return True
     return False
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _clang_rt_dylibs_partial_impl(
         *,
-        ctx,
         actions,
         binary_artifact,
         clangrttool,

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -193,10 +193,8 @@ def _bundle_dsym_files(
 
     return outputs
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _debug_symbols_partial_impl(
         *,
-        ctx,
         actions,
         bin_root_path,
         bundle_extension,
@@ -278,9 +276,7 @@ def _debug_symbols_partial_impl(
 
     # Only output dependency debug files if requested.
     # TODO(b/131699846): Remove this.
-    # TODO(b/161370390): Remove ctx from all invocations of defines.bool_value.
     propagate_embedded_extra_outputs = defines.bool_value(
-        ctx = None,
         config_vars = platform_prerequisites.config_vars,
         define_name = "apple.propagate_embedded_extra_outputs",
         default = False,

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -251,7 +251,6 @@ def _debug_symbols_partial_impl(
             )
 
             include_symbols = defines.bool_value(
-                ctx = None,
                 config_vars = platform_prerequisites.config_vars,
                 define_name = "apple.package_symbols",
                 default = False,

--- a/apple/internal/partials/embedded_bundles.bzl
+++ b/apple/internal/partials/embedded_bundles.bzl
@@ -52,10 +52,8 @@ of the packaging bundle. Only applicable for macOS applications.""",
     },
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _embedded_bundles_partial_impl(
         *,
-        ctx,
         bundle_embedded_bundles,
         embeddable_targets,
         platform_prerequisites,

--- a/apple/internal/partials/extension_safe_validation.bzl
+++ b/apple/internal/partials/extension_safe_validation.bzl
@@ -26,10 +26,8 @@ _AppleExtensionSafeValidationInfo = provider(
     },
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _extension_safe_validation_partial_impl(
         *,
-        ctx,
         is_extension_safe,
         rule_label,
         targets_to_validate):

--- a/apple/internal/partials/framework_headers.bzl
+++ b/apple/internal/partials/framework_headers.bzl
@@ -23,8 +23,7 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
-def _framework_headers_partial_impl(*, ctx, hdrs):
+def _framework_headers_partial_impl(*, hdrs):
     """Implementation for the framework headers partial."""
     return struct(
         bundle_files = [

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -59,10 +59,8 @@ load(
     "sets",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _framework_import_partial_impl(
         *,
-        ctx,
         actions,
         label_name,
         package_symbols,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -203,7 +203,6 @@ def _framework_import_partial_impl(
         signed_frameworks_list.append(framework_basename)
 
     symbols_requested = defines.bool_value(
-        ctx = None,
         config_vars = platform_prerequisites.config_vars,
         define_name = "apple.package_symbols",
         default = False,

--- a/apple/internal/partials/framework_provider.bzl
+++ b/apple/internal/partials/framework_provider.bzl
@@ -23,10 +23,8 @@ load(
     "paths",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _framework_provider_partial_impl(
         *,
-        ctx,
         actions,
         bin_root_path,
         binary_provider,

--- a/apple/internal/partials/macos_additional_contents.bzl
+++ b/apple/internal/partials/macos_additional_contents.bzl
@@ -36,8 +36,7 @@ load(
     "paths",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
-def _macos_additional_contents_partial_impl(*, ctx, additional_contents):
+def _macos_additional_contents_partial_impl(*, additional_contents):
     """Implementation for the additional contents processing partial."""
 
     if not additional_contents:

--- a/apple/internal/partials/messages_stub.bzl
+++ b/apple/internal/partials/messages_stub.bzl
@@ -39,10 +39,8 @@ archive.
     },
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _messages_stub_partial_impl(
         *,
-        ctx,
         actions,
         binary_artifact,
         extensions,

--- a/apple/internal/partials/provisioning_profile.bzl
+++ b/apple/internal/partials/provisioning_profile.bzl
@@ -27,10 +27,8 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _provisioning_profile_partial_impl(
         *,
-        ctx,
         actions,
         extension,
         location,

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -274,7 +274,6 @@ def _validate_processed_locales(*, label, locales_dropped, locales_included, loc
 
 def _resources_partial_impl(
         *,
-        ctx,
         actions,
         bundle_extension,
         bundle_id,

--- a/apple/internal/partials/settings_bundle.bzl
+++ b/apple/internal/partials/settings_bundle.bzl
@@ -35,10 +35,8 @@ load(
     "partial",
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _settings_bundle_partial_impl(
         *,
-        ctx,
         actions,
         platform_prerequisites,
         rule_label,

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -116,10 +116,8 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _static_framework_header_modulemap_partial_impl(
         *,
-        ctx,
         actions,
         binary_objc_provider,
         bundle_name,

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -123,10 +123,8 @@ def _swift_dylib_action(
         xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _swift_dylibs_partial_impl(
         *,
-        ctx,
         actions,
         binary_artifact,
         bundle_dylibs,
@@ -167,7 +165,6 @@ def _swift_dylibs_partial_impl(
     strip_bitcode = bitcode_support.bitcode_mode_string(platform_prerequisites.apple_fragment) == "none"
 
     swift_support_requested = defines.bool_value(
-        ctx = None,
         config_vars = platform_prerequisites.config_vars,
         define_name = "apple.package_swift_support",
         default = True,

--- a/apple/internal/partials/swift_dynamic_framework.bzl
+++ b/apple/internal/partials/swift_dynamic_framework.bzl
@@ -39,7 +39,6 @@ def _get_header_imports(framework_imports):
 # TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _swift_dynamic_framework_partial_impl(
         *,
-        ctx,
         actions,
         bundle_name,
         label_name,
@@ -65,7 +64,7 @@ frameworks expect a single swift_library dependency with `module_name` set to th
         bundle_doc = intermediates.file(actions, label_name, "{}.swiftdoc".format(arch))
         actions.symlink(target_file = swiftdoc, output = bundle_doc)
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_doc])))
-    
+
     for arch, swiftmodule in swiftmodules.items():
         bundle_doc = intermediates.file(actions, label_name, "{}.swiftmodule".format(arch))
         actions.symlink(target_file = swiftmodule, output = bundle_doc)

--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -40,10 +40,8 @@ framework module {module_name} {{
 }}
 """.format(module_name = module_name)
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _swift_static_framework_partial_impl(
         *,
-        ctx,
         actions,
         bundle_name,
         label_name,

--- a/apple/internal/partials/watchos_stub.bzl
+++ b/apple/internal/partials/watchos_stub.bzl
@@ -39,10 +39,8 @@ archive.
     },
 )
 
-# TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.
 def _watchos_stub_partial_impl(
         *,
-        ctx,
         actions,
         binary_artifact,
         label_name,

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -37,24 +37,6 @@ _DEVICE_FAMILY_VALUES = {
     "mac": None,
 }
 
-def _families(ctx):
-    """Returns the device families that apply to the target being built.
-
-    Some platforms, such as iOS, support multiple device families (iPhone and
-    iPad) and provide a `families` attribute that lets the user specify which
-    to use. Other platforms, like tvOS, only support one family, so they do not
-    provide the public attribute and instead we implicitly get the supported
-    families from the private attribute instead.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      The list of device families that apply to the target being built.
-    """
-    rule_descriptor = rule_support.rule_descriptor(ctx)
-    return getattr(ctx.attr, "families", rule_descriptor.allowed_device_families)
-
 def _ui_device_family_plist_value(*, platform_prerequisites):
     """Returns the value to use for `UIDeviceFamily` in an info.plist.
 
@@ -78,18 +60,6 @@ def _ui_device_family_plist_value(*, platform_prerequisites):
     if family_ids:
         return family_ids
     return None
-
-def _is_device_build(ctx):
-    """Returns True if the target is being built for a device.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      True if this is a device build, or False if it is a simulator build.
-    """
-    platform = _platform(ctx)
-    return platform.is_device
 
 def _platform_prerequisites(
         *,
@@ -173,72 +143,9 @@ def _platform_prerequisites_from_rule_ctx(ctx):
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 
-def _minimum_os(ctx):
-    """Returns the minimum OS version required for the current target.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      A string containing the dotted minimum OS version.
-    """
-    min_os = ctx.attr.minimum_os_version
-    if not min_os:
-        # TODO(b/38006810): Use the SDK version instead of the flag value as a soft
-        # default.
-        min_os = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].minimum_os_for_platform_type(_platform_type(ctx)))
-    return min_os
-
-def _platform_type(ctx):
-    """Returns the platform type for the current target.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      The `PlatformType` for the current target, after being converted from its
-      string attribute form.
-    """
-    platform_type_string = ctx.attr.platform_type
-    return getattr(apple_common.platform_type, platform_type_string)
-
-def _platform(ctx):
-    """Returns the platform for the current target.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      The Platform object for the target.
-    """
-    apple = ctx.fragments.apple
-    platform = apple.multi_arch_platform(_platform_type(ctx))
-    return platform
-
-def _platform_and_sdk_version(ctx):
-    """Returns the platform and SDK version for the current target.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      A tuple containing the Platform object for the target and the SDK version
-      to build against for that platform.
-    """
-    platform = _platform(ctx)
-    sdk_version = (ctx.attr._xcode_config[apple_common.XcodeVersionConfig].sdk_version_for_platform(platform))
-
-    return platform, sdk_version
-
 # Define the loadable module that lists the exported symbols in this file.
 platform_support = struct(
-    families = _families,
-    is_device_build = _is_device_build,
-    minimum_os = _minimum_os,
-    platform = _platform,
-    platform_and_sdk_version = _platform_and_sdk_version,
     platform_prerequisites = _platform_prerequisites,
     platform_prerequisites_from_rule_ctx = _platform_prerequisites_from_rule_ctx,
-    platform_type = _platform_type,
     ui_device_family_plist_value = _ui_device_family_plist_value,
 )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -254,9 +254,7 @@ def _bundle_partial_outputs_files(
     config_vars = platform_prerequisites.config_vars
     requested_locales_flag = config_vars.get("apple.locales_to_include")
 
-    # TODO(b/161370390): Remove ctx from all invocations of defines.bool_value.
     trim_locales = defines.bool_value(
-        ctx = None,
         config_vars = config_vars,
         default = None,
         define_name = "apple.trim_lproj_locales",
@@ -666,9 +664,7 @@ def _process(
       any additional output groups is in the `output_groups` field.
     """
 
-    # TODO(b/161370390): Remove the ctx kwarg passed to this call once ctx is removed from the args
-    # of all of the partials.
-    partial_outputs = [partial.call(p, ctx = None) for p in partials]
+    partial_outputs = [partial.call(p) for p in partials]
 
     if bundle_post_process_and_sign:
         output_archive = outputs.archive(

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -23,11 +23,13 @@ load(
     "intermediates",
 )
 
-def _create_stub_binary(ctx, xcode_stub_path):
+def _create_stub_binary(*, actions, platform_prerequisites, rule_label, xcode_stub_path):
     """Returns a symlinked stub binary from the Xcode distribution.
 
     Args:
-        ctx: The rule context.
+        actions: The actions provider from `ctx.actions`.
+        platform_prerequisites: Struct containing information on the platform being targeted.
+        rule_label: The label of the target being analyzed.
         xcode_stub_path: The Xcode SDK root relative path to where the stub binary is to be copied
             from.
 
@@ -35,21 +37,22 @@ def _create_stub_binary(ctx, xcode_stub_path):
         A File reference to the stub binary artifact.
     """
     binary_artifact = intermediates.file(
-        ctx.actions,
-        ctx.label.name,
+        actions,
+        rule_label.name,
         "StubBinary",
     )
 
     # TODO(b/79323243): Replace this with a symlink instead of a hard copy.
     legacy_actions.run_shell(
-        ctx,
-        outputs = [binary_artifact],
+        actions = actions,
         command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
             output_path = binary_artifact.path,
             xcode_stub_path = xcode_stub_path,
         ),
         mnemonic = "CopyStubExecutable",
-        progress_message = "Copying stub executable for %s" % (ctx.label),
+        outputs = [binary_artifact],
+        platform_prerequisites = platform_prerequisites,
+        progress_message = "Copying stub executable for %s" % (rule_label),
     )
     return binary_artifact
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -383,7 +383,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
     ]
 
-    if platform_support.platform_type(ctx) == apple_common.platform_type.macos:
+    if platform_prerequisites.platform_type == apple_common.platform_type.macos:
         processor_partials.append(
             partials.macos_additional_contents_partial(
                 additional_contents = ctx.attr.additional_contents,

--- a/apple/internal/utils/BUILD
+++ b/apple/internal/utils/BUILD
@@ -33,7 +33,6 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        "//apple/internal:platform_support",
         "@bazel_skylib//lib:types",
         "@build_bazel_apple_support//lib:apple_support",
     ],

--- a/apple/internal/utils/defines.bzl
+++ b/apple/internal/utils/defines.bzl
@@ -14,13 +14,12 @@
 
 """Support functions for common --define operations."""
 
-def _bool_value(ctx, define_name, default, *, config_vars = None):
+def _bool_value(define_name, default, *, config_vars = None):
     """Looks up a define on ctx for a boolean value.
 
     Will also report an error if the value is not a supported value.
 
     Args:
-      ctx: A Starlark context. Deprecated.
       define_name: The name of the define to look up.
       default: The value to return if the define isn't found.
       config_vars: A dictionary (String to String) of configuration variables. Can be from ctx.var.
@@ -28,9 +27,6 @@ def _bool_value(ctx, define_name, default, *, config_vars = None):
     Returns:
       True/False or the default value if the define wasn't found.
     """
-    if not config_vars:
-        config_vars = ctx.var
-
     value = config_vars.get(define_name, None)
     if value != None:
         if value.lower() in ("true", "yes", "1"):

--- a/apple/internal/utils/legacy_actions.bzl
+++ b/apple/internal/utils/legacy_actions.bzl
@@ -18,10 +18,6 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
-    "platform_support",
-)
 
 def _add_dicts(*dictionaries):
     """Adds a list of dictionaries into a single dictionary."""
@@ -34,7 +30,6 @@ def _add_dicts(*dictionaries):
     return result
 
 def _kwargs_for_apple_platform(
-        ctx,
         *,
         platform_prerequisites,
         **kwargs):
@@ -47,19 +42,11 @@ def _kwargs_for_apple_platform(
         env_dicts.append(original_env)
 
     # This is where things differ from apple_support.
-
-    # TODO(b/161370390): Eliminate need to make platform_prerequisites optional when all calls to
-    # run and run_shell with a ctx argument are eliminated.
-    if platform_prerequisites:
-        platform = platform_prerequisites.platform
-        xcode_config = platform_prerequisites.xcode_version_config
-        action_execution_requirements = apple_support.action_required_execution_requirements(
-            xcode_config = xcode_config,
-        )
-    else:
-        platform = platform_support.platform(ctx)
-        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
-        action_execution_requirements = apple_support.action_required_execution_requirements(ctx)
+    platform = platform_prerequisites.platform
+    xcode_config = platform_prerequisites.xcode_version_config
+    action_execution_requirements = apple_support.action_required_execution_requirements(
+        xcode_config = xcode_config,
+    )
 
     env_dicts.append(apple_common.apple_host_system_env(xcode_config))
     env_dicts.append(apple_common.target_apple_env(xcode_config, platform))
@@ -78,10 +65,9 @@ def _kwargs_for_apple_platform(
     return processed_args
 
 def _run(
-        ctx = None,
         *,
-        actions = None,
-        platform_prerequisites = None,
+        actions,
+        platform_prerequisites,
         **kwargs):
     """Executes a Darwin-only action with the necessary platform environment.
 
@@ -97,28 +83,19 @@ def _run(
     rule context gets the correct platform value configured.
 
     Args:
-      ctx: The Starlark context. Deprecated.
       actions: The actions provider from ctx.actions.
       platform_prerequisites: Struct containing information on the platform being targeted.
       **kwargs: Arguments to be passed into ctx.actions.run.
     """
-
-    # TODO(b/161370390): Eliminate need to make actions and platform_prerequisites optional when all
-    # calls to this method with a ctx argument are eliminated.
-    if not actions:
-        actions = ctx.actions
-
     actions.run(**_kwargs_for_apple_platform(
-        ctx = ctx,
         platform_prerequisites = platform_prerequisites,
         **kwargs
     ))
 
 def _run_shell(
-        ctx = None,
         *,
-        actions = None,
-        platform_prerequisites = None,
+        actions,
+        platform_prerequisites,
         **kwargs):
     """Executes a Darwin-only action with the necessary platform environment.
 
@@ -134,19 +111,11 @@ def _run_shell(
     rule context gets the correct platform value configured.
 
     Args:
-      ctx: The Starlark context. Deprecated.
       actions: The actions provider from ctx.actions.
       platform_prerequisites: Struct containing information on the platform being targeted.
       **kwargs: Arguments to be passed into ctx.actions.run_shell.
     """
-
-    # TODO(b/161370390): Eliminate need to make actions and platform_prerequisites optional when all
-    # calls to this method with a ctx argument are eliminated.
-    if not actions:
-        actions = ctx.actions
-
     actions.run_shell(**_kwargs_for_apple_platform(
-        ctx = ctx,
         platform_prerequisites = platform_prerequisites,
         **kwargs
     ))

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -311,7 +311,9 @@ def _watchos_application_impl(ctx):
     rule_executables = ctx.executable
 
     binary_artifact = stub_support.create_stub_binary(
-        ctx,
+        actions = actions,
+        platform_prerequisites = platform_prerequisites,
+        rule_label = label,
         xcode_stub_path = rule_descriptor.stub_binary_path,
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 349565752
(cherry picked from commit 0398730486a4af383950c30fd13668482549b17f)