### PR TITLE
Fix bazel 5.x support for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,9 +16,9 @@ x_defaults:
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
 tasks:
-  macos_rolling:
-    name: "Rolling Bazel"
-    bazel: rolling
+  macos_latest:
+    name: "Latest Bazel"
+    bazel: latest
     <<: *common
 
   macos_last_green:
@@ -26,9 +26,9 @@ tasks:
     bazel: last_green
     <<: *common
 
-  macos_rolling_head_deps:
-    name: "Rolling Bazel with Head Deps"
-    bazel: rolling
+  macos_latest_head_deps:
+    name: "Latest Bazel with Head Deps"
+    bazel: latest
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -157,12 +157,20 @@ def _register_linking_action(
         linkopts.extend(["-bundle_loader", bundle_loader_file.path])
         link_inputs.append(bundle_loader_file)
 
+    # TODO: This is a hack to support bazel 5.x and 6.x at the same time after
+    # should_lipo was removed from the arguments list, but is still required
+    # before that point. The addition of link_multi_arch_static_library probably
+    # doesn't line up perfectly, but should be good enough
+    kwargs = {"should_lipo": False}
+    if getattr(apple_common, "link_multi_arch_static_library", False):
+        kwargs = {}
     linking_outputs = apple_common.link_multi_arch_binary(
         ctx = ctx,
         avoid_deps = all_avoid_deps,
         extra_linkopts = linkopts,
         extra_link_inputs = link_inputs,
         stamp = stamp,
+        **kwargs
     )
 
     fat_binary = ctx.actions.declare_file("{}_lipobin".format(ctx.label.name))

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -160,7 +160,7 @@ def _register_linking_action(
     # TODO: This is a hack to support bazel 5.x and 6.x at the same time after
     # should_lipo was removed from the arguments list, but is still required
     # before that point. The addition of link_multi_arch_static_library probably
-    # doesn't line up perfectly, but should be good enough
+    # doesn't line up perfectly, but should be good enough.
     kwargs = {"should_lipo": False}
     if getattr(apple_common, "link_multi_arch_static_library", False):
         kwargs = {}


### PR DESCRIPTION
This hack allows us to fake a bazel version check for now.