### PR TITLE
Use the platform type string literal directly instead of stringifying…

### DIFF
--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -62,7 +62,7 @@ def _ios_unit_test_impl(ctx):
 # Declare it with an underscore so it shows up that way in queries.
 _ios_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _ios_ui_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.ios),
+    platform_type = "ios",
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an iOS UI Test Bundle. Internal target not to be depended upon.",
 )
@@ -86,13 +86,13 @@ The following is a list of the `ios_ui_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/versions/master/docs/be/common-definitions.html#common-attributes-tests).
 """,
-    platform_type = str(apple_common.platform_type.ios),
+    platform_type = "ios",
 )
 
 # Declare it with an underscore so it shows up that way in queries.
 _ios_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _ios_unit_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.ios),
+    platform_type = "ios",
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an iOS Unit Test Bundle. Internal target not to be depended upon.",
 )
@@ -121,5 +121,5 @@ To run the same test on multiple simulators/devices see
 The following is a list of the `ios_unit_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/versions/master/docs/be/common-definitions.html#common-attributes-tests).""",
-    platform_type = str(apple_common.platform_type.ios),
+    platform_type = "ios",
 )

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -62,7 +62,7 @@ def _macos_unit_test_impl(ctx):
 # Declare it with an underscore so it shows up that way in queries.
 _macos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _macos_ui_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.macos),
+    platform_type = "macos",
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an macOS UI Test Bundle.  Internal target not to be depended upon.",
 )
@@ -78,13 +78,13 @@ tests built with this target, `runner` will not be used since Xcode is the test
 runner in that case.
 
 Note: macOS UI tests are not currently supported in the default test runner.""",
-    platform_type = str(apple_common.platform_type.macos),
+    platform_type = "macos",
 )
 
 # Declare it with an underscore so it shows up that way in queries.
 _macos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _macos_unit_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.macos),
+    platform_type = "macos",
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an macOS Unit Test Bundle.  Internal target not to be depended upon.",
 )
@@ -106,5 +106,5 @@ will run outside the context of an macOS application. Because of this, certain
 functionalities might not be present (e.g. UI layout, NSUserDefaults). You can
 find more information about testing for Apple platforms
 [here](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/testing_with_xcode/chapters/03-testing_basics.html).""",
-    platform_type = str(apple_common.platform_type.macos),
+    platform_type = "macos",
 )

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -62,7 +62,7 @@ def _tvos_unit_test_impl(ctx):
 # Declare it with an underscore so it shows up that way in queries.
 _tvos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _tvos_ui_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.tvos),
+    platform_type = "tvos",
     product_type = apple_product_type.ui_test_bundle,
     doc = "Builds and bundles an tvOS UI Test Bundle.  Internal target not to be depended upon.",
 )
@@ -84,13 +84,13 @@ The following is a list of the `tvos_ui_test` specific attributes; for a list of
 the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/versions/master/docs/be/common-definitions.html#common-attributes-tests).
 """,
-    platform_type = str(apple_common.platform_type.tvos),
+    platform_type = "tvos",
 )
 
 # Declare it with an underscore so it shows up that way in queries.
 _tvos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule(
     implementation = _tvos_unit_test_bundle_impl,
-    platform_type = str(apple_common.platform_type.tvos),
+    platform_type = "tvos",
     product_type = apple_product_type.unit_test_bundle,
     doc = "Builds and bundles an tvOS Unit Test Bundle. Internal target not to be depended upon.",
 )
@@ -120,5 +120,5 @@ The following is a list of the `tvos_unit_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/versions/master/docs/be/common-definitions.html#common-attributes-tests).
 """,
-    platform_type = str(apple_common.platform_type.tvos),
+    platform_type = "tvos",
 )


### PR DESCRIPTION
… the native enum value.

The regular bundling rules already do this; it was only the testing rules that stringified the enum value. This version is more concise, and more importantly, lets us delete the fake Apple APIs for Skydoc since they can be replaced by the generic faking.

RELNOTES: None
PiperOrigin-RevId: 375097263
(cherry picked from commit 877b849c01d02076abe73cab3023c848fbc10edb)