### PR TITLE
Remove reference to should_lipo on call to apple_common.link_multi_arch_binary.

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -163,7 +163,6 @@ def _register_linking_action(
         extra_linkopts = linkopts,
         extra_link_inputs = link_inputs,
         stamp = stamp,
-        should_lipo = False,
     )
 
     fat_binary = ctx.actions.declare_file("{}_lipobin".format(ctx.label.name))


### PR DESCRIPTION
Required to clean up usage of this argument in native code, which should now be a no-op.

PiperOrigin-RevId: 432295101
(cherry picked from commit dfea7694a5aff348790adbc9e19319a7cd5a386c)
