### PR TITLE
Added an output_discriminator argument to intermediates, adjusted all partials to allow for future usage of the output_discriminator argument.

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -84,6 +84,12 @@ def _apple_resource_aspect_impl(target, ctx):
 
     providers = []
     bucketize_args = {}
+
+    # TODO(b/174858377) Follow up to see if we need to define output_discriminator for process_args
+    # if an input from the aspect context indicates that the Apple resource aspect is being sent
+    # down a split transition that builds for multiple platforms. This should match an existing
+    # output_discriminator used for resource processing in the top level rule. It might not be
+    # necessary to do this on account of how deduping resources works in the resources partial.
     process_args = {
         "actions": ctx.actions,
         "apple_toolchain_info": ctx.attr._toolchain[AppleSupportToolchainInfo],

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -426,6 +426,7 @@ def _generate_codesigning_dossier_action(
         actions,
         label_name,
         resolved_codesigning_dossier_tool,
+        output_discriminator,
         output_dossier,
         platform_prerequisites,
         embedded_dossiers = [],
@@ -440,6 +441,8 @@ def _generate_codesigning_dossier_action(
           dossier.
       entitlements: Optional file representing the entitlements to sign with.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       output_dossier: The `File` representing the output dossier file - the zipped dossier will be placed here.
       platform_prerequisites: Struct containing information on the platform being targeted.
       provisioning_profile: The provisioning profile file. May be `None`.
@@ -484,9 +487,10 @@ def _generate_codesigning_dossier_action(
         dossier_arguments.extend(["--embedded_dossier", embedded_dossier.relative_bundle_path, embedded_dossier.dossier_file.path])
 
     args_file = intermediates.file(
-        actions,
-        label_name,
-        "dossier_arguments",
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "dossier_arguments",
     )
     actions.write(
         output = args_file,
@@ -526,6 +530,7 @@ def _post_process_and_sign_archive_action(
         label_name,
         output_archive,
         output_archive_root_path,
+        output_discriminator,
         platform_prerequisites,
         process_and_sign_template,
         provisioning_profile,
@@ -548,6 +553,8 @@ def _post_process_and_sign_archive_action(
       output_archive: The `File` representing the processed and signed archive.
       output_archive_root_path: The `string` path to where the processed, uncompressed archive
           should be located.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       platform_prerequisites: Struct containing information on the platform being targeted.
       process_and_sign_template: A template for a shell script to process and sign as a file.
       provisioning_profile: The provisioning profile file. May be `None`.
@@ -623,9 +630,10 @@ def _post_process_and_sign_archive_action(
         return
 
     process_and_sign_expanded_template = intermediates.file(
-        actions,
-        label_name,
-        "process-and-sign-%s.sh" % hash(output_archive.path),
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "process-and-sign-%s.sh" % hash(output_archive.path),
     )
     actions.expand_template(
         template = process_and_sign_template,

--- a/apple/internal/intermediates.bzl
+++ b/apple/internal/intermediates.bzl
@@ -16,36 +16,54 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def _directory(actions, target_name, dir_name):
+def _intermediates_path_string(*, target_name, output_discriminator):
+    """Returns a preferred path string given a target name and an optional output discriminator."""
+    if not output_discriminator:
+        return "%s-intermediates" % target_name
+    return "%s-intermediates-%s" % (target_name, output_discriminator)
+
+def _directory(*, actions, target_name, output_discriminator, dir_name):
     """Declares an intermediate directory with the given name.
 
     Args:
       actions: The actions object as returned by ctx.actions.
-      target_name: The owning target name to differentiate between different
-        target intermediate files.
+      target_name: The owning target name used to differentiate between different target
+          intermediate files.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       dir_name: Name of the directory to declare.
 
     Returns:
       A new File object that represents an intermediate directory.
     """
+    intermediates_path = _intermediates_path_string(
+        target_name = target_name,
+        output_discriminator = output_discriminator,
+    )
     return actions.declare_directory(
-        paths.join("%s-intermediates" % target_name, dir_name),
+        paths.join(intermediates_path, dir_name),
     )
 
-def _file(actions, target_name, file_name):
+def _file(*, actions, target_name, output_discriminator, file_name):
     """Declares an intermediate file with the given name.
 
     Args:
       actions: The actions object as returned by ctx.actions.
-      target_name: The owning target name to differentiate between different
-        target intermediate files.
+      target_name: The owning target name used to differentiate between different target
+          intermediate files.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       file_name: Name of the file to declare.
 
     Returns:
       A new File object that represents an intermediate file.
     """
+    intermediates_path = _intermediates_path_string(
+        target_name = target_name,
+        output_discriminator = output_discriminator,
+    )
     return actions.declare_file(
-        paths.join("%s-intermediates" % target_name, file_name),
+        paths.join(intermediates_path, file_name),
     )
 
 intermediates = struct(

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -185,6 +185,7 @@ def _ios_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -457,6 +458,7 @@ def _ios_app_clip_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -696,6 +698,7 @@ def _ios_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -911,6 +914,7 @@ def _ios_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1139,6 +1143,7 @@ def _ios_dynamic_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1302,6 +1307,7 @@ def _ios_static_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1430,6 +1436,7 @@ def _ios_imessage_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1604,6 +1611,7 @@ def _ios_imessage_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1799,6 +1807,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -90,9 +90,10 @@ def _macos_binary_infoplist_impl(ctx):
              "should have been provided")
 
     merged_infoplist = intermediates.file(
-        actions,
-        rule_label.name,
-        "Info.plist",
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = None,
+        file_name = "Info.plist",
     )
 
     resource_actions.merge_root_infoplists(
@@ -105,6 +106,7 @@ def _macos_binary_infoplist_impl(ctx):
         include_executable_name = False,
         input_plists = infoplists,
         launch_storyboard = None,
+        output_discriminator = None,
         output_pkginfo = None,
         output_plist = merged_infoplist,
         platform_prerequisites = platform_prerequisites,
@@ -160,9 +162,10 @@ def _macos_command_line_launchdplist_impl(ctx):
         fail("Internal error: launchdplists should have been provided")
 
     merged_launchdplist = intermediates.file(
-        actions,
-        rule_label.name,
-        "Launchd.plist",
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = None,
+        file_name = "Launchd.plist",
     )
 
     resource_actions.merge_resource_infoplists(
@@ -170,6 +173,7 @@ def _macos_command_line_launchdplist_impl(ctx):
         bundle_id = None,
         bundle_name_with_extension = bundle_name + bundle_extension,
         input_files = launchdplists,
+        output_discriminator = None,
         output_plist = merged_launchdplist,
         platform_prerequisites = platform_prerequisites,
         resolved_plisttool = ctx.attr._toolchain[AppleSupportToolchainInfo].resolved_plisttool,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -147,6 +147,7 @@ def _macos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -360,6 +361,7 @@ def _macos_bundle_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -524,6 +526,7 @@ def _macos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -702,6 +705,7 @@ def _macos_quick_look_plugin_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -870,6 +874,7 @@ def _macos_kernel_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -1199,6 +1204,7 @@ def _macos_xpc_service_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -78,12 +78,12 @@ def _archive_for_embedding(
 
 def _binary(*, actions, bundle_name, executable_name, label_name, output_discriminator):
     """Returns a file reference for the binary that will be packaged into this target's archive. """
+    file_name = executable_name if executable_name else bundle_name
     return intermediates.file(
         actions = actions,
-        executable_name = executable_name,
         target_name = label_name,
         output_discriminator = output_discriminator,
-        file_name = bundle_name,
+        file_name = file_name,
     )
 
 def _executable(*, actions, label_name):

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -76,17 +76,28 @@ def _archive_for_embedding(
             predeclared_outputs = predeclared_outputs,
         )
 
-def _binary(ctx = None, *, actions = None, executable_name = None, label_name = None):
+def _binary(*, actions, bundle_name, executable_name, label_name, output_discriminator):
     """Returns a file reference for the binary that will be packaged into this target's archive. """
-    return intermediates.file(actions, label_name, executable_name)
+    return intermediates.file(
+        actions = actions,
+        executable_name = executable_name,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = bundle_name,
+    )
 
 def _executable(*, actions, label_name):
     """Returns a file reference for the executable that would be invoked with `bazel run`."""
     return actions.declare_file(label_name)
 
-def _infoplist(*, actions, label_name):
+def _infoplist(*, actions, label_name, output_discriminator):
     """Returns a file reference for this target's Info.plist file."""
-    return intermediates.file(actions, label_name, "Info.plist")
+    return intermediates.file(
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "Info.plist",
+    )
 
 def _has_different_embedding_archive(*, platform_prerequisites, rule_descriptor):
     """Returns True if this target exposes a different archive when embedded in another target."""

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -53,6 +53,7 @@ def _apple_bundle_info_partial_impl(
 
     binary = outputs.binary(
         actions = actions,
+        bundle_name = bundle_name,
         executable_name = executable_name,
         label_name = label_name,
         output_discriminator = output_discriminator,

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -36,6 +36,7 @@ def _apple_bundle_info_partial_impl(
         executable_name,
         entitlements,
         label_name,
+        output_discriminator,
         platform_prerequisites,
         predeclared_outputs,
         product_type):
@@ -54,6 +55,7 @@ def _apple_bundle_info_partial_impl(
         actions = actions,
         executable_name = executable_name,
         label_name = label_name,
+        output_discriminator = output_discriminator,
     )
 
     infoplist = None
@@ -62,6 +64,7 @@ def _apple_bundle_info_partial_impl(
         infoplist = outputs.infoplist(
             actions = actions,
             label_name = label_name,
+            output_discriminator = output_discriminator,
         )
 
     return struct(
@@ -94,6 +97,7 @@ def apple_bundle_info_partial(
         executable_name,
         entitlements,
         label_name,
+        output_discriminator = None,
         platform_prerequisites,
         predeclared_outputs,
         product_type):
@@ -109,6 +113,8 @@ def apple_bundle_info_partial(
       executable_name: The name of the output executable.
       entitlements: The entitlements file to sign with. Can be `None` if one was not provided.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`.
       product_type: Product type identifier used to describe the current bundle type.
@@ -125,6 +131,7 @@ def apple_bundle_info_partial(
         executable_name = executable_name,
         entitlements = entitlements,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         product_type = product_type,

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -50,6 +50,7 @@ def _apple_symbols_file_partial_impl(
         debug_outputs_provider,
         dependency_targets,
         label_name,
+        output_discriminator,
         include_symbols_in_bundle,
         platform_prerequisites):
     """Implementation for the Apple .symbols file processing partial."""
@@ -62,7 +63,12 @@ def _apple_symbols_file_partial_impl(
         for target in dependency_targets:
             if AppleFrameworkImportInfo in target:
                 inputs.extend(target[AppleFrameworkImportInfo].debug_info_binaries.to_list())
-        output = intermediates.directory(actions, label_name, "symbols_output")
+        output = intermediates.directory(
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            dir_name = "symbols_output",
+        )
         outputs.append(output)
         apple_support.run_shell(
             actions = actions,
@@ -106,6 +112,7 @@ def apple_symbols_file_partial(
         debug_outputs_provider,
         dependency_targets = [],
         label_name,
+        output_discriminator = None,
         include_symbols_in_bundle,
         platform_prerequisites):
     """Constructor for the Apple .symbols package processing partial.
@@ -118,6 +125,8 @@ def apple_symbols_file_partial(
       dependency_targets: List of targets that should be checked for files that need to be
         bundled.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       include_symbols_in_bundle: Whether the partial should package in its bundle
         the .symbols files for this binary plus all binaries in `dependency_targets`.
       platform_prerequisites: Struct containing information on the platform being targeted.
@@ -131,7 +140,8 @@ def apple_symbols_file_partial(
         binary_artifact = binary_artifact,
         debug_outputs_provider = debug_outputs_provider,
         dependency_targets = dependency_targets,
-        label_name = label_name,
         include_symbols_in_bundle = include_symbols_in_bundle,
+        label_name = label_name,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
     )

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -27,7 +27,14 @@ load(
     "partial",
 )
 
-def _binary_partial_impl(*, actions, binary_artifact, executable_name, label_name):
+def _binary_partial_impl(
+        *,
+        actions,
+        binary_artifact,
+        bundle_name,
+        executable_name,
+        label_name,
+        output_discriminator):
     """Implementation for the binary processing partial."""
 
     # Create intermediate file with proper name for the binary.
@@ -35,6 +42,7 @@ def _binary_partial_impl(*, actions, binary_artifact, executable_name, label_nam
         actions = actions,
         executable_name = executable_name,
         label_name = label_name,
+        output_discriminator = output_discriminator,
     )
     actions.symlink(target_file = binary_artifact, output = output_binary)
 
@@ -44,7 +52,14 @@ def _binary_partial_impl(*, actions, binary_artifact, executable_name, label_nam
         ],
     )
 
-def binary_partial(actions, binary_artifact, executable_name, label_name):
+def binary_partial(
+        *,
+        actions,
+        binary_artifact,
+        bundle_name,
+        executable_name,
+        label_name,
+        output_discriminator = None):
     """Constructor for the binary processing partial.
 
     This partial propagates the bundle location for the main binary artifact for the target.
@@ -54,6 +69,8 @@ def binary_partial(actions, binary_artifact, executable_name, label_name):
       binary_artifact: The main binary artifact for this target.
       executable_name: The name of the output executable.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
 
     Returns:
       A partial that returns the bundle location of the binary artifact.
@@ -64,4 +81,5 @@ def binary_partial(actions, binary_artifact, executable_name, label_name):
         binary_artifact = binary_artifact,
         executable_name = executable_name,
         label_name = label_name,
+        output_discriminator = output_discriminator,
     )

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -40,6 +40,7 @@ def _binary_partial_impl(
     # Create intermediate file with proper name for the binary.
     output_binary = outputs.binary(
         actions = actions,
+        bundle_name = bundle_name,
         executable_name = executable_name,
         label_name = label_name,
         output_discriminator = output_discriminator,
@@ -67,6 +68,7 @@ def binary_partial(
     Args:
       actions: The actions provider from ctx.actions.
       binary_artifact: The main binary artifact for this target.
+      bundle_name: The name of the output bundle.
       executable_name: The name of the output executable.
       label_name: Name of the target being built.
       output_discriminator: A string to differentiate between different target intermediate files
@@ -79,6 +81,7 @@ def binary_partial(
         _binary_partial_impl,
         actions = actions,
         binary_artifact = binary_artifact,
+        bundle_name = bundle_name,
         executable_name = executable_name,
         label_name = label_name,
         output_discriminator = output_discriminator,

--- a/apple/internal/partials/bitcode_symbols.bzl
+++ b/apple/internal/partials/bitcode_symbols.bzl
@@ -45,6 +45,7 @@ def _bitcode_symbols_partial_impl(
         debug_outputs_provider,
         dependency_targets,
         label_name,
+        output_discriminator,
         package_bitcode,
         platform_prerequisites):
     """Implementation for the bitcode symbols processing partial."""
@@ -74,7 +75,12 @@ def _bitcode_symbols_partial_impl(
             )
 
         if bitcode_files:
-            bitcode_dir = intermediates.directory(actions, label_name, "bitcode_files")
+            bitcode_dir = intermediates.directory(
+                actions = actions,
+                target_name = label_name,
+                output_discriminator = output_discriminator,
+                dir_name = "bitcode_files",
+            )
             bitcode_dirs.append(bitcode_dir)
 
             apple_support.run_shell(
@@ -114,6 +120,7 @@ def bitcode_symbols_partial(
         debug_outputs_provider = None,
         dependency_targets = [],
         label_name,
+        output_discriminator = None,
         package_bitcode = False,
         platform_prerequisites):
     """Constructor for the bitcode symbols processing partial.
@@ -126,6 +133,8 @@ def bitcode_symbols_partial(
       dependency_targets: List of targets that should be checked for bitcode files that need to be
         bundled..
       label_name: Name of the target being built
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       package_bitcode: Whether the partial should package the bitcode files for all dependency
         binaries.
       platform_prerequisites: Struct containing information on the platform being targeted.
@@ -140,6 +149,7 @@ def bitcode_symbols_partial(
         debug_outputs_provider = debug_outputs_provider,
         dependency_targets = dependency_targets,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         package_bitcode = package_bitcode,
         platform_prerequisites = platform_prerequisites,
     )

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -54,14 +54,16 @@ def _clang_rt_dylibs_partial_impl(
         binary_artifact,
         features,
         label_name,
+        output_discriminator,
         platform_prerequisites):
     """Implementation for the Clang runtime dylibs processing partial."""
     bundle_zips = []
     if _should_package_clang_runtime(features = features):
         clang_rt_zip = intermediates.file(
-            actions,
-            label_name,
-            "clang_rt.zip",
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "clang_rt.zip",
         )
 
         resolved_clangrttool = apple_toolchain_info.resolved_clangrttool
@@ -97,6 +99,7 @@ def clang_rt_dylibs_partial(
         binary_artifact,
         features,
         label_name,
+        output_discriminator = None,
         platform_prerequisites):
     """Constructor for the Clang runtime dylibs processing partial.
 
@@ -106,6 +109,8 @@ def clang_rt_dylibs_partial(
       binary_artifact: The main binary artifact for this target.
       features: List of features enabled by the user. Typically from `ctx.features`.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       platform_prerequisites: Struct containing information on the platform being targeted.
 
     Returns:
@@ -119,5 +124,6 @@ def clang_rt_dylibs_partial(
         binary_artifact = binary_artifact,
         features = features,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
     )

--- a/apple/internal/partials/codesigning_dossier.bzl
+++ b/apple/internal/partials/codesigning_dossier.bzl
@@ -145,6 +145,7 @@ def _codesigning_dossier_partial_impl(
         embedded_targets = [],
         entitlements = None,
         label_name,
+        output_discriminator,
         platform_prerequisites,
         provisioning_profile = None,
         rule_descriptor):
@@ -178,6 +179,7 @@ def _codesigning_dossier_partial_impl(
         actions = actions,
         label_name = label_name,
         resolved_codesigning_dossier_tool = apple_toolchain_info.resolved_dossier_codesigningtool,
+        output_discriminator = output_discriminator,
         output_dossier = output_dossier,
         platform_prerequisites = platform_prerequisites,
         embedded_dossiers = embedded_codesign_dossiers,
@@ -221,6 +223,7 @@ def codesigning_dossier_partial(
         embedded_targets = [],
         entitlements = None,
         label_name,
+        output_discriminator = None,
         platform_prerequisites,
         provisioning_profile = None,
         rule_descriptor):
@@ -240,6 +243,8 @@ def codesigning_dossier_partial(
             propagate.
       entitlements: Optional entitlements for this bundle.
       label_name: Name of the target being built
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       platform_prerequisites: Struct containing information on the platform being targeted.
       provisioning_profile: Optional File for the provisioning profile.
       rule_descriptor: A rule descriptor for platform and product types from the rule context.
@@ -259,6 +264,7 @@ def codesigning_dossier_partial(
         embedded_targets = embedded_targets,
         entitlements = entitlements,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
         provisioning_profile = provisioning_profile,
         rule_descriptor = rule_descriptor,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -56,6 +56,7 @@ def _framework_import_partial_impl(
         actions,
         apple_toolchain_info,
         label_name,
+        output_discriminator,
         platform_prerequisites,
         provisioning_profile,
         rule_descriptor,
@@ -128,9 +129,10 @@ def _framework_import_partial_impl(
         # Create a temporary path for intermediate files and the anticipated zip output.
         temp_path = paths.join("_imported_frameworks/", framework_basename)
         framework_zip = intermediates.file(
-            actions,
-            label_name,
-            temp_path + ".zip",
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = temp_path + ".zip",
         )
         temp_framework_bundle_path = paths.split_extension(framework_zip.path)[0]
 
@@ -219,6 +221,7 @@ def framework_import_partial(
         actions,
         apple_toolchain_info,
         label_name,
+        output_discriminator = None,
         platform_prerequisites,
         provisioning_profile,
         rule_descriptor,
@@ -233,6 +236,8 @@ def framework_import_partial(
         actions: The actions provider from `ctx.actions`.
         apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
         label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         platform_prerequisites: Struct containing information on the platform being targeted.
         provisioning_profile: File for the provisioning profile.
         rule_descriptor: A rule descriptor for platform and product types from the rule context.
@@ -248,6 +253,7 @@ def framework_import_partial(
         actions = actions,
         apple_toolchain_info = apple_toolchain_info,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
         provisioning_profile = provisioning_profile,
         rule_descriptor = rule_descriptor,

--- a/apple/internal/partials/messages_stub.bzl
+++ b/apple/internal/partials/messages_stub.bzl
@@ -45,6 +45,7 @@ def _messages_stub_partial_impl(
         binary_artifact,
         extensions,
         label_name,
+        output_discriminator,
         package_messages_support):
     """Implementation for the messages support stub processing partial."""
 
@@ -69,9 +70,10 @@ def _messages_stub_partial_impl(
 
         if binary_artifact:
             intermediate_file = intermediates.file(
-                actions,
-                label_name,
-                "MessagesApplicationSupportStub",
+                actions = actions,
+                target_name = label_name,
+                output_discriminator = output_discriminator,
+                file_name = "MessagesApplicationSupportStub",
             )
             actions.symlink(
                 target_file = binary_artifact,
@@ -88,9 +90,10 @@ def _messages_stub_partial_impl(
 
     elif binary_artifact:
         intermediate_file = intermediates.file(
-            actions,
-            label_name,
-            "MessagesApplicationExtensionSupportStub",
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "MessagesApplicationExtensionSupportStub",
         )
         actions.symlink(
             target_file = binary_artifact,
@@ -109,6 +112,7 @@ def messages_stub_partial(
         binary_artifact = None,
         extensions = None,
         label_name,
+        output_discriminator = None,
         package_messages_support = False):
     """Constructor for the messages support stub processing partial.
 
@@ -119,6 +123,8 @@ def messages_stub_partial(
         binary_artifact: The stub binary to copy.
         extensions: List of extension bundles associated with this rule.
         label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         package_messages_support: Whether to package the messages stub binary in the archive root.
 
     Returns:
@@ -130,5 +136,6 @@ def messages_stub_partial(
         binary_artifact = binary_artifact,
         extensions = extensions,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         package_messages_support = package_messages_support,
     )

--- a/apple/internal/partials/provisioning_profile.bzl
+++ b/apple/internal/partials/provisioning_profile.bzl
@@ -32,6 +32,7 @@ def _provisioning_profile_partial_impl(
         actions,
         extension,
         location,
+        output_discriminator,
         profile_artifact,
         rule_label):
     """Implementation for the provisioning profile partial."""
@@ -46,9 +47,10 @@ def _provisioning_profile_partial_impl(
 
     # Create intermediate file with proper name for the binary.
     intermediate_file = intermediates.file(
-        actions,
-        rule_label.name,
-        "embedded.%s" % extension,
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        file_name = "embedded.%s" % extension,
     )
     actions.symlink(
         target_file = profile_artifact,
@@ -66,6 +68,7 @@ def provisioning_profile_partial(
         actions,
         extension = "mobileprovision",
         location = processor.location.resource,
+        output_discriminator = None,
         profile_artifact,
         rule_label):
     """Constructor for the provisioning profile partial.
@@ -77,6 +80,8 @@ def provisioning_profile_partial(
       actions: The actions provider from `ctx.actions`.
       extension: The embedded provisioning profile extension.
       location: The location within the bundle to place the profile.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       profile_artifact: The provisioning profile to embed for this target.
       rule_label: The label of the target being analyzed.
 
@@ -88,6 +93,7 @@ def provisioning_profile_partial(
         actions = actions,
         extension = extension,
         location = location,
+        output_discriminator = output_discriminator,
         profile_artifact = profile_artifact,
         rule_label = rule_label,
     )

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -69,6 +69,7 @@ def _merge_root_infoplists(
         *,
         actions,
         out_infoplist,
+        output_discriminator,
         rule_descriptor,
         rule_label,
         **kwargs):
@@ -77,6 +78,8 @@ def _merge_root_infoplists(
     Args:
       actions: The actions provider from `ctx.actions`.
       out_infoplist: Reference to the output Info plist.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       rule_descriptor: A rule descriptor for platform and product types from the rule context.
       rule_label: The label of the target being analyzed.
       **kwargs: Extra parameters forwarded into the merge_root_infoplists action.
@@ -90,14 +93,16 @@ def _merge_root_infoplists(
     out_pkginfo = None
     if rule_descriptor.requires_pkginfo:
         out_pkginfo = intermediates.file(
-            actions,
-            rule_label.name,
-            "PkgInfo",
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = "PkgInfo",
         )
         files.append(out_pkginfo)
 
     resource_actions.merge_root_infoplists(
         actions = actions,
+        output_discriminator = output_discriminator,
         output_plist = out_infoplist,
         output_pkginfo = out_pkginfo,
         rule_descriptor = rule_descriptor,
@@ -283,6 +288,7 @@ def _resources_partial_impl(
         bundle_verification_targets,
         environment_plist,
         launch_storyboard,
+        output_discriminator,
         platform_prerequisites,
         resource_deps,
         rule_descriptor,
@@ -414,6 +420,7 @@ def _resources_partial_impl(
                 "apple_toolchain_info": apple_toolchain_info,
                 "bundle_id": bundle_id,
                 "files": files,
+                "output_discriminator": output_discriminator,
                 "parent_dir": parent_dir,
                 "platform_prerequisites": platform_prerequisites,
                 "product_type": rule_descriptor.product_type,
@@ -458,6 +465,7 @@ def _resources_partial_impl(
         out_infoplist = outputs.infoplist(
             actions = actions,
             label_name = rule_label.name,
+            output_discriminator = output_discriminator,
         )
         bundle_files.extend(
             _merge_root_infoplists(
@@ -472,6 +480,7 @@ def _resources_partial_impl(
                 input_plists = infoplists,
                 launch_storyboard = launch_storyboard,
                 out_infoplist = out_infoplist,
+                output_discriminator = output_discriminator,
                 platform_prerequisites = platform_prerequisites,
                 resolved_plisttool = apple_toolchain_info.resolved_plisttool,
                 rule_descriptor = rule_descriptor,
@@ -494,6 +503,7 @@ def resources_partial(
         bundle_verification_targets = [],
         environment_plist,
         launch_storyboard,
+        output_discriminator = None,
         platform_prerequisites,
         resource_deps,
         rule_descriptor,
@@ -525,6 +535,8 @@ def resources_partial(
         environment_plist: File referencing a plist with the required variables about the versions
             the target is being built for and with.
         launch_storyboard: A file to be used as a launch screen for the application.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         platform_prerequisites: Struct containing information on the platform being targeted.
         resource_deps: A list of dependencies that the resource aspect has been applied to.
         rule_descriptor: A rule descriptor for platform and product types from the rule context.
@@ -551,6 +563,7 @@ def resources_partial(
         bundle_verification_targets = bundle_verification_targets,
         environment_plist = environment_plist,
         launch_storyboard = launch_storyboard,
+        output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
         resource_deps = resource_deps,
         rule_descriptor = rule_descriptor,

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -26,10 +26,6 @@ load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
 
 def _get_link_declarations(dylibs = [], frameworks = []):
     """Returns the module map lines that link to the given dylibs and frameworks.
@@ -170,9 +166,9 @@ def _static_framework_header_modulemap_partial_impl(
     if any([sdk_dylibs, sdk_frameworks, umbrella_header_name]):
         modulemap_file = intermediates.file(
             actions = actions,
-            target_name = label_name,
+            target_name = label_name + ".modulemaps",
             output_discriminator = output_discriminator,
-            file_name = paths.join(label_name, label_name + ".modulemaps"),
+            file_name = "module.modulemap",
         )
         _create_modulemap(
             actions,

--- a/apple/internal/partials/static_framework_header_modulemap.bzl
+++ b/apple/internal/partials/static_framework_header_modulemap.bzl
@@ -123,6 +123,7 @@ def _static_framework_header_modulemap_partial_impl(
         bundle_name,
         hdrs,
         label_name,
+        output_discriminator,
         umbrella_header):
     """Implementation for the static framework headers and modulemaps partial."""
     bundle_files = []
@@ -135,7 +136,12 @@ def _static_framework_header_modulemap_partial_impl(
         )
     elif hdrs:
         umbrella_header_name = "{}.h".format(bundle_name)
-        umbrella_header_file = intermediates.file(actions, label_name, umbrella_header_name)
+        umbrella_header_file = intermediates.file(
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = umbrella_header_name,
+        )
         _create_umbrella_header(
             actions,
             umbrella_header_file,
@@ -163,9 +169,10 @@ def _static_framework_header_modulemap_partial_impl(
     # headers or if there are dylibs/frameworks that the target depends on).
     if any([sdk_dylibs, sdk_frameworks, umbrella_header_name]):
         modulemap_file = intermediates.file(
-            actions,
-            paths.join(label_name, label_name + ".modulemaps"),
-            "module.modulemap",
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = paths.join(label_name, label_name + ".modulemaps"),
         )
         _create_modulemap(
             actions,
@@ -188,6 +195,7 @@ def static_framework_header_modulemap_partial(
         bundle_name,
         hdrs,
         label_name,
+        output_discriminator = None,
         umbrella_header):
     """Constructor for the static framework headers and modulemaps partial.
 
@@ -199,6 +207,8 @@ def static_framework_header_modulemap_partial(
       bundle_name: The name of the output bundle.
       hdrs: The list of headers to bundle.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       umbrella_header: An umbrella header to use instead of generating one
 
     Returns:
@@ -212,5 +222,6 @@ def static_framework_header_modulemap_partial(
         bundle_name = bundle_name,
         hdrs = hdrs,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         umbrella_header = umbrella_header,
     )

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -183,9 +183,10 @@ def _asset_catalogs(
             # Process icon PNGs like any other PNG
             alticon_id = paths.basename(f.dirname)
             png_file = intermediates.file(
-                actions,
-                rule_label.name,
-                paths.join("alticons", alticon_id, f.basename),
+                actions = actions,
+                file_name = paths.join("alticons", alticon_id, f.basename),
+                output_discriminator = None,
+                target_name = rule_label.name,
             )
             resource_actions.copy_png(
                 actions = actions,
@@ -377,9 +378,10 @@ def _metals(
     """
     metallib_path = paths.join(parent_dir or "", output_filename)
     metallib_file = intermediates.file(
-        actions,
-        rule_label.name,
-        metallib_path,
+        actions = actions,
+        file_name = metallib_path,
+        output_discriminator = None,
+        target_name = rule_label.name,
     )
     resource_actions.compile_metals(
         actions = actions,

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -16,10 +16,10 @@
 
 All methods in this file follow this convention:
   - The argument signature is a combination of; actions, apple_toolchain_info, bundle_id, files,
-    parent_dir, platform_prerequisites, product_type, and/or rule_label. Only the arguments required
-    for each resource action should be referenced directly by keyword in the argument signature and
-    implementation. Arguments should not be referenced through kwargs. The presence of kwargs is
-    only necessary to ignore unused keywords.
+    output_discriminator, parent_dir, platform_prerequisites, product_type, and/or rule_label. Only
+    the arguments required for each resource action should be referenced directly by keyword in the
+    argument signature and implementation. Arguments should not be referenced through kwargs. The
+    presence of kwargs is only necessary to ignore unused keywords.
   - They all return a struct with the following optional fields:
       - files: A list of tuples with the following structure:
           - Processor location: The location type in the archive where these files should be placed.
@@ -57,6 +57,7 @@ def _compile_datamodels(
         actions,
         datamodel_groups,
         label_name,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         resolved_xctoolrunner,
@@ -71,16 +72,18 @@ def _compile_datamodels(
         if datamodel_path.endswith(".xcdatamodeld"):
             basename = datamodel_name + ".momd"
             output_file = intermediates.directory(
-                actions,
-                label_name,
-                basename,
+                actions = actions,
+                target_name = label_name,
+                output_discriminator = output_discriminator,
+                dir_name = basename,
             )
             datamodel_parent = paths.join(datamodel_parent or "", basename)
         else:
             output_file = intermediates.file(
-                actions,
-                label_name,
-                datamodel_name + ".mom",
+                actions = actions,
+                target_name = label_name,
+                output_discriminator = output_discriminator,
+                file_name = datamodel_name + ".mom",
             )
 
         resource_actions.compile_datamodels(
@@ -103,6 +106,7 @@ def _compile_mappingmodels(
         actions,
         label_name,
         mappingmodel_groups,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         resolved_xctoolrunner):
@@ -111,9 +115,10 @@ def _compile_mappingmodels(
     for mappingmodel_path, input_files in mappingmodel_groups.items():
         compiled_model_name = paths.replace_extension(paths.basename(mappingmodel_path), ".cdm")
         output_file = intermediates.file(
-            actions,
-            label_name,
-            paths.join(parent_dir or "", compiled_model_name),
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = paths.join(parent_dir or "", compiled_model_name),
         )
 
         resource_actions.compile_mappingmodel(
@@ -137,6 +142,7 @@ def _asset_catalogs(
         apple_toolchain_info,
         bundle_id,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         product_type,
@@ -152,16 +158,18 @@ def _asset_catalogs(
         # TODO(kaipi): Merge this into the top level Info.plist.
         assets_plist_path = paths.join(parent_dir or "", "xcassets-info.plist")
         assets_plist = intermediates.file(
-            actions,
-            rule_label.name,
-            assets_plist_path,
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = assets_plist_path,
         )
         infoplists.append(assets_plist)
 
     assets_dir = intermediates.directory(
-        actions,
-        rule_label.name,
-        paths.join(parent_dir or "", "xcassets"),
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        dir_name = paths.join(parent_dir or "", "xcassets"),
     )
 
     # Separate alternate icons from regular assets
@@ -213,6 +221,7 @@ def _datamodels(
         actions,
         apple_toolchain_info,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -257,16 +266,18 @@ def _datamodels(
 
     output_files = list(_compile_datamodels(
         actions = actions,
-        label_name = rule_label.name,
-        parent_dir = parent_dir,
-        swift_module = swift_module,
         datamodel_groups = datamodel_groups,
+        label_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        parent_dir = parent_dir,
         platform_prerequisites = platform_prerequisites,
         resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
+        swift_module = swift_module,
     ))
     output_files.extend(_compile_mappingmodels(
         actions = actions,
         label_name = rule_label.name,
+        output_discriminator = output_discriminator,
         parent_dir = parent_dir,
         mappingmodel_groups = mappingmodel_groups,
         platform_prerequisites = platform_prerequisites,
@@ -281,6 +292,7 @@ def _infoplists(
         apple_toolchain_info,
         bundle_id,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -295,8 +307,10 @@ def _infoplists(
     Args:
         actions: The actions provider from `ctx.actions`.
         apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
-        files: The infoplist files to process.
         bundle_id: The bundle ID to use when templating plist files.
+        files: The infoplist files to process.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         parent_dir: The path under which the merged Info.plist should be placed for resource bundles.
         platform_prerequisites: Struct containing information on the platform being targeted.
         rule_label: The label of the target being analyzed.
@@ -310,9 +324,10 @@ def _infoplists(
         input_files = files.to_list()
         processed_origins = {}
         out_plist = intermediates.file(
-            actions,
-            rule_label.name,
-            paths.join(parent_dir, "Info.plist"),
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = paths.join(parent_dir, "Info.plist"),
         )
         processed_origins[out_plist.short_path] = [f.short_path for f in input_files]
         resource_actions.merge_resource_infoplists(
@@ -320,6 +335,7 @@ def _infoplists(
             bundle_id = bundle_id,
             bundle_name_with_extension = paths.basename(parent_dir),
             input_files = input_files,
+            output_discriminator = output_discriminator,
             output_plist = out_plist,
             platform_prerequisites = platform_prerequisites,
             resolved_plisttool = apple_toolchain_info.resolved_plisttool,
@@ -385,6 +401,7 @@ def _mlmodels(
         actions,
         apple_toolchain_info,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -397,14 +414,16 @@ def _mlmodels(
         basename = file.basename
 
         output_bundle = intermediates.directory(
-            actions,
-            rule_label.name,
-            paths.join(parent_dir or "", paths.replace_extension(basename, ".mlmodelc")),
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            dir_name = paths.join(parent_dir or "", paths.replace_extension(basename, ".mlmodelc")),
         )
         output_plist = intermediates.file(
-            actions,
-            rule_label.name,
-            paths.join(parent_dir or "", paths.replace_extension(basename, ".plist")),
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = paths.join(parent_dir or "", paths.replace_extension(basename, ".plist")),
         )
 
         resource_actions.compile_mlmodel(
@@ -435,9 +454,10 @@ def _plists_and_strings(
         actions,
         files,
         force_binary = False,
-        rule_label,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
+        rule_label,
         **kwargs):
     """Processes plists and string files.
 
@@ -450,9 +470,11 @@ def _plists_and_strings(
         files: The plist or string files to process.
         force_binary: If true, files will be converted to binary independently of the compilation
             mode.
-        rule_label: The label of the target being analyzed.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         parent_dir: The path under which the files should be placed.
         platform_prerequisites: Struct containing information on the platform being targeted.
+        rule_label: The label of the target being analyzed.
         **kwargs: Extra parameters forwarded to this support macro.
 
     Returns:
@@ -470,9 +492,10 @@ def _plists_and_strings(
     processed_origins = {}
     for file in files.to_list():
         plist_file = intermediates.file(
-            actions,
-            rule_label.name,
-            paths.join(parent_dir or "", file.basename),
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = paths.join(parent_dir or "", file.basename),
         )
         processed_origins[plist_file.short_path] = [file.short_path]
         resource_actions.compile_plist(
@@ -494,6 +517,7 @@ def _pngs(
         *,
         actions,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -505,6 +529,8 @@ def _pngs(
     Args:
         actions: The actions provider from `ctx.actions`.
         files: The PNG files to process.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         parent_dir: The path under which the images should be placed.
         platform_prerequisites: Struct containing information on the platform being targeted.
         rule_label: The label of the target being analyzed.
@@ -517,7 +543,12 @@ def _pngs(
     processed_origins = {}
     for file in files.to_list():
         png_path = paths.join(parent_dir or "", file.basename)
-        png_file = intermediates.file(actions, rule_label.name, png_path)
+        png_file = intermediates.file(
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = png_path,
+        )
         processed_origins[png_file.short_path] = [file.short_path]
         resource_actions.copy_png(
             actions = actions,
@@ -539,6 +570,7 @@ def _storyboards(
         actions,
         apple_toolchain_info,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -560,9 +592,10 @@ def _storyboards(
             paths.replace_extension(storyboard.basename, ".storyboardc"),
         )
         storyboardc_dir = intermediates.directory(
-            actions,
-            rule_label.name,
-            storyboardc_path,
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            dir_name = storyboardc_path,
         )
         resource_actions.compile_storyboard(
             actions = actions,
@@ -577,9 +610,10 @@ def _storyboards(
     # Then link all the output folders into one folder, which will then be the
     # folder to be bundled.
     linked_storyboard_dir = intermediates.directory(
-        actions,
-        rule_label.name,
-        paths.join("storyboards", parent_dir or "", swift_module or ""),
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        dir_name = paths.join("storyboards", parent_dir or "", swift_module or ""),
     )
     resource_actions.link_storyboards(
         actions = actions,
@@ -598,6 +632,7 @@ def _texture_atlases(
         *,
         actions,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -616,9 +651,10 @@ def _texture_atlases(
             paths.replace_extension(paths.basename(atlas_path), ".atlasc"),
         )
         atlasc_dir = intermediates.directory(
-            actions,
-            rule_label.name,
-            atlasc_path,
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            dir_name = atlasc_path,
         )
         resource_actions.compile_texture_atlas(
             actions = actions,
@@ -640,6 +676,7 @@ def _xibs(
         actions,
         apple_toolchain_info,
         files,
+        output_discriminator,
         parent_dir,
         platform_prerequisites,
         rule_label,
@@ -651,7 +688,12 @@ def _xibs(
     for file in files.to_list():
         basename = paths.replace_extension(file.basename, "")
         out_path = paths.join("nibs", parent_dir or "", basename)
-        out_dir = intermediates.directory(actions, rule_label.name, out_path)
+        out_dir = intermediates.directory(
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            dir_name = out_path,
+        )
         resource_actions.compile_xib(
             actions = actions,
             input_file = file,

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -203,9 +203,10 @@ def _swift_dylibs_partial_impl(
                     # Swift Support, so we register another action for copying
                     # them without stripping bitcode.
                     swift_support_output_dir = intermediates.directory(
-                        actions,
-                        label_name,
-                        "swiftlibs_for_swiftsupport",
+                        actions = actions,
+                        target_name = label_name,
+                        output_discriminator = output_discriminator,
+                        dir_name = "swiftlibs_for_swiftsupport",
                     )
                     _swift_dylib_action(
                         actions = actions,

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -132,6 +132,7 @@ def _swift_dylibs_partial_impl(
         bundle_dylibs,
         dependency_targets,
         label_name,
+        output_discriminator,
         package_swift_support_if_needed,
         platform_prerequisites):
     """Implementation for the Swift dylibs processing partial."""
@@ -179,9 +180,10 @@ def _swift_dylibs_partial_impl(
         if binaries_to_check:
             platform_name = platform_prerequisites.platform.name_in_plist.lower()
             output_dir = intermediates.directory(
-                actions,
-                label_name,
-                "swiftlibs",
+                actions = actions,
+                target_name = label_name,
+                output_discriminator = output_discriminator,
+                dir_name = "swiftlibs",
             )
             _swift_dylib_action(
                 actions = actions,
@@ -257,6 +259,7 @@ def swift_dylibs_partial(
         bundle_dylibs = False,
         dependency_targets = [],
         label_name,
+        output_discriminator = None,
         package_swift_support_if_needed = False,
         platform_prerequisites):
     """Constructor for the Swift dylibs processing partial.
@@ -272,6 +275,8 @@ def swift_dylibs_partial(
       dependency_targets: List of targets that should be checked for binaries that might contain
         Swift, so that the Swift dylibs can be collected.
       label_name: Name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       package_swift_support_if_needed: Whether the partial should also bundle the Swift dylib for
         each dependency platform into the SwiftSupport directory at the root of the archive. It
         might still not be included depending on what it is being built for.
@@ -289,6 +294,7 @@ def swift_dylibs_partial(
         bundle_dylibs = bundle_dylibs,
         dependency_targets = dependency_targets,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         package_swift_support_if_needed = package_swift_support_if_needed,
         platform_prerequisites = platform_prerequisites,
     )

--- a/apple/internal/partials/swift_dynamic_framework.bzl
+++ b/apple/internal/partials/swift_dynamic_framework.bzl
@@ -61,26 +61,42 @@ frameworks expect a single swift_library dependency with `module_name` set to th
     modules_parent = paths.join("Modules", "{}.swiftmodule".format(bundle_name))
 
     for arch, swiftdoc in swiftdocs.items():
-        bundle_doc = intermediates.file(actions, label_name, "{}.swiftdoc".format(arch))
+        bundle_doc = intermediates.file(
+            actions = actions,
+            file_name = "{}.swiftdoc".format(arch),
+            output_discriminator = None,
+            target_name = label_name,
+        )
         actions.symlink(target_file = swiftdoc, output = bundle_doc)
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_doc])))
 
     for arch, swiftmodule in swiftmodules.items():
-        bundle_doc = intermediates.file(actions, label_name, "{}.swiftmodule".format(arch))
+        bundle_doc = intermediates.file(
+            actions = actions,
+            file_name = "{}.swiftmodule".format(arch),
+            output_discriminator = None,
+            target_name = label_name,
+        )
         actions.symlink(target_file = swiftmodule, output = bundle_doc)
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_doc])))
 
     if generated_header:
         bundle_header = intermediates.file(
-            actions,
-            label_name,
-            "{}.h".format(bundle_name),
+            actions = actions,
+            file_name = "{}.h".format(bundle_name),
+            output_discriminator = None,
+            target_name = label_name,
         )
         actions.symlink(target_file = generated_header, output = bundle_header)
         bundle_files.append((processor.location.bundle, "Headers", depset([bundle_header])))
 
     if modulemap_file:
-        modulemap = intermediates.file(actions, label_name, "module.modulemap")
+        modulemap = intermediates.file(
+            actions = actions,
+            file_name = "module.modulemap",
+            output_discriminator = None,
+            target_name = label_name,
+        )
         actions.symlink(target_file = modulemap_file, output = modulemap)
         bundle_files.append((processor.location.bundle, "Modules", depset([modulemap])))
 

--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -45,6 +45,7 @@ def _swift_static_framework_partial_impl(
         actions,
         bundle_name,
         label_name,
+        output_discriminator,
         swift_static_framework_info):
     """Implementation for the Swift static framework processing partial."""
 
@@ -68,9 +69,10 @@ frameworks expect a single swift_library dependency with `module_name` set to th
 
     for arch, swiftinterface in swiftinterfaces.items():
         bundle_interface = intermediates.file(
-            actions,
-            label_name,
-            "{}.swiftinterface".format(arch),
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "{}.swiftinterface".format(arch),
         )
         actions.symlink(
             target_file = swiftinterface,
@@ -79,7 +81,12 @@ frameworks expect a single swift_library dependency with `module_name` set to th
         bundle_files.append((processor.location.bundle, modules_parent, depset([bundle_interface])))
 
     for arch, swiftdoc in swiftdocs.items():
-        bundle_doc = intermediates.file(actions, label_name, "{}.swiftdoc".format(arch))
+        bundle_doc = intermediates.file(
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "{}.swiftdoc".format(arch),
+        )
         actions.symlink(
             target_file = swiftdoc,
             output = bundle_doc,
@@ -88,9 +95,10 @@ frameworks expect a single swift_library dependency with `module_name` set to th
 
     if generated_header:
         bundle_header = intermediates.file(
-            actions,
-            label_name,
-            "{}.h".format(expected_module_name),
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "{}.h".format(expected_module_name),
         )
         actions.symlink(
             target_file = generated_header,
@@ -98,7 +106,12 @@ frameworks expect a single swift_library dependency with `module_name` set to th
         )
         bundle_files.append((processor.location.bundle, "Headers", depset([bundle_header])))
 
-        modulemap = intermediates.file(actions, label_name, "module.modulemap")
+        modulemap = intermediates.file(
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "module.modulemap",
+        )
         actions.write(modulemap, _modulemap_contents(expected_module_name))
         bundle_files.append((processor.location.bundle, "Modules", depset([modulemap])))
 
@@ -109,6 +122,7 @@ def swift_static_framework_partial(
         actions,
         bundle_name,
         label_name,
+        output_discriminator = None,
         swift_static_framework_info):
     """Constructor for the Swift static framework processing partial.
 
@@ -119,6 +133,8 @@ def swift_static_framework_partial(
         actions: The actions provider from `ctx.actions`.
         bundle_name: The name of the output bundle.
         label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         swift_static_framework_info: The SwiftStaticFrameworkInfo provider containing the required
             artifacts.
 
@@ -131,5 +147,6 @@ def swift_static_framework_partial(
         actions = actions,
         bundle_name = bundle_name,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         swift_static_framework_info = swift_static_framework_info,
     )

--- a/apple/internal/partials/watchos_stub.bzl
+++ b/apple/internal/partials/watchos_stub.bzl
@@ -44,6 +44,7 @@ def _watchos_stub_partial_impl(
         actions,
         binary_artifact,
         label_name,
+        output_discriminator,
         watch_application):
     """Implementation for the watchOS stub processing partial."""
 
@@ -52,9 +53,10 @@ def _watchos_stub_partial_impl(
     if binary_artifact:
         # Create intermediate file with proper name for the binary.
         intermediate_file = intermediates.file(
-            actions,
-            label_name,
-            "WK",
+            actions = actions,
+            target_name = label_name,
+            output_discriminator = output_discriminator,
+            file_name = "WK",
         )
         actions.symlink(
             target_file = binary_artifact,
@@ -81,6 +83,7 @@ def watchos_stub_partial(
         actions,
         binary_artifact = None,
         label_name,
+        output_discriminator = None,
         watch_application = None):
     """Constructor for the watchOS stub processing partial.
 
@@ -92,6 +95,8 @@ def watchos_stub_partial(
         actions: The actions provider from `ctx.actions`.
         binary_artifact: The stub binary to copy.
         label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         watch_application: Optional. A reference to the watch application associated with the rule.
             If defined, this partial will package the watchOS stub binary in the archive root.
 
@@ -103,5 +108,6 @@ def watchos_stub_partial(
         actions = actions,
         binary_artifact = binary_artifact,
         label_name = label_name,
+        output_discriminator = output_discriminator,
         watch_application = watch_application,
     )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -229,10 +229,11 @@ def _bundle_partial_outputs_files(
         extra_input_files = [],
         ipa_post_processor = None,
         label_name,
+        output_discriminator,
+        output_file,
         partial_outputs,
         platform_prerequisites,
         provisioning_profile,
-        output_file,
         rule_descriptor):
     """Invokes bundletool to bundle the files specified by the partial outputs.
 
@@ -248,11 +249,13 @@ def _bundle_partial_outputs_files(
       extra_input_files: Extra files to include in the bundling action.
       ipa_post_processor: A file that acts as a bundle post processing tool. May be `None`.
       label_name: The name of the target being built.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
+      output_file: The file where the final zipped bundle should be created.
       partial_outputs: List of partial outputs from which to collect the files
         that will be bundled inside the final archive.
       platform_prerequisites: Struct containing information on the platform being targeted.
       provisioning_profile: File for the provisioning profile.
-      output_file: The file where the final zipped bundle should be created.
       rule_descriptor: A rule descriptor for platform and product types from the rule context.
     """
 
@@ -379,9 +382,10 @@ def _bundle_partial_outputs_files(
         control_file_name = "bundletool_control.json"
 
     control_file = intermediates.file(
-        actions,
-        label_name,
-        control_file_name,
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = control_file_name,
     )
     actions.write(
         output = control_file,
@@ -462,6 +466,7 @@ def _bundle_post_process_and_sign(
         executable_name,
         ipa_post_processor,
         output_archive,
+        output_discriminator,
         partial_outputs,
         platform_prerequisites,
         predeclared_outputs,
@@ -482,6 +487,8 @@ def _bundle_post_process_and_sign(
         executable_name: The name of the output executable.
         ipa_post_processor: A file that acts as a bundle post processing tool. May be `None`.
         output_archive: The file representing the final bundled, post-processed and signed archive.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         partial_outputs: The outputs of the partials used to process this target's bundle.
         platform_prerequisites: Struct containing information on the platform being targeted.
         predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`.
@@ -536,10 +543,11 @@ def _bundle_post_process_and_sign(
             extra_input_files = extra_input_files,
             ipa_post_processor = ipa_post_processor,
             label_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            output_file = output_archive,
             partial_outputs = partial_outputs,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = provisioning_profile,
-            output_file = output_archive,
             rule_descriptor = rule_descriptor,
         )
 
@@ -551,9 +559,10 @@ def _bundle_post_process_and_sign(
         # This output, while an intermediate artifact not exposed through the AppleBundleInfo
         # provider, is used by Tulsi for custom processing logic. (b/120221708)
         unprocessed_archive = intermediates.file(
-            actions,
-            rule_label.name,
-            "unprocessed_archive.zip",
+            actions = actions,
+            target_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            file_name = "unprocessed_archive.zip",
         )
         _bundle_partial_outputs_files(
             actions = actions,
@@ -562,10 +571,11 @@ def _bundle_post_process_and_sign(
             bundle_name = bundle_name,
             ipa_post_processor = ipa_post_processor,
             label_name = rule_label.name,
+            output_discriminator = output_discriminator,
+            output_file = unprocessed_archive,
             partial_outputs = partial_outputs,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = provisioning_profile,
-            output_file = unprocessed_archive,
             rule_descriptor = rule_descriptor,
         )
 
@@ -587,6 +597,7 @@ def _bundle_post_process_and_sign(
             label_name = rule_label.name,
             output_archive = output_archive,
             output_archive_root_path = output_archive_root_path,
+            output_discriminator = output_discriminator,
             platform_prerequisites = platform_prerequisites,
             process_and_sign_template = process_and_sign_template,
             provisioning_profile = provisioning_profile,
@@ -621,9 +632,10 @@ def _bundle_post_process_and_sign(
             embedding_frameworks_path = embedding_archive_paths[_LOCATION_ENUM.framework]
             embedding_archive_root_path = outputs.root_path_from_archive(archive = embedding_archive)
             unprocessed_embedded_archive = intermediates.file(
-                actions,
-                rule_label.name,
-                "unprocessed_embedded_archive.zip",
+                actions = actions,
+                target_name = rule_label.name,
+                output_discriminator = output_discriminator,
+                file_name = "unprocessed_embedded_archive.zip",
             )
             _bundle_partial_outputs_files(
                 actions = actions,
@@ -633,10 +645,11 @@ def _bundle_post_process_and_sign(
                 embedding = True,
                 ipa_post_processor = ipa_post_processor,
                 label_name = rule_label.name,
+                output_discriminator = output_discriminator,
+                output_file = unprocessed_embedded_archive,
                 partial_outputs = partial_outputs,
                 platform_prerequisites = platform_prerequisites,
                 provisioning_profile = provisioning_profile,
-                output_file = unprocessed_embedded_archive,
                 rule_descriptor = rule_descriptor,
             )
 
@@ -652,6 +665,7 @@ def _bundle_post_process_and_sign(
                 label_name = rule_label.name,
                 output_archive = embedding_archive,
                 output_archive_root_path = embedding_archive_root_path,
+                output_discriminator = output_discriminator,
                 platform_prerequisites = platform_prerequisites,
                 process_and_sign_template = process_and_sign_template,
                 provisioning_profile = provisioning_profile,
@@ -672,6 +686,7 @@ def _process(
         entitlements,
         executable_name,
         ipa_post_processor,
+        output_discriminator = None,
         partials,
         platform_prerequisites,
         predeclared_outputs,
@@ -693,6 +708,8 @@ def _process(
       entitlements: The entitlements file to sign with. Can be `None` if one was not provided.
       executable_name: The name of the output executable.
       ipa_post_processor: A file that acts as a bundle post processing tool. May be `None`.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       partials: The list of partials to process to construct the complete bundle.
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`.
@@ -729,6 +746,7 @@ def _process(
             entitlements = entitlements,
             ipa_post_processor = ipa_post_processor,
             output_archive = output_archive,
+            output_discriminator = output_discriminator,
             partial_outputs = partial_outputs,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -246,9 +246,10 @@ def compile_asset_catalog(
         if alternate_icons:
             alticons_outputs = [output_plist]
             actool_output_plist = intermediates.file(
-                actions,
-                rule_label.name,
-                "{}.noalticon.plist".format(output_plist.basename),
+                actions = actions,
+                target_name = rule_label.name,
+                output_discriminator = None,
+                file_name = "{}.noalticon.plist".format(output_plist.basename),
             )
         else:
             actool_output_plist = output_plist

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -118,6 +118,7 @@ def merge_resource_infoplists(
         bundle_id,
         bundle_name_with_extension,
         input_files,
+        output_discriminator,
         output_plist,
         platform_prerequisites,
         resolved_plisttool,
@@ -129,6 +130,8 @@ def merge_resource_infoplists(
       bundle_id: The bundle ID to use when templating plist files.
       bundle_name_with_extension: The full name of the bundle where the plist will be placed.
       input_files: The list of plists to merge.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       output_plist: The file reference for the output plist.
       platform_prerequisites: Struct containing information on the platform being targeted.
       resolved_plisttool: A struct referencing the resolved plist tool.
@@ -160,9 +163,10 @@ def merge_resource_infoplists(
     )
 
     control_file = intermediates.file(
-        actions,
-        rule_label.name,
-        paths.join(bundle_name_with_extension, "%s-control" % output_plist.basename),
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        file_name = paths.join(bundle_name_with_extension, "%s-control" % output_plist.basename),
     )
     actions.write(
         output = control_file,
@@ -192,6 +196,7 @@ def merge_root_infoplists(
         include_executable_name = True,
         input_plists,
         launch_storyboard,
+        output_discriminator,
         output_plist,
         output_pkginfo,
         platform_prerequisites,
@@ -224,6 +229,8 @@ def merge_root_infoplists(
           plists embedded in a command line tool which don't need this value.
       input_plists: The root plist files to merge.
       launch_storyboard: A file to be used as a launch screen for the application.
+      output_discriminator: A string to differentiate between different target intermediate files
+          or `None`.
       output_pkginfo: The file reference for the PkgInfo file. Can be None if not
         required.
       output_plist: The file reference for the merged output plist.
@@ -359,9 +366,10 @@ def merge_root_infoplists(
     )
 
     control_file = intermediates.file(
-        actions,
-        rule_label.name,
-        "%s-root-control" % output_plist.basename,
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        file_name = "%s-root-control" % output_plist.basename,
     )
     actions.write(
         output = control_file,

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -353,6 +353,7 @@ def _process_bucketized_data(
         bucketized_owners = [],
         buckets,
         bundle_id,
+        output_discriminator = None,
         platform_prerequisites,
         processing_owner = None,
         product_type,
@@ -371,6 +372,8 @@ def _process_bucketized_data(
         bucketized_owners: A list of tuples indicating the owner of each bucketized resource.
         buckets: A dictionary with bucketized resources organized by resource type.
         bundle_id: The bundle ID to configure for this target.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         platform_prerequisites: Struct containing information on the platform being targeted.
         processing_owner: An optional string that has a unique identifier to the target that should
             own the resources. If an owner should be passed, it's usually equal to `str(ctx.label)`.
@@ -397,6 +400,7 @@ def _process_bucketized_data(
                 "apple_toolchain_info": apple_toolchain_info,
                 "bundle_id": bundle_id,
                 "files": files,
+                "output_discriminator": output_discriminator,
                 "parent_dir": parent_dir,
                 "platform_prerequisites": platform_prerequisites,
                 "product_type": product_type,

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -23,11 +23,19 @@ load(
     "intermediates",
 )
 
-def _create_stub_binary(*, actions, platform_prerequisites, rule_label, xcode_stub_path):
+def _create_stub_binary(
+        *,
+        actions,
+        output_discriminator = None,
+        platform_prerequisites,
+        rule_label,
+        xcode_stub_path):
     """Returns a symlinked stub binary from the Xcode distribution.
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
         platform_prerequisites: Struct containing information on the platform being targeted.
         rule_label: The label of the target being analyzed.
         xcode_stub_path: The Xcode SDK root relative path to where the stub binary is to be copied
@@ -37,9 +45,10 @@ def _create_stub_binary(*, actions, platform_prerequisites, rule_label, xcode_st
         A File reference to the stub binary artifact.
     """
     binary_artifact = intermediates.file(
-        actions,
-        rule_label.name,
-        "StubBinary",
+        actions = actions,
+        target_name = rule_label.name,
+        output_discriminator = output_discriminator,
+        file_name = "StubBinary",
     )
 
     # TODO(b/79323243): Replace this with a symlink instead of a hard copy.

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -331,6 +331,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -158,6 +158,7 @@ def _tvos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -394,6 +395,7 @@ def _tvos_dynamic_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -588,6 +590,7 @@ def _tvos_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -765,6 +768,7 @@ def _tvos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -913,6 +917,7 @@ def _tvos_static_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -186,6 +186,7 @@ def _watchos_dynamic_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -391,6 +392,7 @@ def _watchos_application_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),
@@ -602,6 +604,7 @@ def _watchos_extension_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = ctx.label.name,
         ),
@@ -768,6 +771,7 @@ def _watchos_static_framework_impl(ctx):
         partials.binary_partial(
             actions = actions,
             binary_artifact = binary_artifact,
+            bundle_name = bundle_name,
             executable_name = executable_name,
             label_name = label.name,
         ),


### PR DESCRIPTION
Added a comment to the resource aspect to indicate how future usage of this argument should work, for the purposes of keeping aspect-based resource processing in sync with top level resource processing.

PiperOrigin-RevId: 379610868
(cherry picked from commit 89f04b742ecf60487462fe7dc5ee130d1f2c8bf1)
