### PR TITLE
Fix entitlement validation with appattest

### DIFF
--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -1776,6 +1776,21 @@ class PlistToolTest(unittest.TestCase):
           },
       }, plist)
 
+  def test_attest_valid(self):
+    plist = {
+      'com.apple.developer.devicecheck.appattest-environment': 'development'}
+    self._assert_plisttool_result({
+        'plists': [plist],
+        'entitlements_options': {
+            'profile_metadata_file': {
+                'Entitlements': {
+                    'com.apple.developer.devicecheck.appattest-environment': ['development', 'production'],
+                },
+                'Version': 1,
+            },
+        },
+    }, plist)
+
   def test_attest_mismatch(self):
     with self.assertRaisesRegex(
         plisttool.PlistToolError,


### PR DESCRIPTION
f0404bc5e593f77d84820ad35fd016fc6a82eb24 introduced a regression where
the value of this entitlement was in the potential list, so it fell
through to the next conditional which validated they were equal, which
will never be the case. This also adds a test for this successful case.