### PR TITLE
Remove explicit --source-libraries argument to swift-stdlib-tool

### DIFF
--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -19,10 +19,6 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:xcode_support.bzl",
-    "xcode_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:bitcode_support.bzl",
     "bitcode_support",
 )
@@ -85,22 +81,11 @@ def _swift_dylib_action(
         resolved_swift_stdlib_tool,
         strip_bitcode):
     """Registers a swift-stlib-tool action to gather Swift dylibs to bundle."""
-
-    swift_dylibs_path = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift"
-
-    # Xcode 11 changed the location of the Swift dylibs within the default toolchain, so we need to
-    # make the dylibs path conditional on the Xcode version.
-    xcode_config = platform_prerequisites.xcode_version_config
-    if xcode_support.is_xcode_at_least_version(xcode_config, "11"):
-        swift_dylibs_path += "-5.0"
-
     swift_stdlib_tool_args = [
         "--platform",
         platform_name,
         "--output_path",
         output_dir.path,
-        "--swift_dylibs_path",
-        swift_dylibs_path,
     ]
     for x in binary_files:
         swift_stdlib_tool_args.extend([

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -24,27 +24,13 @@ from build_bazel_rules_apple.tools.wrapper_common import execute
 from build_bazel_rules_apple.tools.wrapper_common import lipo
 
 
-def _copy_swift_stdlibs(binaries_to_scan, swift_dylibs_path, sdk_platform,
-                        destination_path):
+def _copy_swift_stdlibs(binaries_to_scan, sdk_platform, destination_path):
   """Copies the Swift stdlibs required by the binaries to the destination."""
-  # Use the currently selected Xcode developer directory and SDK to determine
-  # exactly which Swift stdlibs we should be copying.
-  developer_dir_cmd = ["xcode-select", "--print-path"]
-  _, stdout, stderr = execute.execute_and_filter_output(developer_dir_cmd,
-                                                        raise_on_failure=True)
-  if stderr:
-    print(stderr)
-  developer_dir = stdout.strip()
-  library_source_dir = os.path.join(
-      developer_dir, swift_dylibs_path, sdk_platform
-  )
-
   # Rely on the swift-stdlib-tool to determine the subset of Swift stdlibs that
   # these binaries require.
   cmd = [
-      "xcrun", "swift-stdlib-tool", "--copy", "--source-libraries",
-      library_source_dir, "--platform", sdk_platform, "--destination",
-      destination_path
+      "xcrun", "swift-stdlib-tool", "--copy", "--platform", sdk_platform,
+      "--destination", destination_path
   ]
   for binary_to_scan in binaries_to_scan:
     cmd.extend(["--scan-executable", binary_to_scan])
@@ -97,11 +83,6 @@ def main():
       "'iphoneos'"
   )
   parser.add_argument(
-      "--swift_dylibs_path", type=str, required=True, help="path relative from "
-      "the developer directory to find the Swift standard libraries, "
-      "independent of platform"
-  )
-  parser.add_argument(
       "--strip_bitcode", action="store_true", default=False, help="strip "
       "bitcode from the Swift support libraries"
   )
@@ -115,9 +96,7 @@ def main():
   temp_path = tempfile.mkdtemp(prefix="swift_stdlib_tool.XXXXXX")
 
   # Use the binaries to copy only the Swift stdlibs we need for this app.
-  _copy_swift_stdlibs(
-      args.binary, args.swift_dylibs_path, args.platform, temp_path
-  )
+  _copy_swift_stdlibs(args.binary, args.platform, temp_path)
 
   # Determine the binary slices we need to strip with lipo.
   target_archs = lipo.find_archs_for_binaries(args.binary)


### PR DESCRIPTION
swift-stdlib-tool automatically derives this path when it is not passed
based on the platform we provide. This way we can avoid this extra
`xcode-select` call and future proof this a bit more. This also makes it
easier to support custom toolchains, where the XcodeDefault.xctoolchain
part of this path logic was invalid.