### PR TITLE
Uniquify architecture list when collecting architectures from imported frameworks

### DIFF
--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -92,12 +92,11 @@ def _framework_import_partial_impl(
             files_to_bundle = [x for x in files_to_bundle if x not in avoid_files]
 
     # Collect the architectures that we are using for the build.
-    build_archs_found = [
-        build_arch
+    build_archs_found = depset(transitive = [
+        x[AppleFrameworkImportInfo].build_archs
         for x in targets
         if AppleFrameworkImportInfo in x
-        for build_arch in x[AppleFrameworkImportInfo].build_archs.to_list()
-    ]
+    ]).to_list()
 
     # Start assembling our partial's outputs.
     bundle_zips = []


### PR DESCRIPTION
Previously this could contain duplicate values if there are more than
one imported dynamic frameworks in deps, which caused some processing
commands to be unnecessarily invoked multiple times.
