### PR TITLE
Migrate the apple_core_ml_library rules to leverage the shared Apple toolchain.

### DIFF
--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -27,7 +27,6 @@ load(
     "versions",
 )
 
-
 def generate_intent_classes_sources(
         *,
         actions,
@@ -41,7 +40,7 @@ def generate_intent_classes_sources(
         swift_version,
         class_visibility,
         platform_prerequisites,
-        xctoolrunner_executable):
+        resolved_xctoolrunner):
     """Creates an action that cgenerates intent classes from an intentdefinition file.
 
     Args:
@@ -56,7 +55,7 @@ def generate_intent_classes_sources(
         swift_version: Version of Swift to use for the generated classes.
         class_visibility: Visibility attribute for the generated classes.
         platform_prerequisites: Struct containing information on the platform being targeted.
-        xctoolrunner_executable: A reference to the executable wrapper for "xcrun" tools.
+        resolved_xctoolrunner: A reference to the executable wrapper for "xcrun" tools.
     """
 
     is_swift = language == "Swift"
@@ -104,8 +103,8 @@ def generate_intent_classes_sources(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = arguments,
-        executable = xctoolrunner_executable,
-        inputs = [input_file],
+        executable = resolved_xctoolrunner.executable,
+        inputs = depset([input_file], transitive = [resolved_xctoolrunner.inputs]),
         mnemonic = "IntentGenerate",
         outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,

--- a/apple/internal/resource_rules/BUILD
+++ b/apple/internal/resource_rules/BUILD
@@ -44,7 +44,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        "//apple/internal:apple_support_toolchain",
+        "//apple:providers",
         "//apple/internal:platform_support",
         "//apple/internal:resource_actions",
         "//apple/internal:swift_support",

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -15,6 +15,10 @@
 """Implementation of ObjC/Swift Intent library rule."""
 
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleSupportToolchainInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
@@ -62,6 +66,7 @@ def _apple_intent_library_impl(ctx):
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 
+    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
     resource_actions.generate_intent_classes_sources(
         actions = ctx.actions,
         input_file = ctx.file.src,
@@ -74,7 +79,7 @@ def _apple_intent_library_impl(ctx):
         swift_version = ctx.attr.swift_version,
         class_visibility = ctx.attr.class_visibility,
         platform_prerequisites = platform_prerequisites,
-        xctoolrunner_executable = ctx.executable._xctoolrunner,
+        resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
     )
 
     if is_swift:
@@ -121,11 +126,9 @@ Label to a single or multiple intentdefinition files from which to generate sour
         "header_name": attr.string(
             doc = "Name of the public header file (only when using Objective-C).",
         ),
-        "_xctoolrunner": attr.label(
-            cfg = "host",
-            executable = True,
-            default = Label("@build_bazel_rules_apple//tools/xctoolrunner"),
-            doc = "Private attribute to specify the xctoolrunner executable.",
+        "_toolchain": attr.label(
+            default = Label("@build_bazel_rules_apple//apple/internal:toolchain_support"),
+            providers = [[AppleSupportToolchainInfo]],
         ),
     }),
     output_to_genfiles = True,

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -235,12 +235,12 @@ and zipped as a cacheable artifact.
 A `struct` from `ctx.resolve_tools` referencing a tool to perform plist operations such as variable
 substitution, merging, and conversion of plist files to binary format.
 """,
-        "resolved_xctoolrunner": """\
-A `struct` from `ctx.resolve_tools` referencing a tool that acts as a wrapper for xcrun actions.
-""",
         "resolved_swift_stdlib_tool": """\
 A `struct` from `ctx.resolve_tools` referencing a tool that copies and lipos Swift stdlibs required
 for the target to run.
+""",
+        "resolved_xctoolrunner": """\
+A `struct` from `ctx.resolve_tools` referencing a tool that acts as a wrapper for xcrun actions.
 """,
         "std_redirect_dylib": """\
 A `File` referencing a dynamic library used to redirect stdout and stderr when necessary.

--- a/test/BUILD
+++ b/test/BUILD
@@ -124,7 +124,7 @@ apple_shell_test(
 
 apple_shell_test(
     name = "apple_intent_library_test",
-    size = "small",
+    size = "medium",
     src = "apple_intent_library_test.sh",
     data = [
         "//test/testdata/resources:intent_srcs",

--- a/tools/xctoolrunner/BUILD
+++ b/tools/xctoolrunner/BUILD
@@ -7,10 +7,9 @@ py_binary(
     srcs = ["xctoolrunner.py"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [":xctoolrunner_lib"],
 )
 


### PR DESCRIPTION
Constrain the visibility for the xctoolrunner tool in the process.

PiperOrigin-RevId: 356517386
(cherry picked from commit 4a616a4fcb8beec4e40ecd10783ec154061d8e20)