### PR TITLE
Restrict visibility of a subset of our tools, now that the Apple rules toolchain allows for stricter visibility.

### DIFF
--- a/tools/bundletool/BUILD
+++ b/tools/bundletool/BUILD
@@ -6,10 +6,9 @@ py_binary(
     name = "bundletool",
     srcs = ["bundletool.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [":bundletool_lib"],
 )
 
@@ -23,10 +22,9 @@ py_binary(
     name = "bundletool_experimental",
     srcs = ["bundletool_experimental.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
 )
 
 py2and3_test(
@@ -41,10 +39,9 @@ py2and3_test(
 filegroup(
     name = "process_and_sign_template",
     srcs = ["process_and_sign.sh.template"],
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
 )
 
 # Consumed by bazel tests.

--- a/tools/clangrttool/BUILD
+++ b/tools/clangrttool/BUILD
@@ -4,10 +4,9 @@ py_binary(
     name = "clangrttool",
     srcs = ["clangrttool.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
 )
 
 # Consumed by bazel tests.

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -4,10 +4,9 @@ py_binary(
     name = "codesigningtool",
     srcs = ["codesigningtool.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [":codesigningtool_lib"],
 )
 

--- a/tools/dossier_codesigningtool/BUILD
+++ b/tools/dossier_codesigningtool/BUILD
@@ -4,10 +4,9 @@ py_binary(
     name = "dossier_codesigningtool",
     srcs = ["dossier_codesigningtool.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [":dossier_codesigningtool_lib"],
 )
 

--- a/tools/environment_plist/BUILD
+++ b/tools/environment_plist/BUILD
@@ -3,10 +3,9 @@ licenses(["notice"])
 sh_binary(
     name = "environment_plist",
     srcs = ["environment_plist.sh"],
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
 )
 
 # Consumed by bazel tests.

--- a/tools/imported_dynamic_framework_processor/BUILD
+++ b/tools/imported_dynamic_framework_processor/BUILD
@@ -4,10 +4,9 @@ py_binary(
     name = "imported_dynamic_framework_processor",
     srcs = ["imported_dynamic_framework_processor.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [
         "//tools/bitcode_strip",
         "//tools/codesigningtool:codesigningtool_lib",

--- a/tools/swift_stdlib_tool/BUILD
+++ b/tools/swift_stdlib_tool/BUILD
@@ -4,10 +4,9 @@ py_binary(
     name = "swift_stdlib_tool",
     srcs = ["swift_stdlib_tool.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [
         "//tools/bitcode_strip",
         "//tools/wrapper_common:execute",

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -9,6 +9,7 @@ py_library(
     visibility = [
         "//apple/internal:__pkg__",
         "//test/testdata/fmwk:__pkg__",
+        "//tools/bitcode_strip:__pkg__",
         "//tools/codesigningtool:__pkg__",
         "//tools/dossier_codesigningtool:__pkg__",
         "//tools/swift_stdlib_tool:__pkg__",

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -6,10 +6,14 @@ py_library(
     name = "execute",
     srcs = ["execute.py"],
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+        "//test/testdata/fmwk:__pkg__",
+        "//tools/codesigningtool:__pkg__",
+        "//tools/dossier_codesigningtool:__pkg__",
+        "//tools/swift_stdlib_tool:__pkg__",
+        "//tools/xctoolrunner:__pkg__",
+    ],
 )
 
 py2and3_test(


### PR DESCRIPTION
Will investigate other uses of tools to see if deps can be changed such that the toolchain can be used for more rules, allowing for stricter visibility.

PiperOrigin-RevId: 356283280
(cherry picked from commit 4f4bb66d34f6817f68a9adc008c85eea5674ba20)