### PR TITLE
Pass through tags to `native.apple_static_library`

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -170,6 +170,7 @@ def ios_static_framework(name, **kwargs):
         avoid_deps = avoid_deps,
         minimum_os_version = kwargs.get("minimum_os_version"),
         platform_type = str(apple_common.platform_type.ios),
+        tags = kwargs.get("tags"),
         testonly = kwargs.get("testonly"),
         visibility = kwargs.get("visibility"),
     )

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -118,6 +118,7 @@ def tvos_static_framework(name, **kwargs):
         avoid_deps = avoid_deps,
         minimum_os_version = kwargs.get("minimum_os_version"),
         platform_type = str(apple_common.platform_type.tvos),
+        tags = kwargs.get("tags"),
         testonly = kwargs.get("testonly"),
         visibility = kwargs.get("visibility"),
     )

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -167,6 +167,7 @@ def watchos_static_framework(name, **kwargs):
         avoid_deps = avoid_deps,
         minimum_os_version = kwargs.get("minimum_os_version"),
         platform_type = str(apple_common.platform_type.watchos),
+        tags = kwargs.get("tags"),
         visibility = kwargs.get("visibility"),
     )
 


### PR DESCRIPTION
This allows setting execution requirements, such as `no-remote`.