### PR TITLE
Add name arguments to the test suites.

### DIFF
--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -44,89 +44,89 @@ load(":watchos_unit_test_tests.bzl", "watchos_unit_test_test_suite")
 
 licenses(["notice"])
 
-apple_bundle_version_test_suite()
+apple_bundle_version_test_suite(name = "apple_bundle_version")
 
-apple_core_data_model_test_suite()
+apple_core_data_model_test_suite(name = "apple_core_data_model")
 
-apple_static_xcframework_test_suite()
+apple_static_xcframework_test_suite(name = "apple_static_xcframework")
 
-apple_universal_binary_test_suite()
+apple_universal_binary_test_suite(name = "apple_universal_binary")
 
-apple_xcframework_test_suite()
+apple_xcframework_test_suite(name = "apple_xcframework")
 
-dtrace_compile_test_suite()
+dtrace_compile_test_suite(name = "dtrace_compile")
 
-ios_application_resources_test_suite()
+ios_application_resources_test_suite(name = "ios_application_resources")
 
-ios_application_test_suite()
+ios_application_test_suite(name = "ios_application")
 
-ios_app_clip_test_suite()
+ios_app_clip_test_suite(name = "ios_app_clip")
 
-ios_extension_test_suite()
+ios_extension_test_suite(name = "ios_extension")
 
-ios_framework_test_suite()
+ios_framework_test_suite(name = "ios_framework")
 
-ios_dynamic_framework_test_suite()
+ios_dynamic_framework_test_suite(name = "ios_dynamic_framework")
 
-ios_imessage_application_test_suite()
+ios_imessage_application_test_suite(name = "ios_imessage_application")
 
-ios_static_framework_test_suite()
+ios_static_framework_test_suite(name = "ios_static_framework")
 
-ios_sticker_pack_extension_test_suite()
+ios_sticker_pack_extension_test_suite(name = "ios_sticker_pack_extension")
 
-ios_ui_test_test_suite()
+ios_ui_test_test_suite(name = "ios_ui_test")
 
-ios_unit_test_test_suite()
+ios_unit_test_test_suite(name = "ios_unit_test")
 
-macos_application_resources_test_suite()
+macos_application_resources_test_suite(name = "macos_application_resources")
 
-macos_application_test_suite()
+macos_application_test_suite(name = "macos_application")
 
-macos_bundle_test_suite()
+macos_bundle_test_suite(name = "macos_bundle")
 
-macos_command_line_application_test_suite()
+macos_command_line_application_test_suite(name = "macos_command_line_application")
 
-macos_dylib_test_suite()
+macos_dylib_test_suite(name = "macos_dylib")
 
-macos_extension_test_suite()
+macos_extension_test_suite(name = "macos_extension")
 
-macos_kernel_extension_test_suite()
+macos_kernel_extension_test_suite(name = "macos_kernel_extension")
 
-macos_quick_look_plugin_test_suite()
+macos_quick_look_plugin_test_suite(name = "macos_quick_look_plugin")
 
-macos_ui_test_test_suite()
+macos_ui_test_test_suite(name = "macos_ui_test")
 
-macos_unit_test_test_suite()
+macos_unit_test_test_suite(name = "macos_unit_test")
 
-tvos_application_swift_test_suite()
+tvos_application_swift_test_suite(name = "tvos_application_swift")
 
-tvos_application_test_suite()
+tvos_application_test_suite(name = "tvos_application")
 
-tvos_extension_test_suite()
+tvos_extension_test_suite(name = "tvos_extension")
 
-tvos_dynamic_framework_test_suite()
+tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework")
 
-tvos_framework_test_suite()
+tvos_framework_test_suite(name = "tvos_framework")
 
-tvos_static_framework_test_suite()
+tvos_static_framework_test_suite(name = "tvos_static_framework")
 
-tvos_ui_test_test_suite()
+tvos_ui_test_test_suite(name = "tvos_ui_test")
 
-tvos_unit_test_test_suite()
+tvos_unit_test_test_suite(name = "tvos_unit_test")
 
-watchos_application_swift_test_suite()
+watchos_application_swift_test_suite(name = "watchos_application_swift")
 
-watchos_application_test_suite()
+watchos_application_test_suite(name = "watchos_application")
 
-watchos_dynamic_framework_test_suite()
+watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework")
 
-watchos_extension_test_suite()
+watchos_extension_test_suite(name = "watchos_extension")
 
-watchos_static_framework_test_suite()
+watchos_static_framework_test_suite(name = "watchos_static_framework")
 
-watchos_ui_test_test_suite()
+watchos_ui_test_test_suite(name = "watchos_ui_test")
 
-watchos_unit_test_test_suite()
+watchos_unit_test_test_suite(name = "watchos_unit_test")
 
 test_suite(
     name = "all_tests",

--- a/test/starlark_tests/apple_bundle_version_tests.bzl
+++ b/test/starlark_tests/apple_bundle_version_tests.bzl
@@ -23,11 +23,11 @@ load(
     "infoplist_contents_test",
 )
 
-def apple_bundle_version_test_suite(name = "apple_bundle_version"):
+def apple_bundle_version_test_suite(name):
     """Test suite for apple_bundle_version.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Tests that manual version numbers work correctly.

--- a/test/starlark_tests/apple_core_data_model_tests.bzl
+++ b/test/starlark_tests/apple_core_data_model_tests.bzl
@@ -47,10 +47,12 @@ _analysis_registered_actions_and_mnemonic_test = analysistest.make(
     _analysis_registered_actions_and_mnemonic_impl,
 )
 
-# buildifier: disable=unnamed-macro
-def apple_core_data_model_test_suite():
-    """Test suite for apple_bundle_version."""
-    name = "apple_core_data_model"
+def apple_core_data_model_test_suite(name):
+    """Test suite for apple_bundle_version.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
 
     # Test outputs a directory (non-empty assertion is verified by xctoolrunner).
     analysis_target_outputs_test(

--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -19,11 +19,12 @@ load(
     "archive_contents_test",
 )
 
-# buildifier: disable=unnamed-macro
-def apple_static_xcframework_test_suite():
-    """Test suite for apple_static_xcframework."""
-    name = "apple_static_xcframework"
+def apple_static_xcframework_test_suite(name):
+    """Test suite for apple_static_xcframework.
 
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     archive_contents_test(
         name = "{}_ios_root_plist_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/apple_universal_binary_tests.bzl
+++ b/test/starlark_tests/apple_universal_binary_tests.bzl
@@ -23,10 +23,12 @@ load(
     "binary_contents_test",
 )
 
-# buildifier: disable=unnamed-macro
-def apple_universal_binary_test_suite():
-    """Test suite for apple_universal_binary."""
-    name = "apple_universal_binary"
+def apple_universal_binary_test_suite(name):
+    """Test suite for apple_universal_binary.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     test_target = "//test/starlark_tests/targets_under_test/apple:multi_arch_cc_binary"
 
     analysis_target_outputs_test(

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -32,11 +32,12 @@ load(
     "linkmap_test",
 )
 
-# buildifier: disable=unnamed-macro
-def apple_xcframework_test_suite():
-    """Test suite for apple_xcframework."""
-    name = "apple_xcframework"
+def apple_xcframework_test_suite(name):
+    """Test suite for apple_xcframework.
 
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     infoplist_contents_test(
         name = "{}_ios_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",

--- a/test/starlark_tests/dtrace_compile_tests.bzl
+++ b/test/starlark_tests/dtrace_compile_tests.bzl
@@ -19,13 +19,12 @@ load(
     "output_text_match_test",
 )
 
-def dtrace_compile_test_suite(name = "dtrace_compile"):
+def dtrace_compile_test_suite(name):
     """Test suite for `dtrace_compile`.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     output_text_match_test(
         name = "{}_generates_expected_header_contents".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/dtrace:dtrace",

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -32,11 +32,11 @@ load(
     "linkmap_test",
 )
 
-def ios_app_clip_test_suite(name = "ios_app_clip"):
+def ios_app_clip_test_suite(name):
     """Test suite for ios_app_clip.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Tests that app clip is codesigned when built as a standalone app

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -27,11 +27,11 @@ load(
     "analysis_xcasset_argv_test",
 )
 
-def ios_application_resources_test_suite(name = "ios_application_resources"):
+def ios_application_resources_test_suite(name):
     """Test suite for apple_bundle_version.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Tests that various nonlocalized resource types are bundled correctly with

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -41,13 +41,12 @@ load(
     "linkmap_test",
 )
 
-def ios_application_test_suite(name = "ios_application"):
+def ios_application_test_suite(name):
     """Test suite for ios_application.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     analysis_target_outputs_test(
         name = "{}_ipa_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -27,11 +27,11 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_dynamic_framework_test_suite(name = "ios_dynamic_framework"):
+def ios_dynamic_framework_test_suite(name):
     """Test suite for ios_dynamic_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     archive_contents_test(

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -37,13 +37,12 @@ load(
     "linkmap_test",
 )
 
-def ios_extension_test_suite(name = "ios_extension"):
+def ios_extension_test_suite(name):
     """Test suite for ios_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -23,13 +23,12 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_framework_test_suite(name = "ios_framework"):
+def ios_framework_test_suite(name):
     """Test suite for ios_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:fmwk",

--- a/test/starlark_tests/ios_imessage_application_tests.bzl
+++ b/test/starlark_tests/ios_imessage_application_tests.bzl
@@ -23,13 +23,12 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_imessage_application_test_suite(name = "ios_imessage_application"):
+def ios_imessage_application_test_suite(name):
     """Test suite for ios_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -19,11 +19,11 @@ load(
     "archive_contents_test",
 )
 
-def ios_static_framework_test_suite(name = "ios_static_framework"):
+def ios_static_framework_test_suite(name):
     """Test suite for ios_static_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Test that it's permitted for a static framework to have multiple

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -23,13 +23,12 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_sticker_pack_extension_test_suite(name = "ios_sticker_pack_extension"):
+def ios_sticker_pack_extension_test_suite(name):
     """Test suite for ios_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_ui_test_tests.bzl
+++ b/test/starlark_tests/ios_ui_test_tests.bzl
@@ -31,13 +31,12 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_ui_test_test_suite(name = "ios_ui_test"):
+def ios_ui_test_test_suite(name):
     """Test suite for ios_ui_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -31,13 +31,12 @@ load(
     "infoplist_contents_test",
 )
 
-def ios_unit_test_test_suite(name = "ios_unit_test"):
+def ios_unit_test_test_suite(name):
     """Test suite for ios_unit_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/macos_application_resources_tests.bzl
+++ b/test/starlark_tests/macos_application_resources_tests.bzl
@@ -19,10 +19,12 @@ load(
     "archive_contents_test",
 )
 
-# buildifier: disable=unnamed-macro
-def macos_application_resources_test_suite():
-    """Test suite for macos_application resources."""
-    name = "macos_application_resources"
+def macos_application_resources_test_suite(name):
+    """Test suite for macos_application resources.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
 
     # Tests that various nonlocalized resource types are bundled correctly with
     # the application (at the top-level, rather than inside an .lproj directory).

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -36,13 +36,12 @@ load(
     "analysis_xcasset_argv_test",
 )
 
-def macos_application_test_suite(name = "macos_application"):
+def macos_application_test_suite(name):
     """Test suite for macos_application.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -27,13 +27,12 @@ load(
     "dsyms_test",
 )
 
-def macos_bundle_test_suite(name = "macos_bundle"):
+def macos_bundle_test_suite(name):
     """Test suite for macos_bundle.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -27,11 +27,12 @@ load(
     "dsyms_test",
 )
 
-# buildifier: disable=unnamed-macro
-def macos_command_line_application_test_suite():
-    """Test suite for macos_command_line_application."""
-    name = "macos_command_line_application"
+def macos_command_line_application_test_suite(name):
+    """Test suite for macos_command_line_application.
 
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_dylib_tests.bzl
+++ b/test/starlark_tests/macos_dylib_tests.bzl
@@ -31,11 +31,12 @@ load(
     "output_group_test",
 )
 
-# buildifier: disable=unnamed-macro
-def macos_dylib_test_suite():
-    """Test suite for macos_dylib."""
-    name = "macos_dylib"
+def macos_dylib_test_suite(name):
+    """Test suite for macos_dylib.
 
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -19,13 +19,12 @@ load(
     "entry_point_test",
 )
 
-def macos_extension_test_suite(name = "macos_extension"):
+def macos_extension_test_suite(name):
     """Test suite for macos_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     entry_point_test(
         name = "{}_entry_point_nsextensionmain_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/macos_kernel_extension_tests.bzl
+++ b/test/starlark_tests/macos_kernel_extension_tests.bzl
@@ -74,11 +74,12 @@ _analysis_default_macos_cpu_test = analysistest.make(
     fragments = ["apple"],
 )
 
-# buildifier: disable=unnamed-macro
-def macos_kernel_extension_test_suite():
-    """Test suite for macos_kernel_extension."""
-    name = "macos_kernel_extension"
+def macos_kernel_extension_test_suite(name):
+    """Test suite for macos_kernel_extension.
 
+    Args:
+      name: the base name to be used in things created by this macro
+    """
     analysis_target_outputs_test(
         name = "{}_zip_file_output_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:kext",

--- a/test/starlark_tests/macos_quick_look_plugin_tests.bzl
+++ b/test/starlark_tests/macos_quick_look_plugin_tests.bzl
@@ -23,13 +23,12 @@ load(
     "archive_contents_test",
 )
 
-def macos_quick_look_plugin_test_suite(name = "macos_quick_look_plugin"):
+def macos_quick_look_plugin_test_suite(name):
     """Test suite for macos_quick_look_plugin.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_ui_test_tests.bzl
+++ b/test/starlark_tests/macos_ui_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "dsyms_test",
 )
 
-def macos_ui_test_test_suite(name = "macos_ui_test"):
+def macos_ui_test_test_suite(name):
     """Test suite for macos_ui_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "dsyms_test",
 )
 
-def macos_unit_test_test_suite(name = "macos_unit_test"):
+def macos_unit_test_test_suite(name):
     """Test suite for macos_unit_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/tvos_application_swift_tests.bzl
+++ b/test/starlark_tests/tvos_application_swift_tests.bzl
@@ -19,11 +19,11 @@ load(
     "archive_contents_test",
 )
 
-def tvos_application_swift_test_suite(name = "tvos_application_swift"):
+def tvos_application_swift_test_suite(name):
     """Test suite for tvos_application_swift.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # If an app is built with a min OS before ABI stability, targeting the

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -40,13 +40,12 @@ load(
     "analysis_xcasset_argv_test",
 )
 
-def tvos_application_test_suite(name = "tvos_application"):
+def tvos_application_test_suite(name):
     """Test suite for tvos_application.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/tvos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/tvos_dynamic_framework_tests.bzl
@@ -27,11 +27,11 @@ load(
     "infoplist_contents_test",
 )
 
-def tvos_dynamic_framework_test_suite(name = "tvos_dynamic_framework"):
+def tvos_dynamic_framework_test_suite(name):
     """Test suite for tvos_dynamic_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     archive_contents_test(

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -32,13 +32,12 @@ load(
     "infoplist_contents_test",
 )
 
-def tvos_extension_test_suite(name = "tvos_extension"):
+def tvos_extension_test_suite(name):
     """Test suite for tvos_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/tvos_framework_tests.bzl
+++ b/test/starlark_tests/tvos_framework_tests.bzl
@@ -23,13 +23,12 @@ load(
     "infoplist_contents_test",
 )
 
-def tvos_framework_test_suite(name = "tvos_framework"):
+def tvos_framework_test_suite(name):
     """Test suite for tvos_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:fmwk",

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -19,13 +19,12 @@ load(
     "archive_contents_test",
 )
 
-def tvos_static_framework_test_suite(name = "tvos_static_framework"):
+def tvos_static_framework_test_suite(name):
     """Test suite for tvos_static_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     archive_contents_test(
         name = "{}_contents_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/tvos_ui_test_tests.bzl
+++ b/test/starlark_tests/tvos_ui_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "infoplist_contents_test",
 )
 
-def tvos_ui_test_test_suite(name = "tvos_ui_test"):
+def tvos_ui_test_test_suite(name):
     """Test suite for tvos_ui_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "infoplist_contents_test",
 )
 
-def tvos_unit_test_test_suite(name = "tvos_unit_test"):
+def tvos_unit_test_test_suite(name):
     """Test suite for tvos_unit_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/watchos_application_swift_tests.bzl
+++ b/test/starlark_tests/watchos_application_swift_tests.bzl
@@ -19,11 +19,11 @@ load(
     "archive_contents_test",
 )
 
-def watchos_application_swift_test_suite(name = "watchos_application_swift"):
+def watchos_application_swift_test_suite(name):
     """Test suite for watchos_application_swift.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Pre-ABI stability, simulator build, iOS companion app uses Swift but

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -31,13 +31,12 @@ load(
     "analysis_xcasset_argv_test",
 )
 
-def watchos_application_test_suite(name = "watchos_application"):
+def watchos_application_test_suite(name):
     """Test suite for watchos_application.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/watchos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/watchos_dynamic_framework_tests.bzl
@@ -27,11 +27,11 @@ load(
     "infoplist_contents_test",
 )
 
-def watchos_dynamic_framework_test_suite(name = "watchos_dynamic_framework"):
+def watchos_dynamic_framework_test_suite(name):
     """Test suite for watchos_dynamic_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     archive_contents_test(

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -36,13 +36,12 @@ load(
     "linkmap_test",
 )
 
-def watchos_extension_test_suite(name = "watchos_extension"):
+def watchos_extension_test_suite(name):
     """Test suite for watchos_extension.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/watchos_static_framework_tests.bzl
+++ b/test/starlark_tests/watchos_static_framework_tests.bzl
@@ -19,11 +19,11 @@ load(
     "archive_contents_test",
 )
 
-def watchos_static_framework_test_suite(name = "watchos_static_framework"):
+def watchos_static_framework_test_suite(name):
     """Test suite for watchos_static_framework.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     archive_contents_test(

--- a/test/starlark_tests/watchos_ui_test_tests.bzl
+++ b/test/starlark_tests/watchos_ui_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "infoplist_contents_test",
 )
 
-def watchos_ui_test_test_suite(name = "watchos_ui_test"):
+def watchos_ui_test_test_suite(name):
     """Test suite for watchos_ui_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/watchos_unit_test_tests.bzl
+++ b/test/starlark_tests/watchos_unit_test_tests.bzl
@@ -27,13 +27,12 @@ load(
     "infoplist_contents_test",
 )
 
-def watchos_unit_test_test_suite(name = "watchos_unit_test"):
+def watchos_unit_test_test_suite(name):
     """Test suite for watchos_unit_test.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
-
     apple_verification_test(
         name = "{}_codesign_test".format(name),
         build_type = "simulator",


### PR DESCRIPTION
Silences the buildifier warning, but also provides an name so tools like
buildozer that work on the AST can better handle the BUILD files where they are
called.

RELNOTES: None
PiperOrigin-RevId: 420123866
(cherry picked from commit e3ebb8f4b7b8ed8b155b49d434bc7e13e41ba092)