### PR TITLE
Add Swift runtime linker options when creating an `apple_binary`.

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -97,8 +97,9 @@ def _register_linking_action(ctx, *, stamp, extra_linkopts = []):
     if hasattr(ctx.attr, "_product_type"):
         rule_descriptor = rule_support.rule_descriptor(ctx)
         linkopts.extend(["-Wl,-rpath,{}".format(rpath) for rpath in rule_descriptor.rpaths])
-        linkopts.extend(rule_descriptor.extra_linkopts + extra_linkopts)
+        linkopts.extend(rule_descriptor.extra_linkopts)
 
+    linkopts.extend(extra_linkopts)
     return apple_common.link_multi_arch_binary(
         ctx = ctx,
         extra_linkopts = linkopts,

--- a/apple/internal/swift_support.bzl
+++ b/apple/internal/swift_support.bzl
@@ -100,5 +100,6 @@ swift_runtime_linkopts = rule(
 
 # Define the loadable module that lists the exported symbols in this file.
 swift_support = struct(
+    swift_usage_info = _swift_usage_info,
     uses_swift = _uses_swift,
 )


### PR DESCRIPTION
PiperOrigin-RevId: 368476099
(cherry picked from commit 45bcf73e983afef23bfac4e58d4db28f83f3dadf)