### PR TITLE
Update codesigning support to be able to call the dossier codesigning tool. Update the apple support toolchain to support the dossier codesigning tool.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -18,6 +18,7 @@ apple_support_toolchain(
     bundletool_experimental = "//tools/bundletool:bundletool_experimental",
     clangrttool = "//tools/clangrttool",
     codesigningtool = "//tools/codesigningtool",
+    dossier_codesigningtool = "//tools/dossier_codesigningtool",
     dsym_info_plist_template = "//apple/internal/templates:dsym_info_plist_template",
     imported_dynamic_framework_processor = "//tools/imported_dynamic_framework_processor",
     plisttool = "//tools/plisttool",

--- a/apple/internal/apple_support_toolchain.bzl
+++ b/apple/internal/apple_support_toolchain.bzl
@@ -59,6 +59,10 @@ def _apple_support_toolchain_impl(ctx):
                 attr_name = "codesigningtool",
                 rule_ctx = ctx,
             ),
+            resolved_dossier_codesigningtool = _resolve_tools_for_executable(
+                attr_name = "dossier_codesigningtool",
+                rule_ctx = ctx,
+            ),
             resolved_clangrttool = _resolve_tools_for_executable(
                 attr_name = "clangrttool",
                 rule_ctx = ctx,
@@ -112,6 +116,11 @@ post-processing, and signing steps into a single action that eliminates the arch
             cfg = "host",
             executable = True,
             doc = "A `File` referencing a tool to assist in signing bundles.",
+        ),
+        "dossier_codesigningtool": attr.label(
+            cfg = "host",
+            executable = True,
+            doc = "A `File` referencing a tool to assist in generating signing dossiers.",
         ),
         "dsym_info_plist_template": attr.label(
             cfg = "host",

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -15,6 +15,10 @@
 """Actions related to codesigning."""
 
 load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
     "defines",
 )
@@ -422,6 +426,91 @@ def _codesigning_command(
         codesignopts = codesignopts,
     )
 
+def _generate_codesigning_dossier_action(
+        actions,
+        label_name,
+        resolved_codesigning_dossier_tool,
+        output_dossier,
+        platform_prerequisites,
+        embedded_dossiers = [],
+        entitlements = None,
+        provisioning_profile = None):
+    """Generates a codesigning dossier based on parameters.
+
+    Args:
+      actions: The actions provider from `ctx.actions`.
+      embedded_dossiers: An optional List of Structs generated from
+         `embedded_codesigning_dossier` that should also be included in this
+          dossier.
+      entitlements: Optional file representing the entitlements to sign with.
+      label_name: Name of the target being built.
+      output_dossier: The `File` representing the output dossier file - the zipped dossier will be placed here.
+      platform_prerequisites: Struct containing information on the platform being targeted.
+      provisioning_profile: The provisioning profile file. May be `None`.
+      resolved_codesigning_dossier_tool: The `struct` from resolve_tools representing the code signing tool.
+    """
+    input_files = [x.dossier_path for x in embedded_dossiers]
+
+    mnemonic = "GenerateCodesigningDossier"
+    progress_message = "Generating codesigning dossier for %s" % label_name
+
+    dossier_arguments = ["--output", output_dossier.path, "--zip"]
+
+    is_device = platform_prerequisites.platform.is_device
+    fragment = platform_prerequisites.objc_fragment
+    codesign_identity = fragment.signing_certificate_name if is_device else "-"
+    if not codesign_identity and not provisioning_profile:
+        codesign_identity = "-"
+    if codesign_identity:
+        dossier_arguments.extend(["--codesign_identity", codesign_identity])
+    if entitlements:
+        input_files.append(entitlements)
+        dossier_arguments.extend(["--entitlements_file", entitlements.path])
+    if provisioning_profile:
+        input_files.append(provisioning_profile)
+        dossier_arguments.extend(["--provisioning_profile", provisioning_profile.path])
+
+    for embedded_dossier in embedded_dossiers:
+        input_files.append(embedded_dossier.dossier_file)
+        dossier_arguments.extend(["--embedded_dossier", embedded_dossier.relative_bundle_path, embedded_dossier.dossier_file.path])
+
+    args_file = intermediates.file(
+        actions,
+        label_name,
+        "dossier_arguments",
+    )
+    actions.write(
+        output = args_file,
+        content = "\n".join(dossier_arguments),
+    )
+
+    input_files.append(args_file)
+    args_path_argument = "@%s" % args_file.path
+    args = ["create", args_path_argument]
+
+    apple_support.run(
+        actions = actions,
+        apple_fragment = platform_prerequisites.apple_fragment,
+        arguments = args,
+        executable = resolved_codesigning_dossier_tool.executable,
+        execution_requirements = {
+            # Added so that the output of this action is not cached remotely, in case multiple
+            # developers sign the same artifact with different identities.
+            "no-cache": "1",
+            # Unsure, but may be needed for keychain access, especially for files that live in
+            # $HOME.
+            "no-sandbox": "1",
+        },
+        inputs = depset(input_files, transitive = [resolved_codesigning_dossier_tool.inputs]),
+        input_manifests = resolved_codesigning_dossier_tool.input_manifests,
+        mnemonic = mnemonic,
+        outputs = [output_dossier],
+        progress_message = progress_message,
+        tools = [resolved_codesigning_dossier_tool.executable],
+        xcode_config = platform_prerequisites.xcode_version_config,
+        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
+    )
+
 def _post_process_and_sign_archive_action(
         *,
         actions,
@@ -642,10 +731,23 @@ def _sign_binary_action(
         tools = [resolved_codesigningtool.executable],
     )
 
+def _embedded_codesigning_dossier(relative_bundle_path, dossier_file):
+    """Returns a struct describing a dossier to be embedded in another dossier.
+
+    Args:
+      dossier_file: The File representing the zipped dossier to be embedded.
+      relative_bundle_path: The string path of the artifact this dossier
+        describes relative to the root of the bundle it is embedded in.
+        E.g. 'PlugIns/NetworkExtension.appex'
+    """
+    return struct(relative_bundle_path = relative_bundle_path, dossier_file = dossier_file)
+
 codesigning_support = struct(
     codesigning_args = _codesigning_args,
     codesigning_command = _codesigning_command,
     codesignopts_from_rule_ctx = _codesignopts_from_rule_ctx,
+    embedded_codesigning_dossier = _embedded_codesigning_dossier,
+    generate_codesigning_dossier_action = _generate_codesigning_dossier_action,
     post_process_and_sign_archive_action = _post_process_and_sign_archive_action,
     sign_binary_action = _sign_binary_action,
 )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -225,6 +225,9 @@ binary.
 A `struct` from `ctx.resolve_tools` referencing a tool to select the appropriate signing identity
 for Apple apps and Apple executable bundles.
 """,
+        "resolved_dossier_codesigningtool": """\
+A `struct` from `ctx.resolve_tools` referencing a tool to generate codesigning dossiers.
+""",
         "resolved_imported_dynamic_framework_processor": """\
 A `struct` from `ctx.resolve_tools` referencing a tool to process an imported dynamic framework
 such that the given framework only contains the same slices as the app binary, every file belonging

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -16,6 +16,7 @@ filegroup(
         "//tools/bundletool:for_bazel_tests",
         "//tools/clangrttool:for_bazel_tests",
         "//tools/codesigningtool:for_bazel_tests",
+        "//tools/dossier_codesigningtool:for_bazel_tests",
         "//tools/environment_plist:for_bazel_tests",
         "//tools/plisttool:for_bazel_tests",
         "//tools/provisioning_profile_tool:for_bazel_tests",


### PR DESCRIPTION
PiperOrigin-RevId: 355866356
(cherry picked from commit 68a8b48ae59d699551ee68222658dc6b2bbf8cc3)
