### PR TITLE
Fix bundle loader coverage and add tests

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -235,13 +235,19 @@ lcov_args=(
 )
 has_binary=false
 IFS=";"
+arch=$(uname -m)
 for binary in $TEST_BINARIES_FOR_LLVM_COV; do
   if [[ "$has_binary" == false ]]; then
     lcov_args+=("${binary}")
     has_binary=true
+    if file "$binary" | grep -q "executable $arch"; then
+      arch=x86_64
+    fi
   else
-    lcov_args+=(-object ${binary})
+    lcov_args+=(-object "${binary}")
   fi
+
+  lcov_args+=("-arch=$arch")
 done
 
 readonly error_file="$TMP_DIR/llvm-cov-error.txt"

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -61,13 +61,11 @@ if [[ "$TEST_BUNDLE_PATH" == *.xctest ]]; then
   cp -RL "$TEST_BUNDLE_PATH" "$TMP_DIR"
   chmod -R 777 "${TMP_DIR}/$(basename "$TEST_BUNDLE_PATH")"
   runner_flags+=("--test_bundle_path=${TEST_BUNDLE_PATH}")
-  test_binary="$TEST_BUNDLE_PATH/$(basename "$TEST_BUNDLE_PATH" .xctest)"
 else
   TEST_BUNDLE_NAME=$(basename_without_extension "${TEST_BUNDLE_PATH}")
   TEST_BUNDLE_TMP_DIR="${TMP_DIR}/${TEST_BUNDLE_NAME}"
   unzip -qq -d "${TEST_BUNDLE_TMP_DIR}" "${TEST_BUNDLE_PATH}"
   runner_flags+=("--test_bundle_path=${TEST_BUNDLE_TMP_DIR}/${TEST_BUNDLE_NAME}.xctest")
-  test_binary="${TEST_BUNDLE_TMP_DIR}/${TEST_BUNDLE_NAME}.xctest/$TEST_BUNDLE_NAME"
 fi
 
 
@@ -229,15 +227,28 @@ fi
 readonly profdata="$TMP_DIR/coverage.profdata"
 xcrun llvm-profdata merge "$profraw" --output "$profdata"
 
+lcov_args=(
+  -format lcov
+  -instr-profile "$profdata"
+  -ignore-filename-regex='.*external/.+'
+  -path-equivalence="$ROOT",.
+)
+has_binary=false
+IFS=";"
+for binary in $TEST_BINARIES_FOR_LLVM_COV; do
+  if [[ "$has_binary" == false ]]; then
+    lcov_args+=("${binary}")
+    has_binary=true
+  else
+    lcov_args+=(-object ${binary})
+  fi
+done
+
 readonly error_file="$TMP_DIR/llvm-cov-error.txt"
 llvm_cov_status=0
 xcrun llvm-cov \
   export \
-  -format lcov \
-  -instr-profile "$profdata" \
-  -ignore-filename-regex='.*external/.+' \
-  -path-equivalence="$ROOT",. \
-  "$test_binary" \
+  "${lcov_args[@]}" \
   @"$COVERAGE_MANIFEST" \
   > "$COVERAGE_OUTPUT_FILE" \
   2> "$error_file" \

--- a/test/BUILD
+++ b/test/BUILD
@@ -341,11 +341,10 @@ apple_multi_shell_test(
     shard_count = 6,
 )
 
-apple_multi_shell_test(
+apple_shell_test(
     name = "ios_coverage_test",
     size = "medium",
     src = "ios_coverage_test.sh",
-    configurations = IOS_TEST_CONFIGURATIONS,
 )
 
 apple_multi_shell_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -342,6 +342,13 @@ apple_multi_shell_test(
 )
 
 apple_multi_shell_test(
+    name = "ios_coverage_test",
+    size = "medium",
+    src = "ios_coverage_test.sh",
+    configurations = IOS_TEST_CONFIGURATIONS,
+)
+
+apple_multi_shell_test(
     name = "ios_ui_test_test",
     size = "medium",
     src = "ios_ui_test_test.sh",

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -449,6 +449,8 @@ function do_action() {
       # Explicitly pass these flags to ensure the external testing infrastructure
       # matches the internal one.
       "--incompatible_merge_genfiles_directory"
+      # TODO: Remove this once we can use the late bound coverage attribute
+      "--test_env=LCOV_MERGER=/usr/bin/true"
   )
 
   local bazel_version="$(bazel --version)"

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -140,6 +140,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "9.0",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
 

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration tests for testing iOS tests with code coverage enabled.
+
+set -euo pipefail
+
+function set_up() {
+  mkdir -p app
+}
+
+function tear_down() {
+  rm -rf app
+}
+
+function create_common_files() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+objc_library(
+    name = "app_lib",
+    hdrs = ["main.h"],
+    srcs = ["main.m"],
+)
+
+objc_library(
+    name = "shared_logic",
+    hdrs = ["SharedLogic.h"],
+    srcs = ["SharedLogic.m"],
+)
+
+objc_library(
+    name = "hosted_test_lib",
+    srcs = ["HostedTest.m"],
+    deps = [":app_lib", ":shared_logic"],
+)
+
+objc_library(
+    name = "standalone_test_lib",
+    srcs = ["StandaloneTest.m"],
+    deps = [":shared_logic"],
+)
+EOF
+
+  cat > app/main.h <<EOF
+int foo();
+EOF
+
+  cat > app/main.m <<EOF
+#import <UIKit/UIKit.h>
+
+int foo() {
+  return 1;
+}
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@end
+
+@implementation AppDelegate
+@end
+
+int main(int argc, char **argv) {
+  return UIApplicationMain(argc, argv, nil, @"AppDelegate");
+}
+EOF
+
+  cat > app/SharedLogic.h <<EOF
+#import <Foundation/Foundation.h>
+
+@interface SharedLogic: NSObject
+- (void)doSomething;
+@end
+EOF
+
+  cat > app/SharedLogic.m <<EOF
+#import "app/SharedLogic.h"
+
+@implementation SharedLogic
+- (void)doSomething {}
+@end
+EOF
+
+  cat > app/HostedTest.m <<EOF
+#import <XCTest/XCTest.h>
+#import "app/main.h"
+#import "app/SharedLogic.h"
+@interface HostedTest: XCTestCase
+@end
+
+@implementation HostedTest
+- (void)testHostedAPI {
+  [[SharedLogic new] doSomething];
+  XCTAssertEqual(1, foo());
+}
+@end
+EOF
+
+  cat > app/StandaloneTest.m <<EOF
+#import <XCTest/XCTest.h>
+#import "app/SharedLogic.h"
+@interface StandaloneTest: XCTestCase
+@end
+
+@implementation StandaloneTest
+- (void)testAnything {
+  [[SharedLogic new] doSomething];
+  XCTAssert(true);
+}
+@end
+EOF
+
+  cat > app/Info.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1.0";
+  CFBundleVersion = "1.0";
+}
+EOF
+
+  cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "9.0",
+    deps = [":app_lib"],
+)
+
+ios_unit_test(
+    name = "hosted_test",
+    deps = [":hosted_test_lib"],
+    minimum_os_version = "9.0",
+    test_host = ":app",
+)
+
+ios_unit_test(
+    name = "standalone_test",
+    deps = [":standalone_test_lib"],
+    minimum_os_version = "9.0",
+)
+EOF
+}
+
+function test_standalone_unit_test_coverage() {
+  create_common_files
+  do_coverage ios --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
+
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
+}
+
+function test_hosted_unit_test_coverage() {
+  create_common_files
+  do_coverage ios --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
+
+  # Validate normal coverage is included
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"
+  # Validate coverage for the hosting binary is included
+  assert_contains "FN:3,foo" "test-testlogs/app/hosted_test/coverage.dat"
+
+  # Validate that the symbol called from the hosted binary exists and is undefined
+  unzip_single_file \
+    "test-bin/app/hosted_test.runfiles/build_bazel_rules_apple_integration_tests/app/hosted_test.zip" \
+    "hosted_test.xctest/hosted_test" \
+    nm -u - | grep foo || fail "Undefined 'foo' symbol not found"
+}
+
+run_suite "ios coverage tests"

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -161,14 +161,14 @@ EOF
 
 function test_standalone_unit_test_coverage() {
   create_common_files
-  do_coverage ios --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
 
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
 }
 
 function test_hosted_unit_test_coverage() {
   create_common_files
-  do_coverage ios --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
 
   # Validate normal coverage is included
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"


### PR DESCRIPTION
This adds tests covering iOS coverage logic, and also fixes a previously
broken case where coverage for the bundle loader was not collected since
we did not pass the binary to llvm-cov.

This also passes the arch flag to llvm-cov, which is required for multi-arch binaries.
This is a bit complicated to handle rosetta, it first attempts to use the host arch,
and if the binary doesn't contain that, falls back to x86_64. This should be improved.
It also doesn't allow binaries to be different archs, but realistically I don't think we
could easily produce that with rules_apple anyways.