### PR TITLE
Take upstream swift_stdlib_tool directory fix

### DIFF
--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -52,8 +52,7 @@ def _lipo_exec_files(exec_files, target_archs, strip_bitcode, source_path,
   )
 
   # Ensure directory for remote execution
-  if not os.path.exists(destination_path):
-    os.makedirs(destination_path)
+  os.makedirs(destination_path, exist_ok=True)
 
   # Copy or lipo each file as needed, from source to destination.
   for exec_file in exec_files:

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -51,9 +51,6 @@ def _lipo_exec_files(exec_files, target_archs, strip_bitcode, source_path,
       [os.path.join(source_path, f) for f in exec_files]
   )
 
-  # Ensure directory for remote execution
-  os.makedirs(destination_path, exist_ok=True)
-
   # Copy or lipo each file as needed, from source to destination.
   for exec_file in exec_files:
     exec_file_source_path = os.path.join(source_path, exec_file)

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -108,9 +108,13 @@ def main():
       )
   ]
 
+  destination_path = args.output_path
+  # Ensure directory exists for remote execution.
+  os.makedirs(destination_path, exist_ok=True)
+
   # Copy or use lipo to strip the executable Swift stdlibs to their destination.
   _lipo_exec_files(stdlib_files, target_archs, args.strip_bitcode, temp_path,
-                   args.output_path)
+                   destination_path)
 
   shutil.rmtree(temp_path)
 


### PR DESCRIPTION
We no longer need to support py2 here, the only functional difference from upstream is doing this outside of this function