### PR TITLE
Add forced entitlements from provisioning profile

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1101,6 +1101,29 @@ class EntitlementsTask(PlistToolTask):
   def unknown_variable_message_additions(self):
     return self._unknown_var_msg_addtions
 
+  def update_plist(self, out_plist, subs_engine):
+    # Retrieves forced entitlement keys from provisioning profile metadata to
+    # add them to the final entitlements used by codesign and clang.
+    profile_entitlements = self._profile_metadata.get('Entitlements')
+
+    if not profile_entitlements:
+      return
+
+    forced_profile_entitlements = [
+        'application-identifier',
+        'com.apple.security.get-task-allow',
+        'get-task-allow',
+    ]
+
+    for forced_entitlement in forced_profile_entitlements:
+
+      if forced_entitlement in out_plist:
+        # Validation is skipped since validate_plist takes care of this.
+        continue
+
+      if forced_entitlement in profile_entitlements:
+        out_plist[forced_entitlement] = profile_entitlements[forced_entitlement]
+
   def validate_plist(self, plist):
     bundle_id = self.options.get('bundle_id')
     if bundle_id:

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -19,8 +19,6 @@ import datetime
 import io
 import json
 import os
-import plistlib
-import random
 import re
 import tempfile
 import unittest
@@ -1996,6 +1994,148 @@ class PlistToolTest(unittest.TestCase):
               },
           },
       })
+
+
+class PlistEntitlementsMerge(PlistToolTest):
+
+  def test_entitlements_merge_from_profile_metadata(self):
+    control = {
+        'plists': [{
+            'com.apple.developer.healthkit': True
+        }],
+        'entitlements_options': {
+            'bundle_id': 'my.bundle.id',
+            'profile_metadata_file': {
+                'Entitlements': {
+                    'application-identifier': 'QWERTY.my.bundle.id',
+                    'get-task-allow': True
+                },
+                'Version': 1,
+            },
+        },
+    }
+    expected = {
+        'application-identifier': 'QWERTY.my.bundle.id',
+        'com.apple.developer.healthkit': True,
+        'get-task-allow': True,
+    }
+    self._assert_plisttool_result(control, expected)
+
+  def test_entitlement_task_update_plist(self):
+    testcases = [
+        {
+            'testcase_name': 'adds get-task-allow from profile metadata',
+            'options': {
+                'profile_metadata_file': {
+                    'Entitlements': {
+                        'get-task-allow': True
+                    },
+                    'Version': 1,
+                },
+            },
+            'out_plist': {},
+            'expected': {
+                'get-task-allow': True,
+            }
+        },
+        {
+            'testcase_name':
+                'adds application-identifier from profile metadata',
+            'options': {
+                'profile_metadata_file': {
+                    'Entitlements': {
+                        'application-identifier': 'QWERTY.my.bundle.id',
+                    },
+                    'Version': 1,
+                },
+            },
+            'out_plist': {},
+            'expected': {
+                'application-identifier': 'QWERTY.my.bundle.id',
+            }
+        },
+        {
+            'testcase_name':
+                'adds both get-task-allow and application-identifier',
+            'options': {
+                'profile_metadata_file': {
+                    'Entitlements': {
+                        'get-task-allow': True,
+                        'application-identifier': 'QWERTY.my.bundle.id',
+                    },
+                    'Version': 1,
+                },
+            },
+            'out_plist': {},
+            'expected': {
+                'get-task-allow': True,
+                'application-identifier': 'QWERTY.my.bundle.id',
+            }
+        },
+        {
+            'testcase_name':
+                'updates plist with get-task-allow and application-identifier',
+            'options': {
+                'profile_metadata_file': {
+                    'Entitlements': {
+                        'get-task-allow': True,
+                        'application-identifier': 'QWERTY.my.bundle.id',
+                    },
+                    'Version': 1,
+                },
+            },
+            'out_plist': {
+                'com.apple.developer.healthkit': True
+            },
+            'expected': {
+                'application-identifier': 'QWERTY.my.bundle.id',
+                'com.apple.developer.healthkit': True,
+                'get-task-allow': True,
+            }
+        },
+        {
+            'testcase_name':
+                'does not update since no Entitlements on profile metadata',
+            'options': {
+                'profile_metadata_file': {
+                    'Version': 1,
+                },
+            },
+            'out_plist': {
+                'com.apple.developer.healthkit': True
+            },
+            'expected': {
+                'com.apple.developer.healthkit': True
+            }
+        },
+        {
+            'testcase_name':
+                'does not update key already defined in entitlements',
+            'options': {
+                'profile_metadata_file': {
+                    'Entitlements': {
+                        'get-task-allow': True,
+                        'application-identifier': 'QWERTY.my.bundle.id',
+                    },
+                    'Version': 1,
+                },
+            },
+            'out_plist': {
+                'get-task-allow': False
+            },
+            'expected': {
+                'get-task-allow': False,
+                'application-identifier': 'QWERTY.my.bundle.id',
+            }
+        },
+    ]
+
+    for testcase in testcases:
+      with self.subTest(testcase.get('testcase_name')):
+        task = plisttool.EntitlementsTask(
+            _testing_target, testcase.get('options'))
+        task.update_plist(testcase.get('out_plist'), None)
+        self.assertEqual(testcase.get('out_plist'), testcase.get('expected'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Per Apple documentation on Entitlements, `get-task-allow` and
`application-identifier` are now defined by the provisioning profile.
This change updates `plisttool` Entitlements processing to pull these
properties from the provisioning profile instead and adds them if they
are not already added in the provided Entitlements file.

See more at
https://developer.apple.com/documentation/bundleresources/entitlements/diagnosing_issues_with_entitlements?language=objc

PiperOrigin-RevId: 394024261
(cherry picked from commit f6315eacfdc83f909630ca1f11add03bee71c143)