### PR TITLE
Move target_environment to apple_support so it can be relied upon by rules_swift and rules_apple.

### DIFF
--- a/apple/constraints/BUILD
+++ b/apple/constraints/BUILD
@@ -1,4 +1,4 @@
-# Standard constraint_settings and constraint_values for Apple.
+# Standard constraint_settings and constraint_values for rules_apple.
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,20 +7,4 @@ licenses(["notice"])
 filegroup(
     name = "srcs",
     srcs = ["BUILD"],
-)
-
-# Constraint indicating the target environment (e.g. device, simulator).
-constraint_setting(
-    name = "target_environment",
-    visibility = ["//visibility:private"],
-)
-
-constraint_value(
-    name = "device",
-    constraint_setting = ":target_environment",
-)
-
-constraint_value(
-    name = "simulator",
-    constraint_setting = ":target_environment",
 )


### PR DESCRIPTION
PiperOrigin-RevId: 355196884
(cherry picked from commit 99aaede76b8b1a59c6f6061a56daf0338d233fb1)