### PR TITLE
Remove bazel release version from CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,9 +16,9 @@ x_defaults:
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
 tasks:
-  macos_latest:
-    name: "Latest Bazel"
-    bazel: latest
+  macos_rolling:
+    name: "Rolling Bazel"
+    bazel: rolling
     <<: *common
 
   macos_last_green:
@@ -26,9 +26,9 @@ tasks:
     bazel: last_green
     <<: *common
 
-  macos_latest_head_deps:
-    name: "Latest Bazel with Head Deps"
-    bazel: latest
+  macos_rolling_head_deps:
+    name: "Rolling Bazel with Head Deps"
+    bazel: rolling
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -163,7 +163,6 @@ def _register_linking_action(
         extra_linkopts = linkopts,
         extra_link_inputs = link_inputs,
         stamp = stamp,
-        should_lipo = False,
     )
 
     fat_binary = ctx.actions.declare_file("{}_lipobin".format(ctx.label.name))


### PR DESCRIPTION
Bazel made a breaking change that makes it impossible for us to support
5.x and bazel HEAD at the same time. This drops support for 5.x on CI,
and adds the most recent rolling release instead.

If we ever want to create a new 5.x release, we'll have to do so off the
another branch.

https://github.com/bazelbuild/bazel/issues/14996