### PR TITLE
Add feature flag to disable legacy code signing. This will be used to enable rollout of new manifest driven code signing.

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -302,12 +302,14 @@ def _should_sign_simulator_bundles(
         default = True,
     )
 
-def _should_sign_bundles(*, provisioning_profile, rule_descriptor):
+def _should_sign_bundles(*, provisioning_profile, rule_descriptor, features):
     should_sign_bundles = True
 
     codesigning_exceptions = rule_descriptor.codesigning_exceptions
-    if (codesigning_exceptions ==
-        rule_support.codesigning_exceptions.sign_with_provisioning_profile):
+    if "disable_legacy_signing" in features:
+        should_sign_bundles = False
+    elif (codesigning_exceptions ==
+          rule_support.codesigning_exceptions.sign_with_provisioning_profile):
         # If the rule doesn't have a provisioning profile, do not sign the binary or its
         # frameworks.
         if not provisioning_profile:
@@ -322,6 +324,7 @@ def _should_sign_bundles(*, provisioning_profile, rule_descriptor):
 def _codesigning_args(
         *,
         entitlements,
+        features,
         full_archive_path,
         is_framework = False,
         platform_prerequisites,
@@ -331,6 +334,7 @@ def _codesigning_args(
 
     Args:
         entitlements: The entitlements file to sign with. Can be None.
+        features: List of features enabled by the user. Typically from `ctx.features`.
         full_archive_path: The full path to the codesigning target.
         is_framework: If the target is a framework. False by default.
         platform_prerequisites: Struct containing information on the platform being targeted.
@@ -343,6 +347,7 @@ def _codesigning_args(
     should_sign_bundles = _should_sign_bundles(
         provisioning_profile = provisioning_profile,
         rule_descriptor = rule_descriptor,
+        features = features,
     )
     if not should_sign_bundles:
         return []
@@ -379,6 +384,7 @@ def _codesigning_command(
         codesigningtool,
         codesignopts,
         entitlements,
+        features,
         frameworks_path,
         platform_prerequisites,
         provisioning_profile,
@@ -391,6 +397,7 @@ def _codesigning_command(
         codesigningtool: The executable `File` representing the code signing tool.
         codesignopts: Extra options to pass to the `codesign` tool
         entitlements: The entitlements file to sign with. Can be None.
+        features: List of features enabled by the user. Typically from `ctx.features`.
         frameworks_path: The location of the Frameworks directory, relative to the archive.
         platform_prerequisites: Struct containing information on the platform being targeted.
         provisioning_profile: File for the provisioning profile.
@@ -403,6 +410,7 @@ def _codesigning_command(
     should_sign_bundles = _should_sign_bundles(
         provisioning_profile = provisioning_profile,
         rule_descriptor = rule_descriptor,
+        features = features,
     )
     if not should_sign_bundles:
         return ""
@@ -558,6 +566,7 @@ def _post_process_and_sign_archive_action(
         codesign_inputs,
         codesignopts,
         entitlements = None,
+        features,
         frameworks_path,
         input_archive,
         ipa_post_processor,
@@ -579,6 +588,7 @@ def _post_process_and_sign_archive_action(
       codesign_inputs: Extra inputs needed for the `codesign` tool.
       codesignopts: Extra options to pass to the `codesign` tool.
       entitlements: Optional file representing the entitlements to sign with.
+      features: List of features enabled by the user. Typically from `ctx.features`.
       frameworks_path: The Frameworks path relative to the archive.
       input_archive: The `File` representing the archive containing the bundle
           that has not yet been processed or signed.
@@ -610,6 +620,7 @@ def _post_process_and_sign_archive_action(
         codesigningtool = resolved_codesigningtool.executable,
         codesignopts = codesignopts,
         entitlements = entitlements,
+        features = features,
         frameworks_path = frameworks_path,
         platform_prerequisites = platform_prerequisites,
         provisioning_profile = provisioning_profile,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -238,6 +238,7 @@ def _ios_application_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -328,6 +329,7 @@ def _ios_application_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -513,6 +515,7 @@ def _ios_app_clip_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -567,6 +570,7 @@ def _ios_app_clip_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -813,6 +817,7 @@ def _ios_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1025,6 +1030,7 @@ def _ios_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1286,6 +1292,10 @@ def _ios_static_framework_impl(ctx):
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
     )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -1361,6 +1371,7 @@ def _ios_static_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         executable_name = executable_name,
         entitlements = entitlements,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1384,6 +1395,10 @@ def _ios_imessage_application_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     bundle_verification_targets = [struct(target = ctx.attr.extension)]
     embeddable_targets = [ctx.attr.extension]
     entitlements = entitlements_support.entitlements(
@@ -1459,6 +1474,7 @@ def _ios_imessage_application_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -1518,6 +1534,7 @@ def _ios_imessage_application_impl(ctx):
         bundle_name = bundle_name,
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1713,6 +1730,7 @@ def _ios_imessage_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1747,6 +1765,10 @@ def _ios_sticker_pack_extension_impl(ctx):
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
+    )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
@@ -1867,6 +1889,7 @@ def _ios_sticker_pack_extension_impl(ctx):
         bundle_name = bundle_name,
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1243,6 +1243,7 @@ def _ios_dynamic_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -179,6 +179,7 @@ def _macos_application_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -246,6 +247,7 @@ def _macos_application_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -438,6 +440,7 @@ def _macos_bundle_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -612,6 +615,7 @@ def _macos_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -792,6 +796,7 @@ def _macos_quick_look_plugin_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -960,6 +965,7 @@ def _macos_kernel_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1124,6 +1130,7 @@ def _macos_spotlight_importer_impl(ctx):
         codesign_inputs = ctx.files.codesign_inputs,
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1289,6 +1296,7 @@ def _macos_xpc_service_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -1330,6 +1338,10 @@ def _macos_command_line_application_impl(ctx):
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
     )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -1357,6 +1369,7 @@ def _macos_command_line_application_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = None,
         partials = [debug_outputs_partial],
         platform_prerequisites = platform_prerequisites,
@@ -1418,6 +1431,10 @@ def _macos_dylib_impl(ctx):
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
     )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -1445,6 +1462,7 @@ def _macos_dylib_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = None,
         partials = [debug_outputs_partial],
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -55,6 +55,7 @@ def _framework_import_partial_impl(
         *,
         actions,
         apple_toolchain_info,
+        features,
         label_name,
         output_discriminator,
         platform_prerequisites,
@@ -157,6 +158,7 @@ def _framework_import_partial_impl(
 
         codesign_args = codesigning_support.codesigning_args(
             entitlements = None,
+            features = features,
             full_archive_path = temp_framework_bundle_path,
             is_framework = True,
             platform_prerequisites = platform_prerequisites,
@@ -220,6 +222,7 @@ def framework_import_partial(
         *,
         actions,
         apple_toolchain_info,
+        features,
         label_name,
         output_discriminator = None,
         platform_prerequisites,
@@ -235,6 +238,7 @@ def framework_import_partial(
     Args:
         actions: The actions provider from `ctx.actions`.
         apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
+        features: List of features enabled by the user. Typically from `ctx.features`.
         label_name: Name of the target being built.
         output_discriminator: A string to differentiate between different target intermediate files
             or `None`.
@@ -252,6 +256,7 @@ def framework_import_partial(
         _framework_import_partial_impl,
         actions = actions,
         apple_toolchain_info = apple_toolchain_info,
+        features = features,
         label_name = label_name,
         output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -464,6 +464,7 @@ def _bundle_post_process_and_sign(
         codesignopts,
         entitlements,
         executable_name,
+        features,
         ipa_post_processor,
         output_archive,
         output_discriminator,
@@ -485,6 +486,7 @@ def _bundle_post_process_and_sign(
         codesignopts: Extra options to pass to the `codesign` tool.
         entitlements: The entitlements file to sign with. Can be `None` if one was not provided.
         executable_name: The name of the output executable.
+        features: List of features enabled by the user. Typically from `ctx.features`.
         ipa_post_processor: A file that acts as a bundle post processing tool. May be `None`.
         output_archive: The file representing the final bundled, post-processed and signed archive.
         output_discriminator: A string to differentiate between different target intermediate files
@@ -525,6 +527,7 @@ def _bundle_post_process_and_sign(
         codesigning_command = codesigning_support.codesigning_command(
             codesigningtool = apple_toolchain_info.resolved_codesigningtool.executable,
             entitlements = entitlements,
+            features = features,
             frameworks_path = archive_paths[_LOCATION_ENUM.framework],
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = provisioning_profile,
@@ -591,6 +594,7 @@ def _bundle_post_process_and_sign(
             codesign_inputs = codesign_inputs,
             codesignopts = codesignopts,
             entitlements = entitlements,
+            features = features,
             frameworks_path = frameworks_path,
             input_archive = unprocessed_archive,
             ipa_post_processor = ipa_post_processor,
@@ -659,6 +663,7 @@ def _bundle_post_process_and_sign(
                 codesign_inputs = codesign_inputs,
                 codesignopts = codesignopts,
                 entitlements = entitlements,
+                features = features,
                 frameworks_path = embedding_frameworks_path,
                 input_archive = unprocessed_embedded_archive,
                 ipa_post_processor = ipa_post_processor,
@@ -685,6 +690,7 @@ def _process(
         codesignopts = [],
         entitlements,
         executable_name,
+        features,
         ipa_post_processor,
         output_discriminator = None,
         partials,
@@ -707,6 +713,7 @@ def _process(
       codesignopts: Extra options to pass to the `codesign` tool.
       entitlements: The entitlements file to sign with. Can be `None` if one was not provided.
       executable_name: The name of the output executable.
+      features: List of features enabled by the user. Typically from `ctx.features`.
       ipa_post_processor: A file that acts as a bundle post processing tool. May be `None`.
       output_discriminator: A string to differentiate between different target intermediate files
           or `None`.
@@ -744,6 +751,7 @@ def _process(
             codesignopts = codesignopts,
             executable_name = executable_name,
             entitlements = entitlements,
+            features = features,
             ipa_post_processor = ipa_post_processor,
             output_archive = output_archive,
             output_discriminator = output_discriminator,

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -363,6 +363,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -415,6 +416,7 @@ def _apple_test_bundle_impl(ctx, extra_providers = []):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -496,6 +496,7 @@ def _tvos_dynamic_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -106,6 +106,10 @@ def _tvos_application_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     executable_name = bundling_support.executable_name(ctx)
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = ctx.attr.extensions + ctx.attr.frameworks
     entitlements = entitlements_support.entitlements(
@@ -199,6 +203,7 @@ def _tvos_application_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -260,6 +265,7 @@ def _tvos_application_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         executable_name = executable_name,
         entitlements = entitlements,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -682,6 +688,7 @@ def _tvos_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -856,6 +863,7 @@ def _tvos_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -895,6 +903,10 @@ def _tvos_static_framework_impl(ctx):
     entitlements = entitlements_support.entitlements(
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
+    )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
@@ -973,6 +985,7 @@ def _tvos_static_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -281,6 +281,7 @@ def _watchos_dynamic_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -754,6 +755,10 @@ def _watchos_static_framework_impl(ctx):
         entitlements_attr = getattr(ctx.attr, "entitlements", None),
         entitlements_file = getattr(ctx.file, "entitlements", None),
     )
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
     predeclared_outputs = ctx.outputs
@@ -844,6 +849,7 @@ def _watchos_static_framework_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -491,6 +491,7 @@ def _watchos_application_impl(ctx):
         bundle_name = bundle_name,
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,
@@ -662,6 +663,7 @@ def _watchos_extension_impl(ctx):
         partials.framework_import_partial(
             actions = actions,
             apple_toolchain_info = apple_toolchain_info,
+            features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
             provisioning_profile = getattr(ctx.file, "provisioning_profile", None),
@@ -714,6 +716,7 @@ def _watchos_extension_impl(ctx):
         codesignopts = codesigning_support.codesignopts_from_rule_ctx(ctx),
         entitlements = entitlements,
         executable_name = executable_name,
+        features = features,
         ipa_post_processor = ctx.executable.ipa_post_processor,
         partials = processor_partials,
         platform_prerequisites = platform_prerequisites,


### PR DESCRIPTION
PiperOrigin-RevId: 384377651
(cherry picked from commit 0478507a6480ff5e06b4ca24514409f6522e43a2)