### PR TITLE
Make rules compatible with Starlark objc_library

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -438,7 +438,7 @@ in the list.
         attrs.append({
             "settings_bundle": attr.label(
                 aspects = [apple_resource_aspect],
-                providers = [["objc"], [AppleResourceBundleInfo]],
+                providers = [["objc"], [AppleResourceBundleInfo], [apple_common.Objc]],
                 doc = """
 A resource bundle (e.g. `apple_bundle_import`) target that contains the files that make up the
 application's settings bundle. These files will be copied into the root of the final application


### PR DESCRIPTION
We are in the process of rewriting objc_library to Starlark. The Starlark
provided objc provider cannot be referenced as "objc", but it can be referenced
as apple_common.Objc instead.

PiperOrigin-RevId: 374172147
(cherry picked from commit c12e6b43a466269f98647e7e53c1b2c0da2cad48)