### PR TITLE
Propagate Swift-specific linker flags as an implicit dependency of the toolchain.

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -22,14 +22,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
-    "swift_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_common",
-)
 
 def _linker_flag_for_sdk_dylib(dylib):
     """Returns a linker flag suitable for linking the given `sdk_dylib` value.
@@ -59,16 +51,6 @@ def _apple_binary_impl(ctx):
         "-Wl,-weak_framework,{}".format(framework)
         for framework in ctx.attr.weak_sdk_frameworks
     ]
-
-    deps = getattr(ctx.attr, "deps", [])
-    swift_usage_info = swift_support.swift_usage_info(deps)
-    if swift_usage_info:
-        swift_linkopts = swift_common.swift_runtime_linkopts(
-            is_static = False,
-            is_test = False,
-            toolchain = swift_usage_info.toolchain,
-        )
-        extra_linkopts.extend(swift_linkopts)
 
     link_result = linking_support.register_linking_action(
         ctx,

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -174,12 +174,15 @@ def _grouped_framework_files(framework_imports):
 
     return framework_groups
 
-def _objc_provider_with_dependencies(ctx, objc_provider_fields):
+def _objc_provider_with_dependencies(ctx, objc_provider_fields, additional_objc_infos = []):
     """Returns a new Objc provider which includes transitive Objc dependencies."""
-    objc_provider_fields["providers"] = [dep[apple_common.Objc] for dep in ctx.attr.deps]
+    objc_provider_fields["providers"] = [
+        dep[apple_common.Objc]
+        for dep in ctx.attr.deps
+    ] + additional_objc_infos
     return apple_common.new_objc_provider(**objc_provider_fields)
 
-def _cc_info_with_dependencies(ctx, header_imports):
+def _cc_info_with_dependencies(ctx, header_imports, additional_cc_infos = []):
     """Returns a new CcInfo which includes transitive Cc dependencies."""
     cc_info = CcInfo(
         compilation_context = cc_common.create_compilation_context(
@@ -189,7 +192,7 @@ def _cc_info_with_dependencies(ctx, header_imports):
     )
     dep_cc_infos = [dep[CcInfo] for dep in ctx.attr.deps]
     return cc_common.merge_cc_infos(
-        cc_infos = [cc_info] + dep_cc_infos,
+        cc_infos = [cc_info] + dep_cc_infos + additional_cc_infos,
     )
 
 def _transitive_framework_imports(deps):
@@ -415,9 +418,20 @@ def _apple_static_framework_import_impl(ctx):
         if _is_swiftmodule(header.basename)
     ]
 
+    additional_objc_infos = []
+    additional_cc_infos = []
+
     if swiftmodule_imports:
         toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(SwiftUsageInfo(toolchain = toolchain))
+
+        # The Swift toolchain propagates Swift-specific linker flags (e.g.,
+        # library/framework search paths) as an implicit dependency. In the
+        # rare case that a binary has a Swift framework import dependency but
+        # no other Swift dependencies, make sure we pick those up so that it
+        # links to the standard libraries correctly.
+        additional_objc_infos.extend(toolchain.implicit_deps_providers.objc_infos)
+        additional_cc_infos.extend(toolchain.implicit_deps_providers.cc_infos)
 
         if _is_debugging(ctx):
             cpu = ctx.fragments.apple.single_arch_cpu
@@ -425,8 +439,12 @@ def _apple_static_framework_import_impl(ctx):
             if swiftmodule:
                 objc_provider_fields.update(_ensure_swiftmodule_is_embedded(swiftmodule))
 
-    providers.append(_objc_provider_with_dependencies(ctx, objc_provider_fields))
-    providers.append(_cc_info_with_dependencies(ctx, header_imports))
+    providers.append(
+        _objc_provider_with_dependencies(ctx, objc_provider_fields, additional_objc_infos),
+    )
+    providers.append(
+        _cc_info_with_dependencies(ctx, header_imports, additional_cc_infos),
+    )
 
     # For now, Swift interop is restricted only to a Clang module map inside
     # the framework.

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -82,11 +82,8 @@ framework module {module_name} {{
 def _swift_dynamic_framework_aspect_impl(target, ctx):
     """Aspect implementation for Swift dynamic framework support."""
 
-    if not hasattr(ctx.rule.attr, "deps"):
-        return []
-
-    swiftdeps = [x for x in ctx.rule.attr.deps if SwiftInfo in x]
-    ccinfos = [x for x in ctx.rule.attr.deps if CcInfo in x]
+    swiftdeps = [x for x in [target] if SwiftInfo in x]
+    ccinfos = [x for x in [target] if CcInfo in x]
 
     # If there are no Swift dependencies, return nothing.
     if not swiftdeps:

--- a/apple/internal/binary_support.bzl
+++ b/apple/internal/binary_support.bzl
@@ -18,60 +18,19 @@ load(
     "@build_bazel_rules_apple//apple/internal:entitlement_rules.bzl",
     "entitlements",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
-    "swift_runtime_linkopts",
-)
 
-def _create_swift_runtime_linkopts_target(
-        name,
-        deps,
-        is_static,
-        is_test,
-        tags,
-        testonly):
-    """Creates a build target to propagate Swift runtime linker flags.
-
-    Args:
-      name: The name of the base target.
-      deps: The list of dependencies of the base target.
-      is_static: True to use the static Swift runtime, or False to use the
-          dynamic Swift runtime.
-      is_test: True to make sure test specific linkopts are propagated.
-      tags: Tags to add to the created targets.
-      testonly: Whether the target should be testonly.
-
-    Returns:
-      A build label that can be added to the deps of the binary target.
-    """
-    swift_runtime_linkopts_name = name + ".swift_runtime_linkopts"
-    swift_runtime_linkopts(
-        name = swift_runtime_linkopts_name,
-        is_static = is_static,
-        is_test = is_test,
-        testonly = testonly,
-        tags = tags,
-        deps = deps,
-    )
-    return ":" + swift_runtime_linkopts_name
-
-def _add_entitlements_and_swift_linkopts(
+def _add_entitlements(
         name,
         platform_type,
         product_type,
         include_entitlements = True,
         is_stub = False,
-        link_swift_statically = False,
-        is_test = False,
         **kwargs):
-    """Adds entitlements and Swift linkopts targets for a bundle target.
+    """Adds entitlements targets for a bundle target.
 
     This function creates an entitlements target to ensure that a binary
     created using the `link_multi_arch_binary` API or by copying a stub
     executable gets signed appropriately.
-
-    Similarly, for bundles with user-provided binaries, this function also
-    adds any Swift linkopts that are necessary for it to link correctly.
 
     Args:
       name: The name of the bundle target, from which the targets' names
@@ -82,9 +41,6 @@ def _add_entitlements_and_swift_linkopts(
           Defaults to True.
       is_stub: True/False, indicates whether the function is being called for a bundle that uses a
           stub executable.
-      link_swift_statically: True/False, indicates whether the static versions of the Swift standard
-          libraries should be used during linking. Only used if include_swift_linkopts is True.
-      is_test: True/False, indicates if test specific linker flags should be propagated.
       **kwargs: The arguments that were passed into the top-level macro.
 
     Returns:
@@ -119,23 +75,7 @@ def _add_entitlements_and_swift_linkopts(
             # propagate linkopts.
             additional_deps.append(":{}".format(entitlements_name))
 
-    deps = bundling_args.get("deps", [])
-
-    if not is_stub:
-        # Propagate the linker flags that dynamically link the Swift runtime, if Swift was used. If
-        # it wasn't, this target propagates no linkopts.
-        additional_deps.append(
-            _create_swift_runtime_linkopts_target(
-                name,
-                deps,
-                link_swift_statically,
-                bool(is_test or testonly),
-                tags = tags,
-                testonly = testonly,
-            ),
-        )
-
-    all_deps = deps + additional_deps
+    all_deps = bundling_args.get("deps", []) + additional_deps
     if all_deps:
         bundling_args["deps"] = all_deps
 
@@ -143,5 +83,5 @@ def _add_entitlements_and_swift_linkopts(
 
 # Define the loadable module that lists the exported symbols in this file.
 binary_support = struct(
-    add_entitlements_and_swift_linkopts = _add_entitlements_and_swift_linkopts,
+    add_entitlements = _add_entitlements,
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1013,17 +1013,16 @@ def _ios_extension_impl(ctx):
 def _ios_dynamic_framework_impl(ctx):
     """Experimental implementation of ios_dynamic_framework."""
 
-    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
-    # because of the swift_runtime_linkopts dep that comes with the swift_libray
+    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 1
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
-    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
+    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 1:
         fail(
             """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         )
 
-    binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
+    binary_target = ctx.attr.deps[0]
     extra_linkopts = []
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -98,12 +98,11 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
     if "bundle_name" in kwargs:
         fail("bundle_name is not supported in test rules.")
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         test_bundle_name,
         bundle_name = name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.unit_test_bundle,
-        is_test = True,
         include_entitlements = False,
         testonly = True,
         **bundle_attrs

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -302,17 +302,16 @@ def _tvos_application_impl(ctx):
 def _tvos_dynamic_framework_impl(ctx):
     """Experimental implementation of tvos_dynamic_framework."""
 
-    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
-    # because of the swift_runtime_linkopts dep that comes with the swift_libray
+    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 1
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
-    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
+    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 1:
         fail(
             """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         )
 
-    binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
+    binary_target = ctx.attr.deps[0]
     link_result = linking_support.register_linking_action(
         ctx,
         stamp = ctx.attr.stamp,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -94,17 +94,16 @@ load(
 def _watchos_dynamic_framework_impl(ctx):
     """Experimental implementation of watchos_dynamic_framework."""
 
-    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 2
-    # because of the swift_runtime_linkopts dep that comes with the swift_libray
+    # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 1
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
-    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 2:
+    if len(swiftdeps) != 1 or len(ctx.attr.deps) > 1:
         fail(
             """\
     error: Swift dynamic frameworks expect a single swift_library dependency.
     """,
         )
 
-    binary_target = [deps for deps in ctx.attr.deps if deps.label.name.endswith("swift_runtime_linkopts")][0]
+    binary_target = ctx.attr.deps[0]
     extra_linkopts = []
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -52,7 +52,7 @@ load(
 
 def ios_application(name, **kwargs):
     """Builds and bundles an iOS application."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.application,
@@ -67,7 +67,7 @@ def ios_application(name, **kwargs):
 
 def ios_app_clip(name, **kwargs):
     """Builds and bundles an iOS app clip."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.app_clip,
@@ -82,7 +82,7 @@ def ios_app_clip(name, **kwargs):
 
 def ios_extension(name, **kwargs):
     """Builds and bundles an iOS application extension."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.app_extension,
@@ -108,7 +108,7 @@ def ios_framework(name, **kwargs):
         "-install_name,@rpath/%s.framework/%s" % (bundle_name, bundle_name),
     ]
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.ios),
@@ -139,7 +139,7 @@ def ios_dynamic_framework(name, **kwargs):
         "-install_name",
         "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
     ]
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.ios),
@@ -188,7 +188,7 @@ def ios_static_framework(name, **kwargs):
 # TODO(b/118104491): Remove this macro and move the rule definition back to this file.
 def ios_imessage_application(name, **kwargs):
     """Macro to preprocess entitlements for iMessage applications."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.messages_application,
@@ -204,7 +204,7 @@ def ios_imessage_application(name, **kwargs):
 # TODO(b/118104491): Remove this macro and move the rule definition back to this file.
 def ios_sticker_pack_extension(name, **kwargs):
     """Macro to preprocess entitlements for Sticker Pack extensions."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.messages_sticker_pack_extension,
@@ -220,7 +220,7 @@ def ios_sticker_pack_extension(name, **kwargs):
 # TODO(b/118104491): Remove this macro and move the rule definition back to this file.
 def ios_imessage_extension(name, **kwargs):
     """Macro to override the linkopts and preprocess entitlements for iMessage extensions."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.messages_extension,

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -62,7 +62,7 @@ def macos_application(name, **kwargs):
     features = binary_args.pop("features", [])
     features.append("link_cocoa")
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.application,
@@ -82,7 +82,7 @@ def macos_bundle(name, **kwargs):
     features = binary_args.pop("features", [])
     features.append("link_cocoa")
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.bundle,
@@ -100,7 +100,7 @@ def macos_quick_look_plugin(name, **kwargs):
     """Builds and bundles an macOS Quick Look plugin."""
     binary_args = dict(kwargs)
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.quicklook_plugin,
@@ -120,7 +120,7 @@ def macos_kernel_extension(name, **kwargs):
     features = binary_args.pop("features", [])
     features.append("kernel_extension")
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.kernel_extension,
@@ -135,7 +135,7 @@ def macos_kernel_extension(name, **kwargs):
 
 def macos_spotlight_importer(name, **kwargs):
     """Packages a macOS Spotlight Importer Bundle."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.spotlight_importer,
@@ -151,7 +151,7 @@ def macos_xpc_service(name, **kwargs):
     """Packages a macOS XPC Service Application."""
     binary_args = dict(kwargs)
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.xpc_service,
@@ -211,11 +211,10 @@ def macos_command_line_application(name, **kwargs):
         )
         binary_deps.extend([":" + merged_launchdplists_name])
 
-    cmd_line_app_args = binary_support.add_entitlements_and_swift_linkopts(
+    cmd_line_app_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.tool,
-        link_swift_statically = True,
         include_entitlements = False,
         deps = binary_deps,
         **binary_args
@@ -264,11 +263,10 @@ def macos_dylib(name, **kwargs):
         )
         binary_deps.extend([":" + merged_infoplist_name])
 
-    dylib_args = binary_support.add_entitlements_and_swift_linkopts(
+    dylib_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.dylib,
-        link_swift_statically = True,
         include_entitlements = False,
         deps = binary_deps,
         **binary_args
@@ -287,7 +285,7 @@ def macos_extension(name, **kwargs):
     features = binary_args.pop("features", [])
     features.append("link_cocoa")
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.macos),
         product_type = apple_product_type.app_extension,

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -48,7 +48,7 @@ load(
 
 def tvos_application(name, **kwargs):
     """Builds and bundles a tvOS application."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.tvos),
         product_type = apple_product_type.application,
@@ -63,7 +63,7 @@ def tvos_application(name, **kwargs):
 
 def tvos_extension(name, **kwargs):
     """Builds and bundles a tvOS extension."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.tvos),
         product_type = apple_product_type.app_extension,
@@ -89,7 +89,7 @@ def tvos_framework(name, **kwargs):
         "-install_name,@rpath/%s.framework/%s" % (bundle_name, bundle_name),
     ]
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.tvos),
         product_type = apple_product_type.framework,
@@ -171,7 +171,7 @@ def tvos_dynamic_framework(name, **kwargs):
         "-install_name",
         "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
     ]
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.watchos),

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -51,7 +51,7 @@ load(
 def watchos_application(name, **kwargs):
     """Builds and bundles a watchOS application."""
 
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.watchos),
         product_type = apple_product_type.application,
@@ -66,7 +66,7 @@ def watchos_application(name, **kwargs):
 
 def watchos_extension(name, **kwargs):
     """Builds and bundles a watchOS extension."""
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.watchos),
         product_type = apple_product_type.app_extension,
@@ -92,7 +92,7 @@ def watchos_dynamic_framework(name, **kwargs):
         "-install_name",
         "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
     ]
-    bundling_args = binary_support.add_entitlements_and_swift_linkopts(
+    bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.watchos),


### PR DESCRIPTION
Propagate Swift-specific linker flags as an implicit dependency of the toolchain.

Apple binaries/bundles will automatically get these linker flags if they have any Swift target in their dependencies; this eliminates the need to pass them separately at the top level.

PiperOrigin-RevId: 378024438
(cherry picked from commit c253e4f)

# Conflicts:
#	apple/internal/binary_support.bzl
