### PR TITLE
Cleanup _report method to deprecate report_extras

### DIFF
--- a/tools/plisttool/plisttool.py
+++ b/tools/plisttool/plisttool.py
@@ -1040,6 +1040,9 @@ class EntitlementsTask(PlistToolTask):
     self._extra_var_subs = {}
     self._unknown_var_msg_addtions = {}
     self._profile_metadata = {}
+    self._validation_mode = self.options.get('validation_mode', 'error')
+
+    assert self._validation_mode in ('error', 'warn', 'skip')
 
     # Load the metadata so the content can be used for substitutions and
     # validations.
@@ -1106,11 +1109,8 @@ class EntitlementsTask(PlistToolTask):
     if self._profile_metadata:
       self._sanity_check_profile()
 
-      validation_mode = self.options.get('validation_mode', 'error')
-      assert validation_mode in ('error', 'warn', 'skip')
-      if validation_mode != 'skip':
-        self._validate_entitlements_against_profile(
-            plist, warn_only=(validation_mode == 'warn'))
+      if self._validation_mode != 'skip':
+        self._validate_entitlements_against_profile(plist)
 
   def _validate_bundle_id_covered(self, bundle_id, entitlements):
     """Checks that the bundle id is covered by the entitlements.
@@ -1161,20 +1161,14 @@ class EntitlementsTask(PlistToolTask):
     # for setting up substitutions. At the moment no validation between them
     # is being done.
 
-  def _validate_entitlements_against_profile(
-      self, entitlements, warn_only):
+  def _validate_entitlements_against_profile(self, entitlements):
     """Checks that the given entitlements are valid for the current profile.
 
     Args:
       entitlements: The entitlements.
-      warn_only: Only issue warnings for issues.
     Raises:
       PlistToolError: For any issues found.
     """
-    report_extras = {}
-    if warn_only:
-      report_extras['warn_only'] = True
-
     # com.apple.developer.team-identifier vs profile's TeamIdentifier and
     # ApplicationIdentifierPrefix
     src_team_id = entitlements.get('com.apple.developer.team-identifier')
@@ -1184,8 +1178,7 @@ class EntitlementsTask(PlistToolTask):
         if src_team_id not in from_profile:
           self._report(
               ENTITLEMENTS_TEAM_ID_PROFILE_MISMATCH % (
-                self.target, src_team_id, key, from_profile),
-              **report_extras)
+                self.target, src_team_id, key, from_profile))
 
     profile_entitlements = self._profile_metadata.get('Entitlements')
 
@@ -1198,34 +1191,39 @@ class EntitlementsTask(PlistToolTask):
           id_supports_wildcards=True):
         self._report(
             ENTITLEMENTS_APP_ID_PROFILE_MISMATCH % (
-              self.target, src_app_id, profile_app_id),
-            **report_extras)
+              self.target, src_app_id, profile_app_id))
 
     for key in _MATCHING_KEYS:
       entitlements_value = entitlements.get(key)
       if entitlements_value is not None and profile_entitlements:
         profile_value = profile_entitlements.get(key)
         if not profile_value:
-          self._report(ENTITLEMENTS_MISSING % (self.target, key),
-                       **report_extras)
+          self._report(ENTITLEMENTS_MISSING % (self.target, key))
         if entitlements_value != profile_value:
           self._report(
             ENTITLEMENTS_VALUE_MISMATCH % (
-              self.target, key, entitlements_value, profile_value),
-            **report_extras)
+              self.target, key, entitlements_value, profile_value))
 
     for key in _POTENTIAL_LIST_KEYS:
       entitlements_value = entitlements.get(key)
       if entitlements_value is not None and profile_entitlements:
         profile_value = profile_entitlements.get(key)
         if not profile_value:
-          self._report(ENTITLEMENTS_MISSING % (self.target, key),
-                      **report_extras)
+          self._report(ENTITLEMENTS_MISSING % (self.target, key))
         elif entitlements_value not in profile_value:
           self._report(
             ENTITLEMENTS_VALUE_NOT_IN_LIST % (
-              self.target, key, entitlements_value, profile_value),
-            **report_extras)
+              self.target, key, entitlements_value, profile_value))
+
+    aps_environment = entitlements.get('aps-environment')
+    if aps_environment and profile_entitlements:
+      profile_aps_environment = profile_entitlements.get('aps-environment')
+      if not profile_aps_environment:
+        self._report(ENTITLEMENTS_APS_ENVIRONMENT_MISSING % self.target)
+      elif aps_environment != profile_aps_environment:
+        self._report(
+            ENTITLEMENTS_APS_ENVIRONMENT_MISMATCH %
+            (self.target, aps_environment, profile_aps_environment))
 
     # If beta-reports-active is in either the profile or the entitlements file
     # it must be in both or the upload will get rejected by Apple
@@ -1237,33 +1235,29 @@ class EntitlementsTask(PlistToolTask):
       if profile_key is None:
         error_msg = ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISSING_PROFILE % (
           self.target, beta_reports_active)
-      self._report(error_msg, **report_extras)
+      self._report(error_msg)
 
     # keychain-access-groups
     self._check_entitlements_array(
         entitlements, profile_entitlements,
         'keychain-access-groups', self.target,
-        report_extras=report_extras,
         supports_wildcards=True)
 
     self._check_entitlements_array(
         entitlements, profile_entitlements,
-        'com.apple.developer.nfc.readersession.formats', self.target,
-        report_extras=report_extras)
+        'com.apple.developer.nfc.readersession.formats', self.target)
 
     # com.apple.security.application-groups
     # (This check does not apply to macOS-only provisioning profiles.)
     if self._profile_metadata.get('Platform', []) != ['OSX']:
       self._check_entitlements_array(
         entitlements, profile_entitlements,
-        'com.apple.security.application-groups', self.target,
-        report_extras=report_extras)
+        'com.apple.security.application-groups', self.target)
 
     # com.apple.developer.associated-domains
     self._check_entitlements_array(
         entitlements, profile_entitlements,
         'com.apple.developer.associated-domains', self.target,
-        report_extras=report_extras,
         supports_wildcards=True,
         allow_wildcards_in_entitlements=True)
 
@@ -1333,7 +1327,6 @@ class EntitlementsTask(PlistToolTask):
                                 key_name,
                                 target,
                                 supports_wildcards=False,
-                                report_extras=None,
                                 allow_wildcards_in_entitlements=False):
     """Checks if the requested entitlements against the profile for a key
 
@@ -1346,7 +1339,6 @@ class EntitlementsTask(PlistToolTask):
       supports_wildcards: True/False for if wildcards should be supported
           value from the profile_entitlements. This also means the entries
           are reverse DNS style.
-      report_extras: A dictionary of extra args for the _report helper.
     Raises:
       PlistToolError: For any issues found.
     """
@@ -1357,47 +1349,35 @@ class EntitlementsTask(PlistToolTask):
     if not profile_entitlements:
       return  # Allow no profile_entitlements just for the plisttool_unittests.
 
-    if report_extras is None:
-      report_extras = dict()
-
     profile_grps = profile_entitlements.get(key_name)
     if not profile_grps:
       self._report(
-          ENTITLEMENTS_HAS_GROUP_PROFILE_DOES_NOT % (target, key_name),
-          **report_extras)
+          ENTITLEMENTS_HAS_GROUP_PROFILE_DOES_NOT % (target, key_name))
       return
 
     for src_grp in src_grps:
       if '*' in src_grp and not allow_wildcards_in_entitlements:
         self._report(
-            ENTITLEMENTS_VALUE_HAS_WILDCARD % (target, key_name, src_grp),
-            **report_extras)
+            ENTITLEMENTS_VALUE_HAS_WILDCARD % (target, key_name, src_grp))
 
       if not self._does_id_match_list(src_grp, profile_grps,
           allowed_supports_wildcards=supports_wildcards):
         self._report(
             ENTITLEMENTS_HAS_GROUP_ENTRY_PROFILE_DOES_NOT % (
-              target, key_name, src_grp, '", "'.join(profile_grps)),
-            **report_extras)
+              target, key_name, src_grp, '", "'.join(profile_grps)))
 
-  def _report(self, msg, msg_suffix=None, warn_only=False):
+  def _report(self, msg):
     """Helper for reporting things.
 
     Args:
       msg: Message to report.
-      msg_suffix: String to append to the message.
-      warn_only: True/False for if a warning should be issued instead of failing
-          the build.
+    Raises:
+      PlistToolError: if 'validation_mode' flag was set to 'error'.
     """
-    if msg_suffix:
-      full_msg = msg + " " + msg_suffix
+    if self._validation_mode != 'error':
+      print('WARNING: ' + msg)
     else:
-      full_msg = msg
-
-    if warn_only:
-      print('WARNING: ' + full_msg)
-    else:
-      raise PlistToolError(full_msg)
+      raise PlistToolError(msg)
 
 
 class PlistTool(object):


### PR DESCRIPTION
This change deprecates two `EntitlementsTask._report()` parameters:
- Removes `warn_only` replaced by `_validation_mode` instance variable.
  - This instance variable is defined by `validation_mode` flag/parameter.
- Removes `msg_suffix` as it's no longer used within the tool and can be added later if needed.

Methods having `_report()` references have been cleaned up to remove
parameters used:
- Removed `warn_only` parameter from `_validate_entitlements_against_profile`.
- Removed `report_extras` from `_check_entitlements_array`.

PiperOrigin-RevId: 398803673
(cherry picked from commit 1143850b7acb98fe56d5c43390d994f97e97327a)