### PR TITLE
Add an error for when structured resources reference processed resources.

### DIFF
--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -91,6 +91,18 @@ def ios_application_resources_test_suite(name = "ios_application_resources"):
         tags = [name],
     )
 
+    # Tests bundling generated resources within structured resources should fail with a nice
+    # message.
+    analysis_failure_message_test(
+        name = "{}_invalid_resources_in_structured_resources".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_processed_resources_in_structured_resources",
+        expected_error = "Error: Found ignored resource providers for target " +
+                         "//test/starlark_tests/resources:processed_resources_in_structured_resources. " +
+                         "Check that there are no processed resource targets being referenced by " +
+                         "structured_resources.",
+        tags = [name],
+    )
+
     # Tests that various localized resource types are bundled correctly with the
     # application (preserving their parent .lproj directory).
     archive_contents_test(

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -287,6 +287,21 @@ objc_library(
     tags = FIXTURE_TAGS,
 )
 
+apple_resource_group(
+    name = "processed_resources_in_structured_resources",
+    structured_resources = [
+        ":localization",
+    ],
+)
+
+objc_library(
+    name = "processed_resources_in_structured_resources_lib",
+    srcs = ["main.m"],
+    data = [
+        ":processed_resources_in_structured_resources",
+    ],
+)
+
 filegroup(
     name = "localized_plists",
     srcs = glob(["*.lproj/*.plist"]),

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -170,6 +170,27 @@ ios_application(
 )
 
 ios_application(
+    name = "app_with_processed_resources_in_structured_resources",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = [
+        "manual",
+        "notap",
+    ],
+    deps = [
+        "//test/starlark_tests/resources:processed_resources_in_structured_resources_lib",
+    ],
+)
+
+ios_application(
     name = "app_launch_images",
     app_icons = ["//test/starlark_tests/resources:app_icons_ios"],
     bundle_id = "com.google.example",


### PR DESCRIPTION
PiperOrigin-RevId: 378425541
(cherry picked from commit 9ebba9a58b583459746926af2ca9dab4f709ca89)
