### PR TITLE
Only read the `AppleFrameworkImportInfo.framework_imports` provider f…

### DIFF
--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -65,7 +65,8 @@ def _framework_import_partial_impl(
     transitive_sets = [
         x[AppleFrameworkImportInfo].framework_imports
         for x in targets
-        if AppleFrameworkImportInfo in x
+        if AppleFrameworkImportInfo in x and
+           hasattr(x[AppleFrameworkImportInfo], "framework_imports")
     ]
     files_to_bundle = depset(transitive = transitive_sets).to_list()
 
@@ -73,7 +74,8 @@ def _framework_import_partial_impl(
         avoid_transitive_sets = [
             x[AppleFrameworkImportInfo].framework_imports
             for x in targets_to_avoid
-            if AppleFrameworkImportInfo in x
+            if AppleFrameworkImportInfo in x and
+               hasattr(x[AppleFrameworkImportInfo], "framework_imports")
         ]
         if avoid_transitive_sets:
             avoid_files = depset(transitive = avoid_transitive_sets).to_list()


### PR DESCRIPTION
…ield if it is set on the provider.

This matches other access patterns throughout the rules_apple code. Eventually, this should be cleaned up to make the field always present to avoid the ugliness of this access.

PiperOrigin-RevId: 377055205
(cherry picked from commit 324b730edb42998f793e90b43fa1b1463ee5037c)