### PR TITLE
Ignore duplicate class warnings when generating plists

### DIFF
--- a/tools/environment_plist/environment_plist.sh
+++ b/tools/environment_plist/environment_plist.sh
@@ -65,7 +65,8 @@ trap 'rm -rf "${TEMPDIR}"' ERR EXIT
 
 os_build=$(/usr/bin/sw_vers -buildVersion)
 compiler=$(/usr/libexec/PlistBuddy -c "Print :DefaultProperties:DEFAULT_COMPILER" "${PLATFORM_PLIST}")
-xcodebuild_version_sdk_output=$(/usr/bin/xcodebuild -version -sdk "${PLATFORM}")
+# Ignore duplicate class warnings in stderr on Apple Silicon FB9089778
+xcodebuild_version_sdk_output=$(/usr/bin/xcodebuild -version -sdk "${PLATFORM}" 2>/dev/null)
 xcodebuild_version_output=$(/usr/bin/xcodebuild -version)
 # Parses 'PlatformVersion N.N' into N.N.
 platform_version=$(echo "${xcodebuild_version_sdk_output}" | grep PlatformVersion | cut -d ' ' -f2)


### PR DESCRIPTION
Otherwise on a M1 machine you see this:

```
objc[79978]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x207db1160) and /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x116ea42b8). One of the two will be used. Which one is undefined.
objc[79978]: Class AMSupportURLSession is implemented in both /usr/lib/libauthinstall.dylib (0x207db11b0) and /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x116ea4308). One of the two will be used. Which one is undefined.
```