### PR TITLE
Replace host transition by execution transition for all tools

### DIFF
--- a/apple/internal/apple_support_toolchain.bzl
+++ b/apple/internal/apple_support_toolchain.bzl
@@ -99,14 +99,14 @@ def _apple_support_toolchain_impl(ctx):
 apple_support_toolchain = rule(
     attrs = {
         "alticonstool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool to insert alternate icons entries in the app bundle's `Info.plist`.
 """,
         ),
         "bundletool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool to create an Apple bundle by taking a list of files/ZIPs and destination
@@ -114,7 +114,7 @@ paths to build the directory structure for those files.
 """,
         ),
         "bundletool_experimental": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing an experimental tool to create an Apple bundle by combining the bundling,
@@ -122,27 +122,27 @@ post-processing, and signing steps into a single action that eliminates the arch
 """,
         ),
         "clangrttool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = "A `File` referencing a tool to find all Clang runtime libs linked to a binary.",
         ),
         "codesigningtool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = "A `File` referencing a tool to assist in signing bundles.",
         ),
         "dossier_codesigningtool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = "A `File` referencing a tool to assist in generating signing dossiers.",
         ),
         "dsym_info_plist_template": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
             doc = "A `File` referencing a plist template for dSYM bundles.",
         ),
         "imported_dynamic_framework_processor": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool to process an imported dynamic framework such that the given framework
@@ -152,7 +152,7 @@ artifact.
 """,
         ),
         "plisttool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool to perform plist operations such as variable substitution, merging, and
@@ -164,21 +164,21 @@ conversion of plist files to binary format.
             doc = "A `File` referencing a template for a shell script to process and sign.",
         ),
         "provisioning_profile_tool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool that extracts entitlements from a provisioning profile.
 """,
         ),
         "swift_stdlib_tool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = """
 A `File` referencing a tool that copies and lipos Swift stdlibs required for the target to run.
 """,
         ),
         "xctoolrunner": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             doc = "A `File` referencing a tool that acts as a wrapper for xcrun actions.",
         ),

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -71,7 +71,7 @@ environment_plist = rule(
         rule_factory.common_tool_attributes,
         {
             "_environment_plist_tool": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 executable = True,
                 default = Label("@build_bazel_rules_apple//tools/environment_plist"),
             ),

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -104,7 +104,7 @@ def _is_test_product_type(product_type):
 _COMMON_ATTRS = dicts.add(
     {
         "_grep_includes": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_single_file = True,
             executable = True,
             default = Label("@bazel_tools//tools/cpp:grep-includes"),
@@ -138,7 +138,7 @@ _COMMON_BINARY_RULE_ATTRS = dicts.add(
         # apple_common.link_multi_arch_binary requires this attribute.
         # TODO(b/117932394): Remove this attribute once Bazel no longer uses xcrunwrapper.
         "_xcrunwrapper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
         ),
@@ -177,7 +177,7 @@ AppleTestRunnerInfo provider.
         providers = [AppleBundleInfo],
     ),
     "_apple_coverage_support": attr.label(
-        cfg = "host",
+        cfg = "exec",
         default = Label("@build_bazel_apple_support//tools:coverage_support"),
     ),
 }
@@ -335,7 +335,7 @@ the target will be used instead.
         "ipa_post_processor": attr.label(
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = """
 A tool that edits this target's archive after it is assembled but before it is signed. The tool is
 invoked with a single command-line argument that denotes the path to a directory containing the
@@ -601,7 +601,7 @@ the application bundle.
 """,
             ),
             "_runner_template": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 allow_single_file = True,
                 default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
             ),
@@ -627,7 +627,7 @@ Info.plist under the key `UILaunchStoryboardName`.
 """,
             ),
             "_runner_template": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 allow_single_file = True,
                 default = Label("@build_bazel_rules_apple//apple/internal/templates:ios_sim_template"),
             ),
@@ -751,7 +751,7 @@ set, then the default extension is determined by the application's product_type.
                 doc = "A list of macOS XPC Services to include in the final application bundle.",
             ),
             "_runner_template": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 allow_single_file = True,
                 default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
             ),
@@ -794,7 +794,7 @@ def _get_tvos_attrs(rule_descriptor):
                 doc = "A list of tvOS extensions to include in the final application bundle.",
             ),
             "_runner_template": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 allow_single_file = True,
                 # Currently using the iOS Simulator template for tvOS, as tvOS does not require
                 # significantly different sim runner logic from iOS.

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -783,12 +783,12 @@ apple_xcframework = rule(
             ),
         ),
         "_xcode_path_wrapper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("@build_bazel_apple_support//tools:xcode_path_wrapper"),
         ),
         "_xcrunwrapper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
             executable = True,
         ),

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -102,7 +102,7 @@ into the XCTest invocation.
                 "@xctestrunner//:ios_test_runner",
             ),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = """
 It is the rule that needs to provide the AppleTestRunnerInfo provider. This
 dependency is the test runner binary.

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -93,7 +93,7 @@ By default, it is the latest supported version of the device type.'
                 "@xctestrunner//:ios_test_runner",
             ),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = """
 It is the rule that needs to provide the AppleTestRunnerInfo provider. This
 dependency is the test runner binary.

--- a/apple/testing/default_runner/watchos_test_runner.bzl
+++ b/apple/testing/default_runner/watchos_test_runner.bzl
@@ -93,7 +93,7 @@ By default, it is the latest supported version of the device type.'
                 "@xctestrunner//:ios_test_runner",
             ),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             doc = """
 It is the rule that needs to provide the AppleTestRunnerInfo provider. This
 dependency is the test runner binary.

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -185,7 +185,7 @@ be used for this key as well.
 """,
         ),
         "_versiontool": attr.label(
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@build_bazel_rules_apple//tools/versiontool",
             ),

--- a/test/testdata/fmwk/generate_framework.bzl
+++ b/test/testdata/fmwk/generate_framework.bzl
@@ -130,7 +130,7 @@ binary.
 """,
         ),
         "_generate_framework_script": attr.label(
-            cfg = "host",
+            cfg = "exec",
             allow_files = True,
             default = Label(
                 "@build_bazel_rules_apple//test/testdata/fmwk:generate_framework.py",


### PR DESCRIPTION
This doesn't really matter now because all tools here are just Bash and
Python scripts, but could prevent problems later when an incompatible
flag to disable cfg="host" from Starlark lands.

https://github.com/bazelbuild/bazel/pull/14383