### PR TITLE
Refactor the Swift compilation APIs to use a style similar to the C++ APIs.

### DIFF
--- a/apple/internal/aspects/swift_static_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_static_framework_aspect.bzl
@@ -144,7 +144,7 @@ swift_library dependency with no transitive swift_library dependencies.\
                 # If this is both a Swift and a Clang module, then the header in its compilation
                 # context is its Swift generated header.
                 if module.swift and module.clang:
-                    headers = module.clang.compilation_context.headers.to_list()
+                    headers = module.clang.compilation_context.direct_headers
                     if headers:
                         generated_header = headers[0]
 


### PR DESCRIPTION
## Changes to compilation

`swift_common.compile` now returns a tuple with two elements, very similar to `cc_common.compile`:

1. A "module context" (the same kind of value returned by `swift_common.create_module` that has `clang` and `swift` fields)
2. A `CcCompilationOutputs` object containing the object files.

The returned module context is slightly different than those propagated by the rules previously, in that its `clang` field will be present even if the Swift module doesn't propagate a Clang module. This is so that callers can easily retrieve its `compilation_context` and return it in a `CcInfo` provider. Therefore, callers who want to know whether a module context exposes a Clang module should check the `clang.module_map` field rather than just the `clang` field; it will be `None` if there is no Clang module.

## Changes to linking

A new method, `swift_common.create_linking_context_from_compilation_outputs`, has also been added, which provides similar functionality to the `cc_common` method of the same name. This takes the module context and compilation outputs from the `compile` call and produces a `LinkingContext` that can be returned in a `CcInfo` provider.

Of particular note, any toolchain-specific post-compile actions, such as module-wrapping or autolink extraction, have been moved into `create_linking_context_from_compilation_outputs`; they are no longer outputs of `compile`. This provides a clean API division between what is strictly compilation vs. the other supplemental outputs/flags that are passed to the linker, without making extra work to ensure that those outputs are generated.

PiperOrigin-RevId: 380030635
(cherry picked from commit ccc3843bc78999e795ff81bf34c7344329af4047)
