### PR TITLE
Removing this ios_static_framework target that isn't covered by any tests.

### DIFF
--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -4,7 +4,6 @@ load(
     "//apple:ios.bzl",
     "ios_application",
     "ios_extension",
-    "ios_static_framework",
     "ios_ui_test",
     "ios_unit_test",
 )
@@ -107,13 +106,6 @@ ios_extension(
     infoplists = ["ButtonsExtension/Info.plist"],
     minimum_os_version = "9.0",
     deps = [":ButtonsExtensionLib"],
-)
-
-ios_static_framework(
-    name = "ButtonsStaticFramework",
-    bundle_name = "Buttons",
-    minimum_os_version = "8.0",
-    deps = [":ButtonsLib"],
 )
 
 ## Tests


### PR DESCRIPTION
Tulsi doesn't allow list ios_static_framework rules, so the e2e test appears to ignore this target.

PiperOrigin-RevId: 378933587
(cherry picked from commit c00b1504d9b381147c8f2da02f3e64d2b7056d27)

 Conflicts:
	examples/multi_platform/Buttons/BUILD
