### PR TITLE
Add forced entitlements always

### DIFF
--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -296,7 +296,7 @@ def _process_entitlements(
     inputs = list(plists)
 
     # Return early if there is no entitlements to use.
-    if not inputs:
+    if not inputs and not forced_plists:
         return None, None
 
     final_entitlements = actions.declare_file(


### PR DESCRIPTION
Before they were only added if a custom entitlements file was provided. This fix is needed in order to eventually land f6315eacfdc83f909630ca1f11add03bee71c143.
