### PR TITLE
Add override_archs to macos_command_line_application

### DIFF
--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -1416,6 +1416,17 @@ macos_command_line_application = rule_factory.create_apple_binary_rule(
     platform_type = "macos",
     product_type = apple_product_type.tool,
     doc = "Builds a macOS Command Line Application binary.",
+    additional_attrs = {
+        "override_archs": attr.string_list(
+            doc = """
+Override the default architecture(s) the tool would be built for. In general
+wherever possible you should prefer --macos_cpus, but that doesn't work when
+building for the host configuration, so you may instead want to set them here.
+By default they will default to your host machine's CPU but you might want to
+built fat binaries to share caches between different architectures.
+""",
+        ),
+    },
 )
 
 macos_dylib = rule_factory.create_apple_binary_rule(

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -51,12 +51,14 @@ def _min_os_version_or_none(attr, platform):
 
 def _apple_rule_base_transition_impl(settings, attr):
     """Rule transition for Apple rules."""
+    override_archs = ",".join(getattr(attr, "override_archs", []))
     return {
         "//command_line_option:apple configuration distinguisher": "applebin_" + attr.platform_type,
         "//command_line_option:apple_platform_type": attr.platform_type,
         "//command_line_option:apple_split_cpu": "",
         "//command_line_option:compiler": settings["//command_line_option:apple_compiler"],
         "//command_line_option:cpu": _cpu_string(attr.platform_type, settings),
+        "//command_line_option:macos_cpus": override_archs or settings["//command_line_option:macos_cpus"],
         "//command_line_option:crosstool_top": (
             settings["//command_line_option:apple_crosstool_top"]
         ),
@@ -93,6 +95,7 @@ _apple_rule_base_transition_outputs = [
     "//command_line_option:grte_top",
     "//command_line_option:ios_minimum_os",
     "//command_line_option:macos_minimum_os",
+    "//command_line_option:macos_cpus",
     "//command_line_option:tvos_minimum_os",
     "//command_line_option:watchos_minimum_os",
 ]
@@ -117,7 +120,7 @@ def _apple_rule_arm64_as_arm64e_transition_impl(settings, attr):
 _apple_rule_arm64_as_arm64e_transition = transition(
     implementation = _apple_rule_arm64_as_arm64e_transition_impl,
     inputs = _apple_rule_base_transition_inputs,
-    outputs = _apple_rule_base_transition_outputs + ["//command_line_option:macos_cpus"],
+    outputs = _apple_rule_base_transition_outputs,
 )
 
 def _static_framework_transition_impl(settings, attr):


### PR DESCRIPTION
This allows you to specify that the rule be built for multiple
architectures and produce a fat binary. This is useful to force binaries
to be share-able between Apple Silicon and Intel machines which is
useful for making sure host tools don't invalidate caches.