### PR TITLE
Make sure that the alias `_linkopts_test_main` is exported and not dead stripped now that dead stripping is performed automatically by `-c opt`.

### DIFF
--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -96,6 +96,8 @@ macos_application(
         "-alias",
         "_main",
         "_linkopts_test_main",
+        "-exported_symbol",
+        "_linkopts_test_main",
     ],
     minimum_os_version = "10.10",
     tags = FIXTURE_TAGS,


### PR DESCRIPTION
The test was just testing linkopts, so adding a few more linkopts to make it pass should not break the intention of the test.

PiperOrigin-RevId: 375488786
(cherry picked from commit f4534222f2854de3d333edbab0c6f3bad5e60fb7)