### PR TITLE
Fix codesign verification (grep/regex error)

### DIFF
--- a/test/starlark_tests/targets_under_test/apple/ipa_post_processor_verify_codesigning.sh
+++ b/test/starlark_tests/targets_under_test/apple/ipa_post_processor_verify_codesigning.sh
@@ -48,7 +48,7 @@ for app in \
       $(find "$FRAMEWORK_DIR" -type d -maxdepth 1 -mindepth 1); do
     # codesign writes all output to stderr; redirect to stdout and egrep to
     # filter problematic outputs.
-    /usr/bin/codesign --display --verbose=3 "$fmwk" 2>&1 | egrep "^[^Executable=]" >> "$CODESIGN_FMWKS_OUTPUT"
+    /usr/bin/codesign --display --verbose=3 "$fmwk" 2>&1 | egrep -v "^Executable=" >> "$CODESIGN_FMWKS_OUTPUT"
   done
   if [ ! -f "$CODESIGN_FMWKS_OUTPUT" ]; then
       echo "Internal Error: Failed to create codesign output file at $CODESIGN_FMWKS_OUTPUT" >&2


### PR DESCRIPTION
The previous version would drop any line that started with any character in `[Executable=]`. We actually want to drop any line starting with the exact string "Executable=".

PiperOrigin-RevId: 415032465
(cherry picked from commit 4aabad4dd6839e538f4f3bc4db7aa3a1ad306d4d)
