### PR TITLE
Remove rules_cc as a dependency

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -127,7 +127,6 @@ bzl_library(
         "//apple/internal/resource_rules:apple_core_ml_library",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
-        "@rules_cc//cc:defs.bzl",
     ],
 )
 

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -14,7 +14,6 @@
 
 """# Rules related to Apple resources and resource bundles."""
 
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "@build_bazel_rules_apple//apple/internal/resource_rules:apple_bundle_import.bzl",
     _apple_bundle_import = "apple_bundle_import",
@@ -81,7 +80,7 @@ def apple_core_ml_library(name, mlmodel, **kwargs):
         visibility = ["//visibility:private"],
         **core_ml_args
     )
-    objc_library(
+    native.objc_library(
         name = name,
         srcs = [":{}.m".format(core_ml_name)],
         hdrs = [":{}".format(core_ml_name)],
@@ -126,7 +125,7 @@ def objc_intent_library(
         tags = ["manual"],
         testonly = testonly,
     )
-    objc_library(
+    native.objc_library(
         name = name,
         srcs = [intent_srcs],
         hdrs = [intent_hdrs],

--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//apple:ios.bzl", "ios_application")
 load(

--- a/examples/ios/PrenotCalculator/BUILD
+++ b/examples/ios/PrenotCalculator/BUILD
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:ios.bzl",

--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//apple:ios.bzl", "ios_unit_test")
 
 licenses(["notice"])

--- a/examples/macos/CommandLine/BUILD
+++ b/examples/macos/CommandLine/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:macos.bzl",

--- a/examples/macos/HelloToday/BUILD
+++ b/examples/macos/HelloToday/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:macos.bzl",

--- a/examples/macos/HelloWorld/BUILD
+++ b/examples/macos/HelloWorld/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:macos.bzl",

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:ios.bzl",

--- a/examples/tvos/HelloWorld/BUILD
+++ b/examples/tvos/HelloWorld/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:tvos.bzl",

--- a/examples/watchos/HelloWorld/BUILD
+++ b/examples/watchos/HelloWorld/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//apple:ios.bzl",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:resources.bzl",
     "apple_bundle_import",

--- a/test/starlark_tests/resources/kext_resources/BUILD
+++ b/test/starlark_tests/resources/kext_resources/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//test/starlark_tests:common.bzl", "FIXTURE_TAGS")
 
 licenses(["notice"])

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_app_clip",

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:macos.bzl",
     "macos_application",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:tvos.bzl",
     "tvos_application",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_application",

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//apple:apple_binary.bzl",
     "apple_binary",


### PR DESCRIPTION
This repo has been abandoned in favor of the `@_builtins` repo
(Starlark rules implemented in Bazel's core).
