### PR TITLE
Add objc_provider to dynamic framework rules

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1120,7 +1120,9 @@ def _ios_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # ios_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
+            objc_provider = apple_common.new_objc_provider(
+                dynamic_framework_file = provider.framework_files
+            )
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1120,7 +1120,7 @@ def _ios_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # ios_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
+            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1113,6 +1113,17 @@ def _ios_dynamic_framework_impl(ctx):
 
     providers = processor_result.providers
 
+    new_providers = []
+    for provider in providers:
+        new_providers.append(provider)
+        if type(provider) == "AppleDynamicFramework":
+            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
+            # This is to make the ios_dynamic_framework usable as a dependency in swift_library
+            objc_provider_fields = {}
+            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
+            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            new_providers.append(objc_provider)
+
     return [
         DefaultInfo(files = processor_result.output_files),
         IosFrameworkBundleInfo(),
@@ -1122,7 +1133,7 @@ def _ios_dynamic_framework_impl(ctx):
                 processor_result.output_groups,
             )
         ),
-    ] + providers
+    ] + new_providers
 
 def _ios_static_framework_impl(ctx):
     """Experimental implementation of ios_static_framework."""

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1120,9 +1120,7 @@ def _ios_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # ios_dynamic_framework usable as a dependency in swift_library
-            objc_provider_fields = {}
-            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
-            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1113,9 +1113,8 @@ def _ios_dynamic_framework_impl(ctx):
 
     providers = processor_result.providers
 
-    new_providers = []
+    additional_providers = []
     for provider in providers:
-        new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
@@ -1123,7 +1122,8 @@ def _ios_dynamic_framework_impl(ctx):
             objc_provider = apple_common.new_objc_provider(
                 dynamic_framework_file = provider.framework_files
             )
-            new_providers.append(objc_provider)
+            additional_providers.append(objc_provider)
+    providers.extend(additional_providers)
 
     return [
         DefaultInfo(files = processor_result.output_files),
@@ -1134,7 +1134,7 @@ def _ios_dynamic_framework_impl(ctx):
                 processor_result.output_groups,
             )
         ),
-    ] + new_providers
+    ] + providers
 
 def _ios_static_framework_impl(ctx):
     """Experimental implementation of ios_static_framework."""

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1117,8 +1117,9 @@ def _ios_dynamic_framework_impl(ctx):
     for provider in providers:
         new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
-            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
-            # This is to make the ios_dynamic_framework usable as a dependency in swift_library
+            # Make the ObjC provider using the framework_files depset found
+            # in the AppleDynamicFramework provider. This is to make the
+            # ios_dynamic_framework usable as a dependency in swift_library
             objc_provider_fields = {}
             objc_provider_fields["dynamic_framework_file"] = provider.framework_files
             objc_provider = apple_common.new_objc_provider(**objc_provider_fields)

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -476,11 +476,10 @@ def _tvos_dynamic_framework_impl(ctx):
     for provider in providers:
         new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
-            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
-            # This is to make the tvos_dynamic_framework usable as a dependency in swift_library
-            objc_provider_fields = {}
-            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
-            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            # Make the ObjC provider using the framework_files depset found
+            # in the AppleDynamicFramework provider. This is to make the
+            # ios_dynamic_framework usable as a dependency in swift_library
+            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -479,7 +479,9 @@ def _tvos_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # tvos_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
+            objc_provider = apple_common.new_objc_provider(
+                dynamic_framework_file = provider.framework_files
+            )
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -471,6 +471,18 @@ def _tvos_dynamic_framework_impl(ctx):
         rule_label = label,
     )
 
+    providers = processor_result.providers
+    new_providers = []
+    for provider in providers:
+        new_providers.append(provider)
+        if type(provider) == "AppleDynamicFramework":
+            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
+            # This is to make the tvos_dynamic_framework usable as a dependency in swift_library
+            objc_provider_fields = {}
+            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
+            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            new_providers.append(objc_provider)
+
     return [
         DefaultInfo(files = processor_result.output_files),
         OutputGroupInfo(
@@ -480,7 +492,7 @@ def _tvos_dynamic_framework_impl(ctx):
             )
         ),
         TvosFrameworkBundleInfo(),
-    ] + processor_result.providers
+    ] + new_providers
 
 def _tvos_framework_impl(ctx):
     """Experimental implementation of tvos_framework."""

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -478,7 +478,7 @@ def _tvos_dynamic_framework_impl(ctx):
         if type(provider) == "AppleDynamicFramework":
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
-            # ios_dynamic_framework usable as a dependency in swift_library
+            # tvos_dynamic_framework usable as a dependency in swift_library
             objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
             new_providers.append(objc_provider)
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -472,9 +472,8 @@ def _tvos_dynamic_framework_impl(ctx):
     )
 
     providers = processor_result.providers
-    new_providers = []
+    additional_providers = []
     for provider in providers:
-        new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
@@ -482,7 +481,8 @@ def _tvos_dynamic_framework_impl(ctx):
             objc_provider = apple_common.new_objc_provider(
                 dynamic_framework_file = provider.framework_files
             )
-            new_providers.append(objc_provider)
+            additional_providers.append(objc_provider)
+    providers.extend(additional_providers)
 
     return [
         DefaultInfo(files = processor_result.output_files),
@@ -493,7 +493,7 @@ def _tvos_dynamic_framework_impl(ctx):
             )
         ),
         TvosFrameworkBundleInfo(),
-    ] + new_providers
+    ] + providers
 
 def _tvos_framework_impl(ctx):
     """Experimental implementation of tvos_framework."""

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -479,7 +479,7 @@ def _tvos_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # tvos_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
+            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -280,7 +280,7 @@ def _watchos_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # watchos_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
+            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -280,7 +280,9 @@ def _watchos_dynamic_framework_impl(ctx):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # watchos_dynamic_framework usable as a dependency in swift_library
-            objc_provider = apple_common.new_objc_provider(dynamic_framework_file = provider.framework_files)
+            objc_provider = apple_common.new_objc_provider(
+                dynamic_framework_file = provider.framework_files
+            )
             new_providers.append(objc_provider)
 
     return [

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -273,6 +273,17 @@ def _watchos_dynamic_framework_impl(ctx):
 
     providers = processor_result.providers
 
+    new_providers = []
+    for provider in providers:
+        new_providers.append(provider)
+        if type(provider) == "AppleDynamicFramework":
+            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
+            # This is to make the watchos_dynamic_framework usable as a dependency in swift_library
+            objc_provider_fields = {}
+            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
+            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            new_providers.append(objc_provider)
+
     return [
         DefaultInfo(files = processor_result.output_files),
         IosFrameworkBundleInfo(),
@@ -282,7 +293,7 @@ def _watchos_dynamic_framework_impl(ctx):
                 processor_result.output_groups,
             )
         ),
-    ] + providers
+    ] + new_providers
 
 def _watchos_application_impl(ctx):
     """Implementation of watchos_application."""

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -272,10 +272,8 @@ def _watchos_dynamic_framework_impl(ctx):
     )
 
     providers = processor_result.providers
-
-    new_providers = []
+    additional_providers = []
     for provider in providers:
-        new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
@@ -283,7 +281,8 @@ def _watchos_dynamic_framework_impl(ctx):
             objc_provider = apple_common.new_objc_provider(
                 dynamic_framework_file = provider.framework_files
             )
-            new_providers.append(objc_provider)
+            additional_providers.append(objc_provider)
+    providers.extend(additional_providers)
 
     return [
         DefaultInfo(files = processor_result.output_files),
@@ -294,7 +293,7 @@ def _watchos_dynamic_framework_impl(ctx):
                 processor_result.output_groups,
             )
         ),
-    ] + new_providers
+    ] + providers
 
 def _watchos_application_impl(ctx):
     """Implementation of watchos_application."""

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -277,11 +277,10 @@ def _watchos_dynamic_framework_impl(ctx):
     for provider in providers:
         new_providers.append(provider)
         if type(provider) == "AppleDynamicFramework":
-            # Make the ObjC provider using the framework_files depset found in the AppleDynamicFramework provider
-            # This is to make the watchos_dynamic_framework usable as a dependency in swift_library
-            objc_provider_fields = {}
-            objc_provider_fields["dynamic_framework_file"] = provider.framework_files
-            objc_provider = apple_common.new_objc_provider(**objc_provider_fields)
+            # Make the ObjC provider using the framework_files depset found
+            # in the AppleDynamicFramework provider. This is to make the
+            # watchos_dynamic_framework usable as a dependency in swift_library
+            objc_provider = apple_common.new_objc_provider(**{"dynamic_framework_file": provider.framework_files})
             new_providers.append(objc_provider)
 
     return [

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -131,6 +131,28 @@ def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
     )
 
     archive_contents_test(
+        name = "{}_symbols_from_shared_library_not_in_framework_with_dynamic_framework_dependency".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_dynamic_framework_dependency",
+        binary_test_file = "$BUNDLE_ROOT/DirectDependencyWithDynamicFrameworkTest",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_$s40DirectDependencyWithDynamicFrameworkTestMXM"],
+        binary_not_contains_symbols = ["_$s14BasicFrameworkAAC10HelloWorldyyF"],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_symbols_from_shared_library_not_in_framework_with_transitive_dependencies_and_dynamic_framework_dependencies".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_transitive_dependency_with_dynamic_frameworks",
+        binary_test_file = "$BUNDLE_ROOT/TransitiveDependencyWithDynamicFrameworksTest",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_$s45TransitiveDependencyWithDynamicFrameworksTestMXM"],
+        binary_not_contains_symbols = ["_$s14BasicFrameworkAAC10HelloWorldyyF", "_$s40DirectDependencyWithDynamicFrameworkTestMXM"],
+        tags = [name],
+    )
+
+    archive_contents_test(
         name = "{}_app_includes_transitive_framework_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_dynamic_framework_with_dynamic_framework",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1886,6 +1886,71 @@ ios_dynamic_framework(
     ],
 )
 
+swift_library(
+    name = "basic_framework_with_dynamic_framework_dependency_lib",
+    srcs = [
+        "//test/starlark_tests/resources:DirectDependencyTest.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "DirectDependencyWithDynamicFrameworkTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":basic_framework",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_dynamic_framework_dependency",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "DirectDependencyWithDynamicFrameworkTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_dynamic_framework_dependency_lib",
+    ],
+)
+
+swift_library(
+    name = "basic_framework_with_transitive_dependency_with_dynamic_frameworks_lib",
+    srcs = [
+        "//test/starlark_tests/resources:TransitiveDependencyTest.swift",
+    ],
+    features = ["swift.no_generated_module_map"],
+    module_name = "TransitiveDependencyWithDynamicFrameworksTest",
+    tags = FIXTURE_TAGS,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":basic_framework",
+        ":basic_framework_with_direct_dependency",
+    ],
+)
+
+ios_dynamic_framework(
+    name = "basic_framework_with_transitive_dependency_with_dynamic_frameworks",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "TransitiveDependencyWithDynamicFrameworksTest",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":basic_framework_with_transitive_dependency_with_dynamic_frameworks_lib",
+    ],
+)
+
 ios_dynamic_framework(
     name = "dynamic_framework_with_resources",
     bundle_id = "com.google.example.framework",


### PR DESCRIPTION
In its current state, the dynamic framework rules are only packaging rules. They take one swift_library as a dependency and bundle it into a dynamic framework that xcode can consume. Because swift_library outputs a static library, if it has any swift_library dependencies, they are linked into the library that gets bundled into the dynamic framework. This can cause a runtime error if multiple dynamic frameworks imported in Xcode have the same swift_library linked.

To avoid the runtime error, I am adding the objc_provider to the dynamic framework rules. This allows them to be used as a dependency of a swift_library and the framework will be linked dynamically instead of statically. So, in the above example, instead of packaging a swift_library that depends on a swift_library, you would package a swift_library that depends on a dynamic framework. Then, in Xcode, when you import two dynamic frameworks that depend on the same swift_library, you won’t get two copies at runtime since they are dynamically linked instead of statically linked.