### PR TITLE
Format depset declaration to avoid long line length.

### DIFF
--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -397,7 +397,10 @@ def _create_xcframework_bundle(
     actions.run(
         arguments = [bundletool_control_file.path],
         executable = resolved_bundletool.executable,
-        inputs = depset([bundletool_control_file, root_info_plist], transitive = [resolved_bundletool.inputs] + framework_archive_files),
+        inputs = depset(
+            direct = [bundletool_control_file, root_info_plist],
+            transitive = [resolved_bundletool.inputs] + framework_archive_files,
+        ),
         input_manifests = resolved_bundletool.input_manifests,
         mnemonic = "CreateXCFrameworkBundle",
         outputs = [output_archive],


### PR DESCRIPTION
PiperOrigin-RevId: 431991068
(cherry picked from commit 67fb31639d2dd8cf06b0b6d2b57127e7b841e823)