### PR TITLE
Ignore stderr from commands

### DIFF
--- a/tools/environment_plist/environment_plist.sh
+++ b/tools/environment_plist/environment_plist.sh
@@ -47,7 +47,7 @@ shift
 done
 
 set +e
-PLATFORM_DIR=$(/usr/bin/xcrun --sdk "${PLATFORM}" --show-sdk-platform-path)
+PLATFORM_DIR=$(/usr/bin/xcrun --sdk "${PLATFORM}" --show-sdk-platform-path 2>/dev/null)
 XCRUN_EXITCODE=$?
 set -e
 if [[ ${XCRUN_EXITCODE} -ne 0 ]] ; then
@@ -65,8 +65,8 @@ trap 'rm -rf "${TEMPDIR}"' ERR EXIT
 
 os_build=$(sw_vers -buildVersion)
 compiler=$(/usr/libexec/PlistBuddy -c "Print :DefaultProperties:DEFAULT_COMPILER" "${PLATFORM_PLIST}")
-xcodebuild_version_sdk_output=$(/usr/bin/xcrun xcodebuild -version -sdk "${PLATFORM}")
-xcodebuild_version_output=$(/usr/bin/xcrun xcodebuild -version)
+xcodebuild_version_sdk_output=$(/usr/bin/xcrun xcodebuild -version -sdk "${PLATFORM}" 2>/dev/null)
+xcodebuild_version_output=$(/usr/bin/xcrun xcodebuild -version 2>/dev/null)
 # Parses 'PlatformVersion N.N' into N.N.
 platform_version=$(echo "${xcodebuild_version_sdk_output}" | grep PlatformVersion | cut -d ' ' -f2)
 # Parses 'ProductBuildVersion NNNN' into NNNN.


### PR DESCRIPTION
On m1 machines xcrun and xcodebuild prints warnings like these:

```
objc[11792]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libauthinstall.dylib (0x207db1160) and /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1186102b8). One of the two will be used. Which one is undefined.
```

I reported this 4/21 as FB9089778, but in the meantime we can just
ignore it.