### PR TITLE
Propagate `AppleFrameworkImportInfo` through `dart_library`

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -47,6 +47,14 @@ bzl_library(
 )
 
 bzl_library(
+    name = "aspects",
+    srcs = ["aspects.bzl"],
+    deps = [
+        "//apple/internal/aspects:framework_import_aspect",
+    ],
+)
+
+bzl_library(
     name = "common",
     srcs = ["common.bzl"],
 )

--- a/apple/aspects.bzl
+++ b/apple/aspects.bzl
@@ -1,0 +1,22 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Aspects that apply to all Apple platforms."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal/aspects:framework_import_aspect.bzl",
+    _framework_import_aspect = "framework_import_aspect",
+)
+
+framework_import_aspect = _framework_import_aspect

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -40,6 +40,7 @@ bzl_library(
     ],
     deps = [
         ":resources",
+        "//apple:providers",
         "//apple:utils",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -35,6 +35,10 @@ load(
     "sets",
 )
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleFrameworkImportInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resources.bzl",
     "resources",
 )
@@ -49,10 +53,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple:utils.bzl",
     "group_files_by_directory",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleFrameworkImportInfo",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -11,10 +11,10 @@ bzl_library(
     name = "framework_import_aspect",
     srcs = ["framework_import_aspect.bzl"],
     visibility = [
-        "//apple/internal:__pkg__",
+        "//apple:__subpackages__",
     ],
     deps = [
-        "//apple/internal:apple_framework_import",
+        "//apple:providers",
     ],
 )
 

--- a/apple/internal/aspects/framework_import_aspect.bzl
+++ b/apple/internal/aspects/framework_import_aspect.bzl
@@ -17,6 +17,7 @@
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkImportInfo",
+    "merge_apple_framework_import_info",
 )
 
 # List of attributes through which the aspect propagates. We include `runtime_deps` here as
@@ -30,32 +31,21 @@ def _framework_import_aspect_impl(target, ctx):
     if AppleFrameworkImportInfo in target:
         return []
 
-    transitive_debug_info_binaries = []
-    transitive_dsyms = []
-    transitive_sets = []
-    build_archs = []
+    apple_framework_infos = []
+
     for attribute in _FRAMEWORK_IMPORT_ASPECT_ATTRS:
         if not hasattr(ctx.rule.attr, attribute):
             continue
         for dep_target in getattr(ctx.rule.attr, attribute):
             if AppleFrameworkImportInfo in dep_target:
-                if hasattr(dep_target[AppleFrameworkImportInfo], "debug_info_binaries"):
-                    transitive_debug_info_binaries.append(dep_target[AppleFrameworkImportInfo].debug_info_binaries)
-                if hasattr(dep_target[AppleFrameworkImportInfo], "dsym_imports"):
-                    transitive_dsyms.append(dep_target[AppleFrameworkImportInfo].dsym_imports)
-                if hasattr(dep_target[AppleFrameworkImportInfo], "framework_imports"):
-                    transitive_sets.append(dep_target[AppleFrameworkImportInfo].framework_imports)
-                build_archs.append(dep_target[AppleFrameworkImportInfo].build_archs)
+                apple_framework_infos.append(dep_target[AppleFrameworkImportInfo])
 
-    if not transitive_sets:
+    apple_framework_info = merge_apple_framework_import_info(apple_framework_infos)
+
+    if not apple_framework_info.framework_imports:
         return []
 
-    return [AppleFrameworkImportInfo(
-        debug_info_binaries = depset(transitive = transitive_debug_info_binaries),
-        dsym_imports = depset(transitive = transitive_dsyms),
-        framework_imports = depset(transitive = transitive_sets),
-        build_archs = depset(transitive = build_archs),
-    )]
+    return [apple_framework_info]
 
 framework_import_aspect = aspect(
     implementation = _framework_import_aspect_impl,

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -160,7 +160,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
-        "//apple/internal:apple_framework_import",
+        "//apple:providers",
         "//apple/internal:codesigning_support",
         "//apple/internal:intermediates",
         "//apple/internal:processor",

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -171,6 +171,37 @@ provide debug info.
     },
 )
 
+def merge_apple_framework_import_info(apple_framework_import_infos):
+    """
+    Merges multiple `AppleFrameworkImportInfo` into one.
+
+    Args:
+        apple_framework_import_infos: List of `AppleFrameworkImportInfo` to be merged.
+
+    Returns:
+        Result of merging all the received framework infos.
+    """
+    transitive_debug_info_binaries = []
+    transitive_dsyms = []
+    transitive_sets = []
+    build_archs = []
+
+    for framework_info in apple_framework_import_infos:
+        if hasattr(framework_info, "debug_info_binaries"):
+            transitive_debug_info_binaries.append(framework_info.debug_info_binaries)
+        if hasattr(framework_info, "dsym_imports"):
+            transitive_dsyms.append(framework_info.dsym_imports)
+        if hasattr(framework_info, "framework_imports"):
+            transitive_sets.append(framework_info.framework_imports)
+        build_archs.append(framework_info.build_archs)
+
+    return AppleFrameworkImportInfo(
+        debug_info_binaries = depset(transitive = transitive_debug_info_binaries),
+        dsym_imports = depset(transitive = transitive_dsyms),
+        framework_imports = depset(transitive = transitive_sets),
+        build_archs = depset(transitive = build_archs),
+    )
+
 AppleResourceInfo = provider(
     doc = "Provider that propagates buckets of resources that are differentiated by type.",
     # @unsorted-dict-items

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -872,3 +872,21 @@ is a watchOS .xctest bundle should use this provider to describe that requiremen
 
 
 
+<a id="#merge_apple_framework_import_info"></a>
+
+## merge_apple_framework_import_info
+
+<pre>
+merge_apple_framework_import_info(<a href="#merge_apple_framework_import_info-apple_framework_import_infos">apple_framework_import_infos</a>)
+</pre>
+
+    Merges multiple `AppleFrameworkImportInfo` into one.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="merge_apple_framework_import_info-apple_framework_import_infos"></a>apple_framework_import_infos |  List of <code>AppleFrameworkImportInfo</code> to be merged.   |  none |
+
+


### PR DESCRIPTION
RELNOTES: Expose `AppleFrameworkImportInfo` in `rules_apple`
PiperOrigin-RevId: 390020141
(cherry picked from commit 303aafe2e5404619fbfcd7af322791b5b9e3a45f)
