### PR TITLE
Allow tests to consume files under `doc`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,7 @@ filegroup(
     srcs = [
         "WORKSPACE",
         "//apple:for_bazel_tests",
+        "//doc:for_bazel_tests",
         "//tools:for_bazel_tests",
         "@build_bazel_apple_support//:for_bazel_tests",
         "@build_bazel_rules_swift//:for_bazel_tests",

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -85,3 +85,11 @@ sh_binary(
     srcs = ["update.sh"],
     data = [file + ".md" for file in _DOC_SRCS],
 )
+
+# Consumed by bazel tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)


### PR DESCRIPTION
So that it can reference to the patch file.
