### PR TITLE
Add mnemonic for dSYM DWARF copying (#1227)

### DIFF
--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -154,6 +154,7 @@ def _copy_dsym_into_declared_bundle(
         actions.run_shell(
             inputs = [dsym_binary],
             outputs = [output_binary],
+            mnemonic = "DsymDwarf",
             progress_message = "Copy DWARF into dSYM `%s`" % dsym_binary.short_path,
             command = "cp -p '%s' '%s'" % (dsym_binary.path, output_binary.path),
         )


### PR DESCRIPTION
This allows targeting it with `--modify_execution_info`.

(cherry picked from commit 7fa9a274b9db009da9877daa26be693dca34f326)

Seems accidentally removed in https://github.com/bazelbuild/rules_apple/commit/5eecd97b52bdb4acaa86ba2b91a1c4613fa8a893.
