### PR TITLE
Add support for grep-includes, required by the cc_include_scanning feature, to apple_xcframework.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -532,6 +532,7 @@ bzl_library(
         ":platform_support",
         ":processor",
         ":resources",
+        ":rule_factory",
         ":rule_support",
         ":swift_support",
         ":transition_support",

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -446,6 +446,18 @@ def apple_xcframework_test_suite(name):
         tags = [name],
     )
 
+    # Verifies that the include scanning feature builds for the given XCFramework rule.
+    archive_contents_test(
+        name = "{}_ios_arm64_cc_include_scanning_test".format(name),
+        build_type = "device",
+        target_features = ["cc_include_scanning"],
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/ios_dynamic_xcframework",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -65,10 +65,11 @@ def _apple_verification_transition_impl(settings, attr):
             "//command_line_option:watchos_cpus": "armv7k",
         })
     existing_features = settings.get("//command_line_option:features") or []
+    if hasattr(attr, "target_features"):
+        existing_features.extend(attr.target_features)
     if hasattr(attr, "sanitizer") and attr.sanitizer != "none":
-        output_dictionary["//command_line_option:features"] = existing_features + [attr.sanitizer]
-    else:
-        output_dictionary["//command_line_option:features"] = existing_features
+        existing_features.append(attr.sanitizer)
+    output_dictionary["//command_line_option:features"] = existing_features
     return output_dictionary
 
 apple_verification_transition = transition(
@@ -242,6 +243,12 @@ https://docs.bazel.build/versions/main/command-line-reference.html#flag--macos_c
             doc = """
 Possible values are `none`, `asan`, `tsan` or `ubsan`. Defaults to `none`.
 Passes a sanitizer to the target under test.
+""",
+        ),
+        "target_features": attr.string_list(
+            mandatory = False,
+            doc = """
+List of additional features to build for the target under testing.
 """,
         ),
         "target_under_test": attr.label(


### PR DESCRIPTION
Accomplished through using the rule_factory.common_tool_attributes common endpoint, which also provides a common interface for the apple support toolchain with other Apple BUILD rules.

PiperOrigin-RevId: 421350718
(cherry picked from commit 27e41450ad7fd4873047d182aaa2be826d41226c)