### PR TITLE
Stop adding headers to ObjcProvider

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -244,15 +244,11 @@ def _ensure_swiftmodule_is_embedded(swiftmodule):
 
 def _framework_objc_provider_fields(
         framework_binary_field,
-        header_imports,
         module_map_imports,
         framework_binaries):
     """Return an objc_provider initializer dictionary with information for a given framework."""
 
     objc_provider_fields = {}
-    if header_imports:
-        objc_provider_fields["header"] = depset(header_imports)
-
     if module_map_imports:
         objc_provider_fields["module_map"] = depset(module_map_imports)
 
@@ -349,7 +345,6 @@ def _apple_dynamic_framework_import_impl(ctx):
     framework_dirs_set = depset(framework_groups.keys())
     objc_provider_fields = _framework_objc_provider_fields(
         "dynamic_framework_file",
-        header_imports,
         module_map_imports,
         [] if ctx.attr.bundle_only else framework_binaries,
     )
@@ -396,7 +391,6 @@ def _apple_static_framework_import_impl(ctx):
 
     objc_provider_fields = _framework_objc_provider_fields(
         "static_framework_file",
-        header_imports,
         module_map_imports,
         framework_binaries,
     )


### PR DESCRIPTION
This is no longer needed.  It was leftover from the compile info
migration because (primarily) IDE still relied on it to get direct
header information.  We just migrated those use cases to CcInfo as
well.

PiperOrigin-RevId: 421189227
(cherry picked from commit d4ad14d015757b1dfb32c446b15ce624c5bb76cd)