### PR TITLE
Test 5.0 rc for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,7 +18,8 @@ x_defaults:
 tasks:
   macos_latest:
     name: "Latest Bazel"
-    bazel: latest
+    # TODO(#1263): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     <<: *common
 
   macos_last_green:
@@ -28,7 +29,8 @@ tasks:
 
   macos_latest_head_deps:
     name: "Latest Bazel with Head Deps"
-    bazel: latest
+    # TODO(#1263): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.


### PR DESCRIPTION
We are dropping 4.x support in order to land 5.0 required changes. This changes the CI to test against the 5.0 rc instead of 4.2.1.
