### PR TITLE
Fix `apple_verification_test_runner` unable to remove temporary testing xcframework's archive root

### DIFF
--- a/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
+++ b/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
@@ -27,7 +27,8 @@ if [[ -n "$ARCHIVE_PATH" ]]; then
   # Unzip the archive into a temporary location.
   ARCHIVE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/bundle_tmp_dir.XXXXXX")"
 
-  trap 'rm -rf "${ARCHIVE_ROOT}"' ERR EXIT
+  trap 'chmod -R u+w "${ARCHIVE_ROOT}"
+    rm -rf "${ARCHIVE_ROOT}"' ERR EXIT
 
   unzip -qq "$ARCHIVE_PATH" -d "$ARCHIVE_ROOT"
 


### PR DESCRIPTION
The following tests are failing locally because the user doesn't have
write permission to the inner `Headers` directories in testing
xcframeworks.

```
//test/starlark_tests:apple_static_xcframework_ios_arm64_archive_contents_test
//test/starlark_tests:apple_static_xcframework_ios_root_plist_test
```

Example failure:

```
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test/starlark_tests:apple_static_xcframework_ios_arm64_archive_contents_test
-----------------------------------------------------------------------------
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator/Headers/shared.h: Permission denied
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator/Headers: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64/Headers/shared.h: Permission denied
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64/Headers: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator/Headers/shared.h: Permission denied
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator/Headers: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64_x86_64-simulator: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64/Headers/shared.h: Permission denied
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64/Headers: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework/ios-arm64: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO/ios_static_xcframework.xcframework: Directory not empty
rm: /var/folders/lh/8vynt10s06scyb4z3gfmnsn00000gp/T//bundle_tmp_dir.odvYLO: Directory not empty
```
