### PR TITLE
Add single value in list entitlements validation

### DIFF
--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1790,6 +1790,27 @@ class PlistToolTest(unittest.TestCase):
           },
       }, plist)
 
+  def test_attest_mismatch(self):
+    with self.assertRaisesRegex(
+        plisttool.PlistToolError,
+        re.escape(plisttool.ENTITLEMENTS_VALUE_NOT_IN_LIST % (
+            _testing_target,
+          'com.apple.developer.devicecheck.appattest-environment',
+          'foo', ['development']))):
+      plist = {
+        'com.apple.developer.devicecheck.appattest-environment': 'foo'}
+      self._assert_plisttool_result({
+          'plists': [plist],
+          'entitlements_options': {
+              'profile_metadata_file': {
+                  'Entitlements': {
+                      'com.apple.developer.devicecheck.appattest-environment': ['development'],
+                  },
+                  'Version': 1,
+              },
+          },
+      }, plist)
+
   def test_entitlements_missing_beta_reports_active(self):
     plist = {}
     self._assert_plisttool_result({


### PR DESCRIPTION
This abstracts another case of entitlements where the provisioning
profile has a list of potential values, and the entitlements file must
have a single value that is contained within that list.