### PR TITLE
Abstract entitlement matching value validation

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -277,22 +277,12 @@ ENTITLEMENTS_HAS_GROUP_PROFILE_DOES_NOT = (
     'support use of this key.'
 )
 
-ENTITLEMENTS_APS_ENVIRONMENT_MISSING = (
-    'Target "%s" uses entitlements with the aps-environment key, but the '
-    'profile does not have this key'
-)
-
-ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH = (
-    'In target "%s"; the entitlements "aps-environment" ("%s") did not '
-    'match the value in the provisioning profile ("%s").'
-)
-
-ENTITLEMENTS_BOOLEAN_MISSING = (
+ENTITLEMENTS_MISSING = (
     'Target "%s" uses entitlements with the '
     '"%s" key, but the profile does not have this key'
 )
 
-ENTITLEMENTS_BOOLEAN_MISMATCH = (
+ENTITLEMENTS_VALUE_MISMATCH = (
     'In target "%s"; the entitlement value for "%s" ("%s") '
     'did not match the value in the provisioning profile ("%s").'
 )
@@ -337,6 +327,7 @@ _ENTITLEMENTS_OPTIONS_KEYS = frozenset([
 
 # Keys which should match in the profile and entitlements if they're expected
 _BOOLEAN_KEYS = frozenset([
+  'aps-environment',
   'com.apple.developer.networking.wifi-info',
   'com.apple.developer.passkit.pass-presentation-suppression',
   'com.apple.developer.payment-pass-provisioning',
@@ -1199,28 +1190,16 @@ class EntitlementsTask(PlistToolTask):
               self.target, src_app_id, profile_app_id),
             **report_extras)
 
-    aps_environment = entitlements.get('aps-environment')
-    if aps_environment and profile_entitlements:
-      profile_aps_environment = profile_entitlements.get('aps-environment')
-      if not profile_aps_environment:
-        self._report(ENTITLEMENTS_APS_ENVIRONMENT_MISSING % self.target,
-                     **report_extras)
-      elif aps_environment != profile_aps_environment:
-        self._report(
-            ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH %
-            (self.target, aps_environment, profile_aps_environment),
-            **report_extras)
-
     for key in _BOOLEAN_KEYS:
       entitlements_value = entitlements.get(key)
       if entitlements_value is not None and profile_entitlements:
         profile_value = profile_entitlements.get(key)
         if not profile_value:
-          self._report(ENTITLEMENTS_BOOLEAN_MISSING % (self.target, key),
-                      **report_extras)
+          self._report(ENTITLEMENTS_MISSING % (self.target, key),
+                       **report_extras)
         if entitlements_value != profile_value:
           self._report(
-            ENTITLEMENTS_BOOLEAN_MISMATCH % (
+            ENTITLEMENTS_VALUE_MISMATCH % (
               self.target, key, entitlements_value, profile_value),
             **report_extras)
 

--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -326,7 +326,7 @@ _ENTITLEMENTS_OPTIONS_KEYS = frozenset([
 ])
 
 # Keys which should match in the profile and entitlements if they're expected
-_BOOLEAN_KEYS = frozenset([
+_MATCHING_KEYS = frozenset([
   'aps-environment',
   'com.apple.developer.networking.wifi-info',
   'com.apple.developer.passkit.pass-presentation-suppression',
@@ -1190,7 +1190,7 @@ class EntitlementsTask(PlistToolTask):
               self.target, src_app_id, profile_app_id),
             **report_extras)
 
-    for key in _BOOLEAN_KEYS:
+    for key in _MATCHING_KEYS:
       entitlements_value = entitlements.get(key)
       if entitlements_value is not None and profile_entitlements:
         profile_value = profile_entitlements.get(key)

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1834,7 +1834,8 @@ class PlistToolTest(unittest.TestCase):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
         re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISMATCH % (
-            _testing_target, 'False', 'True'))):
+            _testing_target,'com.apple.developer.networking.wifi-info',
+            'False', 'True'))):
       plist = {'com.apple.developer.networking.wifi-info': False}
       self._assert_plisttool_result({
           'plists': [plist],

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1736,7 +1736,8 @@ class PlistToolTest(unittest.TestCase):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
         re.escape(
-            plisttool.ENTITLEMENTS_APS_ENVIRONMENT_MISSING % _testing_target)):
+            plisttool.ENTITLEMENTS_MISSING % (
+            _testing_target, 'aps-environment'))):
       plist = {'aps-environment': 'production'}
       self._assert_plisttool_result({
           'plists': [plist],
@@ -1753,8 +1754,8 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_aps_environment_mismatch(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH % (
-            _testing_target, 'production', 'development'))):
+        re.escape(plisttool.ENTITLEMENTS_VALUE_MISMATCH % (
+            _testing_target, 'aps-environment', 'production', 'development'))):
       plist = {'aps-environment': 'production'}
       self._assert_plisttool_result({
           'plists': [plist],
@@ -1833,7 +1834,7 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_wifi_info_active_mismatch(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISMATCH % (
+        re.escape(plisttool.ENTITLEMENTS_VALUE_MISMATCH % (
             _testing_target, 'com.apple.developer.networking.wifi-info',
             'False', 'True'))):
       plist = {'com.apple.developer.networking.wifi-info': False}
@@ -1852,7 +1853,7 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_profile_missing_wifi_info_active(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISSING % (
+        re.escape(plisttool.ENTITLEMENTS_MISSING % (
           _testing_target, 'com.apple.developer.networking.wifi-info'))):
       plist = {'com.apple.developer.networking.wifi-info': True}
       self._assert_plisttool_result({

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1833,7 +1833,7 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_wifi_info_active_mismatch(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(plisttool.ENTITLEMENTS_WIFI_INFO_MISMATCH % (
+        re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISMATCH % (
             _testing_target, 'False', 'True'))):
       plist = {'com.apple.developer.networking.wifi-info': False}
       self._assert_plisttool_result({
@@ -1852,7 +1852,7 @@ class PlistToolTest(unittest.TestCase):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
         re.escape(
-            plisttool.ENTITLEMENTS_WIFI_INFO_MISSING % _testing_target)):
+            plisttool.ENTITLEMENTS_BOOLEAN_MISSING % _testing_target)):
       plist = {'com.apple.developer.networking.wifi-info': True}
       self._assert_plisttool_result({
           'plists': [plist],

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1852,8 +1852,8 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_profile_missing_wifi_info_active(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        re.escape(
-            plisttool.ENTITLEMENTS_BOOLEAN_MISSING % _testing_target)):
+        plisttool.ENTITLEMENTS_BOOLEAN_MISSING % (
+          _testing_target, 'com.apple.developer.networking.wifi-info')):
       plist = {'com.apple.developer.networking.wifi-info': True}
       self._assert_plisttool_result({
           'plists': [plist],

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1852,8 +1852,8 @@ class PlistToolTest(unittest.TestCase):
   def test_entitlements_profile_missing_wifi_info_active(self):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
-        plisttool.ENTITLEMENTS_BOOLEAN_MISSING % (
-          _testing_target, 'com.apple.developer.networking.wifi-info')):
+        re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISSING % (
+          _testing_target, 'com.apple.developer.networking.wifi-info'))):
       plist = {'com.apple.developer.networking.wifi-info': True}
       self._assert_plisttool_result({
           'plists': [plist],

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1834,7 +1834,7 @@ class PlistToolTest(unittest.TestCase):
     with self.assertRaisesRegexp(
         plisttool.PlistToolError,
         re.escape(plisttool.ENTITLEMENTS_BOOLEAN_MISMATCH % (
-            _testing_target,'com.apple.developer.networking.wifi-info',
+            _testing_target, 'com.apple.developer.networking.wifi-info',
             'False', 'True'))):
       plist = {'com.apple.developer.networking.wifi-info': False}
       self._assert_plisttool_result({


### PR DESCRIPTION
There are many different entitlements that, when set, require they are
set to the same value in the entitlements file and the
provisioning profile. This extracts that use case into a single set that
we can add these keys to over time.