### PR TITLE
Add config_setting for `watchos_arm64_32`

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -24,6 +24,7 @@ licenses(["notice"])
         "tvos_arm64",
         "watchos_i386",
         "watchos_arm64",
+        "watchos_arm64_32",
         "watchos_armv7k",
         "watchos_arm64_32",
     ]


### PR DESCRIPTION
Based on PR #776

PiperOrigin-RevId: 424385484
(cherry picked from commit 1a06055a1fc948723c36fb1a83a60870fabd8909)