### PR TITLE
Switch default CPU to use host

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -47,7 +47,7 @@ def _cpu_string(*, cpu, platform_type, settings):
         macos_cpus = settings["//command_line_option:macos_cpus"]
         if macos_cpus:
             return "darwin_{}".format(macos_cpus[0])
-        return "darwin_x86_64"
+        return settings["//command_line_option:host_cpu"]
     if platform_type == "tvos":
         if cpu:
             return "tvos_{}".format(cpu)
@@ -190,6 +190,7 @@ _apple_rule_common_transition_inputs = [
 ]
 _apple_rule_base_transition_inputs = _apple_rule_common_transition_inputs + [
     "//command_line_option:cpu",
+    "//command_line_option:host_cpu",
     "//command_line_option:ios_multi_cpus",
     "//command_line_option:macos_cpus",
     "//command_line_option:tvos_cpus",

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -40,6 +40,8 @@ def _cpu_string(*, cpu, platform_type, settings):
         cpu_value = settings["//command_line_option:cpu"]
         if cpu_value.startswith("ios_"):
             return cpu_value
+        if cpu_value == "darwin_arm64":
+            return "ios_sim_arm64"
         return "ios_x86_64"
     if platform_type == "macos":
         if cpu:
@@ -47,7 +49,10 @@ def _cpu_string(*, cpu, platform_type, settings):
         macos_cpus = settings["//command_line_option:macos_cpus"]
         if macos_cpus:
             return "darwin_{}".format(macos_cpus[0])
-        return settings["//command_line_option:host_cpu"]
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith("darwin_"):
+            return cpu_value
+        return "darwin_x86_64"
     if platform_type == "tvos":
         if cpu:
             return "tvos_{}".format(cpu)
@@ -190,7 +195,6 @@ _apple_rule_common_transition_inputs = [
 ]
 _apple_rule_base_transition_inputs = _apple_rule_common_transition_inputs + [
     "//command_line_option:cpu",
-    "//command_line_option:host_cpu",
     "//command_line_option:ios_multi_cpus",
     "//command_line_option:macos_cpus",
     "//command_line_option:tvos_cpus",


### PR DESCRIPTION
When building on an Apple Silicon machine, these CPUs would still have
been for x86_64. This flips the default to match the host machine instead.
Users can still pass the platform specific cpu flags to override them.

Closes https://github.com/bazelbuild/bazel/issues/14284.