### PR TITLE
Add interface generation logic to allow Swift interoperability with dynamic XCFrameworks.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -284,6 +284,7 @@ bzl_library(
         "//apple/internal/partials:debug_symbols",
         "//apple/internal/partials:embedded_bundles",
         "//apple/internal/partials:extension_safe_validation",
+        "//apple/internal/partials:framework_header_modulemap",
         "//apple/internal/partials:framework_headers",
         "//apple/internal/partials:framework_import",
         "//apple/internal/partials:framework_provider",
@@ -292,8 +293,8 @@ bzl_library(
         "//apple/internal/partials:provisioning_profile",
         "//apple/internal/partials:resources",
         "//apple/internal/partials:settings_bundle",
-        "//apple/internal/partials:static_framework_header_modulemap",
         "//apple/internal/partials:swift_dylibs",
+        "//apple/internal/partials:swift_framework",
         "//apple/internal/partials:swift_static_framework",
         "//apple/internal/partials:watchos_stub",
     ],
@@ -419,6 +420,18 @@ bzl_library(
     deps = [
         ":intermediates",
         "@build_bazel_apple_support//lib:apple_support",
+    ],
+)
+
+bzl_library(
+    name = "swift_info_support",
+    srcs = ["swift_info_support.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "//apple/internal:intermediates",
+        "@bazel_skylib//lib:sets",
     ],
 )
 

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -45,6 +45,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//apple/internal:swift_info_support",
         "@bazel_skylib//lib:sets",
         "@build_bazel_rules_swift//swift",
     ],

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1380,12 +1380,13 @@ def _ios_static_framework_impl(ctx):
         )
     else:
         processor_partials.append(
-            partials.static_framework_header_modulemap_partial(
+            partials.framework_header_modulemap_partial(
                 actions = actions,
-                binary_objc_provider = binary_target[apple_common.Objc],
                 bundle_name = bundle_name,
                 hdrs = ctx.files.hdrs,
                 label_name = label.name,
+                sdk_dylibs = getattr(binary_target[apple_common.Objc], "sdk_dylib", []),
+                sdk_frameworks = getattr(binary_target[apple_common.Objc], "sdk_framework", []),
                 umbrella_header = ctx.file.umbrella_header,
             ),
         )

--- a/apple/internal/partials.bzl
+++ b/apple/internal/partials.bzl
@@ -55,6 +55,10 @@ load(
     _extension_safe_validation_partial = "extension_safe_validation_partial",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/partials:framework_header_modulemap.bzl",
+    _framework_header_modulemap_partial = "framework_header_modulemap_partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/partials:framework_headers.bzl",
     _framework_headers_partial = "framework_headers_partial",
 )
@@ -87,16 +91,16 @@ load(
     _settings_bundle_partial = "settings_bundle_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:static_framework_header_modulemap.bzl",
-    _static_framework_header_modulemap_partial = "static_framework_header_modulemap_partial",
-)
-load(
     "@build_bazel_rules_apple//apple/internal/partials:swift_dylibs.bzl",
     _swift_dylibs_partial = "swift_dylibs_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:swift_dynamic_framework.bzl",
     _swift_dynamic_framework_partial = "swift_dynamic_framework_partial",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/partials:swift_framework.bzl",
+    _swift_framework_partial = "swift_framework_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:swift_static_framework.bzl",
@@ -118,6 +122,7 @@ partials = struct(
     embedded_bundles_partial = _embedded_bundles_partial,
     extension_safe_validation_partial = _extension_safe_validation_partial,
     framework_import_partial = _framework_import_partial,
+    framework_header_modulemap_partial = _framework_header_modulemap_partial,
     framework_headers_partial = _framework_headers_partial,
     framework_provider_partial = _framework_provider_partial,
     macos_additional_contents_partial = _macos_additional_contents_partial,
@@ -125,9 +130,9 @@ partials = struct(
     provisioning_profile_partial = _provisioning_profile_partial,
     resources_partial = _resources_partial,
     settings_bundle_partial = _settings_bundle_partial,
-    static_framework_header_modulemap_partial = _static_framework_header_modulemap_partial,
     swift_dylibs_partial = _swift_dylibs_partial,
     swift_dynamic_framework_partial = _swift_dynamic_framework_partial,
+    swift_framework_partial = _swift_framework_partial,
     swift_static_framework_partial = _swift_static_framework_partial,
     apple_symbols_file_partial = _apple_symbols_file_partial,
     watchos_stub_partial = _watchos_stub_partial,

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -142,6 +142,19 @@ bzl_library(
 )
 
 bzl_library(
+    name = "framework_header_modulemap",
+    srcs = ["framework_header_modulemap.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "//apple/internal:intermediates",
+        "//apple/internal:processor",
+        "@bazel_skylib//lib:partial",
+    ],
+)
+
+bzl_library(
     name = "framework_headers",
     srcs = ["framework_headers.bzl"],
     visibility = [
@@ -260,19 +273,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "static_framework_header_modulemap",
-    srcs = ["static_framework_header_modulemap.bzl"],
-    visibility = [
-        "//apple/internal:__pkg__",
-    ],
-    deps = [
-        "//apple/internal:intermediates",
-        "//apple/internal:processor",
-        "@bazel_skylib//lib:partial",
-    ],
-)
-
-bzl_library(
     name = "swift_dylibs",
     srcs = ["swift_dylibs.bzl"],
     visibility = [
@@ -290,14 +290,28 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_framework",
+    srcs = ["swift_framework.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "//apple/internal:processor",
+        "//apple/internal:swift_info_support",
+        "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
     name = "swift_static_framework",
     srcs = ["swift_static_framework.bzl"],
     visibility = [
         "//apple/internal:__pkg__",
     ],
     deps = [
-        "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "//apple/internal:swift_info_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
     ],

--- a/apple/internal/partials/framework_header_modulemap.bzl
+++ b/apple/internal/partials/framework_header_modulemap.bzl
@@ -1,4 +1,4 @@
-# Copyright 2018 The Bazel Authors. All rights reserved.
+# Copyright 2021 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Partial implementation for bundling header and modulemaps for static frameworks."""
+"""Partial implementation for bundling header and modulemaps for external-facing frameworks."""
 
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
@@ -112,16 +112,17 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
-def _static_framework_header_modulemap_partial_impl(
+def _framework_header_modulemap_partial_impl(
         *,
         actions,
-        binary_objc_provider,
         bundle_name,
         hdrs,
         label_name,
         output_discriminator,
+        sdk_dylibs,
+        sdk_frameworks,
         umbrella_header):
-    """Implementation for the static framework headers and modulemaps partial."""
+    """Implementation for the sdk framework headers and modulemaps partial."""
     bundle_files = []
 
     umbrella_header_name = None
@@ -158,9 +159,6 @@ def _static_framework_header_modulemap_partial_impl(
     else:
         umbrella_header_name = None
 
-    sdk_dylibs = getattr(binary_objc_provider, "sdk_dylib", None)
-    sdk_frameworks = getattr(binary_objc_provider, "sdk_framework", None)
-
     # Create a module map if there is a need for one (that is, if there are
     # headers or if there are dylibs/frameworks that the target depends on).
     if any([sdk_dylibs, sdk_frameworks, umbrella_header_name]):
@@ -175,7 +173,7 @@ def _static_framework_header_modulemap_partial_impl(
             modulemap_file,
             bundle_name,
             umbrella_header_name,
-            sorted(sdk_dylibs.to_list()) if sdk_dylibs else [],
+            sorted(sdk_dylibs.to_list() if sdk_dylibs else []),
             sorted(sdk_frameworks.to_list() if sdk_frameworks else []),
         )
         bundle_files.append((processor.location.bundle, "Modules", depset([modulemap_file])))
@@ -184,40 +182,43 @@ def _static_framework_header_modulemap_partial_impl(
         bundle_files = bundle_files,
     )
 
-def static_framework_header_modulemap_partial(
+def framework_header_modulemap_partial(
         *,
         actions,
-        binary_objc_provider,
         bundle_name,
         hdrs,
         label_name,
         output_discriminator = None,
+        sdk_dylibs = [],
+        sdk_frameworks = [],
         umbrella_header):
-    """Constructor for the static framework headers and modulemaps partial.
+    """Constructor for the framework headers and modulemaps partial.
 
-    This partial bundles the headers and modulemaps for static frameworks.
+    This partial bundles the headers and modulemaps for sdk frameworks.
 
     Args:
       actions: The actions provider from `ctx.actions`.
-      binary_objc_provider: The ObjC provider for the binary target.
       bundle_name: The name of the output bundle.
       hdrs: The list of headers to bundle.
       label_name: Name of the target being built.
       output_discriminator: A string to differentiate between different target intermediate files
           or `None`.
+      sdk_dylibs: A list of dynamic libraries referenced by this framework.
+      sdk_frameworks: A list of frameworks referenced by this framework.
       umbrella_header: An umbrella header to use instead of generating one
 
     Returns:
-      A partial that returns the bundle location of the static framework header and modulemap
+      A partial that returns the bundle location of the sdk framework header and modulemap
       artifacts.
     """
     return partial.make(
-        _static_framework_header_modulemap_partial_impl,
+        _framework_header_modulemap_partial_impl,
         actions = actions,
-        binary_objc_provider = binary_objc_provider,
         bundle_name = bundle_name,
         hdrs = hdrs,
         label_name = label_name,
         output_discriminator = output_discriminator,
+        sdk_dylibs = sdk_dylibs,
+        sdk_frameworks = sdk_frameworks,
         umbrella_header = umbrella_header,
     )

--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -1,0 +1,220 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support methods for handling artifacts from SwiftInfo providers."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
+)
+load("@bazel_skylib//lib:sets.bzl", "sets")
+
+def _verify_found_module_name(*, bundle_name, found_module_name):
+    """Validate that the module name fits the requirements for Swift frameworks.
+
+    Args:
+        bundle_name: The bundle name for this Swift framework.
+        found_module_name: The module name that was found from a SwiftInfo provider.
+    """
+    if bundle_name != found_module_name:
+        fail("""
+error: Found swift_library with module name {actual} but expected {expected}. Swift static \
+frameworks expect a single swift_library dependency with `module_name` set to the same \
+`bundle_name` as the static framework target.\
+""".format(
+            actual = found_module_name,
+            expected = bundle_name,
+        ))
+
+def _swift_include_info(
+        *,
+        avoid_modules = sets.make(),
+        found_module_name,
+        transitive_modules):
+    """Returns the module containing the Swift interface information from a SwiftInfo provider.
+
+    Args:
+        avoid_modules: A set of modules to avoid, if specified.
+        found_module_name: The module name that was previously found from transitive deps.
+        transitive_modules: The transitive_modules field of a SwiftInfo provider.
+
+    Returns:
+        The module found from `transitive_modules` that has the necessary swift interfaces.
+    """
+    swift_module = None
+
+    for module in transitive_modules.to_list():
+        if not module.swift or sets.contains(avoid_modules, module.name):
+            continue
+
+        if swift_module or (found_module_name and module.name != found_module_name):
+            fail(
+                """\
+error: Swift third party frameworks expect a single swift_library dependency with no transitive \
+swift_library dependencies.\
+""",
+            )
+
+        if not all([module.name, module.swift.swiftdoc, module.swift.swiftinterface]):
+            fail(
+                """\
+error: Could not find all required artifacts and information to build a Swift framework. \
+Please file an issue with a reproducible error case.\
+""",
+            )
+
+        swift_module = module
+
+    return swift_module
+
+def _modulemap_contents(*, module_name):
+    """Returns the contents for the modulemap file for a Swift framework."""
+    return """\
+framework module {module_name} {{
+  header "{module_name}.h"
+  requires objc
+}}
+""".format(module_name = module_name)
+
+def _declare_modulemap(
+        *,
+        actions,
+        label_name,
+        module_name,
+        output_discriminator):
+    """Generates and declares the modulemap file for this Swift framework.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        label_name: Name of the target being built.
+        module_name: The name of the Swift module.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
+
+    Returns:
+        A File referencing the intermediate generated modulemap.
+    """
+    modulemap = intermediates.file(
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "module.modulemap",
+    )
+    actions.write(modulemap, _modulemap_contents(module_name = module_name))
+    return modulemap
+
+def _declare_generated_header(
+        *,
+        actions,
+        generated_header,
+        label_name,
+        module_name,
+        output_discriminator):
+    """Declares the generated header file for this Swift framework.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        generated_header: A File referencing the generated header from a SwiftInfo provider.
+        label_name: Name of the target being built.
+        module_name: The name of the Swift module.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
+
+    Returns:
+        A File referencing the intermediate generated header.
+    """
+    bundle_header = intermediates.file(
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "{}.h".format(module_name),
+    )
+    actions.symlink(
+        target_file = generated_header,
+        output = bundle_header,
+    )
+    return bundle_header
+
+def _declare_swiftdoc(
+        *,
+        actions,
+        arch,
+        label_name,
+        output_discriminator,
+        swiftdoc):
+    """Declares the swiftdoc for this Swift framework.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        arch: The cpu architecture that the generated swiftdoc belongs to.
+        label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
+        swiftdoc: A File referencing the swiftdoc file from a SwiftInfo provider.
+
+    Returns:
+        A File referencing the intermediate swiftdoc.
+    """
+    bundle_doc = intermediates.file(
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "{}.swiftdoc".format(arch),
+    )
+    actions.symlink(
+        target_file = swiftdoc,
+        output = bundle_doc,
+    )
+    return bundle_doc
+
+def _declare_swiftinterface(
+        *,
+        actions,
+        arch,
+        label_name,
+        output_discriminator,
+        swiftinterface):
+    """Declares the swiftinterface for this Swift framework.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        arch: The cpu architecture that the generated swiftdoc belongs to.
+        label_name: Name of the target being built.
+        output_discriminator: A string to differentiate between different target intermediate files
+            or `None`.
+        swiftinterface: A File referencing the swiftinterface file from a SwiftInfo provider.
+
+    Returns:
+        A File referencing the intermediate swiftinterface.
+    """
+    bundle_interface = intermediates.file(
+        actions = actions,
+        target_name = label_name,
+        output_discriminator = output_discriminator,
+        file_name = "{}.swiftinterface".format(arch),
+    )
+    actions.symlink(
+        target_file = swiftinterface,
+        output = bundle_interface,
+    )
+    return bundle_interface
+
+swift_info_support = struct(
+    verify_found_module_name = _verify_found_module_name,
+    swift_include_info = _swift_include_info,
+    declare_modulemap = _declare_modulemap,
+    declare_generated_header = _declare_generated_header,
+    declare_swiftdoc = _declare_swiftdoc,
+    declare_swiftinterface = _declare_swiftinterface,
+)

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -76,12 +76,20 @@ def _min_os_version_or_none(*, minimum_os_version, platform, platform_type):
         return minimum_os_version
     return None
 
-def _command_line_options(*, cpu = None, minimum_os_version, platform_type, settings):
+def _command_line_options(
+        *,
+        cpu = None,
+        emit_swiftinterface = False,
+        minimum_os_version,
+        platform_type,
+        settings):
     """Generates a dictionary of command line options suitable for the current target.
 
     Args:
         cpu: A valid Apple cpu command line option as a string, or None to infer a value from
             command line options passed through settings.
+        emit_swiftinterface: Wheither to emit swift interfaces for the given target. Defaults to
+            `False`.
         minimum_os_version: A string representing the minimum OS version specified for this
             platform, represented as a dotted version number (for example, `"9.0"`).
         platform_type: The Apple platform for which the rule should build its targets (`"ios"`,
@@ -94,7 +102,7 @@ def _command_line_options(*, cpu = None, minimum_os_version, platform_type, sett
         A dictionary of `"//command_line_option"`s defined for the current target.
     """
 
-    return {
+    output_dictionary = {
         "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,
         "//command_line_option:apple_platform_type": platform_type,
         "//command_line_option:apple_split_cpu": cpu if cpu else "",
@@ -131,12 +139,25 @@ def _command_line_options(*, cpu = None, minimum_os_version, platform_type, sett
         ),
     }
 
-def _command_line_options_multi_cpu(*, cpus = None, minimum_os_version, platform_type, settings):
+    if emit_swiftinterface:
+        output_dictionary["@build_bazel_rules_swift//swift:emit_swiftinterface"] = True
+
+    return output_dictionary
+
+def _command_line_options_multi_cpu(
+        *,
+        cpus = None,
+        emit_swiftinterface = False,
+        minimum_os_version,
+        platform_type,
+        settings):
     """Generates a dictionary of command line options suitable for a natively linked target.
 
     Args:
         cpus: A valid series of Apple cpu command line options as a list of strings, or None to
             infer a value from `*_multi_cpus` command line options passed through settings.
+        emit_swiftinterface: Wheither to emit swift interfaces for the given target. Defaults to
+            `False`.
         minimum_os_version: A string representing the minimum OS version specified for this
             platform, represented as a dotted version number (for example, `"9.0"`).
         platform_type: The Apple platform for which the rule should build its targets (`"ios"`,
@@ -149,7 +170,7 @@ def _command_line_options_multi_cpu(*, cpus = None, minimum_os_version, platform
         A dictionary of `"//command_line_option"`s defined for the current target.
     """
 
-    return {
+    output_dictionary = {
         "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,
         "//command_line_option:apple_platform_type": platform_type,
         # Set apple_split_cpu to the empty string, treating it as though it is not manually set to
@@ -197,6 +218,11 @@ def _command_line_options_multi_cpu(*, cpus = None, minimum_os_version, platform
         "//command_line_option:watchos_cpus": cpus if platform_type == "watchos" else [],
     }
 
+    if emit_swiftinterface:
+        output_dictionary["@build_bazel_rules_swift//swift:emit_swiftinterface"] = True
+
+    return output_dictionary
+
 def _xcframework_split_attr_key(*, cpu, environment, platform_type):
     """Return the split attribute key for this target within the XCFramework given linker options.
 
@@ -227,6 +253,7 @@ def _resolved_cpu_for_cpu(*, cpu, environment):
 
 def _command_line_options_for_platform(
         *,
+        emit_swiftinterface = False,
         minimum_os_version,
         platform_attr,
         platform_type,
@@ -236,6 +263,8 @@ def _command_line_options_for_platform(
     """Generates a dictionary of command line options keyed by 1:2+ transition for this platform.
 
     Args:
+        emit_swiftinterface: Wheither to emit swift interfaces for the given target. Defaults to
+            `False`.
         minimum_os_version: A string representing the minimum OS version specified for this
             platform, represented as a dotted version number (for example, `"9.0"`).
         platform_attr: The attribute for the apple platform specifying in dictionary form which
@@ -272,6 +301,7 @@ def _command_line_options_for_platform(
                             platform_type = platform_type,
                         ): _command_line_options(
                             cpu = resolved_cpu,
+                            emit_swiftinterface = emit_swiftinterface,
                             minimum_os_version = minimum_os_version,
                             platform_type = platform_type,
                             settings = settings,
@@ -294,6 +324,7 @@ def _command_line_options_for_platform(
                         platform_type = platform_type,
                     ): _command_line_options_multi_cpu(
                         cpus = resolved_cpus,
+                        emit_swiftinterface = emit_swiftinterface,
                         minimum_os_version = minimum_os_version,
                         platform_type = platform_type,
                         settings = settings,
@@ -384,11 +415,17 @@ _static_framework_transition = transition(
     ],
 )
 
-def _output_dictionary_for_xcframework_transition(*, attr, settings, split_on_cpus):
+def _output_dictionary_for_xcframework_transition(
+        *,
+        attr,
+        emit_swiftinterface,
+        settings,
+        split_on_cpus):
     """Creates the appropriate output dictionary for each split of an XCFramework transition"""
     output_dictionary = {}
     if hasattr(attr, "macos"):
         command_line_options_for_platform = _command_line_options_for_platform(
+            emit_swiftinterface = emit_swiftinterface,
             minimum_os_version = attr.minimum_os_versions.get("macos"),
             platform_attr = attr.macos,
             platform_type = "macos",
@@ -400,6 +437,7 @@ def _output_dictionary_for_xcframework_transition(*, attr, settings, split_on_cp
     for platform_type in ["ios", "tvos", "watchos"]:
         if hasattr(attr, platform_type):
             command_line_options_for_platform = _command_line_options_for_platform(
+                emit_swiftinterface = emit_swiftinterface,
                 minimum_os_version = attr.minimum_os_versions.get(platform_type),
                 platform_attr = getattr(attr, platform_type),
                 platform_type = platform_type,
@@ -414,6 +452,7 @@ def _xcframework_transition_impl(settings, attr):
     """Starlark 1:2+ transition for generation of multiple frameworks for the current target."""
     return _output_dictionary_for_xcframework_transition(
         attr = attr,
+        emit_swiftinterface = True,
         settings = settings,
         split_on_cpus = True,
     )
@@ -421,13 +460,16 @@ def _xcframework_transition_impl(settings, attr):
 _xcframework_transition = transition(
     implementation = _xcframework_transition_impl,
     inputs = _apple_rule_common_transition_inputs,
-    outputs = _apple_rule_base_transition_outputs,
+    outputs = _apple_rule_base_transition_outputs + [
+        "@build_bazel_rules_swift//swift:emit_swiftinterface",
+    ],
 )
 
 def _xcframework_native_lipo_transition_impl(settings, attr):
     """Starlark 1:2+ transition for native linking and lipoing of libraries for a given target."""
     return _output_dictionary_for_xcframework_transition(
         attr = attr,
+        emit_swiftinterface = False,
         settings = settings,
         split_on_cpus = False,
     )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -1024,12 +1024,13 @@ def _tvos_static_framework_impl(ctx):
         )
     else:
         processor_partials.append(
-            partials.static_framework_header_modulemap_partial(
+            partials.framework_header_modulemap_partial(
                 actions = actions,
-                binary_objc_provider = binary_target[apple_common.Objc],
                 bundle_name = bundle_name,
                 hdrs = ctx.files.hdrs,
                 label_name = label.name,
+                sdk_dylibs = getattr(binary_target[apple_common.Objc], "sdk_dylib", []),
+                sdk_frameworks = getattr(binary_target[apple_common.Objc], "sdk_framework", []),
                 umbrella_header = ctx.file.umbrella_header,
             ),
         )

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -819,12 +819,13 @@ def _watchos_static_framework_impl(ctx):
         )
     else:
         processor_partials.append(
-            partials.static_framework_header_modulemap_partial(
+            partials.framework_header_modulemap_partial(
                 actions = actions,
-                binary_objc_provider = binary_target[apple_common.Objc],
                 bundle_name = bundle_name,
                 hdrs = ctx.files.hdrs,
                 label_name = label.name,
+                sdk_dylibs = getattr(binary_target[apple_common.Objc], "sdk_dylib", []),
+                sdk_frameworks = getattr(binary_target[apple_common.Objc], "sdk_framework", []),
                 umbrella_header = ctx.file.umbrella_header,
             ),
         )

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -84,6 +84,7 @@ load(
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
     "swift_usage_aspect",
 )
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
@@ -536,7 +537,6 @@ def _apple_xcframework_impl(ctx):
             split_attr_keys = split_attr_keys,
         )
 
-        # TODO(b/174858377): Add support for debug outputs such as dSYM bundles.
         processor_partials = [
             partials.apple_bundle_info_partial(
                 actions = actions,
@@ -580,7 +580,6 @@ def _apple_xcframework_impl(ctx):
                 platform_prerequisites = platform_prerequisites,
                 rule_label = label,
             ),
-            partials.framework_headers_partial(hdrs = ctx.files.public_hdrs),
             partials.resources_partial(
                 actions = actions,
                 apple_toolchain_info = apple_toolchain_info,
@@ -609,6 +608,45 @@ def _apple_xcframework_impl(ctx):
                 platform_prerequisites = platform_prerequisites,
             ),
         ]
+
+        swift_infos = {}
+
+        # If there's any Swift dependencies on this framework rule, look for providers to see if we
+        # need to generate Swift interfaces.
+        if uses_swift:
+            # Architecture does matter to the swiftinterfaces. Here, take advantage of the archs to
+            # create a new dictionary of arch-specific deps with SwiftInfo instances.
+            for architecture in link_output.architectures:
+                arch_split_attr_key = transition_support.xcframework_split_attr_key(
+                    cpu = architecture,
+                    environment = link_output.environment,
+                    platform_type = link_output.platform,
+                )
+                for dep in ctx.split_attr.deps[arch_split_attr_key]:
+                    if SwiftInfo in dep:
+                        swift_infos[architecture] = dep[SwiftInfo]
+
+        if swift_infos:
+            processor_partials.append(
+                partials.swift_framework_partial(
+                    actions = actions,
+                    bundle_name = bundle_name,
+                    label_name = label.name,
+                    output_discriminator = library_identifier,
+                    swift_infos = swift_infos,
+                ),
+            )
+        else:
+            processor_partials.append(
+                partials.framework_header_modulemap_partial(
+                    actions = actions,
+                    bundle_name = bundle_name,
+                    hdrs = ctx.files.public_hdrs,
+                    label_name = label.name,
+                    output_discriminator = library_identifier,
+                    umbrella_header = None,
+                ),
+            )
 
         processor_result = processor.process(
             actions = actions,

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -124,6 +124,8 @@ def apple_xcframework_test_suite():
         macho_load_commands_contain = ["name @rpath/ios_dynamic_xcframework.framework/ios_dynamic_xcframework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/Headers/shared.h",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/Headers/ios_dynamic_xcframework.h",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/Modules/module.modulemap",
             "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/ios_dynamic_xcframework",
             "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
@@ -139,6 +141,8 @@ def apple_xcframework_test_suite():
         macho_load_commands_contain = ["name @rpath/ios_dynamic_xcframework.framework/ios_dynamic_xcframework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/Headers/shared.h",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/Headers/ios_dynamic_xcframework.h",
+            "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/Modules/module.modulemap",
             "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/ios_dynamic_xcframework",
             "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
@@ -154,6 +158,8 @@ def apple_xcframework_test_suite():
         macho_load_commands_contain = ["name @rpath/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/ios-arm64_armv7/ios_dynamic_lipoed_xcframework.framework/Headers/shared.h",
+            "$BUNDLE_ROOT/ios-arm64_armv7/ios_dynamic_lipoed_xcframework.framework/Headers/ios_dynamic_lipoed_xcframework.h",
+            "$BUNDLE_ROOT/ios-arm64_armv7/ios_dynamic_lipoed_xcframework.framework/Modules/module.modulemap",
             "$BUNDLE_ROOT/ios-arm64_armv7/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework",
             "$BUNDLE_ROOT/ios-arm64_armv7/ios_dynamic_lipoed_xcframework.framework/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
@@ -169,6 +175,8 @@ def apple_xcframework_test_suite():
         macho_load_commands_contain = ["name @rpath/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework (offset 24)"],
         contains = [
             "$BUNDLE_ROOT/ios-i386_arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/Headers/shared.h",
+            "$BUNDLE_ROOT/ios-i386_arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/Headers/ios_dynamic_lipoed_xcframework.h",
+            "$BUNDLE_ROOT/ios-i386_arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/Modules/module.modulemap",
             "$BUNDLE_ROOT/ios-i386_arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework",
             "$BUNDLE_ROOT/ios-i386_arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
@@ -391,6 +399,49 @@ def apple_xcframework_test_suite():
         binary_test_architecture = "x86_64",
         binary_contains_symbols = ["_anotherFunctionShared"],
         binary_not_contains_symbols = ["_dontCallMeShared", "_anticipatedDeadCode"],
+        tags = [name],
+    )
+
+    # Tests that generated swift interfaces work for XCFrameworks when a swift_library is included.
+    archive_contents_test(
+        name = "{}_swift_interface_generation_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_swift_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/arm64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/arm64.swiftinterface",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/x86_64.swiftinterface",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/ios_dynamic_lipoed_swift_xcframework",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_swift_xcframework.framework/Info.plist",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/arm64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_lipoed_swift_xcframework.framework/Modules/ios_dynamic_lipoed_swift_xcframework.swiftmodule/arm64.swiftinterface",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_lipoed_swift_xcframework.framework/ios_dynamic_lipoed_swift_xcframework",
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_lipoed_swift_xcframework.framework/Info.plist",
+            "$BUNDLE_ROOT/Info.plist",
+        ],
+        tags = [name],
+    )
+
+    # Test that the Swift generated header is propagated to the Headers visible within this iOS
+    # framework along with the swift interfaces and modulemap.
+    archive_contents_test(
+        name = "{}_swift_generates_header_test".format(name),
+        build_type = "simulator",
+        compilation_mode = "opt",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_swift_xcframework_with_generated_header",
+        contains = [
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+            "$BUNDLE_ROOT/ios-arm64/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+            "$BUNDLE_ROOT/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+            "$BUNDLE_ROOT/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+            "$BUNDLE_ROOT/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -96,6 +96,22 @@ def ios_static_framework_test_suite(name = "ios_static_framework"):
         text_test_values = [" umbrella header \"objc_static_framework.h\""],
     )
 
+    # Test that the Swift generated header is propagated to the Headers visible
+    # within this iOS framework along with the swift interfaces and modulemap.
+    archive_contents_test(
+        name = "{}_swift_generates_header_test".format(name),
+        build_type = "simulator",
+        compilation_mode = "opt",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:static_framework_with_generated_header",
+        contains = [
+            "$BUNDLE_ROOT/Headers/StaticFmwkWithGenHeader.h",
+            "$BUNDLE_ROOT/Modules/module.modulemap",
+            "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -18,6 +18,10 @@ load(
     "//apple:resources.bzl",
     "apple_core_data_model",
 )
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
 
 licenses(["notice"])
 
@@ -238,6 +242,15 @@ objc_library(
     tags = TARGETS_UNDER_TEST_TAGS,
 )
 
+swift_library(
+    name = "swift_fmwk_lib",
+    srcs = [
+        "DummyFmwk.swift",
+    ],
+    module_name = "ios_dynamic_lipoed_swift_xcframework",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
 apple_xcframework(
     name = "ios_dynamic_xcframework",
     bundle_id = "com.google.example",
@@ -285,6 +298,29 @@ apple_xcframework(
     ],
     tags = TARGETS_UNDER_TEST_TAGS,
     deps = [":fmwk_lib"],
+)
+
+apple_xcframework(
+    name = "ios_dynamic_lipoed_swift_xcframework",
+    bundle_id = "com.google.example",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": [
+            "arm64",
+        ],
+    },
+    minimum_os_versions = {
+        "ios": "10.0",
+    },
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":swift_fmwk_lib"],
 )
 
 apple_xcframework(
@@ -480,6 +516,33 @@ apple_xcframework(
     deps = [":fmwk_lib"],
 )
 
+apple_xcframework(
+    name = "ios_swift_xcframework_with_generated_header",
+    bundle_id = "com.google.example",
+    bundle_name = "SwiftFmwkWithGenHeader",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": [
+            "arm64",
+        ],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":SwiftFmwkWithGenHeader"],
+)
+
 apple_static_xcframework(
     name = "ios_static_xcframework",
     ios = {
@@ -529,6 +592,12 @@ genrule(
 )
 
 genrule(
+    name = "dummy_fmwk_swift_src",
+    outs = ["DummyFmwk.swift"],
+    cmd = "echo 'import Foundation\n@objc public class SharedClass: NSObject {\n@objc public func doSomethingShared() {\nNSLog(\"Doing something shared!\")\n}\n}\n' > $@",
+)
+
+genrule(
     name = "dummy_fmwk_dependent_objc_src",
     outs = ["DummyFmwkDependent.m"],
     cmd = "echo '#import <Foundation/Foundation.h>\nvoid frameworkDependent() { NSLog(@\"frameworkDependent() called\"); }' > $@",
@@ -547,5 +616,13 @@ objc_library(
 objc_library(
     name = "StaticFmwkLowerLib",
     srcs = ["DummyFmwkDependent.m"],
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+swift_library(
+    name = "SwiftFmwkWithGenHeader",
+    srcs = ["DummyFmwk.swift"],
+    generates_header = True,
+    module_name = "SwiftFmwkWithGenHeader",
     tags = TARGETS_UNDER_TEST_TAGS,
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2275,6 +2275,14 @@ ios_static_framework(
     deps = [":StaticFmwkUpperLib"],
 )
 
+ios_static_framework(
+    name = "static_framework_with_generated_header",
+    bundle_name = "StaticFmwkWithGenHeader",
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [":StaticFmwkWithGenHeader"],
+)
+
 genrule(
     name = "dummy_swift_src",
     outs = ["Dummy.swift"],
@@ -2301,6 +2309,14 @@ swift_library(
     name = "StaticFmwkLowestLib",
     srcs = ["Dummy.swift"],
     module_name = "StaticFmwkLowestLib",
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
+    name = "StaticFmwkWithGenHeader",
+    srcs = ["Dummy.swift"],
+    generates_header = True,
+    module_name = "StaticFmwkWithGenHeader",
     tags = FIXTURE_TAGS,
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 404563952
(cherry picked from commit eeb9b0b)

Refactoring Swift interface generation logic to be more reusable outside of the context of static frameworks.

PiperOrigin-RevId: 404389462
(cherry picked from commit 65d63cb)