### PR TITLE
Remove skylib patch for HEAD deps job

### DIFF
--- a/.bazelci/update_workspace_to_deps_heads.sh
+++ b/.bazelci/update_workspace_to_deps_heads.sh
@@ -28,8 +28,6 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")\
 \
 git_repository(\
 \    name = "bazel_skylib",\
-\    patches = ["@build_bazel_rules_apple//doc:bazel-skylib.pr307.patch"],\
-\    patch_args = ["-p1"],\
 \    remote = "https://github.com/bazelbuild/bazel-skylib.git",\
 \    branch = "main",\
 )\


### PR DESCRIPTION
This was merged upstream, but is still needed for the release version
patching