### PR TITLE
Remove --ios_multi_cpus arg for simulator tests

### DIFF
--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -23,9 +23,7 @@ COMPILATION_MODE_OPTIONS = ["--compilation_mode opt"]
 #
 # TODO(b/35091927): Here and below, switch to Bitcode mode "embedded".
 IOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=arm64,armv7"]
-IOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [
-    "--ios_multi_cpus=i386,x86_64",
-]
+IOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS
 
 IOS_CONFIGURATIONS = {
     "device": IOS_DEVICE_OPTIONS,
@@ -45,7 +43,7 @@ IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS = {
     # "device_bitcode": IOS_DEVICE_OPTIONS + [
     #    "--apple_bitcode=embedded_markers",
     #],
-    "simulator": COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=x86_64"],
+    "simulator": COMPILATION_MODE_OPTIONS,
 }
 
 IOS_TEST_CONFIGURATIONS = {


### PR DESCRIPTION
This changes 2 things:

1. It removes 32 bit simulators for the test suite. I imagine there
   aren't many bugs we'd hit on just 1 arch, and given how old 32 bit
   devices are now I don't think it's a huge deal for us to support, so
   this should lightly improve test performance
2. Support testing on Apple Silicon by using the native simulator
   architecture detection, instead of forcing x86_64