### PR TITLE
Use cpp fragment, instead of objc fragment, to determine whether to generate dsym

### DIFF
--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -145,7 +145,7 @@ macos_binary_infoplist = rule(
             "_product_type": attr.string(default = apple_product_type.tool),
         },
     ),
-    fragments = ["apple", "objc"],
+    fragments = ["apple", "cpp", "objc"],
 )
 
 def _macos_command_line_launchdplist_impl(ctx):
@@ -198,5 +198,5 @@ macos_command_line_launchdplist = rule(
             "_product_type": attr.string(default = apple_product_type.tool),
         },
     ),
-    fragments = ["apple", "objc"],
+    fragments = ["apple", "cpp", "objc"],
 )

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -222,7 +222,7 @@ def _debug_symbols_partial_impl(
 
     if debug_outputs_provider:
         output_providers.append(debug_outputs_provider)
-        if platform_prerequisites.objc_fragment.generate_dsym:
+        if platform_prerequisites.cpp_fragment.apple_generate_dsym:
             dsym_files = _bundle_dsym_files(
                 actions = actions,
                 bundle_name = bundle_name,

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -222,7 +222,9 @@ def _debug_symbols_partial_impl(
 
     if debug_outputs_provider:
         output_providers.append(debug_outputs_provider)
-        if platform_prerequisites.cpp_fragment.apple_generate_dsym:
+
+        # TODO: Remove old API and getattr once bazel is released with this change
+        if getattr(platform_prerequisites.objc_fragment, "generate_dsym", False) or getattr(platform_prerequisites.cpp_fragment, "apple_generate_dsym", False):
             dsym_files = _bundle_dsym_files(
                 actions = actions,
                 bundle_name = bundle_name,

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -69,6 +69,7 @@ def _platform_prerequisites(
         *,
         apple_fragment,
         config_vars,
+        cpp_fragment = None,
         device_families,
         disabled_features,
         explicit_minimum_os,
@@ -83,6 +84,7 @@ def _platform_prerequisites(
     Args:
       apple_fragment: An Apple fragment (ctx.fragments.apple).
       config_vars: A reference to configuration variables, typically from `ctx.var`.
+      cpp_fragment: An cpp fragment (ctx.fragments.cpp), if it is present. Optional.
       device_families: The list of device families that apply to the target being built.
       disabled_features: The list of disabled features applied to the target.
       explicit_minimum_os: A dotted version string indicating minimum OS desired.
@@ -115,6 +117,7 @@ def _platform_prerequisites(
     return struct(
         apple_fragment = apple_fragment,
         config_vars = config_vars,
+        cpp_fragment = cpp_fragment,
         device_families = device_families,
         disabled_features = disabled_features,
         features = features,
@@ -148,6 +151,7 @@ def _platform_prerequisites_from_rule_ctx(ctx):
     return _platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
         device_families = device_families,
         disabled_features = ctx.disabled_features,
         explicit_minimum_os = ctx.attr.minimum_os_version,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -200,7 +200,6 @@ AppleTestRunnerInfo provider.
 
 def _common_binary_linking_attrs(default_binary_type, deps_cfg, product_type):
     deps_aspects = [
-        apple_common.objc_proto_aspect,
         swift_usage_aspect,
     ]
 
@@ -230,7 +229,6 @@ Do not change its value.
     """,
             ),
             "bundle_loader": attr.label(
-                aspects = [apple_common.objc_proto_aspect],
                 providers = [[apple_common.AppleExecutableBinary]],
                 doc = """
 This attribute is public as an implementation detail while we migrate the architecture of the rules.
@@ -238,7 +236,6 @@ Do not change its value.
     """,
             ),
             "dylibs": attr.label_list(
-                aspects = [apple_common.objc_proto_aspect],
                 doc = """
 This attribute is public as an implementation detail while we migrate the architecture of the rules.
 Do not change its value.

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -44,20 +44,6 @@ def _cpu_string(platform_type, settings):
 
     fail("ERROR: Unknown platform type: {}".format(platform_type))
 
-def _enable_apple_binary_native_protos(settings, platform_type):
-    # NOTE(b/170729565): Even though the value in `settings` for
-    # "//command_line_option:enable_apple_binary_native_protos" is a boolean
-    # (True/False), if the transition result includes a boolean,
-    # FunctionTransitionUtil.java will fail with:
-    #   Invalid value type for option 'enable_apple_binary_native_protos'
-    # instead one has to return a String and let it be converted.
-    _platforms_to_force_starlark_protos = ["macos", "tvos", "watchos"]
-    if platform_type in _platforms_to_force_starlark_protos:
-        return "false"
-    if settings["//command_line_option:enable_apple_binary_native_protos"]:
-        return "true"
-    return "false"
-
 def _min_os_version_or_none(attr, platform):
     if attr.platform_type == platform:
         return attr.minimum_os_version
@@ -73,9 +59,6 @@ def _apple_rule_base_transition_impl(settings, attr):
         "//command_line_option:cpu": _cpu_string(attr.platform_type, settings),
         "//command_line_option:crosstool_top": (
             settings["//command_line_option:apple_crosstool_top"]
-        ),
-        "//command_line_option:enable_apple_binary_native_protos": (
-            _enable_apple_binary_native_protos(settings, attr.platform_type)
         ),
         "//command_line_option:fission": [],
         "//command_line_option:grte_top": settings["//command_line_option:apple_grte_top"],
@@ -94,7 +77,6 @@ _apple_rule_base_transition_inputs = [
     "//command_line_option:apple_crosstool_top",
     "//command_line_option:apple_grte_top",
     "//command_line_option:cpu",
-    "//command_line_option:enable_apple_binary_native_protos",
     "//command_line_option:ios_multi_cpus",
     "//command_line_option:macos_cpus",
     "//command_line_option:tvos_cpus",
@@ -107,7 +89,6 @@ _apple_rule_base_transition_outputs = [
     "//command_line_option:compiler",
     "//command_line_option:cpu",
     "//command_line_option:crosstool_top",
-    "//command_line_option:enable_apple_binary_native_protos",
     "//command_line_option:fission",
     "//command_line_option:grte_top",
     "//command_line_option:ios_minimum_os",
@@ -142,9 +123,6 @@ _apple_rule_arm64_as_arm64e_transition = transition(
 def _static_framework_transition_impl(settings, attr):
     """Attribute transition for static frameworks to enable swiftinterface generation."""
     return {
-        "//command_line_option:enable_apple_binary_native_protos": (
-            _enable_apple_binary_native_protos(settings, attr.platform_type)
-        ),
         "@build_bazel_rules_swift//swift:emit_swiftinterface": True,
     }
 
@@ -155,11 +133,8 @@ def _static_framework_transition_impl(settings, attr):
 # rules.
 _static_framework_transition = transition(
     implementation = _static_framework_transition_impl,
-    inputs = [
-        "//command_line_option:enable_apple_binary_native_protos",
-    ],
+    inputs = [],
     outputs = [
-        "//command_line_option:enable_apple_binary_native_protos",
         "@build_bazel_rules_swift//swift:emit_swiftinterface",
     ],
 )


### PR DESCRIPTION
The information is identical, and we would like to migrate all uses to
cpp fragment so that we can delete the info in objc fragment.

PiperOrigin-RevId: 370450547
(cherry picked from commit 3a981f465334985b7a1d29ec805a1d1299081707)