### PR TITLE
Remove doc references to 'provides_main'

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2014,10 +2014,7 @@ ios_extension = rule_factory.create_apple_bundling_rule(
 Most iOS app extensions use a plug-in-based architecture where the executable's entry point
 is provided by a system framework.
 However, iOS 14 introduced Widget Extensions that use a traditional `main` entry point
-(typically expressed through Swift's `@main` attribute).
-If you are building a Widget Extension, you must set `provides_main = True` to indicate
-that your code provides the entry point so that Bazel doesn't direct the linker to use
-the system framework's entry point instead.""",
+(typically expressed through Swift's `@main` attribute).""",
 )
 
 ios_framework = rule_factory.create_apple_bundling_rule(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -1709,11 +1709,7 @@ macos_extension = rule_factory.create_apple_bundling_rule(
 Most macOS app extensions use a plug-in-based architecture where the
 executable's entry point is provided by a system framework. However, macOS 11
 introduced Widget Extensions that use a traditional `main` entry
-point (typically expressed through Swift's `@main` attribute). If you
-are building a Widget Extension, you **must** set
-`provides_main = True` to indicate that your code provides the entry
-point so that Bazel doesn't direct the linker to use the system framework's
-entry point instead.""",
+point (typically expressed through Swift's `@main` attribute).""",
 )
 
 macos_quick_look_plugin = rule_factory.create_apple_bundling_rule(

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -204,9 +204,6 @@ Most iOS app extensions use a plug-in-based architecture where the executable's 
 is provided by a system framework.
 However, iOS 14 introduced Widget Extensions that use a traditional `main` entry point
 (typically expressed through Swift's `@main` attribute).
-If you are building a Widget Extension, you must set `provides_main = True` to indicate
-that your code provides the entry point so that Bazel doesn't direct the linker to use
-the system framework's entry point instead.
 
 **ATTRIBUTES**
 

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -234,11 +234,7 @@ Builds and bundles a macOS Application Extension.
 Most macOS app extensions use a plug-in-based architecture where the
 executable's entry point is provided by a system framework. However, macOS 11
 introduced Widget Extensions that use a traditional `main` entry
-point (typically expressed through Swift's `@main` attribute). If you
-are building a Widget Extension, you **must** set
-`provides_main = True` to indicate that your code provides the entry
-point so that Bazel doesn't direct the linker to use the system framework's
-entry point instead.
+point (typically expressed through Swift's `@main` attribute).
 
 **ATTRIBUTES**
 


### PR DESCRIPTION
Remove doc references to `provides_main` since https://github.com/bazelbuild/rules_apple/pull/1102 removed it as a parameter.