### PR TITLE
Set minimum_deployment_os_version in AppleBundleInfo provider

### DIFF
--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -77,6 +77,7 @@ def _apple_bundle_info_partial_impl(
                 entitlements = entitlements,
                 infoplist = infoplist,
                 minimum_os_version = platform_prerequisites.minimum_os,
+                minimum_deployment_os_version = platform_prerequisites.minimum_deployment_os,
                 platform_type = str(platform_prerequisites.platform_type),
                 product_type = product_type,
                 uses_swift = platform_prerequisites.uses_swift,


### PR DESCRIPTION
This field was added to the provider in https://github.com/bazelbuild/rules_apple/pull/1099/files#diff-f06c6d6866f9332aa9ea85f2e0ccc46f67dfa8e67814a57f243bad6441856f4eR75, but it looks like it was never populated.