### PR TITLE
Add license_text rule that generates a license plist from transitive dependencies

### DIFF
--- a/apple/internal/license_text.bzl
+++ b/apple/internal/license_text.bzl
@@ -1,0 +1,70 @@
+"""Rule that gathers licenses from given dependencies and produces an output of
+all the license text."""
+
+load(
+    "@rules_license//rules:gather_licenses_info.bzl",
+    "gather_licenses_info",
+    "write_licenses_info",
+)
+load(
+    "@rules_license//rules:providers.bzl",
+    "LicensesInfo",
+)
+
+def _license_text_impl(ctx):
+    licenses_info_file = ctx.actions.declare_file(
+        "_{}_licenses_info.json".format(ctx.label.name),
+    )
+    write_licenses_info(ctx, ctx.attr.deps, licenses_info_file)
+
+    inputs = [licenses_info_file]
+    for dep in ctx.attr.deps:
+        if LicensesInfo in dep:
+            for license in dep[LicensesInfo].licenses.to_list():
+                inputs.append(license.license_text)
+
+    output = ctx.actions.declare_file("{}_licenses.plist".format(ctx.label.name))
+    outputs = [output]
+
+    args = ctx.actions.args()
+    args.add("--licenses_info", licenses_info_file)
+    args.add("--out", output)
+
+    ctx.actions.run(
+        arguments = [args],
+        executable = ctx.executable._write_license_text,
+        inputs = inputs,
+        mnemonic = "GenerateLicenseText",
+        outputs = outputs,
+        progress_message = "Generating licenses text for %s" % ctx.label,
+    )
+
+    return [DefaultInfo(files = depset(outputs))]
+
+license_text = rule(
+    implementation = _license_text_impl,
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [gather_licenses_info],
+            allow_files = True,
+            doc = """
+A list of targets to get LicenseInfo for. The output is the union of the
+result, not a list of information for each dependency.
+""",
+        ),
+        "format": attr.string(
+            default = "plist",
+            doc = """
+The format controls how to package the text. Currently only supports the plist
+format, so this attribute is for the validation purpose only.
+""",
+            values = ["plist"],
+        ),
+        "_write_license_text": attr.label(
+            allow_files = True,
+            cfg = "exec",
+            default = Label("//tools/write_license_text"),
+            executable = True,
+        ),
+    },
+)

--- a/apple/licenses.bzl
+++ b/apple/licenses.bzl
@@ -1,0 +1,22 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""# Rules that handle licenses for Apple platforms."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:license_text.bzl",
+    _license_text = "license_text",
+)
+
+license_text = _license_text

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -129,6 +129,17 @@ def apple_rules_dependencies(ignore_version_differences = False):
 
     _maybe(
         http_archive,
+        name = "rules_license",
+        urls = [
+            "https://github.com/bazelbuild/rules_license/archive/ebc0ccbe7397df0b5b279671f83c707a865e2d16.tar.gz",
+        ],
+        strip_prefix = "rules_license-ebc0ccbe7397df0b5b279671f83c707a865e2d16",
+        sha256 = "c843422f8c058b43d7a7a16564124fd1b7a6d21c939886a3936cb3f0d96ae826",
+        ignore_version_differences = ignore_version_differences,
+    )
+
+    _maybe(
+        http_archive,
         name = "subpar",
         urls = [
             "https://github.com/google/subpar/archive/2.0.0.tar.gz",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "objc_library")
+load("@rules_license//rules:license.bzl", "license")
 load(
     "//apple:resources.bzl",
     "apple_bundle_import",
@@ -29,10 +30,24 @@ exports_files(
     visibility = ["//test/starlark_tests:__subpackages__"],
 )
 
+license(
+    name = "license",
+    package_name = "objc_common_lib",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+)
+
 objc_library(
     name = "objc_common_lib",
     srcs = ["common.m"],
     hdrs = ["common.h"],
+    tags = FIXTURE_TAGS,
+)
+
+objc_library(
+    name = "objc_common_lib_with_license",
+    srcs = ["common.m"],
+    hdrs = ["common.h"],
+    applicable_licenses = [":license"],
     tags = FIXTURE_TAGS,
 )
 
@@ -52,6 +67,15 @@ objc_library(
     tags = FIXTURE_TAGS,
     deps = [
         ":objc_common_lib",
+    ],
+)
+
+objc_library(
+    name = "objc_main_lib_with_license",
+    srcs = ["main.m"],
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":objc_common_lib_with_license",
     ],
 )
 

--- a/test/starlark_tests/resources/LICENSE
+++ b/test/starlark_tests/resources/LICENSE
@@ -1,0 +1,1 @@
+Example license

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -20,6 +20,10 @@ load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",
 )
+load(
+    "//apple:licenses.bzl",
+    "license_text",
+)
 load("//test/testdata/rules:substitution.bzl", "substitution")
 load("//test/starlark_tests:common.bzl", "FIXTURE_TAGS")
 load(
@@ -2297,4 +2301,31 @@ generate_import_framework(
     minimum_os_version = "8.0",
     sdk = "iphonesimulator",
     tags = FIXTURE_TAGS,
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for license text generation tests.
+
+ios_application(
+    name = "app_minimal_with_licenses",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "11.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    resources = [":licenses"],
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib_with_license",
+    ],
+)
+
+license_text(
+    name = "licenses",
+    tags = ["manual"],
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib_with_license",
+    ],
 )

--- a/tools/write_license_text/BUILD
+++ b/tools/write_license_text/BUILD
@@ -1,0 +1,9 @@
+py_binary(
+    name = "write_license_text",
+    srcs = ["write_license_text.py"],
+    python_version = "PY3",
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)

--- a/tools/write_license_text/write_license_text.py
+++ b/tools/write_license_text/write_license_text.py
@@ -1,0 +1,80 @@
+"""Writes licenses text into a file."""
+
+import argparse
+import codecs
+import html
+import json
+
+
+def _get_licenses(licenses_info):
+    with codecs.open(licenses_info, encoding='utf-8') as licenses_file:
+        return json.loads(licenses_file.read())
+
+
+def _write_licenses(out, licenses):
+    out.write("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>This application makes use of the following third party libraries:</string>
+			<key>Title</key>
+			<string>Acknowledgements</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+""")
+
+    for lic in licenses:
+        path = lic['license_text']
+        with codecs.open(path, encoding='utf-8') as license_file:
+            out.write("""\
+		<dict>
+			<key>FooterText</key>
+			<string>{license_text}</string>
+			<key>Title</key>
+			<string>{package_name}</string>
+			<key>License</key>
+			<string>{license_kind}</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+""".format(
+                license_text=html.escape(license_file.read()),
+                license_kind=lic['license_kinds'][0]['name'],
+                package_name=lic['package_name'],
+            ))
+
+    out.write("""\
+	</array>
+	<key>StringsTable</key>
+	<string>Acknowledgements</string>
+	<key>Title</key>
+	<string>Acknowledgements</string>
+</dict>
+</plist>
+""")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Writes licenses text to a file given licenses info')
+
+    parser.add_argument('--licenses_info',
+                        help='path to JSON file containing all license data')
+    parser.add_argument('--out', help='output file of all license files')
+    args = parser.parse_args()
+
+    licenses = _get_licenses(args.licenses_info)
+    err = 0
+    with codecs.open(args.out, mode='w', encoding='utf-8') as out:
+        _write_licenses(out, licenses)
+    return err
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This can be used to bundle in the iOS app bundle as-is or within a
`Settings.bundle`. Currently only supports `plist` as the output format,
with the template similar to what CocoaPods generates.