### PR TITLE
Adding false-positive guard for `momc` code generation

### DIFF
--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -343,7 +343,7 @@ def intentbuilderc(args, toolargs):
 
   return return_code
 
-def momc(_, toolargs):
+def momc(args, toolargs):
   """Assemble the call to "xcrun momc"."""
   xcrunargs = ["xcrun", "momc"]
   _apply_realpath(toolargs)
@@ -352,6 +352,13 @@ def momc(_, toolargs):
   return_code, _, _ = execute.execute_and_filter_output(
       xcrunargs,
       print_output=True)
+
+  destination_dir = args.xctoolrunner_assert_nonempty_dir
+  if args.xctoolrunner_assert_nonempty_dir and not os.listdir(destination_dir):
+    raise FileNotFoundError(
+        f"xcrun momc did not generate artifacts at: {destination_dir}\n"
+        "Core Data model was not configured to have code generation.")
+
   return return_code
 
 
@@ -394,6 +401,9 @@ def main(argv):
 
   # MOMC Argument Parser
   momc_parser = subparsers.add_parser("momc")
+  momc_parser.add_argument(
+      "--xctoolrunner_assert_nonempty_dir",
+      help="Enables non-empty destination dir assertion after execution.")
   momc_parser.set_defaults(func=momc)
 
   # MAPC Argument Parser


### PR DESCRIPTION
This change adds a proactive false-positive guard for momc code
generation where return code is successful but no artifacts were
generated. This behavior happens when a Core Data model was not
configured to have code generation.

PiperOrigin-RevId: 386905643
(cherry picked from commit 0bfbc86de2f226336e8b779b03a6e100ffbefd1b)
