### PR TITLE
Fix to allow the families_required and explicit_minimum_os fields to be respected for XCFramework embedded frameworks. Added tests to cover additional XCFramework functionality.

### DIFF
--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -491,22 +491,15 @@ def _apple_xcframework_impl(ctx):
             apple_fragment = ctx.fragments.apple,
             config_vars = ctx.var,
             cpp_fragment = ctx.fragments.cpp,
-            device_families = getattr(
-                ctx.attr.families_required,
+            device_families = ctx.attr.families_required.get(
                 link_output.platform,
-                rule_descriptor.allowed_device_families,
+                default = rule_descriptor.allowed_device_families,
             ),
             disabled_features = ctx.disabled_features,
-            explicit_minimum_deployment_os = getattr(
-                ctx.attr.minimum_deployment_os_versions,
+            explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_versions.get(
                 link_output.platform,
-                None,
             ),
-            explicit_minimum_os = getattr(
-                ctx.attr.minimum_os_versions,
-                link_output.platform,
-                None,
-            ),
+            explicit_minimum_os = ctx.attr.minimum_os_versions.get(link_output.platform),
             features = ctx.features,
             objc_fragment = ctx.fragments.objc,
             platform_type_string = link_output.platform,

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -260,6 +260,140 @@ def apple_xcframework_test_suite():
         tags = [name],
     )
 
+    # Tests that minimum os versions values are respected by the embedded frameworks.
+    archive_contents_test(
+        name = "{}_ios_minimum_os_versions_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_min_ver_10",
+        plist_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_min_ver_10.framework/Info.plist",
+        plist_test_values = {
+            "MinimumOSVersion": "10.0",
+        },
+        tags = [name],
+    )
+
+    # Tests that options to override the device family (in this case, exclusively "ipad" for the iOS
+    # platform) are respected by the embedded frameworks.
+    archive_contents_test(
+        name = "{}_ios_exclusively_ipad_device_family_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_exclusively_ipad_device_family",
+        plist_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_exclusively_ipad_device_family.framework/Info.plist",
+        plist_test_values = {
+            "UIDeviceFamily:0": "2",
+        },
+        tags = [name],
+    )
+
+    # Tests that info plist merging is respected by XCFrameworks.
+    archive_contents_test(
+        name = "{}_multiple_infoplist_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_multiple_infoplists",
+        plist_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_multiple_infoplists.framework/Info.plist",
+        plist_test_values = {
+            "AnotherKey": "AnotherValue",
+            "CFBundleExecutable": "ios_dynamic_xcframework_multiple_infoplists",
+        },
+        tags = [name],
+    )
+
+    # Tests that resource bundles and files assigned through "data" are respected.
+    archive_contents_test(
+        name = "{}_dbg_resources_data_test".format(name),
+        build_type = "device",
+        compilation_mode = "dbg",
+        is_binary_plist = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_data_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_data_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+        ],
+        is_not_binary_plist = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_data_resource_bundle.framework/Another.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_data_resource_bundle.framework/Another.plist",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_with_data_resource_bundle",
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_opt_resources_data_test".format(name),
+        build_type = "device",
+        compilation_mode = "opt",
+        is_binary_plist = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_data_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_data_resource_bundle.framework/Another.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_data_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_data_resource_bundle.framework/Another.plist",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_with_data_resource_bundle",
+        tags = [name],
+    )
+
+    # Tests that resource bundles assigned through "deps" are respected.
+    archive_contents_test(
+        name = "{}_dbg_resources_deps_test".format(name),
+        build_type = "device",
+        compilation_mode = "dbg",
+        is_binary_plist = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_deps_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_deps_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_with_deps_resource_bundle",
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_opt_resources_deps_test".format(name),
+        build_type = "device",
+        compilation_mode = "opt",
+        is_binary_plist = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_with_deps_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_with_deps_resource_bundle.framework/resource_bundle.bundle/Info.plist",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_with_deps_resource_bundle",
+        tags = [name],
+    )
+
+    # Tests that the exported symbols list works for XCFrameworks.
+    archive_contents_test(
+        name = "{}_exported_symbols_lists_stripped_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_stripped",
+        binary_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_stripped.framework/ios_dynamic_xcframework_stripped",
+        compilation_mode = "opt",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_anotherFunctionShared"],
+        binary_not_contains_symbols = ["_dontCallMeShared", "_anticipatedDeadCode"],
+        tags = [name],
+    )
+
+    # Tests that multiple exported symbols lists works for XCFrameworks.
+    archive_contents_test(
+        name = "{}_two_exported_symbols_lists_stripped_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_stripped_two_exported_symbols_lists",
+        binary_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_stripped_two_exported_symbols_lists.framework/ios_dynamic_xcframework_stripped_two_exported_symbols_lists",
+        compilation_mode = "opt",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_anotherFunctionShared", "_dontCallMeShared"],
+        binary_not_contains_symbols = ["_anticipatedDeadCode"],
+        tags = [name],
+    )
+
+    # Tests that dead stripping + exported symbols lists works for XCFrameworks just as it does for
+    # dynamic frameworks.
+    archive_contents_test(
+        name = "{}_exported_symbols_list_dead_stripped_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_dead_stripped",
+        binary_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_dead_stripped.framework/ios_dynamic_xcframework_dead_stripped",
+        compilation_mode = "opt",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_anotherFunctionShared"],
+        binary_not_contains_symbols = ["_dontCallMeShared", "_anticipatedDeadCode"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -284,3 +284,196 @@ apple_xcframework(
     tags = TARGETS_UNDER_TEST_TAGS,
     deps = [":fmwk_lib"],
 )
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_min_ver_10",
+    bundle_id = "com.google.example",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "10.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_exclusively_ipad_device_family",
+    bundle_id = "com.google.example",
+    families_required = {
+        "ios": ["ipad"],
+    },
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+        "//test/starlark_tests/resources:Another.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_multiple_infoplists",
+    bundle_id = "com.google.example",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+        "//test/starlark_tests/resources:Another.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_with_data_resource_bundle",
+    bundle_id = "com.google.example",
+    data = [
+        "//test/starlark_tests/resources:Another.plist",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_with_deps_resource_bundle",
+    bundle_id = "com.google.example",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [
+        ":fmwk_lib",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_stripped",
+    bundle_id = "com.google.example",
+    exported_symbols_lists = [
+        "//test/starlark_tests/resources:ExportAnotherFunctionShared.exp",
+    ],
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    linkopts = ["-x"],
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_stripped_two_exported_symbols_lists",
+    bundle_id = "com.google.example",
+    exported_symbols_lists = [
+        "//test/starlark_tests/resources:ExportAnotherFunctionShared.exp",
+        "//test/starlark_tests/resources:ExportDontCallMeShared.exp",
+    ],
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    linkopts = ["-x"],
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_xcframework_dead_stripped",
+    bundle_id = "com.google.example",
+    exported_symbols_lists = [
+        "//test/starlark_tests/resources:ExportAnotherFunctionShared.exp",
+    ],
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    linkopts = ["-dead_strip"],
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)


### PR DESCRIPTION
PiperOrigin-RevId: 398114251
(cherry picked from commit 9bdf66817451fef6ecf742fb98a32a4da6761bdd)
