### PR TITLE
Adding Core Data model rule for code generation

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -113,6 +113,7 @@ bzl_library(
     srcs = ["resources.bzl"],
     deps = [
         "//apple/internal/resource_rules:apple_bundle_import",
+        "//apple/internal/resource_rules:apple_core_data_model",
         "//apple/internal/resource_rules:apple_core_ml_library",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",

--- a/apple/internal/resource_actions.bzl
+++ b/apple/internal/resource_actions.bzl
@@ -22,6 +22,7 @@ load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:datamodel.bzl",
     _compile_datamodels = "compile_datamodels",
     _compile_mappingmodel = "compile_mappingmodel",
+    _generate_datamodels = "generate_datamodels",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:ibtool.bzl",
@@ -69,6 +70,7 @@ resource_actions = struct(
     compile_texture_atlas = _compile_texture_atlas,
     compile_xib = _compile_xib,
     copy_png = _copy_png,
+    generate_datamodels = _generate_datamodels,
     generate_intent_classes_sources = _generate_intent_classes_sources,
     generate_objc_mlmodel_sources = _generate_objc_mlmodel_sources,
     link_storyboards = _link_storyboards,

--- a/apple/internal/resource_rules/BUILD
+++ b/apple/internal/resource_rules/BUILD
@@ -54,6 +54,24 @@ bzl_library(
 )
 
 bzl_library(
+    name = "apple_core_data_model",
+    srcs = ["apple_core_data_model.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "//apple:providers",
+        "//apple:utils",
+        "//apple/internal:platform_support",
+        "//apple/internal:resource_actions",
+        "//apple/internal:rule_factory",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_apple_support//lib:apple_support",
+    ],
+)
+
+bzl_library(
     name = "apple_resource_bundle",
     srcs = ["apple_resource_bundle.bzl"],
     visibility = [

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -1,0 +1,125 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of Apple Core Data Model resource rule."""
+
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "resource_actions",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleSupportToolchainInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "platform_support",
+)
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
+)
+
+def _apple_core_data_model_impl(ctx):
+    """Implementation of the apple_core_data_model."""
+    actions = ctx.actions
+    swift_version = getattr(ctx.attr, "swift_version")
+    apple_toolchain_info = ctx.attr._toolchain[AppleSupportToolchainInfo]
+
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        device_families = None,
+        objc_fragment = None,
+        platform_type_string = str(
+            ctx.fragments.apple.single_arch_platform.platform_type,
+        ),
+        uses_swift = True,
+        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
+        xcode_version_config =
+            ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
+
+    datamodel_groups = group_files_by_directory(
+        ctx.files.srcs,
+        ["xcdatamodeld"],
+        attr = "datamodels",
+    )
+
+    output_files = []
+    for datamodel_path, files in datamodel_groups.items():
+        datamodel_name = paths.replace_extension(
+            paths.basename(datamodel_path),
+            "",
+        )
+
+        dir_name = "{}.{}.coredata.sources".format(
+            datamodel_name.lower(),
+            ctx.label.name,
+        )
+        output_dir = actions.declare_directory(dir_name)
+
+        resource_actions.generate_datamodels(
+            actions = actions,
+            datamodel_path = datamodel_path,
+            input_files = files.to_list(),
+            output_dir = output_dir,
+            platform_prerequisites = platform_prerequisites,
+            resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
+            swift_version = swift_version,
+        )
+
+        output_files.append(output_dir)
+
+    return [DefaultInfo(files = depset(output_files))]
+
+apple_core_data_model = rule(
+    implementation = _apple_core_data_model_impl,
+    attrs = dicts.add(
+        rule_factory.common_tool_attributes,
+        apple_support.action_required_attrs(),
+        {
+            "srcs": attr.label_list(
+                allow_empty = False,
+                allow_files = ["contents"],
+                mandatory = True,
+            ),
+            "swift_version": attr.string(
+                doc = "Target Swift version for generated classes.",
+            ),
+        },
+    ),
+    fragments = ["apple"],
+    doc = """
+This rule takes a Core Data model definition from a .xcdatamodeld bundle
+and generates Swift or Objective-C source files that can be added as a
+dependency to a swift_library target.
+""",
+)

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -57,6 +57,10 @@ def _apple_core_data_model_impl(ctx):
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
         device_families = None,
+        disabled_features = ctx.disabled_features,
+        explicit_minimum_deployment_os = None,
+        explicit_minimum_os = None,
+        features = ctx.features,
         objc_fragment = None,
         platform_type_string = str(
             ctx.fragments.apple.single_arch_platform.platform_type,

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -35,11 +35,16 @@ load(
     "@build_bazel_rules_apple//apple/internal/resource_rules:apple_resource_group.bzl",
     _apple_resource_group = "apple_resource_group",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_data_model.bzl",
+    _apple_core_data_model = "apple_core_data_model",
+)
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 apple_bundle_import = _apple_bundle_import
 apple_resource_bundle = _apple_resource_bundle
 apple_resource_group = _apple_resource_group
+apple_core_data_model = _apple_core_data_model
 
 # TODO(b/124103649): Create a proper rule when ObjC compilation is available in Starlark.
 # TODO(rdar/48851150): Add support for Swift once the generator supports public interfaces.

--- a/doc/rules-resources.md
+++ b/doc/rules-resources.md
@@ -26,6 +26,30 @@ targets (i.e. `apple_resource_bundle` and `apple_resource_group`) through the
 | <a id="apple_bundle_import-bundle_imports"></a>bundle_imports |  The list of files under a <code>.bundle</code> directory to be propagated to the top-level bundling target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
+<a id="#apple_core_data_model"></a>
+
+## apple_core_data_model
+
+<pre>
+apple_core_data_model(<a href="#apple_core_data_model-name">name</a>, <a href="#apple_core_data_model-srcs">srcs</a>, <a href="#apple_core_data_model-swift_version">swift_version</a>)
+</pre>
+
+
+This rule takes a Core Data model definition from a .xcdatamodeld bundle
+and generates Swift or Objective-C source files that can be added as a
+dependency to a swift_library target.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="apple_core_data_model-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="apple_core_data_model-srcs"></a>srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="apple_core_data_model-swift_version"></a>swift_version |  Target Swift version for generated classes.   | String | optional | "" |
+
+
 <a id="#apple_resource_bundle"></a>
 
 ## apple_resource_bundle

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":apple_bundle_version_tests.bzl", "apple_bundle_version_test_suite")
+load(":apple_core_data_model_tests.bzl", "apple_core_data_model_test_suite")
 load(":dtrace_compile_tests.bzl", "dtrace_compile_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
@@ -41,6 +42,8 @@ load(":watchos_unit_test_tests.bzl", "watchos_unit_test_test_suite")
 licenses(["notice"])
 
 apple_bundle_version_test_suite()
+
+apple_core_data_model_test_suite()
 
 dtrace_compile_test_suite()
 

--- a/test/starlark_tests/apple_core_data_model_tests.bzl
+++ b/test/starlark_tests/apple_core_data_model_tests.bzl
@@ -1,0 +1,106 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""apple_core_data_model Starlark tests."""
+
+load(
+    ":rules/analysis_target_outputs_test.bzl",
+    "analysis_target_outputs_test",
+)
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+    "asserts",
+)
+load(
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
+)
+
+def _analysis_registered_actions_and_mnemonic_impl(ctx):
+    """Tests registers one action per data model file and a single mnemonic."""
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    target_actions = analysistest.target_actions(env)
+    target_files = target_under_test[DefaultInfo].files.to_list()
+    target_mnemonics_set = sets.make([a.mnemonic for a in target_actions])
+    target_mnemonics = sets.to_list(target_mnemonics_set)
+
+    asserts.equals(env, len(target_files), len(target_actions))
+    asserts.equals(env, 1, len(target_mnemonics))
+    asserts.equals(env, "MomGenerate", target_mnemonics[0])
+    return analysistest.end(env)
+
+_analysis_registered_actions_and_mnemonic_test = analysistest.make(
+    _analysis_registered_actions_and_mnemonic_impl,
+)
+
+# buildifier: disable=unnamed-macro
+def apple_core_data_model_test_suite():
+    """Test suite for apple_bundle_version."""
+    name = "apple_core_data_model"
+
+    # Test outputs a directory (non-empty assertion is verified by xctoolrunner).
+    analysis_target_outputs_test(
+        name = "{}_outputs_swift_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:swift_data_model",
+        expected_outputs = ["swift_datamodel.swift_data_model.coredata.sources"],
+        tags = [name],
+    )
+    analysis_target_outputs_test(
+        name = "{}_outputs_objc_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:objc_data_model",
+        expected_outputs = ["objc_datamodel.objc_data_model.coredata.sources"],
+        tags = [name],
+    )
+    analysis_target_outputs_test(
+        name = "{}_outputs_swift_and_objc_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:combined_swift_objc_data_model",
+        expected_outputs = [
+            "swift_datamodel.combined_swift_objc_data_model.coredata.sources",
+            "objc_datamodel.combined_swift_objc_data_model.coredata.sources",
+        ],
+        tags = [name],
+    )
+
+    # Test no code generation data model outputs empty folder (i.e. fails).
+    analysis_target_outputs_test(
+        name = "{}_has_no_outputs_no_code_generation_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:no_code_generation_data_model",
+        expected_outputs = [],
+        tags = [name],
+    )
+
+    # Test registered actions and mnemonics for Obj-C and Swift data models.
+    _analysis_registered_actions_and_mnemonic_test(
+        name = "{}_actions_swift_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:swift_data_model",
+        tags = [name],
+    )
+    _analysis_registered_actions_and_mnemonic_test(
+        name = "{}_actions_objc_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:objc_data_model",
+        tags = [name],
+    )
+    _analysis_registered_actions_and_mnemonic_test(
+        name = "{}_actions_swift_and_objc_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:combined_swift_objc_data_model",
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -554,6 +554,21 @@ filegroup(
 )
 
 filegroup(
+    name = "swift_datamodel",
+    srcs = glob(["core_data_models/swift_datamodel.xcdatamodeld/**"]),
+)
+
+filegroup(
+    name = "objc_datamodel",
+    srcs = glob(["core_data_models/objc_datamodel.xcdatamodeld/**"]),
+)
+
+filegroup(
+    name = "no_code_generation_datamodel",
+    srcs = glob(["core_data_models/no_code_generation_datamodel.xcdatamodeld/**"]),
+)
+
+filegroup(
     name = "unversioned_datamodel",
     srcs = glob(["unversioned_datamodel.xcdatamodel/**"]),
 )

--- a/test/starlark_tests/resources/core_data_models/no_code_generation_datamodel.xcdatamodeld/v1.xcdatamodel/contents
+++ b/test/starlark_tests/resources/core_data_models/no_code_generation_datamodel.xcdatamodeld/v1.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES">
+        <attribute name="attribute" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Entity" positionX="-54" positionY="-9" width="128" height="44"/>
+    </elements>
+</model>

--- a/test/starlark_tests/resources/core_data_models/objc_datamodel.xcdatamodeld/v1.xcdatamodel/contents
+++ b/test/starlark_tests/resources/core_data_models/objc_datamodel.xcdatamodeld/v1.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="category">
+        <attribute name="attribute" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <elements>
+        <element name="Entity" positionX="-54" positionY="-9" width="128" height="44"/>
+    </elements>
+</model>

--- a/test/starlark_tests/resources/core_data_models/swift_datamodel.xcdatamodeld/v1.xcdatamodel/contents
+++ b/test/starlark_tests/resources/core_data_models/swift_datamodel.xcdatamodeld/v1.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="category">
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="Item" positionX="-63" positionY="-18" width="128" height="14"/>
+    </elements>
+</model>

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -218,4 +218,5 @@ apple_core_data_model(
     srcs = [
         "//test/starlark_tests/resources:no_code_generation_datamodel",
     ],
+    tags = ["manual"],
 )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -6,6 +6,10 @@ load(
     "//apple:macos.bzl",
     "macos_bundle",
 )
+load(
+    "//apple:resources.bzl",
+    "apple_core_data_model",
+)
 
 licenses(["notice"])
 
@@ -185,4 +189,33 @@ sh_binary(
         "ipa_post_processor_verify_codesigning.sh",
     ],
     tags = ["requires-darwin"],
+)
+
+apple_core_data_model(
+    name = "swift_data_model",
+    srcs = [
+        "//test/starlark_tests/resources:swift_datamodel",
+    ],
+)
+
+apple_core_data_model(
+    name = "objc_data_model",
+    srcs = [
+        "//test/starlark_tests/resources:objc_datamodel",
+    ],
+)
+
+apple_core_data_model(
+    name = "combined_swift_objc_data_model",
+    srcs = [
+        "//test/starlark_tests/resources:objc_datamodel",
+        "//test/starlark_tests/resources:swift_datamodel",
+    ],
+)
+
+apple_core_data_model(
+    name = "no_code_generation_data_model",
+    srcs = [
+        "//test/starlark_tests/resources:no_code_generation_datamodel",
+    ],
 )


### PR DESCRIPTION
Introduces `apple_core_data_model`, a new experimental rule
to generate Core Data models source files for both Swift and
Objective-C languages from xcdatamodeld bundles.

PiperOrigin-RevId: 386911632
(cherry picked from commit 9dd2d6dc5636b4e2a6535d4ba76bb61eec7cda19)
