### PR TITLE
Add local provisioning profile rules

### DIFF
--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -33,7 +33,7 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:local_provisioning_profiles.bzl",
     _local_provisioning_profile = "local_provisioning_profile",
-    _local_provisioning_profiles = "local_provisioning_profiles",
+    _provisioning_profile_repository = "provisioning_profile_repository",
 )
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
@@ -44,4 +44,4 @@ apple_static_xcframework = _apple_static_xcframework
 apple_universal_binary = _apple_universal_binary
 apple_xcframework = _apple_xcframework
 local_provisioning_profile = _local_provisioning_profile
-local_provisioning_profiles = _local_provisioning_profiles
+provisioning_profile_repository = _provisioning_profile_repository

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -30,6 +30,11 @@ load(
     _apple_static_xcframework = "apple_static_xcframework",
     _apple_xcframework = "apple_xcframework",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:local_provisioning_profiles.bzl",
+    _local_provisioning_profile = "local_provisioning_profile",
+    _local_provisioning_profiles = "local_provisioning_profiles",
+)
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
 apple_dynamic_xcframework_import = _apple_dynamic_xcframework_import
@@ -38,3 +43,5 @@ apple_static_xcframework_import = _apple_static_xcframework_import
 apple_static_xcframework = _apple_static_xcframework
 apple_universal_binary = _apple_universal_binary
 apple_xcframework = _apple_xcframework
+local_provisioning_profile = _local_provisioning_profile
+local_provisioning_profiles = _local_provisioning_profiles

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -1,0 +1,143 @@
+"""# Rules for using locally installed provisioning profiles"""
+
+def _local_provisioning_profiles(repository_ctx):
+    system_profiles_path = "{}/Library/MobileDevice/Provisioning Profiles".format(repository_ctx.os.environ["HOME"])
+    repository_ctx.execute(["mkdir", "-p", system_profiles_path])
+    repository_ctx.symlink(system_profiles_path, "profiles")
+
+    repository_ctx.file("BUILD", """
+filegroup(
+    name = "profiles",
+    srcs = glob(["profiles/*.mobileprovision"], allow_empty = True),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "empty",
+    srcs = [],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "fallback_profiles",
+    actual = "{}",
+    visibility = ["//visibility:public"],
+)
+""".format(repository_ctx.attr.fallback_profiles or ":empty"))
+
+local_provisioning_profiles = repository_rule(
+    environ = ["HOME"],
+    implementation = _local_provisioning_profiles,
+    attrs = {
+        "fallback_profiles": attr.label(
+            allow_files = [".mobileprovision"],
+        ),
+    },
+    doc = """
+This rule declares an external repository for discovering locally installed
+provisioning profiles. This is consumed by `ios_local_provisioning_profile`.
+You can optionally set 'fallback_profiles' to point at a stable location of
+profiles if a newer version of the desired profile does not exist on the local
+machine. This is useful for checking in the current version of the profile, but
+not having to update it every time a new device or certificate is added.
+
+## Example
+
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profiles")
+
+local_provisioning_profiles(
+    name = "local_provisioning_profiles",
+    fallback_profiles = "//path/to/some:filegroup",
+)
+""",
+)
+
+def _local_provisioning_profile(ctx):
+    if not ctx.files._local_srcs and not ctx.attr._fallback_srcs:
+        ctx.fail("Either local or fallback provisioning profiles must exist")
+
+    selected_profile_path = "{name}.mobileprovision".format(name = ctx.attr.profile_name or ctx.attr.name)
+    selected_profile = ctx.actions.declare_file(selected_profile_path)
+
+    args = ctx.actions.args()
+    args.add(ctx.attr.profile_name or ctx.attr.name)
+    args.add(selected_profile)
+    if ctx.attr.team_id:
+        args.add("--team-id")
+        args.add(ctx.attr.team_id)
+    args.add("--local-profiles")
+    args.add_all(ctx.files._local_srcs)
+    args.add("--fallback-profiles")
+    args.add_all(ctx.files._fallback_srcs)
+
+    ctx.actions.run(
+        executable = ctx.executable._finder,
+        arguments = [args],
+        inputs = ctx.files._local_srcs + ctx.files._fallback_srcs,
+        outputs = [selected_profile],
+        execution_requirements = {"no-sandbox": "1", "no-remote-exec": "1"},
+        progress_message = "Finding provisioning profile %{label}",
+    )
+
+    return [DefaultInfo(files = depset([selected_profile]))]
+
+local_provisioning_profile = rule(
+    attrs = {
+        "profile_name": attr.string(
+            doc = "Name of the profile to use, if it's not provided the name of the rule is used",
+        ),
+        "team_id": attr.string(
+            doc = "Team ID of the profile to find. This is useful for disambiguating between multiple profiles with the same name on different developer accounts.",
+        ),
+        "_fallback_srcs": attr.label(
+            default = "@local_provisioning_profiles//:fallback_profiles",
+        ),
+        "_local_srcs": attr.label(
+            default = "@local_provisioning_profiles//:profiles",
+        ),
+        "_finder": attr.label(
+            cfg = "exec",
+            default = "@build_bazel_rules_apple//tools/local_provisioning_profile_finder",
+            executable = True,
+        ),
+    },
+    implementation = _local_provisioning_profile,
+    doc = """
+This rule declares a bazel target that you can pass to the
+'provisioning_profile' attribute of rules that require it. It discovers a
+provisioning profile for the given attributes either on the user's local
+machine, or with the optional 'fallback_profiles' passed to
+'local_provisioning_profiles'. This will automatically pick the newest profile
+if there are multiple profiles matching the given criteria. By default this
+rule will search for a profile with the same name as the rule itself, you can
+pass profile_name to use a different name, and you can pass team_id if you'd
+like to disambiguate between 2 Apple developer accounts that have the same
+profile name.
+
+## Example
+
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+
+local_provisioning_profile(
+    name = "app_debug_profile",
+    profile_name = "Development App",
+    team_id = "abc123",
+)
+
+ios_application(
+    name = "app",
+    ...
+    provisioning_profile = ":app_debug_profile",
+)
+
+local_provisioning_profile(
+    name = "app_release_profile",
+)
+
+ios_application(
+    name = "release_app",
+    ...
+    provisioning_profile = ":app_release_profile",
+)
+""",
+)

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -5,7 +5,7 @@ def _provisioning_profile_repository(repository_ctx):
     repository_ctx.execute(["mkdir", "-p", system_profiles_path])
     repository_ctx.symlink(system_profiles_path, "profiles")
 
-    repository_ctx.file("BUILD", """
+    repository_ctx.file("BUILD.bazel", """\
 filegroup(
     name = "profiles",
     srcs = glob(["profiles/*.mobileprovision"], allow_empty = True),
@@ -81,12 +81,9 @@ def _local_provisioning_profile(ctx):
     args.add(ctx.attr.profile_name or ctx.attr.name)
     args.add(selected_profile)
     if ctx.attr.team_id:
-        args.add("--team-id")
-        args.add(ctx.attr.team_id)
-    args.add("--local-profiles")
-    args.add_all(ctx.files._local_srcs)
-    args.add("--fallback-profiles")
-    args.add_all(ctx.files._fallback_srcs)
+        args.add("--team_id", ctx.attr.team_id)
+    args.add_all("--local_profiles", ctx.files._local_srcs)
+    args.add_all("--fallback_profiles", ctx.files._fallback_srcs)
 
     ctx.actions.run(
         executable = ctx.executable._finder,

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -288,12 +288,12 @@ This rule declares a bazel target that you can pass to the
 'provisioning_profile' attribute of rules that require it. It discovers a
 provisioning profile for the given attributes either on the user's local
 machine, or with the optional 'fallback_profiles' passed to
-'local_provisioning_profiles'. This will automatically pick the newest profile
-if there are multiple profiles matching the given criteria. By default this
-rule will search for a profile with the same name as the rule itself, you can
-pass profile_name to use a different name, and you can pass team_id if you'd
-like to disambiguate between 2 Apple developer accounts that have the same
-profile name.
+'provisioning_profile_repository'. This will automatically pick the newest
+profile if there are multiple profiles matching the given criteria. By default
+this rule will search for a profile with the same name as the rule itself, you
+can pass profile_name to use a different name, and you can pass team_id if
+you'd like to disambiguate between 2 Apple developer accounts that have the
+same profile name.
 
 ## Example
 
@@ -332,12 +332,12 @@ ios_application(
 | <a id="local_provisioning_profile-team_id"></a>team_id |  Team ID of the profile to find. This is useful for disambiguating between multiple profiles with the same name on different developer accounts.   | String | optional | "" |
 
 
-<a id="local_provisioning_profiles"></a>
+<a id="provisioning_profile_repository"></a>
 
-## local_provisioning_profiles
+## provisioning_profile_repository
 
 <pre>
-local_provisioning_profiles(<a href="#local_provisioning_profiles-name">name</a>, <a href="#local_provisioning_profiles-fallback_profiles">fallback_profiles</a>, <a href="#local_provisioning_profiles-repo_mapping">repo_mapping</a>)
+provisioning_profile_repository(<a href="#provisioning_profile_repository-name">name</a>, <a href="#provisioning_profile_repository-fallback_profiles">fallback_profiles</a>, <a href="#provisioning_profile_repository-repo_mapping">repo_mapping</a>)
 </pre>
 
 
@@ -350,11 +350,29 @@ not having to update it every time a new device or certificate is added.
 
 ## Example
 
-load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profiles")
+### In your `WORKSPACE` file:
 
-local_provisioning_profiles(
+load("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository")
+
+provisioning_profile_repository(
     name = "local_provisioning_profiles",
-    fallback_profiles = "//path/to/some:filegroup",
+    fallback_profiles = "//path/to/some:filegroup", # Optional profiles to use if one isn't found locally
+)
+
+### In your `BUILD` files (see `local_provisioning_profile` for more examples):
+
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+
+local_provisioning_profile(
+    name = "app_debug_profile",
+    profile_name = "Development App",
+    team_id = "abc123",
+)
+
+ios_application(
+    name = "app",
+    ...
+    provisioning_profile = ":app_debug_profile",
 )
 
 
@@ -363,8 +381,8 @@ local_provisioning_profiles(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="local_provisioning_profiles-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="local_provisioning_profiles-fallback_profiles"></a>fallback_profiles |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="local_provisioning_profiles-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| <a id="provisioning_profile_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="provisioning_profile_repository-fallback_profiles"></a>fallback_profiles |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="provisioning_profile_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
 
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -275,3 +275,96 @@ apple_xcframework(<a href="#apple_xcframework-name">name</a>, <a href="#apple_xc
 | <a id="apple_xcframework-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-versioning.md#apple_bundle_version).   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
+<a id="local_provisioning_profile"></a>
+
+## local_provisioning_profile
+
+<pre>
+local_provisioning_profile(<a href="#local_provisioning_profile-name">name</a>, <a href="#local_provisioning_profile-profile_name">profile_name</a>, <a href="#local_provisioning_profile-team_id">team_id</a>)
+</pre>
+
+
+This rule declares a bazel target that you can pass to the
+'provisioning_profile' attribute of rules that require it. It discovers a
+provisioning profile for the given attributes either on the user's local
+machine, or with the optional 'fallback_profiles' passed to
+'local_provisioning_profiles'. This will automatically pick the newest profile
+if there are multiple profiles matching the given criteria. By default this
+rule will search for a profile with the same name as the rule itself, you can
+pass profile_name to use a different name, and you can pass team_id if you'd
+like to disambiguate between 2 Apple developer accounts that have the same
+profile name.
+
+## Example
+
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+
+local_provisioning_profile(
+    name = "app_debug_profile",
+    profile_name = "Development App",
+    team_id = "abc123",
+)
+
+ios_application(
+    name = "app",
+    ...
+    provisioning_profile = ":app_debug_profile",
+)
+
+local_provisioning_profile(
+    name = "app_release_profile",
+)
+
+ios_application(
+    name = "release_app",
+    ...
+    provisioning_profile = ":app_release_profile",
+)
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="local_provisioning_profile-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="local_provisioning_profile-profile_name"></a>profile_name |  Name of the profile to use, if it's not provided the name of the rule is used   | String | optional | "" |
+| <a id="local_provisioning_profile-team_id"></a>team_id |  Team ID of the profile to find. This is useful for disambiguating between multiple profiles with the same name on different developer accounts.   | String | optional | "" |
+
+
+<a id="local_provisioning_profiles"></a>
+
+## local_provisioning_profiles
+
+<pre>
+local_provisioning_profiles(<a href="#local_provisioning_profiles-name">name</a>, <a href="#local_provisioning_profiles-fallback_profiles">fallback_profiles</a>, <a href="#local_provisioning_profiles-repo_mapping">repo_mapping</a>)
+</pre>
+
+
+This rule declares an external repository for discovering locally installed
+provisioning profiles. This is consumed by `ios_local_provisioning_profile`.
+You can optionally set 'fallback_profiles' to point at a stable location of
+profiles if a newer version of the desired profile does not exist on the local
+machine. This is useful for checking in the current version of the profile, but
+not having to update it every time a new device or certificate is added.
+
+## Example
+
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profiles")
+
+local_provisioning_profiles(
+    name = "local_provisioning_profiles",
+    fallback_profiles = "//path/to/some:filegroup",
+)
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="local_provisioning_profiles-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="local_provisioning_profiles-fallback_profiles"></a>fallback_profiles |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="local_provisioning_profiles-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+
+

--- a/tools/local_provisioning_profile_finder/BUILD
+++ b/tools/local_provisioning_profile_finder/BUILD
@@ -1,0 +1,10 @@
+py_binary(
+    name = "local_provisioning_profile_finder",
+    srcs = ["local_provisioning_profile_finder.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)

--- a/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
+++ b/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
@@ -12,19 +12,19 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("name", help="The name of the profile to find")
     parser.add_argument("output", help="The path to copy the profile to")
     parser.add_argument(
-        "--local-profiles",
+        "--local_profiles",
         nargs="*",
         required=True,
         help="All local provisioning profiles to search through",
     )
     parser.add_argument(
-        "--fallback-profiles",
+        "--fallback_profiles",
         nargs="*",
         required=True,
         help="Fallback provisioning profiles to use if not found locally",
     )
     parser.add_argument(
-        "--team-id",
+        "--team_id",
         help="The team ID of the profile to find, useful for disambiguation",
         default=None,
         type=str,

--- a/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
+++ b/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
@@ -1,0 +1,86 @@
+import argparse
+import datetime
+import plistlib
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("name", help="The name of the profile to find")
+    parser.add_argument("output", help="The path to copy the profile to")
+    parser.add_argument(
+        "--local-profiles",
+        nargs="*",
+        required=True,
+        help="All local provisioning profiles to search through",
+    )
+    parser.add_argument(
+        "--fallback-profiles",
+        nargs="*",
+        required=True,
+        help="Fallback provisioning profiles to use if not found locally",
+    )
+    parser.add_argument(
+        "--team-id",
+        help="The team ID of the profile to find, useful for disambiguation",
+        default=None,
+        type=str,
+    )
+    return parser
+
+
+def _profile_contents(profile: str) -> Tuple[str, datetime.datetime, str]:
+    output = subprocess.check_output(["security", "cms", "-D", "-i", profile])
+    plist = plistlib.loads(output)
+    return plist["Name"], plist["CreationDate"], plist["TeamIdentifier"][0]
+
+
+def _find_newest_profile(
+    expected_name: str, team_id: Optional[str], profiles: List[str]
+) -> Optional[str]:
+    newest_path: Optional[str] = None
+    newest_date: Optional[datetime.datetime] = None
+    for profile in profiles:
+        profile_name, creation_date, actual_team_id = _profile_contents(profile)
+        if profile_name != expected_name:
+            continue
+        if team_id and team_id != actual_team_id:
+            continue
+        # TODO: Skip expired profiles
+        if not newest_date or creation_date > newest_date:
+            newest_path = profile
+            newest_date = creation_date
+
+    return newest_path
+
+
+def _find_profile(
+    name: str,
+    team_id: Optional[str],
+    output: str,
+    local_profiles: List[str],
+    fallback_profiles: List[str],
+) -> None:
+    profile = _find_newest_profile(
+        name, team_id, local_profiles + fallback_profiles
+    )
+    if not profile:
+        sys.exit(
+            f"\033[31merror:\033[39m no provisioning profile was found named '{name}'"
+        )
+
+    shutil.copyfile(profile, output)
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
+    _find_profile(
+        args.name,
+        args.team_id,
+        args.output,
+        args.local_profiles,
+        args.fallback_profiles,
+    )


### PR DESCRIPTION
These rules allow you to fetch provisioning profiles from developer's
installed profiles to use for signing, instead of having to provide them
from source always. This allows a set of fallback profiles in case the
developer doesn't have any profiles for a given target