### PR TITLE
Fix static frameworks not including a module map that links system frameworks even if the target depends on one.

### DIFF
--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -161,7 +161,7 @@ def _static_framework_header_modulemap_partial_impl(
 
     # Create a module map if there is a need for one (that is, if there are
     # headers or if there are dylibs/frameworks that the target depends on).
-    if any([sdk_dylibs, sdk_dylibs, umbrella_header_name]):
+    if any([sdk_dylibs, sdk_frameworks, umbrella_header_name]):
         modulemap_file = intermediates.file(
             actions,
             paths.join(label_name, label_name + ".modulemaps"),

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -51,6 +51,51 @@ def ios_static_framework_test_suite(name = "ios_static_framework"):
         tags = [name],
     )
 
+    # Test that no module map is generated if the target does not have headers
+    # and does not depend on any system dylibs/frameworks.
+    archive_contents_test(
+        name = "{}_no_module_map_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:objc_static_framework_without_modulemap",
+        not_contains = ["$BUNDLE_ROOT/Modules/module.modulemap"],
+        tags = [name],
+    )
+
+    # Test that a module map is generated if the target depends on system
+    # dylibs.
+    archive_contents_test(
+        name = "{}_module_map_with_sdk_dylibs_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:objc_static_framework_with_sdk_dylibs_dep",
+        contains = ["$BUNDLE_ROOT/Modules/module.modulemap"],
+        tags = [name],
+        text_test_file = "$BUNDLE_ROOT/Modules/module.modulemap",
+        text_test_values = [" link \"z\""],
+    )
+
+    # Test that a module map is generated if the target depends on system
+    # frameworks.
+    archive_contents_test(
+        name = "{}_module_map_with_sdk_fmwks_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:objc_static_framework_with_sdk_fmwks_dep",
+        contains = ["$BUNDLE_ROOT/Modules/module.modulemap"],
+        tags = [name],
+        text_test_file = "$BUNDLE_ROOT/Modules/module.modulemap",
+        text_test_values = [" link framework \"CoreData\""],
+    )
+
+    # Test that a module map is generated if the target's `hdrs` is not empty.
+    archive_contents_test(
+        name = "{}_module_map_with_hdrs_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:objc_static_framework",
+        contains = ["$BUNDLE_ROOT/Modules/module.modulemap"],
+        tags = [name],
+        text_test_file = "$BUNDLE_ROOT/Modules/module.modulemap",
+        text_test_values = [" umbrella header \"objc_static_framework.h\""],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -67,6 +67,22 @@ objc_library(
     tags = FIXTURE_TAGS,
 )
 
+objc_library(
+    name = "objc_lib_with_sdk_dylibs",
+    srcs = ["common.m"],
+    hdrs = ["common.h"],
+    sdk_dylibs = ["libz"],
+    tags = FIXTURE_TAGS,
+)
+
+objc_library(
+    name = "objc_lib_with_sdk_fmwks",
+    srcs = ["common.m"],
+    hdrs = ["common.h"],
+    sdk_frameworks = ["CoreData"],
+    tags = FIXTURE_TAGS,
+)
+
 swift_library(
     name = "swift_main_lib",
     srcs = ["//test/testdata/sources:main.swift"],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2020,6 +2020,36 @@ ios_static_framework(
     ],
 )
 
+ios_static_framework(
+    name = "objc_static_framework_without_modulemap",
+    bundle_name = "objc_static_framework_without_modulemap",
+    minimum_os_version = "9.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_common_lib",
+    ],
+)
+
+ios_static_framework(
+    name = "objc_static_framework_with_sdk_dylibs_dep",
+    bundle_name = "objc_static_framework_with_sdk_dylibs_dep",
+    minimum_os_version = "9.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+    ],
+)
+
+ios_static_framework(
+    name = "objc_static_framework_with_sdk_fmwks_dep",
+    bundle_name = "objc_static_framework_with_sdk_fmwks_dep",
+    minimum_os_version = "9.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_lib_with_sdk_fmwks",
+    ],
+)
+
 swift_library(
     name = "basic_framework_with_dynamic_framework_import_lib",
     srcs = [


### PR DESCRIPTION
Based on https://github.com/bazelbuild/rules_apple/issues/972.

Closes https://github.com/bazelbuild/rules_apple/issues/972.