### PR TITLE
Deprecate `provides_main` and remove branched logic on it.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -753,8 +753,6 @@ def _ios_extension_impl(ctx):
     ]
 
     extra_linkopts = []
-    if not ctx.attr.provides_main:
-        extra_linkopts.extend(["-e", "_NSExtensionMain"])
     if ctx.attr.sdk_frameworks:
         extra_linkopts.extend(
             collections.before_each("-framework", ctx.attr.sdk_frameworks),

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -423,12 +423,8 @@ def _macos_bundle_impl(ctx):
 
 def _macos_extension_impl(ctx):
     """Experimental implementation of macos_extension."""
-    extra_linkopts = []
-    if not ctx.attr.provides_main:
-        extra_linkopts.extend(["-e", "_NSExtensionMain"])
     link_result = linking_support.register_linking_action(
         ctx,
-        extra_linkopts = extra_linkopts,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary_provider.binary

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -198,20 +198,12 @@ AppleTestRunnerInfo provider.
     ),
 }
 
+# TODO(b/182307780): Remove after removing usage.
 _EXTENSION_PROVIDES_MAIN_ATTRS = {
     "provides_main": attr.bool(
         default = False,
         doc = """
-A value indicating whether one of this extension's dependencies provides a `main` entry point.
-
-This is false by default, because most app extensions provide their implementation by specifying a
-principal class or main storyboard in their `Info.plist` file, and the executable's entry point is
-actually in a system framework that delegates to it.
-
-However, some modern extensions (such as SwiftUI widget extensions introduced in iOS 14 and macOS
-11) use the `@main` attribute to identify their primary type, which generates a traditional `main`
-function that passes control to that type. For these extensions, this attribute should be set to
-true.
+No-op and deprecated. Has no function, previously used to denote a `_main` is provided.
 """,
         mandatory = False,
     ),

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -198,17 +198,6 @@ AppleTestRunnerInfo provider.
     ),
 }
 
-# TODO(b/182307780): Remove after removing usage.
-_EXTENSION_PROVIDES_MAIN_ATTRS = {
-    "provides_main": attr.bool(
-        default = False,
-        doc = """
-No-op and deprecated. Has no function, previously used to denote a `_main` is provided.
-""",
-        mandatory = False,
-    ),
-}
-
 def _common_binary_linking_attrs(default_binary_type, deps_cfg, product_type):
     deps_aspects = [
         apple_common.objc_proto_aspect,
@@ -638,8 +627,6 @@ Info.plist under the key `UILaunchStoryboardName`.
                 default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
             ),
         })
-    elif rule_descriptor.product_type == apple_product_type.app_extension:
-        attrs.append(_EXTENSION_PROVIDES_MAIN_ATTRS)
     elif _is_test_product_type(rule_descriptor.product_type):
         required_providers = [
             [AppleBundleInfo, IosApplicationBundleInfo],
@@ -752,9 +739,6 @@ set, then the default extension is determined by the application's product_type.
                 default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
             ),
         })
-
-    elif rule_descriptor.product_type == apple_product_type.app_extension:
-        attrs.append(_EXTENSION_PROVIDES_MAIN_ATTRS)
 
     elif _is_test_product_type(rule_descriptor.product_type):
         test_host_mandatory = rule_descriptor.product_type == apple_product_type.ui_test_bundle

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -270,6 +270,8 @@ _RULE_TYPE_DESCRIPTORS = {
             deps_cfg = apple_common.multi_arch_split,
             extra_linkopts = [
                 "-fapplication-extension",
+                "-e",
+                "_NSExtensionMain",
             ],
             mandatory_families = True,
             product_type = apple_product_type.app_extension,
@@ -461,6 +463,10 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
             deps_cfg = apple_common.multi_arch_split,
+            extra_linkopts = [
+                "-e",
+                "_NSExtensionMain",
+            ],
             product_type = apple_product_type.app_extension,
             provisioning_profile_extension = ".provisionprofile",
             requires_signing_for_device = False,

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -169,9 +169,9 @@ def ios_extension_test_suite(name = "ios_extension"):
     )
 
     entry_point_test(
-        name = "{}_entry_point_main_test".format(name),
+        name = "{}_provides_main_no_function_test".format(name),
         build_type = "simulator",
-        entry_point = "_main",
+        entry_point = "_NSExtensionMain",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_with_main",
         tags = [name],
     )

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -168,14 +168,6 @@ def ios_extension_test_suite(name = "ios_extension"):
         tags = [name],
     )
 
-    entry_point_test(
-        name = "{}_provides_main_no_function_test".format(name),
-        build_type = "simulator",
-        entry_point = "_NSExtensionMain",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_with_main",
-        tags = [name],
-    )
-
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -34,14 +34,6 @@ def macos_extension_test_suite(name = "macos_extension"):
         tags = [name],
     )
 
-    entry_point_test(
-        name = "{}_provides_main_no_function_test".format(name),
-        build_type = "simulator",
-        entry_point = "_NSExtensionMain",
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:ext_with_main",
-        tags = [name],
-    )
-
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -35,9 +35,9 @@ def macos_extension_test_suite(name = "macos_extension"):
     )
 
     entry_point_test(
-        name = "{}_entry_point_main_test".format(name),
+        name = "{}_provides_main_no_function_test".format(name),
         build_type = "simulator",
-        entry_point = "_main",
+        entry_point = "_NSExtensionMain",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ext_with_main",
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -928,26 +928,6 @@ ios_extension(
 )
 
 ios_extension(
-    name = "ext_with_main",
-    bundle_id = "com.google.example.ext",
-    entitlements = "//test/starlark_tests/resources:entitlements.plist",
-    families = [
-        "iphone",
-        "ipad",
-    ],
-    infoplists = [
-        "//test/starlark_tests/resources:Info.plist",
-    ],
-    minimum_os_version = "8.0",
-    provides_main = True,
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = FIXTURE_TAGS,
-    deps = [
-        "//test/starlark_tests/resources:objc_main_lib",
-    ],
-)
-
-ios_extension(
     name = "ext_multiple_infoplists",
     bundle_id = "com.google.example.ext",
     families = [

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -165,24 +165,6 @@ macos_extension(
     ],
 )
 
-macos_extension(
-    name = "ext_with_main",
-    additional_contents = {
-        "//test/starlark_tests/resources:additional.txt": "Additional",
-        "//test/starlark_tests/resources:all_nested": "Nested",
-    },
-    bundle_id = "com.google.example.ext",
-    infoplists = [
-        "//test/starlark_tests/resources:Info.plist",
-    ],
-    minimum_os_version = "10.10",
-    provides_main = True,
-    tags = FIXTURE_TAGS,
-    deps = [
-        "//test/starlark_tests/resources:objc_main_lib",
-    ],
-)
-
 macos_application(
     name = "app_with_imported_fmwk",
     bundle_id = "com.google.example",


### PR DESCRIPTION
`_NSExtensionMain` provides the correct behavior in final release, this behavior was based on observing a beta and adjusting to fit. It's fine to always use this option again now.

PiperOrigin-RevId: 361990582
(cherry picked from commit 8bae498d006ee67450a5a1b2f83577b6f672a36f)
