### PR TITLE
Use testonly to propagate XCTest linker flags

### DIFF
--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -141,7 +141,7 @@ def _add_entitlements_and_swift_linkopts(
                 name,
                 deps,
                 link_swift_statically,
-                is_test or testonly,
+                bool(is_test or testonly),
                 tags = tags,
                 testonly = testonly,
             ),

--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -141,7 +141,7 @@ def _add_entitlements_and_swift_linkopts(
                 name,
                 deps,
                 link_swift_statically,
-                is_test,
+                is_test or testonly,
                 tags = tags,
                 testonly = testonly,
             ),


### PR DESCRIPTION
This reapplies https://github.com/bazelbuild/rules_apple/pull/593 which
broke with some internal refactors around how binaries are created. This
allows you to have an ios_framework containing Swift code that imports
XCTest. This isn't a perfect indication semantically but since we don't
really have another option this gets us some of the way there.