### PR TITLE
Add example working UI test

### DIFF
--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//apple:ios.bzl", "ios_application")
+load("//apple:ios.bzl", "ios_application", "ios_ui_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])
@@ -26,6 +26,19 @@ ios_application(
     launch_storyboard = "//examples/resources:Launch.storyboard",
     minimum_os_version = "8.0",
     deps = [":Sources"],
+)
+
+swift_library(
+    name = "TestLib",
+    srcs = ["UITests/Test.swift"],
+    module_name = "HelloWorldSwiftUITests",
+)
+
+ios_ui_test(
+    name = "HelloWorldSwiftUITests",
+    minimum_os_version = "8.0",
+    test_host = ":HelloWorldSwift",
+    deps = [":TestLib"],
 )
 
 # Not normally needed, just done for rules_apple's examples so a

--- a/examples/ios/HelloWorldSwift/UITests/Test.swift
+++ b/examples/ios/HelloWorldSwift/UITests/Test.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class TestClass: XCTestCase {
+    func testFunc() {
+        XCTAssertEqual(1, 1)
+    }
+}


### PR DESCRIPTION
The key here is the module_name of the test source lib is the same as
the test name so the ProductModuleName in the xctestrun file matches the
module name