### PR TITLE
Improve error message for non matching plist value

### DIFF
--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -330,7 +330,7 @@ if [[ -n "${PLIST_TEST_VALUES-}" ]]; then
         "$newline$(/usr/libexec/PlistBuddy -c Print $path)"
     fi
     if [[ "$value" != $expected_value ]]; then
-      fail "Expected plist value \"$value\" to be \"$expected_value\""
+      fail "Expected plist value \"$value\" at key \"$key\" to be \"$expected_value\""
     fi
   done
 fi


### PR DESCRIPTION
Added `key` to error message to improve error message

PiperOrigin-RevId: 431735660
(cherry picked from commit 3bf5faeb93dd6fab22938d2dde22cd58d1641e89)