### PR TITLE
Add `swift_clang_module_aspect` to `apple_{dynamic,static}_framework_import.deps`.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -59,6 +59,7 @@ load(
     "SwiftInfo",
     "SwiftToolchainInfo",
     "SwiftUsageInfo",
+    "swift_clang_module_aspect",
     "swift_common",
 )
 
@@ -472,6 +473,7 @@ on this target.
 """,
         ),
         "deps": attr.label_list(
+            aspects = [swift_clang_module_aspect],
             doc = """
 A list of targets that are dependencies of the target being built, which will be linked into that
 target.
@@ -554,6 +556,7 @@ are not present at runtime.
 """,
         ),
         "deps": attr.label_list(
+            aspects = [swift_clang_module_aspect],
             doc = """
 A list of targets that are dependencies of the target being built, which will provide headers and be
 linked into that target.

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -260,11 +260,6 @@ def _framework_objc_provider_fields(
 
 def _swift_interop_info_with_dependencies(ctx, framework_groups, module_map_imports):
     """Return a Swift interop provider for the framework if it has a module map."""
-
-    # TODO: Re-enable this once https://github.com/bazelbuild/rules_apple/issues/1147 is fixed
-    if True:
-        return None
-
     if not module_map_imports:
         return None
 


### PR DESCRIPTION
Without this, when a framework target depends on another framework target and they
are dependencies of a Swift target, the parent framework does not see the
`SwiftInfo` provider created by the aspect from the child target's
`swift_interop_info`. It's not clear to me why this happens, but there must be
subtle details about the order aspects are applied and when their providers are
merged with the target's main providers -- I think it has to do with the fact
that `swift_clang_module_aspect` doesn't advertise that it provides `SwiftInfo`
(it can't, because it doesn't always).

Directly applying the aspect to the `deps` attribute seems to work though.

PiperOrigin-RevId: 376191209
(cherry picked from commit 0ba845c998cb183a8ed9f74f720c1ad4caffd217)

Fixes https://github.com/bazelbuild/rules_apple/issues/1147