### PR TITLE
bundletool: fix clonefile for big sur

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -52,7 +52,6 @@ import os
 import shutil
 import sys
 import zipfile
-from ctypes.util import find_library
 from ctypes import cdll, c_char_p, c_int
 
 _CLONEFILE = None
@@ -61,10 +60,7 @@ def _load_clonefile():
   if _CLONEFILE:
     return _CLONEFILE
 
-  library = find_library('libSystem')
-  if not library:
-    raise Exception('libSystem not found')
-  system = cdll.LoadLibrary(library)
+  system = cdll.LoadLibrary('/usr/lib/libSystem.dylib')
   _CLONEFILE = system.clonefile
   _CLONEFILE.argtypes = [c_char_p, c_char_p, c_int] # src, dest, flags
   _CLONEFILE.restype = c_int  # 0 on success


### PR DESCRIPTION
`find_library` seems to work fine against system libraries on the version of python3 that ships with Monterey, but in Big Sur it returns `None`. On all the systems I tested, using `/usr/lib/libSystem.dylib` explicitly works.

related (?): https://stackoverflow.com/questions/62587131/macos-big-sur-python-ctypes-find-library-does-not-find-libraries-ssl-corefou