### PR TITLE
Match macos_extension flags to flags used in Xcode12.5 extension templates

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -464,6 +464,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.extension_or_xpc,
             deps_cfg = apple_common.multi_arch_split,
             extra_linkopts = [
+                "-fapplication-extension",
                 "-e",
                 "_NSExtensionMain",
             ],


### PR DESCRIPTION
PiperOrigin-RevId: 376219043
(cherry picked from commit 9475887357959541115133e264939b6756d23367)