### PR TITLE
Fix execution_requirements for code signing

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -479,7 +479,7 @@ def _generate_codesigning_dossier_action(
             # Added so that the output of this action is not cached remotely,
             # in case multiple developers sign the same artifact with different
             # identities.
-            execution_requirements["no-cache"] = "1"
+            execution_requirements["no-remote"] = "1"
 
     for embedded_dossier in embedded_dossiers:
         input_files.append(embedded_dossier.dossier_file)
@@ -585,7 +585,7 @@ def _post_process_and_sign_archive_action(
                 # Added so that the output of this action is not cached
                 # remotely, in case multiple developers sign the same artifact
                 # with different identities.
-                execution_requirements["no-cache"] = "1"
+                execution_requirements["no-remote"] = "1"
 
     ipa_post_processor_path = ""
     if ipa_post_processor:
@@ -726,7 +726,7 @@ def _sign_binary_action(
         # Added so that the output of this action is not cached remotely,
         # in case multiple developers sign the same artifact with different
         # identities.
-        execution_requirements["no-cache"] = "1"
+        execution_requirements["no-remote"] = "1"
 
     legacy_actions.run_shell(
         actions = actions,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -184,6 +184,11 @@ def _framework_import_partial_impl(
         if provisioning_profile:
             input_files.append(provisioning_profile)
             execution_requirements = {"no-sandbox": "1"}
+            if platform_prerequisites.platform.is_device:
+                # Added so that the output of this action is not cached
+                # remotely, in case multiple developers sign the same artifact
+                # with different identities.
+                execution_requirements["no-remote"] = "1"
 
         transitive_inputs = [
             resolved_imported_dynamic_framework_processor.inputs,


### PR DESCRIPTION
Instead of `no-cache` these should be `no-remote`, since the remote machine might not have the certs in the keychain. Also adds the same condition to `ImportedDynamicFrameworkProcessor`.
