### PR TITLE
Improve error handling for infoplist_contents_test

### DIFF
--- a/test/starlark_tests/rules/infoplist_contents_test.bzl
+++ b/test/starlark_tests/rules/infoplist_contents_test.bzl
@@ -74,6 +74,12 @@ def _infoplist_contents_test_impl(ctx):
             "fi",
         ])
 
+    test_lines.extend([
+        "if [[ \"$EXIT_CODE\" -eq 1 ]]; then",
+        "  echo \"Actual contents were:\"",
+        "  /usr/libexec/PlistBuddy -c \"Print\" {0} 2>/dev/null".format(plist_path),
+        "fi",
+    ])
     test_lines.append("exit $EXIT_CODE")
 
     test_script = ctx.actions.declare_file("{}_test_script".format(ctx.label.name))


### PR DESCRIPTION
When an error occurs, dump the contents of the Info.plist for easier debugging.

PiperOrigin-RevId: 424352170
(cherry picked from commit e7c7276d73e05888114facaac9515cdc7cbefefd)