### PR TITLE
Take workspace name into account in dsyms, linkmap and output_text_match tests

### DIFF
--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -59,6 +59,17 @@ def _dsyms_test_impl(ctx):
             for x in ctx.attr.expected_dsyms
         ]
 
+    workspace = target_under_test.label.workspace_name
+    if workspace != "":
+        expected_infoplists = [
+            paths.join("..", workspace, x)
+            for x in expected_infoplists
+        ]
+        expected_binaries = [
+            paths.join("..", workspace, x)
+            for x in expected_binaries
+        ]
+
     for expected in expected_infoplists + expected_binaries:
         asserts.true(
             env,

--- a/test/starlark_tests/rules/linkmap_test.bzl
+++ b/test/starlark_tests/rules/linkmap_test.bzl
@@ -48,17 +48,20 @@ def _linkmap_test_impl(ctx):
     target_name = target_under_test.label.name
     linkmap_name = "{}_{}.linkmap".format(target_name, architecture)
 
-    expected_linkmaps = [paths.join(package, linkmap_name)]
+    expected_linkmap = paths.join(package, linkmap_name)
 
-    for expected in expected_linkmaps:
-        asserts.true(
-            env,
-            expected in outputs,
-            msg = "Expected\n\n{0}\n\nto be built. Contents were:\n\n{1}\n\n".format(
-                expected,
-                "\n".join(outputs.keys()),
-            ),
-        )
+    workspace = target_under_test.label.workspace_name
+    if workspace != "":
+        expected_linkmap = paths.join("..", workspace, expected_linkmap)
+
+    asserts.true(
+        env,
+        expected_linkmap in outputs,
+        msg = "Expected\n\n{0}\n\nto be built. Contents were:\n\n{1}\n\n".format(
+            expected_linkmap,
+            "\n".join(outputs.keys()),
+        ),
+    )
 
     return analysistest.end(env)
 

--- a/test/starlark_tests/rules/output_text_match_test.bzl
+++ b/test/starlark_tests/rules/output_text_match_test.bzl
@@ -18,6 +18,10 @@ load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
 
 def _output_text_match_test_impl(ctx):
     """Implementation of the `output_text_match_test` rule."""
@@ -49,10 +53,14 @@ def _output_text_match_test_impl(ctx):
 
     # Generate a script that uses the regex matching assertions from
     # unittest.bash to verify the matches (or not-matches) in the outputs.
+    unittest_bash_path = "test/unittest.bash"
+    workspace = target_under_test.label.workspace_name
+    if workspace != "":
+        unittest_bash_path = paths.join("..", workspace, unittest_bash_path)
     generated_script = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
-        "source test/unittest.bash",
+        "source {}".format(unittest_bash_path),
     ]
     for path_suffix, patterns in ctx.attr.files_match.items():
         for pattern in patterns:


### PR DESCRIPTION
This allows running rules_apple's analysis tests as an external
repository, which can be useful for developing custom rules.

Without this, these tests fail because the expected paths are different
when the main workspace isn't rules_apple. Example failure with a
linkmap test:

```
Executing tests from @build_bazel_rules_apple//test/starlark_tests:ios_application_linkmap_test
-----------------------------------------------------------------------------
In test _linkmap_test_impl from @build_bazel_rules_apple//test/starlark_tests:rules/linkmap_test.bzl: Expected

test/starlark_tests/targets_under_test/ios/app_x86_64.linkmap

to be built. Contents were:

../build_bazel_rules_apple/test/starlark_tests/targets_under_test/ios/app.ipa
../build_bazel_rules_apple/test/starlark_tests/targets_under_test/ios/app_x86_64.linkmap
```
