### PR TITLE
Detect architecture in the macOS test runner

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -127,5 +127,5 @@ fi
 # command will return non-zero, which is enough to tell bazel that the test
 # failed.
 xcodebuild test-without-building \
-    -destination "platform=macOS,arch=x86_64" \
+    -destination "platform=macOS" \
     -xctestrun "$XCTESTRUN"


### PR DESCRIPTION
Hardcoded architecture results in failure on Apple Silicon with
arm64 build of 4.1.0. Removing this parameter enables autodection.