### PR TITLE
Enable Apple Silicon iOS simulator support via use of new CPU type. This will be removed in favor of platforms once moved onto the new toolchain resolution system.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+# TODO(b/180572694): Remove ios_sim_arm64 after platforms based toolchain resolution supported.
 # Create a set of public config_settings that can be used in select()s.
 [
     config_setting(
@@ -18,6 +19,7 @@ licenses(["notice"])
         "ios_x86_64",
         "ios_armv7",
         "ios_arm64",
+        "ios_sim_arm64",
         "tvos_x86_64",
         "tvos_arm64",
         "watchos_i386",


### PR DESCRIPTION
PiperOrigin-RevId: 391596112
(cherry picked from commit 2e875c97efb635bf51ba450e669dd5916541200b)