### PR TITLE
Fix module name in example/multi_platform/Buttons

### DIFF
--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -111,7 +111,7 @@ ios_extension(
 
 ios_static_framework(
     name = "ButtonsStaticFramework",
-    bundle_name = "ButtonsStaticFramework",
+    bundle_name = "Buttons",
     minimum_os_version = "8.0",
     deps = [":ButtonsLib"],
 )
@@ -358,6 +358,7 @@ build_test(
     name = "ExamplesBuildTest",
     targets = [
         ":Buttons",
+        ":ButtonsStaticFramework",
         ":ButtonsMac",
         ":ButtonsTV",
         ":ButtonsTVExtension",

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -258,7 +258,7 @@ tvos_extension(
 
 tvos_static_framework(
     name = "ButtonsTVStaticFramework",
-    bundle_name = "ButtonsTVStaticFramework",
+    bundle_name = "ButtonsTV",
     minimum_os_version = "10.0",
     deps = [":ButtonsTVLib"],
 )
@@ -362,6 +362,7 @@ build_test(
         ":ButtonsMac",
         ":ButtonsTV",
         ":ButtonsTVExtension",
+        ":ButtonsTVStaticFramework",
         ":ButtonsWatch",
         ":ButtonsWatchExtension",
     ],


### PR DESCRIPTION
I found this target got error because its `module_name` was wrong.

```sh
bazel build //examples/multi_platform/Buttons:ButtonsStaticFramework
```

```
Error in fail:
error: Found swift_library with module name 'Buttons' but expected 'ButtonsStaticFramework'. Swift static frameworks expect a single swift_library dependency with `module_name` set to the same `bundle_name` as the static framework target.
```

This PR will

- Fix `bundle_name` attribute (Use the same name as `ButtonsLib`)
- Add test case to `ExamplesBuildTest`