### PR TITLE
Propagate custom output groups through apple_verification_test

### DIFF
--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -184,6 +184,7 @@ def _apple_verification_test_impl(ctx):
                         ctx.attr._test_deps.files.to_list(),
             ),
         ),
+        target_under_test[OutputGroupInfo],
     ]
 
 apple_verification_test = rule(


### PR DESCRIPTION
This allows you to use the build artifacts built from the test other
places