### PR TITLE
First set of changes to enable M1 simulator.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -21,6 +21,7 @@ licenses(["notice"])
         "tvos_x86_64",
         "tvos_arm64",
         "watchos_i386",
+        "watchos_arm64",
         "watchos_armv7k",
         "watchos_arm64_32",
     ]


### PR DESCRIPTION
Changes to rules and bazel to enable new watchOS simulator CPU. Verified that this CPU is the one being used for simulator builds by Xcode on an M1 machine.

PiperOrigin-RevId: 361062624
(cherry picked from commit 6728d16d44edd3cd62df06234ad1aeeaf28198c0)
