### PR TITLE
Fix Swift dylib thinning on macOS with Xcode 13.2.1.

### DIFF
--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -121,7 +121,7 @@ def main():
   args = parser.parse_args()
 
   all_binary_archs = args.slice
-  framework_archs = lipo.find_archs_for_binaries(args.framework_binary)
+  framework_archs, _ = lipo.find_archs_for_binaries(args.framework_binary)
 
   if not framework_archs:
     return 1


### PR DESCRIPTION
The current version of the script contained an assumption that all Swift dylibs that would get copied into a bundle would have the same architecture slices. This is no longer the case with back-deployed concurrency. On macOS, the core Swift libs only have x86_64 slices (because there is no need for arm64 slices since all macOS versions compatible with arm64 have Swift in the OS), but `libswift_Concurrency.dylib` has arm64(e) slices. This caused the script to break, attempting to call `lipo -thin` on an already-thin dylib.

Now, we keep track of a mapping of which dylibs had which slices so that we can intersect each one with the set that we want to keep and use that to drive the thinning logic.

PiperOrigin-RevId: 423172109
(cherry picked from commit 1311615beb419adf1fb9d9e12b4c4cf08d694a46)