### PR TITLE
Revert "Disable tests until bazel 4.1.0 is released"

### DIFF
--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -18,6 +18,7 @@ load(":macos_bundle_tests.bzl", "macos_bundle_test_suite")
 load(":macos_command_line_application_tests.bzl", "macos_command_line_application_test_suite")
 load(":macos_dylib_tests.bzl", "macos_dylib_test_suite")
 load(":macos_extension_tests.bzl", "macos_extension_test_suite")
+load(":macos_kernel_extension_tests.bzl", "macos_kernel_extension_test_suite")
 load(":macos_quick_look_plugin_tests.bzl", "macos_quick_look_plugin_test_suite")
 load(":macos_ui_test_tests.bzl", "macos_ui_test_test_suite")
 load(":macos_unit_test_tests.bzl", "macos_unit_test_test_suite")
@@ -77,8 +78,7 @@ macos_dylib_test_suite()
 
 macos_extension_test_suite()
 
-# TODO: Enable once bazel 4.1.0 is released
-# macos_kernel_extension_test_suite()
+macos_kernel_extension_test_suite()
 
 macos_quick_look_plugin_test_suite()
 


### PR DESCRIPTION
We can enable this fully now that bazel 4.1.0 is out

This reverts commit d3fdcb9824808b7b38a66fe80eacdcdd16bbf5b8.