### PR TITLE
Support running tests on device

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -25,12 +25,15 @@ basename_without_extension() {
 
 custom_xctestrunner_args=()
 command_line_args=()
-simulator_id=""
+device_id=""
+platform=""
 while [[ $# -gt 0 ]]; do
   arg="$1"
   case $arg in
-    --destination=platform=ios_simulator,id=*)
-      simulator_id="${arg##*=}"
+    --destination=platform=*,id=*)
+      device_id="${arg##*=}"
+      platform="${arg#*platform=}" # Strip "--destination=platform=" prefix
+      platform="${platform%,id=*}" # Strip suffix starting with ",id="
       ;;
     --command_line_args=*)
       command_line_args+=("${arg##*=}")
@@ -133,7 +136,7 @@ fi
 
 target_flags=()
 if [[ -n "${REUSE_GLOBAL_SIMULATOR:-}" ]]; then
-  if [[ -n "$simulator_id" ]]; then
+  if [[ -n "$device_id" ]]; then
     echo "error: both '\$REUSE_GLOBAL_SIMULATOR' and a custom simulator id cannot be set" >&2
     exit 1
   fi
@@ -154,11 +157,11 @@ if [[ -n "${REUSE_GLOBAL_SIMULATOR:-}" ]]; then
     "--platform=ios_simulator"
     "--id=$id"
   )
-elif [[ -n "$simulator_id" ]]; then
+elif [[ -n "$device_id" ]]; then
   target_flags=(
     "test"
-    "--platform=ios_simulator"
-    "--id=$simulator_id"
+    "--platform=$platform"
+    "--id=$device_id"
   )
 else
   target_flags=(


### PR DESCRIPTION
Testing on device can be done by passing
`--test_arg=--destination=platform=ios_device,id=YOUR_DEVICE_UDID`
to your `bazel test` command.
