### PR TITLE
Clamp down plisttool and provisioning_profile_tool's visibility now that its dependencies appear to have been addressed.

### DIFF
--- a/tools/plisttool/BUILD
+++ b/tools/plisttool/BUILD
@@ -5,10 +5,9 @@ py_binary(
     srcs = ["plisttool.py"],
     python_version = "PY3",
     srcs_version = "PY3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
     deps = [":plisttool_lib"],
 )
 

--- a/tools/provisioning_profile_tool/BUILD
+++ b/tools/provisioning_profile_tool/BUILD
@@ -5,10 +5,9 @@ py_binary(
     srcs = ["provisioning_profile_tool.py"],
     python_version = "PY3",
     srcs_version = "PY3",
-    # Used by the rule implementations, so it needs to be public; but
-    # should be considered an implementation detail of the rules and
-    # not used by other things.
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
 )
 
 # Consumed by bazel tests.


### PR DESCRIPTION
PiperOrigin-RevId: 392429560
(cherry picked from commit deec6a718db3f78910990d50347038023de4f035)
