### PR TITLE
Pass command line arguments through launch options to xctestrunner

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -24,12 +24,16 @@ basename_without_extension() {
 }
 
 custom_xctestrunner_args=()
+command_line_args=()
 simulator_id=""
 while [[ $# -gt 0 ]]; do
   arg="$1"
   case $arg in
     --destination=platform=ios_simulator,id=*)
       simulator_id="${arg##*=}"
+      ;;
+    --command_line_args=*)
+      command_line_args+=("${arg##*=}")
       ;;
     *)
       custom_xctestrunner_args+=("$arg")
@@ -99,6 +103,15 @@ if [[ -n "${TEST_ENV}" ]]; then
   TEST_ENV=${TEST_ENV//$'\n'/\",\"}
   TEST_ENV="{\"${TEST_ENV}\"}"
   LAUNCH_OPTIONS_JSON_STR="\"env_vars\":${TEST_ENV}"
+fi
+
+if [[ -n "${command_line_args}" ]]; then
+  if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
+    LAUNCH_OPTIONS_JSON_STR+=","
+  fi
+  command_line_args="$(IFS=","; echo "${command_line_args[*]}")"
+  command_line_args="${command_line_args//,/\",\"}"
+  LAUNCH_OPTIONS_JSON_STR+="\"args\":[\"$command_line_args\"]"
 fi
 
 # Use the TESTBRIDGE_TEST_ONLY environment variable set by Bazel's --test_filter

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -433,6 +433,25 @@ function test_ios_unit_simulator_id() {
   expect_log "Executed 3 tests, with 0 failures"
 }
 
+function test_ios_unit_test_dot_separated_command_line_args() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test //ios:PassingUnitTest \
+    --test_arg="--command_line_args=arg1,arg2,arg3" || fail "should pass"
+
+  expect_log "Test Suite 'PassingUnitTest' passed"
+}
+
+function test_ios_unit_test_multiple_command_line_args() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test //ios:PassingUnitTest \
+    --test_arg="--command_line_args=arg1" \
+    --test_arg="--command_line_args=arg2" || fail "should pass"
+
+  expect_log "Test Suite 'PassingUnitTest' passed"
+}
+
 function test_ios_unit_other_arg() {
   create_sim_runners
   create_ios_unit_tests


### PR DESCRIPTION
This allows CommandLineArguments to be passed via xcestrunner.
For example, `-AppleLanguages (en)` option to change the language settings of the test execution environment can be passed now.

The options passed are passed through [here](https://github.com/google/xctestrunner/blob/64a9be0b6fa833b4b2371729c5c8cdd2c6f7775b/test_runner/xctestrun.py#L78-L87) to the `CommandLineArguments`, which are consumed by the simulator.
The flags passed in `test_arg` are passed directly to xctestrunner by default, so I defined `--command_line_args` to make them distinguishable.

I've added unit tests, but the tests `//test:ios_test_runner_unit_test` itself don't seem to be passed for several reasons at the moment. Once this PR is merged, I will fix it so that the tests will pass.