### PR TITLE
Move the platform-specific runner templates to individual rule_factory methods.

### DIFF
--- a/apple/internal/apple_support_toolchain.bzl
+++ b/apple/internal/apple_support_toolchain.bzl
@@ -46,7 +46,6 @@ def _apple_support_toolchain_impl(ctx):
     return [
         AppleSupportToolchainInfo(
             dsym_info_plist_template = ctx.file._dsym_info_plist_template,
-            macos_runner_template = ctx.file._macos_runner_template,
             process_and_sign_template = ctx.file._process_and_sign_template,
             resolved_bundletool = _resolve_tools_for_executable(
                 attr_name = "_bundletool",
@@ -80,9 +79,6 @@ def _apple_support_toolchain_impl(ctx):
                 attr_name = "_xctoolrunner",
                 rule_ctx = ctx,
             ),
-            # TODO(b/74731511): Refactor the runner_template attribute into being specified for each
-            # platform.
-            runner_template = ctx.file._runner_template,
             std_redirect_dylib = ctx.file._std_redirect_dylib,
         ),
         DefaultInfo(),
@@ -125,11 +121,6 @@ apple_support_toolchain = rule(
             cfg = "host",
             executable = True,
             default = Label("@build_bazel_rules_apple//tools/imported_dynamic_framework_processor"),
-        ),
-        "_macos_runner_template": attr.label(
-            cfg = "host",
-            allow_single_file = True,
-            default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
         ),
         "_plisttool": attr.label(
             cfg = "host",

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -315,7 +315,7 @@ def _ios_application_impl(ctx):
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = apple_toolchain_info.runner_template,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(
@@ -532,7 +532,7 @@ def _ios_app_clip_impl(ctx):
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = apple_toolchain_info.runner_template,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -239,7 +239,7 @@ def _macos_application_impl(ctx):
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = apple_toolchain_info.macos_runner_template,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -613,6 +613,11 @@ A `watchos_application` target that represents an Apple Watch application that s
 the application bundle.
 """,
             ),
+            "_runner_template": attr.label(
+                cfg = "host",
+                allow_single_file = True,
+                default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
+            ),
         })
     elif rule_descriptor.product_type == apple_product_type.app_clip:
         attrs.append({
@@ -624,6 +629,11 @@ provided file will be compiled into the appropriate format (`.storyboardc` or `.
 the root of the final bundle. The generated file will also be registered in the bundle's
 Info.plist under the key `UILaunchStoryboardName`.
 """,
+            ),
+            "_runner_template": attr.label(
+                cfg = "host",
+                allow_single_file = True,
+                default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
             ),
         })
     elif rule_descriptor.product_type == apple_product_type.app_extension:
@@ -734,6 +744,11 @@ set, then the default extension is determined by the application's product_type.
                 ],
                 doc = "A list of macOS XPC Services to include in the final application bundle.",
             ),
+            "_runner_template": attr.label(
+                cfg = "host",
+                allow_single_file = True,
+                default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
+            ),
         })
 
     elif rule_descriptor.product_type == apple_product_type.app_extension:
@@ -765,6 +780,13 @@ def _get_tvos_attrs(rule_descriptor):
                     [AppleBundleInfo, TvosExtensionBundleInfo],
                 ],
                 doc = "A list of tvOS extensions to include in the final application bundle.",
+            ),
+            "_runner_template": attr.label(
+                cfg = "host",
+                allow_single_file = True,
+                # Currently using the iOS Simulator template for tvOS, as tvOS does not require
+                # significantly different sim runner logic from iOS.
+                default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
             ),
         })
     elif rule_descriptor.product_type == apple_product_type.framework:

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -268,7 +268,7 @@ def _tvos_application_impl(ctx):
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = apple_toolchain_info.runner_template,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -205,9 +205,6 @@ files used as script templates for the purposes of executing Apple actions. Defi
         "dsym_info_plist_template": """\
 A `File` referencing a plist template for dSYM bundles.
 """,
-        "macos_runner_template": """\
-A `File` referencing a template to run the given macOS target.
-""",
         "process_and_sign_template": """\
 A `File` referencing a template for a shell script to process and sign.
 """,
@@ -244,9 +241,6 @@ A `struct` from `ctx.resolve_tools` referencing a tool that acts as a wrapper fo
         "resolved_swift_stdlib_tool": """\
 A `struct` from `ctx.resolve_tools` referencing a tool that copies and lipos Swift stdlibs required
 for the target to run.
-""",
-        "runner_template": """\
-A `File` referencing a template to run the given Apple target.
 """,
         "std_redirect_dylib": """\
 A `File` referencing a dynamic library used to redirect stdout and stderr when necessary.


### PR DESCRIPTION
PiperOrigin-RevId: 351885732
(cherry picked from commit 58c84109201f7633fa60e93700b48834986ea5f7)