### PR TITLE
Move `-install_name` linker flag from the `{ios,tvos}_framework` macro into the rule implementation.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -632,21 +632,6 @@ def _ios_app_clip_impl(ctx):
 
 def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
-
-    # TODO(kaipi): Add support for packaging headers.
-    extra_linkopts = ["-dynamiclib"]
-    if ctx.attr.extension_safe:
-        extra_linkopts.append("-fapplication-extension")
-
-    link_result = linking_support.register_linking_action(
-        ctx,
-        avoid_deps = ctx.attr.frameworks,
-        extra_linkopts = extra_linkopts,
-        stamp = ctx.attr.stamp,
-    )
-    binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
-
     actions = ctx.actions
     apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
     bin_root_path = ctx.bin_dir.path
@@ -679,6 +664,25 @@ def _ios_framework_impl(ctx):
         attr = ctx.attr,
         res_attrs = ["resources"],
     )
+
+    extra_linkopts = [
+        "-dynamiclib",
+        "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
+            extension = bundle_extension,
+            name = bundle_name,
+        ),
+    ]
+    if ctx.attr.extension_safe:
+        extra_linkopts.append("-fapplication-extension")
+
+    link_result = linking_support.register_linking_action(
+        ctx,
+        avoid_deps = ctx.attr.frameworks,
+        extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
+    )
+    binary_artifact = link_result.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -1078,18 +1082,6 @@ def _ios_dynamic_framework_impl(ctx):
         )
 
     binary_target = ctx.attr.deps[0]
-    extra_linkopts = ["-dynamiclib"]
-    if ctx.attr.extension_safe:
-        extra_linkopts.append("-fapplication-extension")
-
-    link_result = linking_support.register_linking_action(
-        ctx,
-        avoid_deps = ctx.attr.frameworks,
-        extra_linkopts = extra_linkopts,
-        stamp = ctx.attr.stamp,
-    )
-    binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
@@ -1130,6 +1122,25 @@ def _ios_dynamic_framework_impl(ctx):
         signed_frameworks = [
             bundle_name + rule_descriptor.bundle_extension,
         ]
+
+    extra_linkopts = [
+        "-dynamiclib",
+        "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
+            extension = bundle_extension,
+            name = bundle_name,
+        ),
+    ]
+    if ctx.attr.extension_safe:
+        extra_linkopts.append("-fapplication-extension")
+
+    link_result = linking_support.register_linking_action(
+        ctx,
+        avoid_deps = ctx.attr.frameworks,
+        extra_linkopts = extra_linkopts,
+        stamp = ctx.attr.stamp,
+    )
+    binary_artifact = link_result.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -333,14 +333,6 @@ def _tvos_dynamic_framework_impl(ctx):
         )
 
     binary_target = ctx.attr.deps[0]
-    link_result = linking_support.register_linking_action(
-        ctx,
-        avoid_deps = ctx.attr.frameworks,
-        extra_linkopts = ["-dynamiclib"],
-        stamp = ctx.attr.stamp,
-    )
-    binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
 
     actions = ctx.actions
     apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
@@ -380,6 +372,21 @@ def _tvos_dynamic_framework_impl(ctx):
         signed_frameworks = [
             bundle_name + rule_descriptor.bundle_extension,
         ]
+
+    link_result = linking_support.register_linking_action(
+        ctx,
+        avoid_deps = ctx.attr.frameworks,
+        extra_linkopts = [
+            "-dynamiclib",
+            "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
+                extension = bundle_extension,
+                name = bundle_name,
+            ),
+        ],
+        stamp = ctx.attr.stamp,
+    )
+    binary_artifact = link_result.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     archive = outputs.archive(
         actions = actions,
@@ -538,15 +545,6 @@ def _tvos_dynamic_framework_impl(ctx):
 
 def _tvos_framework_impl(ctx):
     """Experimental implementation of tvos_framework."""
-    link_result = linking_support.register_linking_action(
-        ctx,
-        avoid_deps = ctx.attr.frameworks,
-        extra_linkopts = ["-dynamiclib"],
-        stamp = ctx.attr.stamp,
-    )
-    binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
-
     actions = ctx.actions
     apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
     bin_root_path = ctx.bin_dir.path
@@ -579,6 +577,21 @@ def _tvos_framework_impl(ctx):
         attr = ctx.attr,
         res_attrs = ["resources"],
     )
+
+    link_result = linking_support.register_linking_action(
+        ctx,
+        avoid_deps = ctx.attr.frameworks,
+        extra_linkopts = [
+            "-dynamiclib",
+            "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
+                extension = bundle_extension,
+                name = bundle_name,
+            ),
+        ],
+        stamp = ctx.attr.stamp,
+    )
+    binary_artifact = link_result.binary
+    debug_outputs_provider = link_result.debug_outputs_provider
 
     archive = outputs.archive(
         actions = actions,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -95,22 +95,12 @@ def ios_extension(name, **kwargs):
 def ios_framework(name, **kwargs):
     # buildifier: disable=function-docstring-args
     """Builds and bundles an iOS dynamic framework."""
-    binary_args = dict(kwargs)
-
-    # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
-    # API does not accept extra linkopts and link inputs. With those, it will be possible to merge
-    # these workarounds into the rule implementations.
-    bundle_name = binary_args.get("bundle_name", name)
-    binary_args["linkopts"] = binary_args.pop("linkopts", []) + [
-        "-install_name,@rpath/%s.framework/%s" % (bundle_name, bundle_name),
-    ]
-
     bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.framework,
-        **binary_args
+        **kwargs
     )
 
     # Remove any kwargs that shouldn't be passed to the underlying rule.
@@ -124,24 +114,13 @@ def ios_framework(name, **kwargs):
 def ios_dynamic_framework(name, **kwargs):
     # buildifier: disable=function-docstring-args
     """Builds and bundles an iOS dynamic framework that is consumable by Xcode."""
-
-    binary_args = dict(kwargs)
-
-    # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
-    # API does not accept extra linkopts and link inputs. With those, it will be possible to merge
-    # these workarounds into the rule implementations.
-    bundle_name = binary_args.get("bundle_name", name)
-    binary_args["linkopts"] = binary_args.pop("linkopts", []) + [
-        "-install_name",
-        "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
-    ]
     bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.ios),
         product_type = apple_product_type.framework,
-        exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
-        **binary_args
+        exported_symbols_lists = kwargs.pop("exported_symbols_lists", None),
+        **kwargs
     )
 
     # Remove any kwargs that shouldn't be passed to the underlying rule.

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -77,21 +77,11 @@ def tvos_extension(name, **kwargs):
 def tvos_framework(name, **kwargs):
     # buildifier: disable=function-docstring-args
     """Builds and bundles a tvOS dynamic framework."""
-    binary_args = dict(kwargs)
-
-    # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
-    # API does not accept extra linkopts and link inputs. With those, it will be possible to merge
-    # these workarounds into the rule implementations.
-    bundle_name = binary_args.get("bundle_name", name)
-    binary_args["linkopts"] = binary_args.pop("linkopts", []) + [
-        "-install_name,@rpath/%s.framework/%s" % (bundle_name, bundle_name),
-    ]
-
     bundling_args = binary_support.add_entitlements(
         name,
         platform_type = str(apple_common.platform_type.tvos),
         product_type = apple_product_type.framework,
-        **binary_args
+        **kwargs
     )
 
     # Remove any kwargs that shouldn't be passed to the underlying rule.
@@ -156,24 +146,13 @@ def tvos_ui_test(name, **kwargs):
 def tvos_dynamic_framework(name, **kwargs):
     # buildifier: disable=function-docstring-args
     """Builds and bundles a tvOS dynamic framework that is consumable by Xcode."""
-
-    binary_args = dict(kwargs)
-
-    # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
-    # API does not accept extra linkopts and link inputs. With those, it will be possible to merge
-    # these workarounds into the rule implementations.
-    bundle_name = binary_args.get("bundle_name", name)
-    binary_args["linkopts"] = binary_args.pop("linkopts", []) + [
-        "-install_name",
-        "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
-    ]
     bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.watchos),
         product_type = apple_product_type.framework,
-        exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
-        **binary_args
+        exported_symbols_lists = kwargs.pop("exported_symbols_lists", None),
+        **kwargs
     )
 
     # Remove any kwargs that shouldn't be passed to the underlying rule.

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -81,24 +81,13 @@ def watchos_extension(name, **kwargs):
 def watchos_dynamic_framework(name, **kwargs):
     # buildifier: disable=function-docstring-args
     """Builds and bundles a watchOS dynamic framework that is consumable by Xcode."""
-
-    binary_args = dict(kwargs)
-
-    # TODO(b/120861201): The linkopts macro additions here only exist because the Starlark linking
-    # API does not accept extra linkopts and link inputs. With those, it will be possible to merge
-    # these workarounds into the rule implementations.
-    bundle_name = binary_args.get("bundle_name", name)
-    binary_args["linkopts"] = binary_args.pop("linkopts", []) + [
-        "-install_name",
-        "@rpath/%s.framework/%s" % (bundle_name, bundle_name),
-    ]
     bundling_args = binary_support.add_entitlements(
         name,
         include_entitlements = False,
         platform_type = str(apple_common.platform_type.watchos),
         product_type = apple_product_type.framework,
-        exported_symbols_lists = binary_args.pop("exported_symbols_lists", None),
-        **binary_args
+        exported_symbols_lists = kwargs.pop("exported_symbols_lists", None),
+        **kwargs
     )
 
     # Remove any kwargs that shouldn't be passed to the underlying rule.


### PR DESCRIPTION
PiperOrigin-RevId: 382086173
(cherry picked from commit 172ad76549d732b3380bef6a7c255c32cc4462d3)

Conflicts:
	apple/internal/ios_rules.bzl
	apple/internal/tvos_rules.bzl
	apple/ios.bzl
	apple/tvos.bzl
