### PR TITLE
Switch `apple_build_test_rule` to use `apple_rule_transition`.

### DIFF
--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -60,6 +60,9 @@ bzl_library(
     visibility = [
         "//apple:__subpackages__",
     ],
+    deps = [
+        "//apple/internal:transition_support",
+    ],
 )
 
 bzl_library(

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -14,6 +14,11 @@
 
 """Rules for writing build tests for libraries that target Apple platforms."""
 
+load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
+
 _PASSING_TEST_SCRIPT = """\
 #!/bin/bash
 exit 0
@@ -89,8 +94,12 @@ number (for example, `"9.0"`).
             # the user has not modified it.
             "platform_type": attr.string(default = platform_type),
             "_platform_type": attr.string(default = platform_type),
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
         },
         doc = doc,
         implementation = _apple_build_test_rule_impl,
         test = True,
+        cfg = transition_support.apple_rule_transition,
     )


### PR DESCRIPTION
This makes it consistent with other top-level Apple rules. The consistency allows to reduce the total number of configured targets (and Bazel memory usage) when the targets in transitive deps of `apple_build_test_rule` overlap with targets in transitive deps of other Apple targets in the same project.

PiperOrigin-RevId: 361613574
(cherry picked from commit 8195f02bdabf681325f2f35402acd37f8d56b440)
