### PR TITLE
Ignore swiftsourceinfo files in frameworks

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -112,7 +112,7 @@ def _classify_framework_imports(config_vars, framework_imports):
             # by Bazel but they aren't processed in any way
             header_imports.append(file)
             continue
-        if file_short_path.endswith(".swiftdoc"):
+        if file_short_path.endswith((".swiftdoc", ".swiftsourceinfo")):
             # Ignore swiftdoc files, they don't matter in the build, only for IDEs
             continue
         bundling_imports.append(file)


### PR DESCRIPTION
Dynamic frameworks vendored from third parties might contain these
files which I'm assuming are only for IDE support, either way we don't
want them in our final bundles