### PR TITLE
Add last_green bazel with HEAD deps to CI matrix

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -35,4 +35,13 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
 
+  macos_last_green_head_deps:
+    name: "Last Green Bazel with Head Deps"
+    bazel: last_green
+    shell_commands:
+    # Update the WORKSPACE to use head versions of some deps to ensure nothing
+    # has landed on them breaking this project.
+    - .bazelci/update_workspace_to_deps_heads.sh
+    <<: *common
+
 buildifier: latest


### PR DESCRIPTION
This is useful to see when this passes, but last_green without head deps
fails, in that case we know something is fixed in newer versions of the
deps already.