### PR TITLE
Make apple_verification_test publicly consumable

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -61,7 +61,7 @@ filegroup(
         "apple_shell_testutils.sh",
         "unittest.bash",
     ],
-    visibility = ["//test/starlark_tests:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 # Gather external dependencies into a target that can be injected into the

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -128,7 +128,4 @@ bzl_library(
     ],
 )
 
-exports_files([
-    "verifier_scripts/apple_verification_test_runner.sh.template",
-    "verifier_scripts/archive_contents_test.sh"
-])
+exports_files(glob(["verifier_scripts/*.sh"]))

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -127,3 +127,8 @@ bzl_library(
         "@build_bazel_apple_support//lib:apple_support",
     ],
 )
+
+exports_files([
+    "verifier_scripts/apple_verification_test_runner.sh.template",
+    "verifier_scripts/archive_contents_test.sh"
+])

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -140,12 +140,17 @@ def _apple_verification_test_impl(ctx):
         fail(("Target %s does not provide AppleBundleInfo or AppleBinaryInfo") %
              target_under_test.label)
 
+    source_dependencies = ""
+    for dep in ctx.attr._test_deps.files.to_list():
+        source_dependencies += "source {}\n".format(dep.short_path)
+
     output_script = ctx.actions.declare_file("{}_test_script".format(ctx.label.name))
     ctx.actions.expand_template(
         template = ctx.file._runner_script,
         output = output_script,
         substitutions = {
             "%{archive}s": archive_short_path,
+            "%{dependencies}s": source_dependencies,
             "%{standalone_binary}s": standalone_binary_short_path,
             "%{archive_relative_binary}s": archive_relative_binary,
             "%{archive_relative_bundle}s": archive_relative_bundle,

--- a/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
+++ b/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
@@ -17,8 +17,7 @@
 set -eu
 
 # Loads the unittest framework for common assert methods.
-source test/unittest.bash
-source test/apple_shell_testutils.sh
+%{dependencies}s
 
 ARCHIVE_PATH="%{archive}s"
 STANDALONE_BINARY="%{standalone_binary}s"


### PR DESCRIPTION
These rules allow you to write tests against the final product of a
build. This can be useful to verify that certain things about your
release application are true. This makes a small number of changes to
make this usable from outside rules_apple.