### PR TITLE
Stop exporting resolve_tools_for_executable.

### DIFF
--- a/apple/internal/apple_support_toolchain.bzl
+++ b/apple/internal/apple_support_toolchain.bzl
@@ -189,6 +189,5 @@ A `File` referencing a tool that copies and lipos Swift stdlibs required for the
 
 # Define the loadable module that lists the exported symbols in this file.
 apple_support_toolchain_utils = struct(
-    resolve_tools_for_executable = _resolve_tools_for_executable,
     shared_attrs = _shared_attrs,
 )


### PR DESCRIPTION
Doesn't seem to be used: http://source/search?q=resolve_tools_for_executable.

PiperOrigin-RevId: 401026620
(cherry picked from commit 581af5da8c665ca7ea6113e2901cc80d37877cea)
