### PR TITLE
basic support for importing .xcframeworks

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -507,7 +507,7 @@ platforms directory, without the extension (for example, iphoneos or iPhoneSimul
 should be case-sensitive variants of values that might be found in the LibraryIdentifier of an Info.plist 
 file in xcframework's root(for example, ios-arm64_i386_x86_64-simulator or ios-arm64_armv7).
 """,
-        ),
+    ),
 }
 
 apple_dynamic_framework_import = rule(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -318,11 +318,36 @@ def _debug_info_binaries(
 
     return all_binaries_dict.values()
 
+def _get_framework_imports(ctx):
+    if not ctx.attr.xcframework_platform_ids:
+        return ctx.files.framework_imports
+    curr_platform = ctx.fragments.apple.single_arch_platform.name_in_plist.lower()
+    xcframework_path = ""
+    for f in ctx.files.framework_imports:
+        if ".xcframework" in f.path:
+            xcframework_path = f.path.split(".xcframework")[0] + ".xcframework"
+            break
+    if not xcframework_path.endswith(".xcframework"):
+        fail("couldn't find xcframework at framework_imports")
+    framework_name = paths.split_extension(paths.basename(xcframework_path))[0]
+
+    if curr_platform not in [p.lower() for p in ctx.attr.xcframework_platform_ids]:
+        fail(
+            "Missing framework path mapping for platform `{}`; is this platform supported?"
+                .format(str(curr_platform)),
+        )
+    else:
+        platform_path = "{}/{}/{}.framework".format(xcframework_path, ctx.attr.xcframework_platform_ids[curr_platform], framework_name)
+        framework_imports_for_platform = [f for f in ctx.files.framework_imports if platform_path in f.short_path]
+        if len(framework_imports_for_platform) == 0:
+            fail("couldn't find framework at path `{}`".format(platform_path))
+        return framework_imports_for_platform
+
 def _apple_dynamic_framework_import_impl(ctx):
     """Implementation for the apple_dynamic_framework_import rule."""
     providers = []
 
-    framework_imports = ctx.files.framework_imports
+    framework_imports = _get_framework_imports(ctx)
     bundling_imports, header_imports, module_map_imports = (
         _classify_framework_imports(ctx.var, framework_imports)
     )
@@ -380,7 +405,7 @@ def _apple_static_framework_import_impl(ctx):
     """Implementation for the apple_static_framework_import rule."""
     providers = []
 
-    framework_imports = ctx.files.framework_imports
+    framework_imports = _get_framework_imports(ctx)
     _, header_imports, module_map_imports = _classify_framework_imports(ctx.var, framework_imports)
 
     transitive_sets = _transitive_framework_imports(ctx.attr.deps)
@@ -472,10 +497,21 @@ def _apple_static_framework_import_impl(ctx):
 
     return providers
 
+_common_attrs = {
+    "xcframework_platform_ids": attr.string_dict(
+        doc = """
+A key-value map of platforms to the corresponding platform IDs (containing all supported architectures), 
+relative to the framework_import. The platform keys should be case-insensitive variants of
+values that might be found in the CFBundleSupportedPlatforms entry of an Info.plist file and in Xcode's
+platforms directory, without the extension (for example, iphoneos or iPhoneSimulator).
+""",
+        ),
+}
+
 apple_dynamic_framework_import = rule(
     implementation = _apple_dynamic_framework_import_impl,
     fragments = ["apple"],
-    attrs = {
+    attrs = dicts.add(_common_attrs, {
         "framework_imports": attr.label_list(
             allow_empty = False,
             allow_files = True,
@@ -509,7 +545,7 @@ Avoid linking the dynamic framework, but still include it in the app. This is us
 to manually dlopen the framework at runtime.
 """,
         ),
-    },
+    }),
     doc = """
 This rule encapsulates an already-built dynamic framework. It is defined by a list of
 files in exactly one `.framework` directory. `apple_dynamic_framework_import` targets
@@ -536,7 +572,7 @@ objc_library(
 apple_static_framework_import = rule(
     implementation = _apple_static_framework_import_impl,
     fragments = ["apple"],
-    attrs = dicts.add(swift_common.toolchain_attrs(), {
+    attrs = dicts.add(_common_attrs, swift_common.toolchain_attrs(), {
         "framework_imports": attr.label_list(
             allow_empty = False,
             allow_files = True,

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -503,7 +503,9 @@ _common_attrs = {
 A key-value map of platforms to the corresponding platform IDs (containing all supported architectures), 
 relative to the framework_import. The platform keys should be case-insensitive variants of
 values that might be found in the CFBundleSupportedPlatforms entry of an Info.plist file and in Xcode's
-platforms directory, without the extension (for example, iphoneos or iPhoneSimulator).
+platforms directory, without the extension (for example, iphoneos or iPhoneSimulator). The platform IDs 
+should be case-sensitive variants of values that might be found in the LibraryIdentifier of an Info.plist 
+file in xcframework's root(for example, ios-arm64_i386_x86_64-simulator or ios-arm64_armv7).
 """,
         ),
 }

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -6,7 +6,8 @@
 ## apple_dynamic_framework_import
 
 <pre>
-apple_dynamic_framework_import(<a href="#apple_dynamic_framework_import-name">name</a>, <a href="#apple_dynamic_framework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_framework_import-deps">deps</a>, <a href="#apple_dynamic_framework_import-dsym_imports">dsym_imports</a>, <a href="#apple_dynamic_framework_import-framework_imports">framework_imports</a>)
+apple_dynamic_framework_import(<a href="#apple_dynamic_framework_import-name">name</a>, <a href="#apple_dynamic_framework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_framework_import-deps">deps</a>, <a href="#apple_dynamic_framework_import-dsym_imports">dsym_imports</a>, <a href="#apple_dynamic_framework_import-framework_imports">framework_imports</a>,
+                               <a href="#apple_dynamic_framework_import-xcframework_platform_ids">xcframework_platform_ids</a>)
 </pre>
 
 
@@ -41,6 +42,7 @@ objc_library(
 | <a id="apple_dynamic_framework_import-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will be linked into that target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="apple_dynamic_framework_import-dsym_imports"></a>dsym_imports |  The list of files under a .dSYM directory, that is the imported framework's dSYM bundle.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="apple_dynamic_framework_import-framework_imports"></a>framework_imports |  The list of files under a .framework directory which are provided to Apple based targets that depend on this target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="apple_dynamic_framework_import-xcframework_platform_ids"></a>xcframework_platform_ids |  A key-value map of platforms to the corresponding platform IDs (containing all supported architectures),  relative to the framework_import. The platform keys should be case-insensitive variants of values that might be found in the CFBundleSupportedPlatforms entry of an Info.plist file and in Xcode's platforms directory, without the extension (for example, iphoneos or iPhoneSimulator). The platform IDs  should be case-sensitive variants of values that might be found in the LibraryIdentifier of an Info.plist  file in xcframework's root(for example, ios-arm64_i386_x86_64-simulator or ios-arm64_armv7).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 
 <a id="#apple_static_framework_import"></a>
@@ -49,7 +51,7 @@ objc_library(
 
 <pre>
 apple_static_framework_import(<a href="#apple_static_framework_import-name">name</a>, <a href="#apple_static_framework_import-alwayslink">alwayslink</a>, <a href="#apple_static_framework_import-deps">deps</a>, <a href="#apple_static_framework_import-framework_imports">framework_imports</a>, <a href="#apple_static_framework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_framework_import-sdk_frameworks">sdk_frameworks</a>,
-                              <a href="#apple_static_framework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>)
+                              <a href="#apple_static_framework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#apple_static_framework_import-xcframework_platform_ids">xcframework_platform_ids</a>)
 </pre>
 
 
@@ -86,6 +88,7 @@ objc_library(
 | <a id="apple_static_framework_import-sdk_dylibs"></a>sdk_dylibs |  Names of SDK .dylib libraries to link with. For instance, <code>libz</code> or <code>libarchive</code>. <code>libc++</code> is included automatically if the binary has any C++ or Objective-C++ sources in its dependency tree. When linking a binary, all libraries named in that binary's transitive dependency graph are used.   | List of strings | optional | [] |
 | <a id="apple_static_framework_import-sdk_frameworks"></a>sdk_frameworks |  Names of SDK frameworks to link with (e.g. <code>AddressBook</code>, <code>QuartzCore</code>). <code>UIKit</code> and <code>Foundation</code> are always included when building for the iOS, tvOS and watchOS platforms. For macOS, only <code>Foundation</code> is always included. When linking a top level binary, all SDK frameworks listed in that binary's transitive dependency graph are linked.   | List of strings | optional | [] |
 | <a id="apple_static_framework_import-weak_sdk_frameworks"></a>weak_sdk_frameworks |  Names of SDK frameworks to weakly link with. For instance, <code>MediaAccessibility</code>. In difference to regularly linked SDK frameworks, symbols from weakly linked frameworks do not cause an error if they are not present at runtime.   | List of strings | optional | [] |
+| <a id="apple_static_framework_import-xcframework_platform_ids"></a>xcframework_platform_ids |  A key-value map of platforms to the corresponding platform IDs (containing all supported architectures),  relative to the framework_import. The platform keys should be case-insensitive variants of values that might be found in the CFBundleSupportedPlatforms entry of an Info.plist file and in Xcode's platforms directory, without the extension (for example, iphoneos or iPhoneSimulator). The platform IDs  should be case-sensitive variants of values that might be found in the LibraryIdentifier of an Info.plist  file in xcframework's root(for example, ios-arm64_i386_x86_64-simulator or ios-arm64_armv7).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 
 
 <a id="#apple_universal_binary"></a>


### PR DESCRIPTION
This pull request is related to https://github.com/bazelbuild/rules_apple/pull/1166.

The original pull request did a great job, but it seems that there is no follow-up for a long time.

Now I'm facing the same thing, I hope rules_apple can officially support for the xcframwork import. So I did a little work on it.

Usage example:

```
apple_dynamic_framework_import(
    name = "AmazonChimeSDK",
    framework_imports = glob(["AmazonChimeSDK.xcframework/**"]),
    visibility = ["//visibility:public"],
    xcframework_platform_ids = {
        "iphoneos": "ios-arm64_armv7",
        "iphonesimulator": "ios-i386_x86_64-simulator",
    },
)
```
