### PR TITLE
Allow re-use of iOS simulator in tests

### DIFF
--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -55,6 +55,7 @@ exports_files([
     "ios_test_runner.template.sh",
     "macos_test_runner.template.sh",
     "macos_test_runner.template.xctestrun",
+    "simulator_creator.py",
     "tvos_test_runner.template.sh",
     "watchos_test_runner.template.sh",
 ])

--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -55,10 +55,20 @@ exports_files([
     "ios_test_runner.template.sh",
     "macos_test_runner.template.sh",
     "macos_test_runner.template.xctestrun",
-    "simulator_creator.py",
     "tvos_test_runner.template.sh",
     "watchos_test_runner.template.sh",
 ])
+
+py_binary(
+    name = "simulator_creator",
+    srcs = ["simulator_creator.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)
 
 ios_test_runner(
     name = "ios_default_runner",

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -27,6 +27,7 @@ def _get_template_substitutions(ctx):
         "device_type": device_type,
         "os_version": str(os_version),
         "testrunner_binary": ctx.executable._testrunner.short_path,
+        "simulator_creator": ctx.executable._simulator_creator.short_path,
     }
     return {"%(" + k + ")s": subs[k] for k in subs}
 
@@ -54,7 +55,9 @@ def _ios_test_runner_impl(ctx):
             test_environment = ctx.attr.test_environment,
         ),
         DefaultInfo(
-            runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,
+            runfiles = ctx.runfiles(
+                files = [ctx.file._simulator_creator],
+            ).merge(ctx.attr._testrunner[DefaultInfo].default_runfiles),
         ),
     ]
 
@@ -107,6 +110,14 @@ into the XCTest invocation.
 It is the rule that needs to provide the AppleTestRunnerInfo provider. This
 dependency is the test runner binary.
 """,
+        ),
+        "_simulator_creator": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator.py",
+            ),
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
         ),
         "_xcode_config": attr.label(
             default = configuration_field(

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -55,9 +55,8 @@ def _ios_test_runner_impl(ctx):
             test_environment = ctx.attr.test_environment,
         ),
         DefaultInfo(
-            runfiles = ctx.runfiles(
-                files = [ctx.file._simulator_creator],
-            ).merge(ctx.attr._testrunner[DefaultInfo].default_runfiles),
+            runfiles = ctx.attr._simulator_creator[DefaultInfo].default_runfiles
+                .merge(ctx.attr._testrunner[DefaultInfo].default_runfiles),
         ),
     ]
 
@@ -113,9 +112,8 @@ dependency is the test runner binary.
         ),
         "_simulator_creator": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator.py",
+                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator",
             ),
-            allow_single_file = True,
             executable = True,
             cfg = "exec",
         ),

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -132,7 +132,20 @@ if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
 fi
 
 target_flags=()
-if [[ -n "$simulator_id" ]]; then
+if [[ -n "${REUSE_GLOBAL_SIMULATOR:-}" ]]; then
+  if [[ -n "$simulator_id" ]]; then
+    echo "error: both '\$REUSE_GLOBAL_SIMULATOR' and a custom simulator id cannot be set" >&2
+    exit 1
+  fi
+
+  # FIXME: right now these arguments have to be set for this to work
+  id="$("./%(simulator_creator)s" "%(os_version)s" "%(device_type)s")"
+  target_flags=(
+    "test"
+    "--platform=ios_simulator"
+    "--id=$id"
+  )
+elif [[ -n "$simulator_id" ]]; then
   target_flags=(
     "test"
     "--platform=ios_simulator"

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -138,7 +138,16 @@ if [[ -n "${REUSE_GLOBAL_SIMULATOR:-}" ]]; then
     exit 1
   fi
 
-  # FIXME: right now these arguments have to be set for this to work
+  if [[ -z "%(os_version)s" ]]; then
+    echo "error: to create a re-useable simulator the OS version must always be set on the test runner or with '--ios_simulator_version'" >&2
+    exit 1
+  fi
+
+  if [[ -z "%(device_type)s" ]]; then
+    echo "error: to create a re-useable simulator the device type must always be set on the test runner or with '--ios_simulator_device'" >&2
+    exit 1
+  fi
+
   id="$("./%(simulator_creator)s" "%(os_version)s" "%(device_type)s")"
   target_flags=(
     "test"

--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import List, Optional
+
+
+def _simctl(extra_args: List[str]) -> str:
+    return subprocess.check_output(["xcrun", "simctl"] + extra_args).decode()
+
+
+def _boot_simulator(simulator_id: str) -> None:
+    # This private command boots the simulator if it isn't already, and waits
+    # for the appropriate amount of time until we can actually run tests
+    try:
+        output = _simctl(["bootstatus", simulator_id, "-b"])
+        print(output, file=sys.stderr)
+    except subprocess.CalledProcessError as e:
+        # Both of these errors translate to strange simulator states that may
+        # end up causing issues, but attempting to actually use the simulator
+        # instead of failing at this point might still succeed
+        #
+        # 164: EBADDEVICE
+        # 165: EBADDEVICESTATE
+        if e.returncode in (164, 165):
+            print(f"Ignoring a failure: {e.returncode}", file=sys.stderr)
+        else:
+            print(f"Not ignoring failure: {e.returncode}", file=sys.stderr)
+            raise
+    # Add more arbitrary delay before tests run. Even bootstatus doesn't wait
+    # long enough and tests can still fail because the simulator isn't read
+    time.sleep(3)
+
+
+def _device_name(device_type: str, os_version: str) -> str:
+    return f"BAZEL_TEST_{device_type}_{os_version}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "os_version", help="The iOS version to run the tests on, ex: 12.1"
+    )
+    parser.add_argument(
+        "device_type", help="The iOS device to run the tests on, ex: iPhone X"
+    )
+    parser.add_argument(
+        "--name",
+        required=False,
+        default=None,
+        help="The name to use for the device; default is 'BAZEL_TEST_[device_type]_[os_version]'",
+    )
+    return parser
+
+
+def _main(os_version: str, device_type: str, name: Optional[str]) -> None:
+    devices = json.loads(_simctl(["list", "devices", "-j"]))["devices"]
+    device_name = name or _device_name(device_type, os_version)
+    runtime_identifier = "com.apple.CoreSimulator.SimRuntime.iOS-{}".format(
+        os_version.replace(".", "-")
+    )
+
+    devices_for_os = devices.get(runtime_identifier) or []
+    existing_device = next(
+        (blob for blob in devices_for_os if blob["name"] == device_name), None
+    )
+
+    if existing_device:
+        simulator_id = existing_device["udid"]
+        # If the device is already booted assume that it was created with this
+        # script and bootstatus has already waited for it to be in a good state
+        # once
+        state = existing_device["state"].lower()
+        print(f"Simulator state is: {state}", file=sys.stderr)
+        if state != "booted":
+            _boot_simulator(simulator_id)
+    else:
+        simulator_id = _simctl(
+            ["create", device_name, device_type, runtime_identifier]
+        ).strip()
+        _boot_simulator(simulator_id)
+
+    print(simulator_id.strip())
+
+
+if __name__ == "__main__":
+    args = _build_parser().parse_args()
+    _main(args.os_version, args.device_type, args.name)

--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python3
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 import subprocess


### PR DESCRIPTION
Previously the test runner allowed you to pass a specific simulator UDID
to run on that, but since you passed that via --test_arg, that UDID
would invalidate any previous test runs on a different simulator UDID.
With this change you can pass `--test_env=REUSE_GLOBAL_SIMULATOR=yes` in
order to either create and boot, or reuse, a simulator with a specific
device / OS type. The potential downsides of this are:

- You could leave around state on your simulator that invalidates future
  test runs, either by causing invalid failures, or hiding real issues
- You have to cleanup the simulator yourself if you need to on CI,
  running `xcrun simctl delete all` is likely enough

For these tradeoffs you run subsequent tests much faster than if you
have to create and boot a new simulator for every test bundle.