### PR TITLE
Add the -sha1 flag to the openssl command used in codesigningtool

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -113,6 +113,7 @@ def _certificate_fingerprint(identity):
   _, fingerprint, _ = execute.execute_and_filter_output([
       "openssl",
       "x509",
+      "-sha1",
       "-inform",
       "DER",
       "-noout",


### PR DESCRIPTION
As called out in https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes, MacOS 12.3 beta updates the builtin version of LibreSSL to 3.3.5, which changes the default digest type of openssl to SHA256.

This breaks codesigningtool's mobileprovision identity extraction. We can fix this by just explicitly specifying the output format with -sha1.

Linked issue: https://github.com/bazelbuild/rules_apple/issues/1358