### PR TITLE
Extended the infoplist_contents_test to validate types of Apple builds. Validate root Info.plist changes when building for bitcode.

### DIFF
--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -53,6 +53,10 @@ def apple_xcframework_test_suite():
             "CFBundlePackageType": "XFWK",
             "XCFrameworkFormatVersion": "1.0",
         },
+        not_expected_keys = [
+            "AvailableLibraries:0:BitcodeSymbolMapsPath",
+            "AvailableLibraries:1:BitcodeSymbolMapsPath",
+        ],
         tags = [name],
     )
 
@@ -75,6 +79,40 @@ def apple_xcframework_test_suite():
             "CFBundlePackageType": "XFWK",
             "XCFrameworkFormatVersion": "1.0",
         },
+        not_expected_keys = [
+            "AvailableLibraries:0:BitcodeSymbolMapsPath",
+            "AvailableLibraries:1:BitcodeSymbolMapsPath",
+        ],
+        tags = [name],
+    )
+
+    infoplist_contents_test(
+        name = "{}_ios_plist_bitcode_test".format(name),
+        apple_bitcode = "embedded",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64",
+            "AvailableLibraries:0:BitcodeSymbolMapsPath": "BCSymbolMaps",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-x86_64-simulator",
+        },
+        not_expected_keys = [
+            "AvailableLibraries:1:BitcodeSymbolMapsPath",
+        ],
+        tags = [name],
+    )
+
+    infoplist_contents_test(
+        name = "{}_ios_fat_plist_bitcode_test".format(name),
+        apple_bitcode = "embedded",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_xcframework",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64_armv7",
+            "AvailableLibraries:0:BitcodeSymbolMapsPath": "BCSymbolMaps",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-i386_arm64_x86_64-simulator",
+        },
+        not_expected_keys = [
+            "AvailableLibraries:1:BitcodeSymbolMapsPath",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -58,7 +58,7 @@ def _apple_verification_transition_impl(settings, attr):
             "//command_line_option:watchos_cpus": "armv7k",
         })
     existing_features = settings.get("//command_line_option:features") or []
-    if attr.sanitizer != "none":
+    if hasattr(attr, "sanitizer") and attr.sanitizer != "none":
         output_dictionary["//command_line_option:features"] = existing_features + [attr.sanitizer]
     else:
         output_dictionary["//command_line_option:features"] = existing_features


### PR DESCRIPTION
PiperOrigin-RevId: 397875319
(cherry picked from commit 12fdd0a610f1448612a6a47d70de9a9de0a1c9b3)