### PR TITLE
Remove doc from for_bazel_tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,7 +17,6 @@ filegroup(
     srcs = [
         "WORKSPACE",
         "//apple:for_bazel_tests",
-        "//doc:for_bazel_tests",
         "//tools:for_bazel_tests",
         "@build_bazel_apple_support//:for_bazel_tests",
         "@build_bazel_rules_swift//:for_bazel_tests",

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -86,11 +86,3 @@ sh_binary(
     srcs = ["update.sh"],
     data = [file + ".md" for file in _DOC_SRCS],
 )
-
-# Consumed by bazel tests.
-filegroup(
-    name = "for_bazel_tests",
-    testonly = 1,
-    srcs = glob(["**"]),
-    visibility = ["//:__pkg__"],
-)


### PR DESCRIPTION
This was needed for a patch file that no longer exists. This breaks
tulsi because of stardoc weirdness.

https://buildkite.com/bazel/tulsi-bazel-darwin/builds/1612#1470bbcc-4ffd-49bf-aa67-8cbe9f7b6cf9