### PR TITLE
Add pre-commit hook for buildifier

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -35,4 +35,5 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
 
-buildifier: latest
+buildifier:
+  version: 4.0.1

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -35,5 +35,4 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
 
-buildifier:
-  version: 4.0.1
+buildifier: latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 4.0.1.1
+    hooks:
+      - id: buildifier
+      - id: buildifier-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
+## Formatting
+
+Starlark files should be formatted by buildifier.
+We suggest using a pre-commit hook to automate this.
+First [install pre-commit](https://pre-commit.com/#installation),
+then run
+
+```shell
+pre-commit install
+```
+
+Otherwise the Buildkite CI will yell at you about formatting/linting violations.
+
 ## File or claim an issue
 
 Please let us know what you're working on if you want to change or add to the


### PR DESCRIPTION
My experience contributing here has been that nearly every PR snapshot required an extra push to run a buildifier command after a red CI run. This is easily automated.