### PR TITLE
Support getting the Clang runtimes from the toolchain instead of from Xcode

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1241,6 +1241,7 @@ def _ios_dynamic_framework_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -83,6 +83,10 @@ load(
     "SwiftDynamicFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleSupportToolchainInfo",
     "IosAppClipBundleInfo",
@@ -234,6 +238,7 @@ def _ios_application_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -526,6 +531,7 @@ def _ios_app_clip_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -777,6 +783,7 @@ def _ios_framework_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -1006,6 +1013,7 @@ def _ios_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,
@@ -1741,6 +1749,7 @@ def _ios_imessage_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -75,6 +75,10 @@ load(
     "transition_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBinaryInfo",
     "AppleBinaryInfoplistInfo",
@@ -170,6 +174,7 @@ def _macos_application_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -417,6 +422,7 @@ def _macos_bundle_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -609,6 +615,7 @@ def _macos_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -822,6 +829,7 @@ def _macos_quick_look_plugin_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -1017,6 +1025,7 @@ def _macos_kernel_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -1211,6 +1220,7 @@ def _macos_spotlight_importer_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -1403,6 +1413,7 @@ def _macos_xpc_service_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -1598,6 +1609,10 @@ def _macos_command_line_application_impl(ctx):
     # There should only be one `AppleBinaryInfoplistInfo` providing dep
     infoplist = infoplists[0] if infoplists else None
 
+    runfiles = []
+    if clang_rt_dylibs.should_package_clang_runtime(features = features):
+        runfiles = clang_rt_dylibs.get_from_toolchain(ctx)
+
     return [
         AppleBinaryInfo(
             binary = output_file,
@@ -1610,6 +1625,7 @@ def _macos_command_line_application_impl(ctx):
                 depset([output_file]),
                 processor_result.output_files,
             ]),
+            runfiles = ctx.runfiles(runfiles),
         ),
         OutputGroupInfo(
             **outputs.merge_output_groups(
@@ -1802,6 +1818,9 @@ code-signed.
 
 Targets created with `macos_command_line_application` can be executed using
 `bazel run`.""",
+    additional_attrs = {
+        "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
+    },
 )
 
 macos_dylib = rule_factory.create_apple_binary_rule(

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -84,6 +84,7 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:partial",
         "@build_bazel_apple_support//lib:apple_support",
     ],

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -86,17 +86,18 @@ def clang_rt_dylibs_partial(
         actions,
         apple_toolchain_info,
         binary_artifact,
+        dylibs,
         features,
         label_name,
         output_discriminator = None,
-        platform_prerequisites,
-        dylibs):
+        platform_prerequisites):
     """Constructor for the Clang runtime dylibs processing partial.
 
     Args:
       actions: The actions provider from `ctx.actions`.
       apple_toolchain_info: `struct` of tools from the shared Apple toolchain.
       binary_artifact: The main binary artifact for this target.
+      dylibs: List of dylibs (usually from a toolchain).
       features: List of features enabled by the user. Typically from `ctx.features`.
       label_name: Name of the target being built.
       output_discriminator: A string to differentiate between different target intermediate files

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -23,6 +23,10 @@ load(
     "processor",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -30,22 +34,6 @@ load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
-
-def _should_package_clang_runtime(*, features):
-    """Returns whether the Clang runtime should be bundled."""
-
-    # List of crosstool sanitizer features that require packaging some clang
-    # runtime libraries.
-    features_requiring_clang_runtime = {
-        "asan": True,
-        "tsan": True,
-        "ubsan": True,
-    }
-
-    for feature in features:
-        if feature in features_requiring_clang_runtime:
-            return True
-    return False
 
 def _clang_rt_dylibs_partial_impl(
         *,
@@ -55,10 +43,11 @@ def _clang_rt_dylibs_partial_impl(
         features,
         label_name,
         output_discriminator,
-        platform_prerequisites):
+        platform_prerequisites,
+        dylibs):
     """Implementation for the Clang runtime dylibs processing partial."""
     bundle_zips = []
-    if _should_package_clang_runtime(features = features):
+    if clang_rt_dylibs.should_package_clang_runtime(features = features):
         clang_rt_zip = intermediates.file(
             actions = actions,
             target_name = label_name,
@@ -77,7 +66,7 @@ def _clang_rt_dylibs_partial_impl(
             executable = resolved_clangrttool.executable,
             # This action needs to read the contents of the Xcode bundle.
             execution_requirements = {"no-sandbox": "1"},
-            inputs = depset([binary_artifact], transitive = [resolved_clangrttool.inputs]),
+            inputs = depset([binary_artifact] + dylibs, transitive = [resolved_clangrttool.inputs]),
             input_manifests = resolved_clangrttool.input_manifests,
             outputs = [clang_rt_zip],
             mnemonic = "ClangRuntimeLibsCopy",
@@ -100,7 +89,8 @@ def clang_rt_dylibs_partial(
         features,
         label_name,
         output_discriminator = None,
-        platform_prerequisites):
+        platform_prerequisites,
+        dylibs):
     """Constructor for the Clang runtime dylibs processing partial.
 
     Args:
@@ -112,6 +102,7 @@ def clang_rt_dylibs_partial(
       output_discriminator: A string to differentiate between different target intermediate files
           or `None`.
       platform_prerequisites: Struct containing information on the platform being targeted.
+      dylibs: The clang dylibs to bundle with the target.
 
     Returns:
       A partial that returns the bundle location of the Clang runtime dylibs, if there were any to
@@ -126,4 +117,5 @@ def clang_rt_dylibs_partial(
         label_name = label_name,
         output_discriminator = output_discriminator,
         platform_prerequisites = platform_prerequisites,
+        dylibs = dylibs,
     )

--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -33,6 +33,7 @@ bzl_library(
         "//apple/internal:platform_support",
         "//apple/internal:processor",
         "//apple/internal:rule_support",
+        "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:types",
         "@build_bazel_rules_swift//swift",
     ],

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -63,6 +63,10 @@ load(
     "rule_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleExtraOutputsInfo",
@@ -354,6 +358,7 @@ def _apple_test_bundle_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -461,6 +461,7 @@ def _tvos_dynamic_framework_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -79,6 +79,10 @@ load(
     "SwiftStaticFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleSupportToolchainInfo",
     "TvosApplicationBundleInfo",
@@ -194,6 +198,7 @@ def _tvos_application_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -661,6 +666,7 @@ def _tvos_framework_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -866,6 +872,7 @@ def _tvos_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,

--- a/apple/internal/utils/BUILD
+++ b/apple/internal/utils/BUILD
@@ -19,6 +19,17 @@ bzl_library(
 )
 
 bzl_library(
+    name = "clang_rt_dylibs",
+    srcs = ["clang_rt_dylibs.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "@bazel_tools//tools/cpp:toolchain_utils",
+    ],
+)
+
+bzl_library(
     name = "defines",
     srcs = ["defines.bzl"],
     visibility = [

--- a/apple/internal/utils/BUILD
+++ b/apple/internal/utils/BUILD
@@ -24,9 +24,6 @@ bzl_library(
     visibility = [
         "//apple:__subpackages__",
     ],
-    deps = [
-        "@bazel_tools//tools/cpp:toolchain_utils",
-    ],
 )
 
 bzl_library(

--- a/apple/internal/utils/clang_rt_dylibs.bzl
+++ b/apple/internal/utils/clang_rt_dylibs.bzl
@@ -1,0 +1,52 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support functions related to getting clang runtime libraries."""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _should_package_clang_runtime(*, features):
+    """Returns whether the Clang runtime should be bundled."""
+
+    # List of crosstool sanitizer features that require packaging some clang
+    # runtime libraries.
+    features_requiring_clang_runtime = {
+        "asan": True,
+        "tsan": True,
+        "ubsan": True,
+    }
+
+    for feature in features:
+        if feature in features_requiring_clang_runtime:
+            return True
+    return False
+
+def _get_from_toolchain(ctx):
+    if hasattr(ctx.attr, "_cc_toolchain"):
+        cc_toolchain = find_cpp_toolchain(ctx)
+        dylibs = [
+            x
+            for x in cc_toolchain.all_files.to_list()
+            if x.basename.startswith("libclang_rt") and x.basename.endswith(".dylib")
+        ]
+    else:
+        dylibs = []
+
+    return dylibs
+
+# Define the loadable module that lists the exported symbols in this file.
+clang_rt_dylibs = struct(
+    should_package_clang_runtime = _should_package_clang_runtime,
+    get_from_toolchain = _get_from_toolchain,
+)

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -216,6 +216,7 @@ def _watchos_dynamic_framework_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.debug_symbols_partial(
             actions = actions,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -79,6 +79,10 @@ load(
     "SwiftStaticFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleSupportToolchainInfo",
     "IosFrameworkBundleInfo",
@@ -426,6 +430,7 @@ def _watchos_application_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,
@@ -651,6 +656,7 @@ def _watchos_extension_impl(ctx):
             features = features,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
+            dylibs = clang_rt_dylibs.get_from_toolchain(ctx),
         ),
         partials.codesigning_dossier_partial(
             actions = actions,


### PR DESCRIPTION
PiperOrigin-RevId: 423352342
(cherry picked from commit 03f5eb995869b3d942f99b6acd1c6c00ccff39d6)