### PR TITLE
Remove std_redirect_dylib

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -24,7 +24,6 @@ apple_support_toolchain(
     imported_dynamic_framework_processor = "//tools/imported_dynamic_framework_processor",
     plisttool = "//tools/plisttool",
     process_and_sign_template = "//tools/bundletool:process_and_sign_template",
-    std_redirect_dylib = "@bazel_tools//tools/objc:StdRedirect.dylib",
     swift_stdlib_tool = "//tools/swift_stdlib_tool",
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and

--- a/apple/internal/apple_support_toolchain.bzl
+++ b/apple/internal/apple_support_toolchain.bzl
@@ -87,7 +87,6 @@ def _apple_support_toolchain_impl(ctx):
                 attr_name = "xctoolrunner",
                 rule_ctx = ctx,
             ),
-            std_redirect_dylib = ctx.file.std_redirect_dylib,
         ),
         DefaultInfo(),
     ]
@@ -159,13 +158,6 @@ conversion of plist files to binary format.
         "process_and_sign_template": attr.label(
             allow_single_file = True,
             doc = "A `File` referencing a template for a shell script to process and sign.",
-        ),
-        "std_redirect_dylib": attr.label(
-            cfg = "host",
-            allow_single_file = True,
-            doc = """
-A `File` referencing a dynamic library used to redirect stdout and stderr when necessary.
-""",
         ),
         "swift_stdlib_tool": attr.label(
             cfg = "host",

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -336,7 +336,7 @@ def _ios_application_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [archive, apple_toolchain_info.std_redirect_dylib],
+                files = [archive],
             ),
         ),
         IosApplicationBundleInfo(),
@@ -553,7 +553,7 @@ def _ios_app_clip_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [archive, apple_toolchain_info.std_redirect_dylib],
+                files = [archive],
             ),
         ),
         IosAppClipBundleInfo(),

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -285,7 +285,7 @@ def _tvos_application_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [archive, apple_toolchain_info.std_redirect_dylib],
+                files = [archive],
             ),
         ),
         OutputGroupInfo(

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -250,9 +250,6 @@ for the target to run.
         "resolved_xctoolrunner": """\
 A `struct` from `ctx.resolve_tools` referencing a tool that acts as a wrapper for xcrun actions.
 """,
-        "std_redirect_dylib": """\
-A `File` referencing a dynamic library used to redirect stdout and stderr when necessary.
-""",
     },
 )
 


### PR DESCRIPTION
The usage of this was removed in 79dbaba43d5f6e4b655c9196ec2b045b410917b5 when simctl introduced `--console-pty`