### PR TITLE
Don't invoke sw_vers with absolute path

### DIFF
--- a/tools/environment_plist/environment_plist.sh
+++ b/tools/environment_plist/environment_plist.sh
@@ -63,7 +63,7 @@ TEMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_environment.XXXXXX")
 PLIST="${TEMPDIR}/env.plist"
 trap 'rm -rf "${TEMPDIR}"' ERR EXIT
 
-os_build=$(/usr/bin/sw_vers -buildVersion)
+os_build=$(sw_vers -buildVersion)
 compiler=$(/usr/libexec/PlistBuddy -c "Print :DefaultProperties:DEFAULT_COMPILER" "${PLATFORM_PLIST}")
 xcodebuild_version_sdk_output=$(/usr/bin/xcodebuild -version -sdk "${PLATFORM}")
 xcodebuild_version_output=$(/usr/bin/xcodebuild -version)


### PR DESCRIPTION
This allows custom toolchains to provide their own sw_vers on hosts that
don't have it.
