### PR TITLE
Correctly set minimum OS value for MetalCompile action

### DIFF
--- a/apple/internal/resource_actions/metals.bzl
+++ b/apple/internal/resource_actions/metals.bzl
@@ -31,12 +31,9 @@ def _metal_apple_target_triple(platform_prerequisites):
     Returns:
         A target triple string describing the platform.
     """
-    platform = platform_prerequisites.apple_fragment.single_arch_platform
-    xcode_config = platform_prerequisites.xcode_version_config
-    target_os_version = xcode_config.minimum_os_for_platform_type(
-        platform.platform_type,
-    )
+    target_os_version = platform_prerequisites.minimum_os
 
+    platform = platform_prerequisites.apple_fragment.single_arch_platform
     platform_string = str(platform.platform_type)
     if platform_string == "macos":
         platform_string = "macosx"


### PR DESCRIPTION
Previously when an `--{i,mac,tv,watch}os_minimum_os` flag wasn't set,
the fallback value was the SDK version. This change ensures this value
is taken from the following order:
- the bundling rule's `minimum_os_version` attribute if the action is
  executed by building an Apple bundle target
- the `--{i,mac,tv,watch}os_minimum_os` flag value if set
- the SDK version
