### PR TITLE
Fix pylint errors for plisttool tests

### DIFF
--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -80,6 +80,7 @@ def _plisttool_result(control):
 
 
 class PlistToolMainTest(unittest.TestCase):
+
   def test_main_invocation(self):
     plist_fp = tempfile.NamedTemporaryFile(delete=False)
     self.addCleanup(lambda: os.unlink(plist_fp.name))
@@ -345,7 +346,7 @@ class PlistToolShortVersionStringTest(unittest.TestCase):
 class PlistToolGetWithKeyPath(unittest.TestCase):
 
   def test_one_level(self):
-    d = { 'a': 'A', 'b': 2, 3: 'c', 'list': [ 'x', 'y' ], 'dict': { 1: 2, 3: 4} }
+    d = {'a': 'A', 'b': 2, 3: 'c', 'list': ['x', 'y'], 'dict': {1: 2, 3: 4}}
     self.assertEqual(plisttool.GetWithKeyPath(d, ['a']), 'A')
     self.assertEqual(plisttool.GetWithKeyPath(d, ['b']), 2)
     self.assertEqual(plisttool.GetWithKeyPath(d, [3]), 'c')
@@ -353,29 +354,29 @@ class PlistToolGetWithKeyPath(unittest.TestCase):
     self.assertEqual(plisttool.GetWithKeyPath(d, ['dict']), {1: 2, 3: 4})
 
   def test_two_level(self):
-    d = { 'list': [ 'x', 'y' ], 'dict': { 1: 2, 3: 4} }
+    d = {'list': ['x', 'y'], 'dict': {1: 2, 3: 4}}
     self.assertEqual(plisttool.GetWithKeyPath(d, ['list', 1]), 'y')
     self.assertEqual(plisttool.GetWithKeyPath(d, ['dict', 3]), 4)
 
   def test_deep(self):
-    d = { 1: { 'a': ['c', [4, 'e']]}}
+    d = {1: {'a': ['c', [4, 'e']]}}
     self.assertEqual(plisttool.GetWithKeyPath(d, [1, 'a', 1, 1]), 'e')
 
   def test_misses(self):
-    d = { 'list': [ 'x', 'y' ], 'dict': { 1: 2, 3: 4} }
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['not_found']), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, [99]), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['list', 99]), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['dict', 'not_found']), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['dict', 99]), None)
+    d = {'list': ['x', 'y'], 'dict': {1: 2, 3: 4}}
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['not_found']))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, [99]))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['list', 99]))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['dict', 'not_found']))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['dict', 99]))
 
   def test_invalids(self):
-    d = { 'list': [ 'x', 'y' ], 'str': 'foo', 'int': 42 }
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['list', 'not_int']), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['str', 'nope']), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['str', 99]), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['int', 'nope']), None)
-    self.assertEqual(plisttool.GetWithKeyPath(d, ['int', 99]), None)
+    d = {'list': ['x', 'y'], 'str': 'foo', 'int': 42}
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['list', 'not_int']))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['str', 'nope']))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['str', 99]))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['int', 'nope']))
+    self.assertIsNone(plisttool.GetWithKeyPath(d, ['int', 99]))
 
 
 class PlistToolTest(unittest.TestCase):
@@ -529,8 +530,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.INVALID_SUBSTITUTION_VARIABLE_NAME % (
             _testing_target, 'foo bar'))):
       _plisttool_result({
-         'plists': [{}],
-         'variable_substitutions': {
+          'plists': [{}],
+          'variable_substitutions': {
               'foo bar': 'bad name',
           },
       })
@@ -541,8 +542,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.INVALID_SUBSTITUTION_VARIABLE_NAME % (
             _testing_target, 'foo-bar'))):
       _plisttool_result({
-         'plists': [{}],
-         'variable_substitutions': {
+          'plists': [{}],
+          'variable_substitutions': {
               'foo-bar': 'bad name',
           },
       })
@@ -553,8 +554,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.INVALID_SUBSTITUTION_VARIABLE_NAME % (
             _testing_target, 'foo:bar'))):
       _plisttool_result({
-         'plists': [{}],
-         'variable_substitutions': {
+          'plists': [{}],
+          'variable_substitutions': {
               'foo:bar': 'bad name',
           },
       })
@@ -565,8 +566,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.SUBSTITUTION_VARIABLE_CANT_HAVE_QUALIFIER % (
             _testing_target, 'foo:rfc1034identifier'))):
       _plisttool_result({
-         'plists': [{}],
-         'variable_substitutions': {
+          'plists': [{}],
+          'variable_substitutions': {
               'foo:rfc1034identifier': 'bad name',
           },
       })
@@ -631,8 +632,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.OVERLAP_IN_SUBSTITUTION_KEYS % (
             _testing_target, 'mum', 'mumble'))):
       _plisttool_result({
-         'plists': [{}],
-         'raw_substitutions': {
+          'plists': [{}],
+          'raw_substitutions': {
               'mumble': 'value1',
               'mum': 'value2',
           },
@@ -644,11 +645,11 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.OVERLAP_IN_SUBSTITUTION_KEYS % (
             _testing_target, '$(mumble)', 'mum'))):
       _plisttool_result({
-         'plists': [{}],
-         'variable_substitutions': {
+          'plists': [{}],
+          'variable_substitutions': {
               'mumble': 'value1',
           },
-         'raw_substitutions': {
+          'raw_substitutions': {
               'mum': 'value2',
           },
       })
@@ -659,8 +660,8 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.RAW_SUBSTITUTION_KEY_IN_VALUE % (
             _testing_target, 'value', '1value2', 'mumble'))):
       _plisttool_result({
-         'plists': [{}],
-         'raw_substitutions': {
+          'plists': [{}],
+          'raw_substitutions': {
               'mumble': '1value2',
               'value': 'spam',
           },
@@ -972,7 +973,7 @@ class PlistToolTest(unittest.TestCase):
           'info_plist_options': {
               'child_plists': children,
               'child_plist_required_values': {
-                '//unknown:label': [['foo', 'bar']],
+                  '//unknown:label': [['foo', 'bar']],
               }
           },
       })
@@ -992,7 +993,7 @@ class PlistToolTest(unittest.TestCase):
           'info_plist_options': {
               'child_plists': children,
               'child_plist_required_values': {
-                '//fake:label': ['not_right'],
+                  '//fake:label': ['not_right'],
               }
           },
       })
@@ -1012,7 +1013,7 @@ class PlistToolTest(unittest.TestCase):
           'info_plist_options': {
               'child_plists': children,
               'child_plist_required_values': {
-                '//fake:label': [['not_right']],
+                  '//fake:label': [['not_right']],
               }
           },
       })
@@ -1032,12 +1033,12 @@ class PlistToolTest(unittest.TestCase):
           'info_plist_options': {
               'child_plists': children,
               'child_plist_required_values': {
-                '//fake:label': [
-                  # This will be found and pass.
-                  [['CFBundleIdentifier'], 'foo.bar.baz' ],
-                  # This will raise.
-                  [['not-there'], 'blah' ],
-                ],
+                  '//fake:label': [
+                      # This will be found and pass.
+                      [['CFBundleIdentifier'], 'foo.bar.baz'],
+                      # This will raise.
+                      [['not-there'], 'blah'],
+                  ],
               }
           },
       })
@@ -1058,9 +1059,7 @@ class PlistToolTest(unittest.TestCase):
           'info_plist_options': {
               'child_plists': children,
               'child_plist_required_values': {
-                '//fake:label': [
-                  [['CFBundleIdentifier'], 'foo.bar.baz.not' ],
-                ],
+                  '//fake:label': [[['CFBundleIdentifier'], 'foo.bar.baz.not']],
               }
           },
       })
@@ -1159,7 +1158,7 @@ class PlistToolTest(unittest.TestCase):
       }
       _plisttool_result({
           'plists': [plist],
-          'info_plist_options': { }  # presence triggers checking
+          'info_plist_options': {}  # presence triggers checking
       })
 
   def test_invalid_short_version(self):
@@ -1172,7 +1171,7 @@ class PlistToolTest(unittest.TestCase):
       }
       _plisttool_result({
           'plists': [plist],
-          'info_plist_options': { }  # presence triggers checking
+          'info_plist_options': {}  # presence triggers checking
       })
 
   def test_versions_not_checked_without_options(self):
@@ -1183,7 +1182,7 @@ class PlistToolTest(unittest.TestCase):
     # Even though they numbers are invalid, the plist comes back fine because
     # there was no info_plist_options to trigger validation.
     self._assert_plisttool_result(
-        { 'plists': [plist] },
+        {'plists': [plist]},
         plist
     )
 
@@ -1222,7 +1221,7 @@ class PlistToolTest(unittest.TestCase):
               _testing_target, '${AppIdentifierPrefix}', 'Foo',
               '${AppIdentifierPrefix}.my.bundle.id'),
             plisttool.UNKNOWN_SUBSTITUTION_ADDITION_AppIdentifierPrefix_MSG
-          ]))):
+        ]))):
       _plisttool_result({
           'plists': [{'Foo': '${AppIdentifierPrefix}.my.bundle.id'}],
           'entitlements_options': {
@@ -1239,14 +1238,15 @@ class PlistToolTest(unittest.TestCase):
               _testing_target, '$(AppIdentifierPrefix:rfc1034identifier)', 'Foo',
               '$(AppIdentifierPrefix:rfc1034identifier).my.bundle.id'),
             plisttool.UNKNOWN_SUBSTITUTION_ADDITION_AppIdentifierPrefix_MSG
-          ]))):
+        ]))):
       _plisttool_result({
-          'plists': [{'Foo': '$(AppIdentifierPrefix:rfc1034identifier).my.bundle.id'}],
+          'plists': [{
+              'Foo': '$(AppIdentifierPrefix:rfc1034identifier).my.bundle.id'
+          }],
           'entitlements_options': {
               'bundle_id': 'my.bundle.id',
           },
       })
-
 
   def test_entitlements_bundle_id_match(self):
     # This is really looking for the lack of an error being raised.
@@ -1311,12 +1311,14 @@ class PlistToolTest(unittest.TestCase):
         re.escape(plisttool.ENTITLEMENTS_PROFILE_HAS_EXPIRED % (
             _testing_target, '0001-01-01T00:00:00'))):
       _plisttool_result({
-          'plists': [{'foo': 'bar'}],
+          'plists': [{
+              'foo': 'bar'
+          }],
           'entitlements_options': {
-            'profile_metadata_file': {
-                'ExpirationDate': datetime.datetime.min,
-                'Version': 1,
-            },
+              'profile_metadata_file': {
+                  'ExpirationDate': datetime.datetime.min,
+                  'Version': 1,
+              },
           },
       })
 
@@ -1329,8 +1331,8 @@ class PlistToolTest(unittest.TestCase):
           'plists': [{'com.apple.developer.team-identifier': 'QWERTY'}],
           'entitlements_options': {
               'profile_metadata_file': {
-                  'ApplicationIdentifierPrefix': [ 'QWERTY' ],
-                  'TeamIdentifier': [ 'ASDFGH' ],
+                  'ApplicationIdentifierPrefix': ['QWERTY'],
+                  'TeamIdentifier': ['ASDFGH'],
                   'Version': 1,
               },
           },
@@ -1345,8 +1347,8 @@ class PlistToolTest(unittest.TestCase):
           'plists': [{'com.apple.developer.team-identifier': 'QWERTY'}],
           'entitlements_options': {
               'profile_metadata_file': {
-                  'TeamIdentifier': [ 'QWERTY' ],
-                  'ApplicationIdentifierPrefix': [ 'ASDFGH' ],
+                  'TeamIdentifier': ['QWERTY'],
+                  'ApplicationIdentifierPrefix': ['ASDFGH'],
                   'Version': 1,
               },
           },
@@ -1360,8 +1362,8 @@ class PlistToolTest(unittest.TestCase):
         'entitlements_options': {
             'bundle_id': 'my.bundle.id',
             'profile_metadata_file': {
-                'ApplicationIdentifierPrefix': [ 'ASDFGH', 'QWERTY' ],
-                'TeamIdentifier': [ 'ASDFGH', 'QWERTY' ],
+                'ApplicationIdentifierPrefix': ['ASDFGH', 'QWERTY'],
+                'TeamIdentifier': ['ASDFGH', 'QWERTY'],
                 'Version': 1,
             },
         },
@@ -1383,7 +1385,7 @@ class PlistToolTest(unittest.TestCase):
         },
     }, plist1)
 
-  def test_entitlements_app_id_wildcard_match(self):
+  def test_entitlements_app_id_wildcard_match_from_profile_metadata(self):
     # This is really looking for the lack of an error being raised.
     plist1 = {'application-identifier': 'QWERTY.my.bundle.id'}
     self._assert_plisttool_result({
@@ -1436,7 +1438,7 @@ class PlistToolTest(unittest.TestCase):
       })
 
   # The edge case in EntitlementsTask._does_id_match()
-  def test_entitlements_app_id_wildcard_match(self):
+  def test_entitlements_app_id_wildcard_match_from_plist(self):
     # This is really looking for the lack of an error being raised.
     plist1 = {'application-identifier': 'QWERTY.*'}
     self._assert_plisttool_result({
@@ -1951,6 +1953,7 @@ class PlistToolTest(unittest.TestCase):
         },
     }, plist1)
 
+  # pylint: disable=line-too-long
   def test_entitlements_associated_domains_match_wildcard_requesting_wildcard(self):
     # This is really looking for the lack of an error being raised.
     plist1 = {


### PR DESCRIPTION
- Update from assertassertRaisesRegexp to assertRaisesRegex.
- Update from assertEquals to assertIsNone for None values.
- Rename test_entitlements_app_id_wildcard_match tests with name collision.
- Add/remove spaces from pylint errors.

Based on PR #1230 by keith

PiperOrigin-RevId: 394524626
(cherry picked from commit c0614fb0f15d6db40164e41a8be6b1d82d7b5e1f)
