### PR TITLE
Add empty `fields` to providers that don't have fields.

### DIFF
--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -239,7 +239,7 @@ a "marker" to indicate that a target is specifically an Apple resource bundle
 dependency is an Apple resource bundle should use this provider to describe that
 requirement.
 """,
-    fields = [],
+    fields = {},
 )
 
 AppleSupportToolchainInfo = provider(
@@ -395,7 +395,7 @@ a "marker" to indicate that a target is specifically an XCFramework bundle
 dependency is an XCFramework should use this provider to describe that
 requirement.
 """,
-    fields = [],
+    fields = {},
 )
 
 AppleXcframeworkBundleInfo = provider(
@@ -408,7 +408,7 @@ a "marker" to indicate that a target is specifically an XCFramework bundle
 dependency is an XCFramework should use this provider to describe that
 requirement.
 """,
-    fields = [],
+    fields = {},
 )
 
 IosApplicationBundleInfo = provider(
@@ -421,11 +421,10 @@ a "marker" to indicate that a target is specifically an iOS application bundle
 dependency is an iOS application should use this provider to describe that
 requirement.
 """,
-    fields = [],
+    fields = {},
 )
 
 IosAppClipBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS app clip.
 
@@ -434,10 +433,10 @@ a "marker" to indicate that a target is specifically an iOS app clip bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is an iOS app clip should use this provider to describe that requirement.
 """,
+    fields = {},
 )
 
 IosExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS application extension.
 
@@ -447,10 +446,10 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is an iOS application extension should use this
 provider to describe that requirement.
 """,
+    fields = {},
 )
 
 IosFrameworkBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS dynamic framework.
 
@@ -460,10 +459,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS dynamic framework should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 IosStaticFrameworkBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS static framework.
 
@@ -473,10 +472,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS static framework should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 IosImessageApplicationBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS iMessage application.
 
@@ -486,10 +485,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS iMessage application should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 IosImessageExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS iMessage extension.
 
@@ -499,10 +498,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS iMessage extension should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 IosStickerPackExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an iOS Sticker Pack extension.
 
@@ -512,10 +511,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS Sticker Pack extension should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 IosXcTestBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes a target that is an iOS .xctest bundle.
 
@@ -524,10 +523,10 @@ a "marker" to indicate that a target is specifically an iOS .xctest bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is an iOS .xctest bundle should use this provider to describe that requirement.
 """,
+    fields = {},
 )
 
 MacosApplicationBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS application.
 
@@ -537,10 +536,10 @@ a "marker" to indicate that a target is specifically a macOS application bundle
 dependency is a macOS application should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 MacosBundleBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS loadable bundle.
 
@@ -550,10 +549,10 @@ a "marker" to indicate that a target is specifically a macOS loadable bundle
 dependency is a macOS loadable bundle should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 MacosExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS application extension.
 
@@ -563,10 +562,10 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a macOS application extension should use this
 provider to describe that requirement.
 """,
+    fields = {},
 )
 
 MacosKernelExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS kernel extension.
 
@@ -576,10 +575,10 @@ a "marker" to indicate that a target is specifically a macOS kernel extension
 dependency is a macOS kernel extension should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 MacosQuickLookPluginBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS Quick Look Generator bundle.
 
@@ -589,10 +588,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a macOS Quick Look generator should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 MacosSpotlightImporterBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS Spotlight Importer bundle.
 
@@ -602,10 +601,10 @@ a "marker" to indicate that a target is specifically a macOS Spotlight importer
 dependency is a macOS Spotlight importer should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 MacosXPCServiceBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a macOS XPC Service bundle.
 
@@ -615,10 +614,10 @@ a "marker" to indicate that a target is specifically a macOS XPC service
 dependency is a macOS XPC service should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 MacosXcTestBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes a target that is a macOS .xctest bundle.
 
@@ -628,10 +627,10 @@ a "marker" to indicate that a target is specifically a macOS .xctest bundle
 dependency is a macOS .xctest bundle should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 TvosApplicationBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a tvOS application.
 
@@ -641,10 +640,10 @@ a "marker" to indicate that a target is specifically a tvOS application bundle
 dependency is a tvOS application should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 TvosExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a tvOS application extension.
 
@@ -654,10 +653,10 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a tvOS application extension should use this
 provider to describe that requirement.
 """,
+    fields = {},
 )
 
 TvosFrameworkBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a tvOS dynamic framework.
 
@@ -667,10 +666,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a tvOS dynamic framework should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 TvosStaticFrameworkBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an tvOS static framework.
 
@@ -680,10 +679,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a tvOS static framework should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 TvosXcTestBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes a target that is a tvOS .xctest bundle.
 
@@ -692,10 +691,10 @@ a "marker" to indicate that a target is specifically a tvOS .xctest bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is a tvOS .xctest bundle should use this provider to describe that requirement.
 """,
+    fields = {},
 )
 
 WatchosApplicationBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a watchOS application.
 
@@ -705,10 +704,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a watchOS application should use this provider to describe that
 requirement.
 """,
+    fields = {},
 )
 
 WatchosExtensionBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is a watchOS application extension.
 
@@ -718,10 +717,10 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a watchOS application extension should use this
 provider to describe that requirement.
 """,
+    fields = {},
 )
 
 WatchosStaticFrameworkBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes that a target is an watchOS static framework.
 
@@ -731,10 +730,10 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a watchOS static framework should use this provider to describe
 that requirement.
 """,
+    fields = {},
 )
 
 WatchosXcTestBundleInfo = provider(
-    fields = [],
     doc = """
 Denotes a target that is a watchOS .xctest bundle.
 
@@ -743,4 +742,5 @@ a "marker" to indicate that a target is specifically a watchOS .xctest bundle (a
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is a watchOS .xctest bundle should use this provider to describe that requirement.
 """,
+    fields = {},
 )


### PR DESCRIPTION
The providers are used as markers themselves, and it isn't that the fields are
undeclared, they have no fields.

RELNOTES: None
PiperOrigin-RevId: 420275818
(cherry picked from commit be1d70fe0697a13c6241ad35849066747c980699)