### PR TITLE
Add actionable verification to inform the user when they have a header file that conflicts with the generated header file.

### DIFF
--- a/apple/internal/partials/framework_header_modulemap.bzl
+++ b/apple/internal/partials/framework_header_modulemap.bzl
@@ -112,6 +112,28 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
+def _verify_headers(
+        *,
+        public_hdrs,
+        umbrella_header_name):
+    """Raises an error if a public header conflicts with the umbrella header.
+
+    Args:
+      public_hdrs: The list of headers to bundle.
+      umbrella_header_name: The basename of the umbrella header file, or None if
+          there is no umbrella header.
+    """
+    conflicting_headers = []
+    for public_hdr in public_hdrs:
+        if public_hdr.basename == umbrella_header_name:
+            conflicting_headers.append(public_hdr.path)
+    if conflicting_headers:
+        fail(("Found imported header file(s) which conflict(s) with the name \"%s\" of the " +
+              "generated umbrella header for this target. Check input files:\n%s\n\nPlease " +
+              "remove the references to these files from your rule's list of headers to import " +
+              "or rename the headers if necessary.\n") %
+             (umbrella_header_name, ", ".join(conflicting_headers)))
+
 def _framework_header_modulemap_partial_impl(
         *,
         actions,
@@ -153,6 +175,11 @@ def _framework_header_modulemap_partial_impl(
                 (processor.location.bundle, "Headers", depset(hdrs)),
             )
         else:
+            _verify_headers(
+                public_hdrs = hdrs,
+                umbrella_header_name = umbrella_header_name,
+            )
+
             bundle_files.append(
                 (processor.location.bundle, "Headers", depset(hdrs + [umbrella_header_file])),
             )

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -15,6 +15,10 @@
 """xcframework Starlark tests."""
 
 load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
     "bitcode_symbol_map_test",
@@ -455,6 +459,15 @@ def apple_xcframework_test_suite(name):
         contains = [
             "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/ios_dynamic_xcframework",
         ],
+        tags = [name],
+    )
+
+    # Test that an actionable error is produced for the user when a header to
+    # bundle conflicts with the generated umbrella header.
+    analysis_failure_message_test(
+        name = "{}_umbrella_header_conflict_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_with_umbrella_header_conflict",
+        expected_error = "Found imported header file(s) which conflict(s) with the name \"UmbrellaHeaderConflict.h\" of the generated umbrella header for this target. Check input files:\nthird_party/bazel_rules/rules_apple/test/starlark_tests/resources/UmbrellaHeaderConflict.h\n\nPlease remove the references to these files from your rule's list of headers to import or rename the headers if necessary.",
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -15,6 +15,10 @@
 """ios_static_framework Starlark tests."""
 
 load(
+    ":rules/analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     ":rules/common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -109,6 +113,15 @@ def ios_static_framework_test_suite(name):
             "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
             "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
         ],
+        tags = [name],
+    )
+
+    # Test that an actionable error is produced for the user when a header to
+    # bundle conflicts with the generated umbrella header.
+    analysis_failure_message_test(
+        name = "{}_umbrella_header_conflict_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:static_framework_with_umbrella_header_conflict",
+        expected_error = "Found imported header file(s) which conflict(s) with the name \"UmbrellaHeaderConflict.h\" of the generated umbrella header for this target. Check input files:\nthird_party/bazel_rules/rules_apple/test/starlark_tests/resources/UmbrellaHeaderConflict.h\n\nPlease remove the references to these files from your rule's list of headers to import or rename the headers if necessary.",
         tags = [name],
     )
 

--- a/test/starlark_tests/resources/UmbrellaHeaderConflict.h
+++ b/test/starlark_tests/resources/UmbrellaHeaderConflict.h
@@ -1,0 +1,21 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for UmbrellaHeaderConflict.
+FOUNDATION_EXPORT double UmbrellaHeaderConflictVersionNumber;
+
+//! Project version string for UmbrellaHeaderConflict.
+FOUNDATION_EXPORT const unsigned char UmbrellaHeaderConflictVersionString[];

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -544,6 +544,29 @@ apple_xcframework(
     deps = [":SwiftFmwkWithGenHeader"],
 )
 
+apple_xcframework(
+    name = "ios_dynamic_xcframework_with_umbrella_header_conflict",
+    bundle_id = "com.google.example",
+    bundle_name = "UmbrellaHeaderConflict",
+    framework_type = ["dynamic"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": ["x86_64"],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": "8.0",
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+        "//test/starlark_tests/resources:UmbrellaHeaderConflict.h",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":fmwk_lib"],
+)
+
 apple_static_xcframework(
     name = "ios_static_xcframework",
     ios = {

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2283,6 +2283,18 @@ ios_static_framework(
     deps = [":StaticFmwkWithGenHeader"],
 )
 
+ios_static_framework(
+    name = "static_framework_with_umbrella_header_conflict",
+    hdrs = [
+        "//test/starlark_tests/resources:UmbrellaHeaderConflict.h",
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    bundle_name = "UmbrellaHeaderConflict",
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [":shared_lib"],
+)
+
 genrule(
     name = "dummy_swift_src",
     outs = ["Dummy.swift"],


### PR DESCRIPTION
PiperOrigin-RevId: 422653074
(cherry picked from commit 1e8d97ef017cb8dff2ecfb1fbd87f0b55c1b2d32)