### PR TITLE
Remove duplicate embeddable_targets in _ios_app_clip_impl

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -378,7 +378,6 @@ def _ios_app_clip_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
-    embeddable_targets = ctx.attr.frameworks
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -371,18 +371,18 @@ def _ios_app_clip_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
     embeddable_targets = ctx.attr.frameworks
-    features = features_support.compute_enabled_features(
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
-    )
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
     )
+    executable_name = bundling_support.executable_name(ctx)
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     label = ctx.label
+    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
     rule_descriptor = rule_support.rule_descriptor(ctx)
 


### PR DESCRIPTION
I'm fairly new to the Bazel + iOS space and opening this PR mainly to get a feel for contributing to this repository. More substantive changes hopefully coming soon!

Alphabetized the variables in a separate commit in case that's not wanted in this PR.