### PR TITLE
Add universal_apple_binary rule for multi-arch binaries

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -34,6 +34,7 @@ bzl_library(
     srcs = ["apple.bzl"],
     deps = [
         "//apple/internal:apple_framework_import",
+        "//apple/internal:apple_universal_binary",
         "//apple/internal:xcframework_rules",
     ],
 )

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -20,10 +20,15 @@ load(
     _apple_static_framework_import = "apple_static_framework_import",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_universal_binary.bzl",
+    _apple_universal_binary = "apple_universal_binary",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:xcframework_rules.bzl",
     _apple_xcframework = "apple_xcframework",
 )
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
 apple_static_framework_import = _apple_static_framework_import
+apple_universal_binary = _apple_universal_binary
 apple_xcframework = _apple_xcframework

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -53,6 +53,19 @@ bzl_library(
 )
 
 bzl_library(
+    name = "apple_universal_binary",
+    srcs = ["apple_universal_binary.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        ":linking_support",
+        ":rule_factory",
+        "//apple:providers",
+    ],
+)
+
+bzl_library(
     name = "apple_product_type",
     srcs = ["apple_product_type.bzl"],
     visibility = [

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -1,0 +1,74 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation for apple universal binary rules."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "linking_support",
+)
+
+def _apple_universal_binary_impl(ctx):
+    inputs = [
+        binary.files.to_list()[0]
+        for binary in ctx.split_attr.binary.values()
+    ]
+
+    if not inputs:
+        fail("Target (%s) `binary` label ('%s') does not provide any " +
+             "file for universal binary" % (ctx.attr.name, ctx.attr.binary))
+
+    fat_binary = ctx.actions.declare_file(ctx.label.name)
+
+    linking_support.lipo_or_symlink_inputs(
+        actions = ctx.actions,
+        inputs = inputs,
+        output = fat_binary,
+        apple_fragment = ctx.fragments.apple,
+        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
+
+    return [
+        AppleBinaryInfo(
+            binary = fat_binary,
+        ),
+        DefaultInfo(
+            executable = fat_binary,
+            files = depset([fat_binary]),
+        ),
+    ]
+
+apple_universal_binary = rule_factory.create_apple_binary_rule(
+    doc = """
+This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
+The `lipo` tool is used to combine built binaries of multiple architectures.
+""",
+    implementation = _apple_universal_binary_impl,
+    require_linking_attrs = False,
+    additional_attrs = {
+        "binary": attr.label(
+            mandatory = True,
+            cfg = apple_common.multi_arch_split,
+            doc = "Target to generate a 'fat' binary from.",
+        ),
+    },
+)

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -170,18 +170,13 @@ def _register_linking_action(
 
     fat_binary = ctx.actions.declare_file("{}_lipobin".format(ctx.label.name))
 
-    if len(linking_outputs.outputs) > 1:
-        lipo.create(
-            actions = ctx.actions,
-            inputs = [output.binary for output in linking_outputs.outputs],
-            output = fat_binary,
-            apple_fragment = ctx.fragments.apple,
-            xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
-        )
-    else:
-        # Symlink if there was only a single architecture created; it's faster.
-        output = linking_outputs.outputs[0]
-        ctx.actions.symlink(target_file = output.binary, output = fat_binary)
+    _lipo_or_symlink_inputs(
+        actions = ctx.actions,
+        inputs = [output.binary for output in linking_outputs.outputs],
+        output = fat_binary,
+        apple_fragment = ctx.fragments.apple,
+        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
 
     return struct(
         binary = fat_binary,
@@ -191,7 +186,32 @@ def _register_linking_action(
         output_groups = linking_outputs.output_groups,
     )
 
+def _lipo_or_symlink_inputs(actions, inputs, output, apple_fragment, xcode_config):
+    """Creates a fat binary with `lipo` if inputs > 1, symlinks otherwise.
+
+    Args:
+      actions: The rule context actions.
+      inputs: Binary inputs to use for lipo action.
+      output: Binary output for universal binary or symlink.
+      apple_fragment: The `apple` configuration fragment used to configure
+                      the action environment.
+      xcode_config: The `apple_common.XcodeVersionConfig` provider used to
+                    configure the action environment.
+    """
+    if len(inputs) > 1:
+        lipo.create(
+            actions = actions,
+            inputs = inputs,
+            output = output,
+            apple_fragment = apple_fragment,
+            xcode_config = xcode_config,
+        )
+    else:
+        # Symlink if there was only a single architecture created; it's faster.
+        actions.symlink(target_file = inputs[0], output = output)
+
 linking_support = struct(
+    lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     parse_platform_key = _parse_platform_key,
     register_linking_action = _register_linking_action,
     sectcreate_objc_provider = _sectcreate_objc_provider,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -1050,7 +1050,8 @@ def _create_apple_binary_rule(
         additional_attrs = {},
         implicit_outputs = None,
         platform_type = None,
-        product_type = None):
+        product_type = None,
+        require_linking_attrs = True):
     """Creates an Apple rule that produces a single binary output."""
     rule_attrs = [
         {
@@ -1127,10 +1128,13 @@ binaries/libraries will be created combining all architectures specified by
         )
     else:
         is_executable = False
-        rule_attrs.append(_common_binary_linking_attrs(
-            deps_cfg = apple_common.multi_arch_split,
-            product_type = None,
-        ))
+        if require_linking_attrs:
+            rule_attrs.append(_common_binary_linking_attrs(
+                deps_cfg = apple_common.multi_arch_split,
+                product_type = None,
+            ))
+        else:
+            rule_attrs.append(_COMMON_ATTRS)
 
     rule_attrs.append(additional_attrs)
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -88,6 +88,32 @@ objc_library(
 | <a id="apple_static_framework_import-weak_sdk_frameworks"></a>weak_sdk_frameworks |  Names of SDK frameworks to weakly link with. For instance, <code>MediaAccessibility</code>. In difference to regularly linked SDK frameworks, symbols from weakly linked frameworks do not cause an error if they are not present at runtime.   | List of strings | optional | [] |
 
 
+<a id="#apple_universal_binary"></a>
+
+## apple_universal_binary
+
+<pre>
+apple_universal_binary(<a href="#apple_universal_binary-name">name</a>, <a href="#apple_universal_binary-binary">binary</a>, <a href="#apple_universal_binary-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#apple_universal_binary-minimum_os_version">minimum_os_version</a>,
+                       <a href="#apple_universal_binary-platform_type">platform_type</a>)
+</pre>
+
+
+This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
+The `lipo` tool is used to combine built binaries of multiple architectures.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="apple_universal_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="apple_universal_binary-binary"></a>binary |  Target to generate a 'fat' binary from.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="apple_universal_binary-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from <code>minimum_os_version</code>, which is effective at compile time. Ensure version specific APIs are guarded with <code>available</code> clauses.   | String | optional | "" |
+| <a id="apple_universal_binary-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "10.11").   | String | required |  |
+| <a id="apple_universal_binary-platform_type"></a>platform_type |  The target Apple platform for which to create a binary. This dictates which SDK is used for compilation/linking and which flag is used to determine the architectures to target. For example, if <code>ios</code> is specified, then the output binaries/libraries will be created combining all architectures specified by <code>--ios_multi_cpus</code>. Options are:<br><br>*   <code>ios</code>: architectures gathered from <code>--ios_multi_cpus</code>. *   <code>macos</code>: architectures gathered from <code>--macos_cpus</code>. *   <code>tvos</code>: architectures gathered from <code>--tvos_cpus</code>. *   <code>watchos</code>: architectures gathered from <code>--watchos_cpus</code>.   | String | required |  |
+
+
 <a id="#apple_xcframework"></a>
 
 ## apple_xcframework

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":apple_bundle_version_tests.bzl", "apple_bundle_version_test_suite")
 load(":apple_core_data_model_tests.bzl", "apple_core_data_model_test_suite")
 load(":apple_static_xcframework_tests.bzl", "apple_static_xcframework_test_suite")
+load(":apple_universal_binary_tests.bzl", "apple_universal_binary_test_suite")
 load(":apple_xcframework_tests.bzl", "apple_xcframework_test_suite")
 load(":dtrace_compile_tests.bzl", "dtrace_compile_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
@@ -48,6 +49,8 @@ apple_bundle_version_test_suite()
 apple_core_data_model_test_suite()
 
 apple_static_xcframework_test_suite()
+
+apple_universal_binary_test_suite()
 
 apple_xcframework_test_suite()
 

--- a/test/starlark_tests/apple_universal_binary_tests.bzl
+++ b/test/starlark_tests/apple_universal_binary_tests.bzl
@@ -1,0 +1,61 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""apple_universal_binary Starlark tests."""
+
+load(
+    ":rules/analysis_target_outputs_test.bzl",
+    "analysis_target_outputs_test",
+)
+load(
+    ":rules/common_verification_tests.bzl",
+    "binary_contents_test",
+)
+
+# buildifier: disable=unnamed-macro
+def apple_universal_binary_test_suite():
+    """Test suite for apple_universal_binary."""
+    name = "apple_universal_binary"
+    test_target = "//test/starlark_tests/targets_under_test/apple:multi_arch_cc_binary"
+
+    analysis_target_outputs_test(
+        name = "{}_output_test".format(name),
+        target_under_test = test_target,
+        expected_outputs = ["multi_arch_cc_binary"],
+        tags = [name],
+    )
+
+    binary_contents_test(
+        name = "{}_x86_binary_contents_test".format(name),
+        build_type = "device",
+        macos_cpus = ["x86_64", "arm64"],
+        target_under_test = test_target,
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["__Z19function_for_x86_64v"],
+        binary_not_contains_symbols = ["__Z19function_for_arch64v"],
+        tags = [name],
+    )
+
+    binary_contents_test(
+        name = "{}_arm64_binary_contents_test".format(name),
+        build_type = "device",
+        macos_cpus = ["x86_64", "arm64"],
+        target_under_test = test_target,
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        binary_contains_symbols = ["__Z19function_for_arch64v"],
+        binary_not_contains_symbols = ["__Z19function_for_x86_64v"],
+        tags = [name],
+    )

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -616,3 +616,9 @@ filegroup(
     name = "WatchAppIcon.xcassets",
     srcs = glob(["WatchAppIcon.xcassets/**"]),
 )
+
+cc_binary(
+    name = "cc_test_binary",
+    srcs = ["main.cc"],
+    tags = FIXTURE_TAGS,
+)

--- a/test/starlark_tests/resources/main.cc
+++ b/test/starlark_tests/resources/main.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// C++ binary with basic hello world for universal Apple binary tests.
+
+#include <iostream>
+
+
+#if defined(__x86_64__)
+void function_for_x86_64() {
+  std::cout << "Compiled for x86_64" << std::endl;
+}
+#elif defined(__aarch64__)
+void function_for_arch64() {
+  std::cout << "Compiled for arm64" << std::endl;
+}
+#endif
+
+int main(int argc, char** argv) {
+  return 0;
+}

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -38,9 +38,16 @@ load(
 
 def _apple_verification_transition_impl(settings, attr):
     """Implementation of the apple_verification_transition transition."""
+
+    # This was added because this transition is also used by
+    # `infoplist_contents_test` and has no "macos_cpus" attribute.
+    macos_cpus = "x86_64"
+    if hasattr(attr, "macos_cpus"):
+        macos_cpus = ",".join(attr.macos_cpus)
+
     output_dictionary = {
         "//command_line_option:ios_signing_cert_name": "-",
-        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:macos_cpus": macos_cpus,
         "//command_line_option:compilation_mode": attr.compilation_mode,
         "//command_line_option:apple_bitcode": attr.apple_bitcode,
         "//command_line_option:apple_generate_dsym": attr.apple_generate_dsym,
@@ -221,6 +228,12 @@ https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode
             default = False,
             doc = """
 If true, generates .dSYM debug symbol bundles for the target(s) under test.
+""",
+        ),
+        "macos_cpus": attr.string_list(
+            doc = """
+List of MacOS CPU's to use for test under target.
+https://docs.bazel.build/versions/main/command-line-reference.html#flag--macos_cpus
 """,
         ),
         "sanitizer": attr.string(

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -4,6 +4,7 @@ load(
 )  # buildifier: disable=bzl-visibility
 load(
     "//apple:apple.bzl",
+    "apple_universal_binary",
     "apple_xcframework",
 )
 load(
@@ -624,5 +625,13 @@ swift_library(
     srcs = ["DummyFmwk.swift"],
     generates_header = True,
     module_name = "SwiftFmwkWithGenHeader",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+apple_universal_binary(
+    name = "multi_arch_cc_binary",
+    binary = "//test/starlark_tests/resources:cc_test_binary",
+    minimum_os_version = "11.0",
+    platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,
 )


### PR DESCRIPTION
Introduces a new `universal_apple_binary` rule to support building
universal ('fat') binaries from other binary targets (e.g. `cc_binary`,
`go_binary`) using a combination of split transitions and Apple's `lipo`
tool for universal binaries.

PiperOrigin-RevId: 407859091
(cherry picked from commit 73c041db161f5058f2e4cc124b7591300618b5a6)
