### PR TITLE
Update dossier codesign threads tests order

### DIFF
--- a/tools/dossier_codesigningtool/dossier_codesigningtool_test.py
+++ b/tools/dossier_codesigningtool/dossier_codesigningtool_test.py
@@ -70,7 +70,7 @@ class DossierCodesigningtoolTest(unittest.TestCase):
         override_codesign_identity='-')
 
     self.assertEqual(mock_codesign.call_count, 5)
-    mock_codesign_paths = [
+    actual_paths = [
         mock_codesign.call_args_list[0][1]['full_path_to_sign'],
         mock_codesign.call_args_list[1][1]['full_path_to_sign'],
         mock_codesign.call_args_list[2][1]['full_path_to_sign'],
@@ -84,8 +84,27 @@ class DossierCodesigningtoolTest(unittest.TestCase):
         '/tmp/fake.app/Watch/WatchApp.app',
         '/tmp/fake.app/'
     ]
+    self.assertSetEqual(set(actual_paths), set(expected_paths))
+
     # assert codesign threads block correctly (executed bottom-up)
-    self.assertListEqual(mock_codesign_paths, expected_paths)
+    self.assertLess(
+        actual_paths.index(
+            '/tmp/fake.app/Watch/WatchApp.app/PlugIns/WatchExtension.appex'),
+        actual_paths.index('/tmp/fake.app/Watch/WatchApp.app'))
+    self.assertLess(
+        actual_paths.index(
+            '/tmp/fake.app/Watch/WatchApp.app/PlugIns/WatchExtension.appex'),
+        actual_paths.index('/tmp/fake.app/'))
+
+    self.assertLess(
+        actual_paths.index('/tmp/fake.app/Watch/WatchApp.app'),
+        actual_paths.index('/tmp/fake.app/'))
+    self.assertLess(
+        actual_paths.index('/tmp/fake.app/PlugIns/IntentsExtension.appex'),
+        actual_paths.index('/tmp/fake.app/'))
+    self.assertLess(
+        actual_paths.index('/tmp/fake.app/PlugIns/IntentsUIExtension.appex'),
+        actual_paths.index('/tmp/fake.app/'))
 
   @mock.patch.object(
       dossier_codesigningtool, '_fetch_preferred_signing_identity')


### PR DESCRIPTION
- Updates a failing dossier codesign test to assert all paths are signed
to use a Python `set` instead of `list` due to signing race conditions.

- Adds tests to assert signing blocks outer bundles (i.e. signing is done
bottom-up) using mock call list index to verify parents are signed after
children.

PiperOrigin-RevId: 401844699
(cherry picked from commit d1efbc987f44c528596b455e595b1873040ec856)
