### PR TITLE
Renaming rule_executables fields and variables to apple_toolchain_info, reflecting new purpose.

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -83,9 +83,9 @@ def _apple_resource_aspect_impl(target, ctx):
     bucketize_args = {}
     process_args = {
         "actions": ctx.actions,
+        "apple_toolchain_info": ctx.attr._toolchain[AppleSupportToolchainInfo],
         "bundle_id": None,
         "product_type": None,
-        "rule_executables": ctx.attr._toolchain[AppleSupportToolchainInfo],
         "rule_label": ctx.label,
     }
     collect_infoplists_args = {}

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1021,11 +1021,11 @@ def _ios_dynamic_framework_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -1060,6 +1060,7 @@ def _ios_dynamic_framework_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1070,7 +1071,6 @@ def _ios_dynamic_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = ["resources"],
@@ -1078,11 +1078,11 @@ def _ios_dynamic_framework_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.swift_dynamic_framework_partial(
             actions = actions,
@@ -1094,6 +1094,7 @@ def _ios_dynamic_framework_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -1106,7 +1107,6 @@ def _ios_dynamic_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -187,11 +187,11 @@ def _ios_application_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -213,16 +213,17 @@ def _ios_application_impl(ctx):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             package_symbols = True,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps + ctx.attr.extensions + ctx.attr.frameworks,
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -234,7 +235,6 @@ def _ios_application_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
@@ -247,13 +247,13 @@ def _ios_application_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             dependency_targets = embeddable_targets,
             label_name = label.name,
             package_swift_support_if_needed = True,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -288,6 +288,7 @@ def _ios_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -300,7 +301,6 @@ def _ios_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -432,11 +432,11 @@ def _ios_app_clip_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -458,15 +458,16 @@ def _ios_app_clip_impl(ctx):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps + ctx.attr.frameworks,
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -477,20 +478,19 @@ def _ios_app_clip_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             dependency_targets = embeddable_targets,
             label_name = label.name,
             package_swift_support_if_needed = True,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -505,6 +505,7 @@ def _ios_app_clip_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -517,7 +518,6 @@ def _ios_app_clip_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -649,11 +649,11 @@ def _ios_framework_impl(ctx):
         # the can be skipped.
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -689,6 +689,7 @@ def _ios_framework_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -699,7 +700,6 @@ def _ios_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = ["resources"],
@@ -707,16 +707,17 @@ def _ios_framework_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -729,7 +730,6 @@ def _ios_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -832,11 +832,11 @@ def _ios_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -862,6 +862,7 @@ def _ios_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -872,18 +873,17 @@ def _ios_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -898,6 +898,7 @@ def _ios_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -910,7 +911,6 @@ def _ios_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1188,6 +1188,7 @@ def _ios_static_framework_impl(ctx):
     if not ctx.attr.exclude_resources:
         processor_partials.append(partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             environment_plist = ctx.file._environment_plist,
@@ -1196,12 +1197,12 @@ def _ios_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
         ))
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -1214,7 +1215,6 @@ def _ios_static_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1286,11 +1286,11 @@ def _ios_imessage_application_impl(ctx):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = [ctx.attr.extension],
         ),
         partials.messages_stub_partial(
@@ -1302,6 +1302,7 @@ def _ios_imessage_application_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1313,19 +1314,18 @@ def _ios_imessage_application_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = None,
             bundle_dylibs = True,
             dependency_targets = [ctx.attr.extension],
             label_name = label.name,
             package_swift_support_if_needed = True,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -1340,6 +1340,7 @@ def _ios_imessage_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         entitlements = entitlements,
@@ -1351,7 +1352,6 @@ def _ios_imessage_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1444,11 +1444,11 @@ def _ios_imessage_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -1474,6 +1474,7 @@ def _ios_imessage_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1484,18 +1485,17 @@ def _ios_imessage_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -1510,6 +1510,7 @@ def _ios_imessage_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -1522,7 +1523,6 @@ def _ios_imessage_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1612,6 +1612,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1622,7 +1623,6 @@ def _ios_sticker_pack_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = top_level_attrs,
         ),
@@ -1644,6 +1644,7 @@ def _ios_sticker_pack_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         entitlements = entitlements,
@@ -1655,7 +1656,6 @@ def _ios_sticker_pack_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -131,11 +131,11 @@ def _macos_application_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -157,11 +157,11 @@ def _macos_application_impl(ctx):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps + embedded_targets,
         ),
         partials.macos_additional_contents_partial(
@@ -169,6 +169,7 @@ def _macos_application_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -180,7 +181,6 @@ def _macos_application_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = [
                 "app_icons",
@@ -190,12 +190,12 @@ def _macos_application_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             dependency_targets = embedded_targets,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -212,6 +212,7 @@ def _macos_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -224,7 +225,6 @@ def _macos_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -325,11 +325,11 @@ def _macos_bundle_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -352,6 +352,7 @@ def _macos_bundle_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -362,7 +363,6 @@ def _macos_bundle_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = [
                 "app_icons",
@@ -372,10 +372,10 @@ def _macos_bundle_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -392,6 +392,7 @@ def _macos_bundle_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -404,7 +405,6 @@ def _macos_bundle_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -482,11 +482,11 @@ def _macos_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -509,6 +509,7 @@ def _macos_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -519,7 +520,6 @@ def _macos_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = [
                 "app_icons",
@@ -529,10 +529,10 @@ def _macos_extension_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -549,6 +549,7 @@ def _macos_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -561,7 +562,6 @@ def _macos_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -643,11 +643,11 @@ def _macos_quick_look_plugin_impl(ctx):
         # they can be skipped.
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -670,6 +670,7 @@ def _macos_quick_look_plugin_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -680,7 +681,6 @@ def _macos_quick_look_plugin_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = [
                 "strings",
@@ -689,10 +689,10 @@ def _macos_quick_look_plugin_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -709,6 +709,7 @@ def _macos_quick_look_plugin_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -721,7 +722,6 @@ def _macos_quick_look_plugin_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -793,11 +793,11 @@ def _macos_kernel_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -820,6 +820,7 @@ def _macos_kernel_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -830,16 +831,15 @@ def _macos_kernel_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = ["resources"],
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -856,6 +856,7 @@ def _macos_kernel_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -868,7 +869,6 @@ def _macos_kernel_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -943,11 +943,11 @@ def _macos_spotlight_importer_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -970,6 +970,7 @@ def _macos_spotlight_importer_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -980,15 +981,14 @@ def _macos_spotlight_importer_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -1005,6 +1005,7 @@ def _macos_spotlight_importer_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -1016,7 +1017,6 @@ def _macos_spotlight_importer_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1090,11 +1090,11 @@ def _macos_xpc_service_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -1117,6 +1117,7 @@ def _macos_xpc_service_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -1127,15 +1128,14 @@ def _macos_xpc_service_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -1152,6 +1152,7 @@ def _macos_xpc_service_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -1164,7 +1165,6 @@ def _macos_xpc_service_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -1218,6 +1218,7 @@ def _macos_command_line_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         bundle_post_process_and_sign = False,
@@ -1231,7 +1232,6 @@ def _macos_command_line_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
     output_file = actions.declare_file(label.name)
@@ -1304,6 +1304,7 @@ def _macos_dylib_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         bundle_post_process_and_sign = False,
@@ -1317,7 +1318,6 @@ def _macos_dylib_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
     output_file = actions.declare_file(label.name + ".dylib")

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -50,11 +50,11 @@ def _should_package_clang_runtime(*, features):
 def _clang_rt_dylibs_partial_impl(
         *,
         actions,
+        apple_toolchain_info,
         binary_artifact,
         features,
         label_name,
-        platform_prerequisites,
-        rule_executables):
+        platform_prerequisites):
     """Implementation for the Clang runtime dylibs processing partial."""
     bundle_zips = []
     if _should_package_clang_runtime(features = features):
@@ -64,7 +64,7 @@ def _clang_rt_dylibs_partial_impl(
             "clang_rt.zip",
         )
 
-        resolved_clangrttool = rule_executables.resolved_clangrttool
+        resolved_clangrttool = apple_toolchain_info.resolved_clangrttool
         legacy_actions.run(
             actions = actions,
             arguments = [
@@ -92,20 +92,20 @@ def _clang_rt_dylibs_partial_impl(
 def clang_rt_dylibs_partial(
         *,
         actions,
+        apple_toolchain_info,
         binary_artifact,
         features,
         label_name,
-        platform_prerequisites,
-        rule_executables):
+        platform_prerequisites):
     """Constructor for the Clang runtime dylibs processing partial.
 
     Args:
       actions: The actions provider from `ctx.actions`.
+      apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
       binary_artifact: The main binary artifact for this target.
       features: List of features enabled by the user. Typically from `ctx.features`.
       label_name: Name of the target being built.
       platform_prerequisites: Struct containing information on the platform being targeted.
-      rule_executables: List of tool executables defined by the rule.
 
     Returns:
       A partial that returns the bundle location of the Clang runtime dylibs, if there were any to
@@ -114,9 +114,9 @@ def clang_rt_dylibs_partial(
     return partial.make(
         _clang_rt_dylibs_partial_impl,
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         binary_artifact = binary_artifact,
         features = features,
         label_name = label_name,
         platform_prerequisites = platform_prerequisites,
-        rule_executables = rule_executables,
     )

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -62,12 +62,12 @@ load(
 def _framework_import_partial_impl(
         *,
         actions,
+        apple_toolchain_info,
         label_name,
         package_symbols,
         platform_prerequisites,
         provisioning_profile,
         rule_descriptor,
-        rule_executables,
         targets,
         targets_to_avoid):
     """Implementation for the framework import file processing partial."""
@@ -171,8 +171,8 @@ def _framework_import_partial_impl(
         )
         args.add_all(codesign_args)
 
-        resolved_codesigningtool = rule_executables.resolved_codesigningtool
-        resolved_imported_dynamic_framework_processor = rule_executables.resolved_imported_dynamic_framework_processor
+        resolved_codesigningtool = apple_toolchain_info.resolved_codesigningtool
+        resolved_imported_dynamic_framework_processor = apple_toolchain_info.resolved_imported_dynamic_framework_processor
 
         # Inputs of action are all the framework files, plus binaries needed for identifying the
         # current build's preferred architecture, plus a generated list of those binaries to prune
@@ -324,12 +324,12 @@ def _generate_symbols(
 def framework_import_partial(
         *,
         actions,
+        apple_toolchain_info,
         label_name,
         package_symbols = False,
         platform_prerequisites,
         provisioning_profile,
         rule_descriptor,
-        rule_executables,
         targets,
         targets_to_avoid = []):
     """Constructor for the framework import file processing partial.
@@ -339,12 +339,12 @@ def framework_import_partial(
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
         label_name: Name of the target being built.
         package_symbols: Whether the partial should package the symbols files for all binaries.
         platform_prerequisites: Struct containing information on the platform being targeted.
         provisioning_profile: File for the provisioning profile.
         rule_descriptor: A rule descriptor for platform and product types from the rule context.
-        rule_executables: List of tool executables defined by the rule.
         targets: The list of targets through which to collect the framework import files.
         targets_to_avoid: The list of targets that may already be bundling some of the frameworks,
             to be used when deduplicating frameworks already bundled.
@@ -355,12 +355,12 @@ def framework_import_partial(
     return partial.make(
         _framework_import_partial_impl,
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         label_name = label_name,
         package_symbols = package_symbols,
         platform_prerequisites = platform_prerequisites,
         provisioning_profile = provisioning_profile,
         rule_descriptor = rule_descriptor,
-        rule_executables = rule_executables,
         targets = targets,
         targets_to_avoid = targets_to_avoid,
     )

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -275,6 +275,7 @@ def _validate_processed_locales(*, label, locales_dropped, locales_included, loc
 def _resources_partial_impl(
         *,
         actions,
+        apple_toolchain_info,
         bundle_extension,
         bundle_id,
         bundle_name,
@@ -286,7 +287,6 @@ def _resources_partial_impl(
         plist_attrs,
         rule_attrs,
         rule_descriptor,
-        rule_executables,
         rule_label,
         targets_to_avoid,
         top_level_attrs,
@@ -421,8 +421,8 @@ def _resources_partial_impl(
 
             processing_args = {
                 "actions": actions,
+                "apple_toolchain_info": apple_toolchain_info,
                 "bundle_id": bundle_id,
-                "executables": rule_executables,
                 "files": files,
                 "parent_dir": parent_dir,
                 "platform_prerequisites": platform_prerequisites,
@@ -483,7 +483,7 @@ def _resources_partial_impl(
                 launch_storyboard = launch_storyboard,
                 out_infoplist = out_infoplist,
                 platform_prerequisites = platform_prerequisites,
-                resolved_plisttool = rule_executables.resolved_plisttool,
+                resolved_plisttool = apple_toolchain_info.resolved_plisttool,
                 rule_descriptor = rule_descriptor,
                 rule_label = rule_label,
                 version = getattr(rule_attrs, "version", None),
@@ -496,6 +496,7 @@ def _resources_partial_impl(
 def resources_partial(
         *,
         actions,
+        apple_toolchain_info,
         bundle_extension,
         bundle_id = None,
         bundle_name,
@@ -507,7 +508,6 @@ def resources_partial(
         plist_attrs = [],
         rule_attrs,
         rule_descriptor,
-        rule_executables,
         rule_label,
         targets_to_avoid = [],
         top_level_attrs = [],
@@ -519,6 +519,7 @@ def resources_partial(
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
         bundle_extension: The extension for the bundle.
         bundle_id: Optional bundle ID to use when processing resources. If no bundle ID is given,
             the bundle will not contain a root Info.plist and no embedded bundle verification will
@@ -538,7 +539,6 @@ def resources_partial(
             merged and processed.
         rule_attrs: List of attributes defined by the rule. Typically from `ctx.attr`.
         rule_descriptor: A rule descriptor for platform and product types from the rule context.
-        rule_executables: List of executables defined by the rule. Typically from `ctx.executable`.
         rule_label: The label of the target being analyzed.
         targets_to_avoid: List of targets containing resources that should be deduplicated from the
             target being processed.
@@ -553,6 +553,7 @@ def resources_partial(
     return partial.make(
         _resources_partial_impl,
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_id = bundle_id,
         bundle_name = bundle_name,
@@ -564,7 +565,6 @@ def resources_partial(
         plist_attrs = plist_attrs,
         rule_attrs = rule_attrs,
         rule_descriptor = rule_descriptor,
-        rule_executables = rule_executables,
         rule_label = rule_label,
         targets_to_avoid = targets_to_avoid,
         top_level_attrs = top_level_attrs,

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -15,9 +15,9 @@
 """Support code for resource processing.
 
 All methods in this file follow this convention:
-  - The argument signature is a combination of; actions, bundle_id, executables, files, parent_dir,
-    platform_prerequisites, product_type, and/or rule_label. Only the arguments required for each
-    resource action should be referenced directly by keyword in the argument signature and
+  - The argument signature is a combination of; actions, apple_toolchain_info, bundle_id, files,
+    parent_dir, platform_prerequisites, product_type, and/or rule_label. Only the arguments required
+    for each resource action should be referenced directly by keyword in the argument signature and
     implementation. Arguments should not be referenced through kwargs. The presence of kwargs is
     only necessary to ignore unused keywords.
   - They all return a struct with the following optional fields:
@@ -134,8 +134,8 @@ def _compile_mappingmodels(
 def _asset_catalogs(
         *,
         actions,
+        apple_toolchain_info,
         bundle_id,
-        executables,
         files,
         parent_dir,
         platform_prerequisites,
@@ -172,7 +172,7 @@ def _asset_catalogs(
         output_plist = assets_plist,
         platform_prerequisites = platform_prerequisites,
         product_type = product_type,
-        resolved_xctoolrunner = executables.resolved_xctoolrunner,
+        resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
     )
 
     return struct(
@@ -183,7 +183,7 @@ def _asset_catalogs(
 def _datamodels(
         *,
         actions,
-        executables,
+        apple_toolchain_info,
         files,
         parent_dir,
         platform_prerequisites,
@@ -234,7 +234,7 @@ def _datamodels(
         swift_module = swift_module,
         datamodel_groups = datamodel_groups,
         platform_prerequisites = platform_prerequisites,
-        resolved_xctoolrunner = executables.resolved_xctoolrunner,
+        resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
     ))
     output_files.extend(_compile_mappingmodels(
         actions = actions,
@@ -242,7 +242,7 @@ def _datamodels(
         parent_dir = parent_dir,
         mappingmodel_groups = mappingmodel_groups,
         platform_prerequisites = platform_prerequisites,
-        resolved_xctoolrunner = executables.resolved_xctoolrunner,
+        resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
     ))
 
     return struct(files = output_files)
@@ -250,7 +250,7 @@ def _datamodels(
 def _infoplists(
         *,
         actions,
-        executables,
+        apple_toolchain_info,
         files,
         parent_dir,
         platform_prerequisites,
@@ -265,7 +265,7 @@ def _infoplists(
 
     Args:
         actions: The actions provider from `ctx.actions`.
-        executables: Struct containing executable files defined by a rule.
+        apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
         files: The infoplist files to process.
         parent_dir: The path under which the merged Info.plist should be placed for resource bundles.
         platform_prerequisites: Struct containing information on the platform being targeted.
@@ -291,7 +291,7 @@ def _infoplists(
             input_files = input_files,
             output_plist = out_plist,
             platform_prerequisites = platform_prerequisites,
-            resolved_plisttool = executables.resolved_plisttool,
+            resolved_plisttool = apple_toolchain_info.resolved_plisttool,
             rule_label = rule_label,
         )
         return struct(
@@ -352,7 +352,7 @@ def _metals(
 def _mlmodels(
         *,
         actions,
-        executables,
+        apple_toolchain_info,
         files,
         parent_dir,
         platform_prerequisites,
@@ -382,7 +382,7 @@ def _mlmodels(
             output_bundle = output_bundle,
             output_plist = output_plist,
             platform_prerequisites = platform_prerequisites,
-            resolved_xctoolrunner = executables.resolved_xctoolrunner,
+            resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
         )
 
         mlmodel_bundles.append(
@@ -506,7 +506,7 @@ def _pngs(
 def _storyboards(
         *,
         actions,
-        executables,
+        apple_toolchain_info,
         files,
         parent_dir,
         platform_prerequisites,
@@ -538,7 +538,7 @@ def _storyboards(
             input_file = storyboard,
             output_dir = storyboardc_dir,
             platform_prerequisites = platform_prerequisites,
-            resolved_xctoolrunner = executables.resolved_xctoolrunner,
+            resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
             swift_module = swift_module,
         )
         compiled_storyboardcs.append(storyboardc_dir)
@@ -554,7 +554,7 @@ def _storyboards(
         actions = actions,
         output_dir = linked_storyboard_dir,
         platform_prerequisites = platform_prerequisites,
-        resolved_xctoolrunner = executables.resolved_xctoolrunner,
+        resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
         storyboardc_dirs = compiled_storyboardcs,
     )
     return struct(
@@ -607,7 +607,7 @@ def _texture_atlases(
 def _xibs(
         *,
         actions,
-        executables,
+        apple_toolchain_info,
         files,
         parent_dir,
         platform_prerequisites,
@@ -626,7 +626,7 @@ def _xibs(
             input_file = file,
             output_dir = out_dir,
             platform_prerequisites = platform_prerequisites,
-            resolved_xctoolrunner = executables.resolved_xctoolrunner,
+            resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
             swift_module = swift_module,
         )
         nib_files.append(out_dir)

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -211,7 +211,7 @@ def _swift_dylibs_partial_impl(
                         output_dir = swift_support_output_dir,
                         platform_name = platform_name,
                         platform_prerequisites = platform_prerequisites,
-                        resolved_swift_stdlib_tool = rule_executables.resolved_swift_stdlib_tool,
+                        resolved_swift_stdlib_tool = apple_toolchain_info.resolved_swift_stdlib_tool,
                         strip_bitcode = False,
                     )
                 else:

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -127,13 +127,13 @@ def _swift_dylib_action(
 def _swift_dylibs_partial_impl(
         *,
         actions,
+        apple_toolchain_info,
         binary_artifact,
         bundle_dylibs,
         dependency_targets,
         label_name,
         package_swift_support_if_needed,
-        platform_prerequisites,
-        rule_executables):
+        platform_prerequisites):
     """Implementation for the Swift dylibs processing partial."""
 
     # Collect transitive data.
@@ -189,7 +189,7 @@ def _swift_dylibs_partial_impl(
                 output_dir = output_dir,
                 platform_name = platform_name,
                 platform_prerequisites = platform_prerequisites,
-                resolved_swift_stdlib_tool = rule_executables.resolved_swift_stdlib_tool,
+                resolved_swift_stdlib_tool = apple_toolchain_info.resolved_swift_stdlib_tool,
                 strip_bitcode = strip_bitcode,
             )
 
@@ -252,19 +252,20 @@ def _swift_dylibs_partial_impl(
 def swift_dylibs_partial(
         *,
         actions,
+        apple_toolchain_info,
         binary_artifact,
         bundle_dylibs = False,
         dependency_targets = [],
         label_name,
         package_swift_support_if_needed = False,
-        platform_prerequisites,
-        rule_executables):
+        platform_prerequisites):
     """Constructor for the Swift dylibs processing partial.
 
     This partial handles the Swift dylibs that may need to be packaged or propagated.
 
     Args:
       actions: The actions provider from `ctx.actions`.
+      apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
       binary_artifact: The main binary artifact for this target.
       bundle_dylibs: Whether the partial should return the Swift files to be bundled inside the
         target's bundle.
@@ -275,7 +276,6 @@ def swift_dylibs_partial(
         each dependency platform into the SwiftSupport directory at the root of the archive. It
         might still not be included depending on what it is being built for.
       platform_prerequisites: Struct containing information on the platform being targeted.
-      rule_executables: List of tool executables defined by the rule.
 
     Returns:
       A partial that returns the bundle location of the Swift dylibs and propagates dylib
@@ -284,11 +284,11 @@ def swift_dylibs_partial(
     return partial.make(
         _swift_dylibs_partial_impl,
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         binary_artifact = binary_artifact,
         bundle_dylibs = bundle_dylibs,
         dependency_targets = dependency_targets,
         label_name = label_name,
         package_swift_support_if_needed = package_swift_support_if_needed,
         platform_prerequisites = platform_prerequisites,
-        rule_executables = rule_executables,
     )

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -347,13 +347,13 @@ def _bucketize_typed(resources, bucket_type, *, owner = None, parent_dir_param =
 def _process_bucketized_data(
         *,
         actions,
+        apple_toolchain_info,
         bucketized_owners = [],
         buckets,
         bundle_id,
         platform_prerequisites,
         processing_owner = None,
         product_type,
-        rule_executables,
         rule_label,
         unowned_resources = []):
     """Registers actions for cacheable resource types, given bucketized groupings of data.
@@ -365,6 +365,7 @@ def _process_bucketized_data(
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
         bucketized_owners: A list of tuples indicating the owner of each bucketized resource.
         buckets: A dictionary with bucketized resources organized by resource type.
         bundle_id: The bundle ID to configure for this target.
@@ -372,7 +373,6 @@ def _process_bucketized_data(
         processing_owner: An optional string that has a unique identifier to the target that should
             own the resources. If an owner should be passed, it's usually equal to `str(ctx.label)`.
         product_type: The product type identifier used to describe the current bundle type.
-        rule_executables: List of tool executables defined by the rule.
         rule_label: The label of the target being analyzed.
         unowned_resources: A list of "unowned" resources.
 
@@ -392,8 +392,8 @@ def _process_bucketized_data(
 
             processing_args = {
                 "actions": actions,
+                "apple_toolchain_info": apple_toolchain_info,
                 "bundle_id": bundle_id,
-                "executables": rule_executables,
                 "files": files,
                 "parent_dir": parent_dir,
                 "platform_prerequisites": platform_prerequisites,

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -323,11 +323,11 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -348,16 +348,17 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps,
             targets_to_avoid = targets_to_avoid,
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -368,7 +369,6 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = targets_to_avoid,
             top_level_attrs = ["resources"],
@@ -376,11 +376,11 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -393,6 +393,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -405,7 +406,6 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -382,11 +382,11 @@ def _tvos_dynamic_framework_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -421,6 +421,7 @@ def _tvos_dynamic_framework_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -431,7 +432,6 @@ def _tvos_dynamic_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = ["resources"],
@@ -439,11 +439,11 @@ def _tvos_dynamic_framework_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.swift_dynamic_framework_partial(
             actions = actions,
@@ -455,6 +455,7 @@ def _tvos_dynamic_framework_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -467,7 +468,6 @@ def _tvos_dynamic_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -161,11 +161,11 @@ def _tvos_application_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -187,15 +187,16 @@ def _tvos_application_impl(ctx):
         ),
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps + embeddable_targets,
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -207,7 +208,6 @@ def _tvos_application_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
@@ -220,13 +220,13 @@ def _tvos_application_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             dependency_targets = swift_dylib_dependencies,
             label_name = label.name,
             package_swift_support_if_needed = True,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -241,6 +241,7 @@ def _tvos_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -253,7 +254,6 @@ def _tvos_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -555,11 +555,11 @@ def _tvos_framework_impl(ctx):
         # the can be skipped.
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -595,6 +595,7 @@ def _tvos_framework_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -605,7 +606,6 @@ def _tvos_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = ["resources"],
@@ -613,16 +613,17 @@ def _tvos_framework_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -635,7 +636,6 @@ def _tvos_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -721,11 +721,11 @@ def _tvos_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -751,6 +751,7 @@ def _tvos_extension_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -761,18 +762,17 @@ def _tvos_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -787,6 +787,7 @@ def _tvos_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -799,7 +800,6 @@ def _tvos_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -886,6 +886,7 @@ def _tvos_static_framework_impl(ctx):
 
         processor_partials.append(partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             environment_plist = ctx.file._environment_plist,
@@ -894,12 +895,12 @@ def _tvos_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
         ))
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -912,7 +913,6 @@ def _tvos_static_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -365,11 +365,11 @@ def _watchos_application_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -390,6 +390,7 @@ def _watchos_application_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -401,18 +402,17 @@ def _watchos_application_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             bundle_dylibs = True,
             dependency_targets = [ctx.attr.extension],
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.watchos_stub_partial(
             actions = actions,
@@ -432,6 +432,7 @@ def _watchos_application_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         entitlements = entitlements,
@@ -443,7 +444,6 @@ def _watchos_application_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -552,11 +552,11 @@ def _watchos_extension_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -578,15 +578,16 @@ def _watchos_extension_impl(ctx):
         # https://developer.apple.com/library/archive/documentation/General/Conceptual/AppleWatch2TransitionGuide/ConfiguretheXcodeProject.html
         partials.framework_import_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             targets = ctx.attr.deps,
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -597,16 +598,15 @@ def _watchos_extension_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             top_level_attrs = top_level_attrs,
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
     ]
 
@@ -621,6 +621,7 @@ def _watchos_extension_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -633,7 +634,6 @@ def _watchos_extension_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -182,11 +182,11 @@ def _watchos_dynamic_framework_impl(ctx):
         ),
         partials.clang_rt_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -221,6 +221,7 @@ def _watchos_dynamic_framework_impl(ctx):
         ),
         partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_id = bundle_id,
             bundle_name = bundle_name,
@@ -231,7 +232,6 @@ def _watchos_dynamic_framework_impl(ctx):
             plist_attrs = ["infoplists"],
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
             targets_to_avoid = ctx.attr.frameworks,
             top_level_attrs = ["resources"],
@@ -239,11 +239,11 @@ def _watchos_dynamic_framework_impl(ctx):
         ),
         partials.swift_dylibs_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             binary_artifact = binary_artifact,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
-            rule_executables = apple_toolchain_info,
         ),
         partials.swift_dynamic_framework_partial(
             actions = actions,
@@ -255,6 +255,7 @@ def _watchos_dynamic_framework_impl(ctx):
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -267,7 +268,6 @@ def _watchos_dynamic_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 
@@ -717,6 +717,7 @@ def _watchos_static_framework_impl(ctx):
 
         processor_partials.append(partials.resources_partial(
             actions = actions,
+            apple_toolchain_info = apple_toolchain_info,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             environment_plist = ctx.file._environment_plist,
@@ -725,12 +726,12 @@ def _watchos_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             rule_attrs = ctx.attr,
             rule_descriptor = rule_descriptor,
-            rule_executables = apple_toolchain_info,
             rule_label = label,
         ))
 
     processor_result = processor.process(
         actions = actions,
+        apple_toolchain_info = apple_toolchain_info,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
@@ -743,7 +744,6 @@ def _watchos_static_framework_impl(ctx):
         process_and_sign_template = apple_toolchain_info.process_and_sign_template,
         provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
         rule_descriptor = rule_descriptor,
-        rule_executables = apple_toolchain_info,
         rule_label = label,
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 351875039
(cherry picked from commit 53dc0891a3acf16ed18253abf7d99daae78f2995)