### PR TITLE
Support skipping tests with --test_filter

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -129,7 +129,7 @@ if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
   IFS=","
   ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
   for TEST in $ALL_TESTS; do
-    if [[ ${TEST:0:1} == "-" ]]; then
+    if [[ $TEST == -* ]]; then
       if [[ -n "$SKIP_TESTS" ]]; then
         SKIP_TESTS+=",${TEST:1}"
       else

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -445,6 +445,7 @@ function test_ios_unit_test_with_multi_filter() {
   expect_log "Test Suite 'PassingUnitTest.xctest' passed"
   expect_log "Executed 2 tests, with 0 failures"
 }
+
 function test_ios_unit_test_with_host_with_filter() {
   create_sim_runners
   create_test_host_app

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -446,6 +446,32 @@ function test_ios_unit_test_with_multi_filter() {
   expect_log "Executed 2 tests, with 0 failures"
 }
 
+function test_ios_unit_test_with_skip_filter() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test --test_filter=-PassingUnitTest/testPass //ios:PassingUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingUnitTest.xctest' passed"
+  expect_log "Executed 1 test, with 0 failures"
+}
+
+function test_ios_unit_test_with_multi_skip_filter() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test --test_filter=-PassingUnitTest/testPass,-PassingUnitTest/testPass2 //ios:PassingUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_not_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingUnitTest.xctest' passed"
+  expect_log "Executed 1 test, with 0 failures"
+}
+
 function test_ios_unit_test_with_host_with_filter() {
   create_sim_runners
   create_test_host_app

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -445,33 +445,6 @@ function test_ios_unit_test_with_multi_filter() {
   expect_log "Test Suite 'PassingUnitTest.xctest' passed"
   expect_log "Executed 2 tests, with 0 failures"
 }
-
-function test_ios_unit_test_with_skip_filter() {
-  create_sim_runners
-  create_ios_unit_tests
-  do_ios_test --test_filter=-PassingUnitTest/testPass //ios:PassingUnitTest || fail "should pass"
-
-  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
-  expect_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
-  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
-  expect_log "Test Suite 'PassingUnitTest' passed"
-  expect_log "Test Suite 'PassingUnitTest.xctest' passed"
-  expect_log "Executed 1 test, with 0 failures"
-}
-
-function test_ios_unit_test_with_multi_skip_filter() {
-  create_sim_runners
-  create_ios_unit_tests
-  do_ios_test --test_filter=-PassingUnitTest/testPass,-PassingUnitTest/testPass2 //ios:PassingUnitTest || fail "should pass"
-
-  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
-  expect_not_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
-  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
-  expect_log "Test Suite 'PassingUnitTest' passed"
-  expect_log "Test Suite 'PassingUnitTest.xctest' passed"
-  expect_log "Executed 1 test, with 0 failures"
-}
-
 function test_ios_unit_test_with_host_with_filter() {
   create_sim_runners
   create_test_host_app
@@ -482,6 +455,48 @@ function test_ios_unit_test_with_host_with_filter() {
   expect_log "Test Suite 'PassingUnitTest' passed"
   expect_log "Test Suite 'PassingWithHost.xctest' passed"
   expect_log "Executed 1 test, with 0 failures"
+}
+
+function test_ios_unit_test_with_host_and_skip_filter() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  do_ios_test --test_filter=-PassingUnitTest/testPass //ios:PassingWithHost || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingWithHost.xctest' passed"
+  expect_log "Executed 3 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_host_and_multi_skip_filter() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  do_ios_test --test_filter=-PassingUnitTest/testPass,-PassingUnitTest/testPass2 //ios:PassingWithHost || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_not_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingWithHost.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_host_and_skip_and_only_filters() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  do_ios_test --test_filter=PassingUnitTest,-PassingUnitTest/testPass2 //ios:PassingWithHost || fail "should pass"
+
+  expect_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_not_log "Test Case '-\[PassingUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[PassingUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingWithHost.xctest' passed"
+  expect_log "Executed 3 tests, with 0 failures"
 }
 
 function test_ios_unit_test_with_env() {


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_apple/issues/1370

Currently the `ios_test_runner` rule only passes the contents of `--test_filter` to `tests_to_run` when invoking xctestrunner.

This PR allows users to now specify if tests should be passed to `skip_tests` by prefixing the test name with `-`

Example:
```
bazel test //Feature:FeatureTests --test_filter=-FeatureTests/someTest
```