### PR TITLE
Build `swift_stdlib_tool` from source

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -14,7 +14,11 @@
 
 """Definitions for handling Bazel repositories used by the Apple rules."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(
+    "@bazel_tools//tools/build_defs/repo:http.bzl",
+    "http_archive",
+    "http_file",
+)
 
 def _colorize(text, color):
     """Applies ANSI color codes around the given text."""
@@ -135,6 +139,18 @@ def apple_rules_dependencies(ignore_version_differences = False):
         ],
         strip_prefix = "subpar-2.0.0",
         sha256 = "b80297a1b8d38027a86836dbadc22f55dc3ecad56728175381aa6330705ac10f",
+        ignore_version_differences = ignore_version_differences,
+    )
+
+    # latest as of 2021-12-16
+    _maybe(
+        http_file,
+        name = "swift_stdlib_tool",
+        urls = [
+            "https://github.com/apple/swift/raw/0a427a3a4033fb2bd4d63323847945c22affb97f/tools/swift-stdlib-tool/swift-stdlib-tool.cpp",
+        ],
+        downloaded_file_path = "swift-stdlib-tool.cpp",
+        sha256 = "088cc03876ae18566e11e2d14f98d1955c70b47e983fa6de0179fc85cc408018",
         ignore_version_differences = ignore_version_differences,
     )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -76,6 +76,7 @@ filegroup(
     testonly = 1,
     srcs = [
         "@bazel_skylib//:test_deps",
+        "@swift_stdlib_tool//file",
         "@xctestrunner//:ios_test_runner",
     ],
 )

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -80,6 +80,12 @@ new_local_repository(
     path = '$PWD/../external/subpar',
 )
 
+new_local_repository(
+    name = 'swift_stdlib_tool',
+    build_file_content = '',
+    path = '$PWD/../external/swift_stdlib_tool',
+)
+
 local_repository(
     name = 'build_bazel_rules_apple',
     path = '$(rlocation build_bazel_rules_apple)',
@@ -118,6 +124,16 @@ load(
 )
 
 swift_rules_dependencies()
+EOF
+
+  # FIXME: Is there any way to copy this file to the test workspace?
+  cat > ../external/swift_stdlib_tool/file/BUILD <<EOF
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "file",
+    srcs = ["swift-stdlib-tool.cpp"],
+)
 EOF
 }
 

--- a/tools/swift_stdlib_tool/BUILD
+++ b/tools/swift_stdlib_tool/BUILD
@@ -1,8 +1,14 @@
 licenses(["notice"])
 
+cc_binary(
+    name = "swift_stdlib_tool_bin",
+    srcs = ["@swift_stdlib_tool//file"],
+)
+
 py_binary(
     name = "swift_stdlib_tool",
     srcs = ["swift_stdlib_tool.py"],
+    data = [":swift_stdlib_tool_bin"],
     python_version = "PY3",
     srcs_version = "PY3",
     visibility = [
@@ -12,6 +18,7 @@ py_binary(
         "//tools/bitcode_strip",
         "//tools/wrapper_common:execute",
         "//tools/wrapper_common:lipo",
+        "@bazel_tools//tools/python/runfiles",
     ],
 )
 


### PR DESCRIPTION
This makes it easier to iterate on this, as Xcode 13.2 still ships with a broken version.