### PR TITLE
Add _lcov_merger attribute to test rules

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -180,6 +180,13 @@ AppleTestRunnerInfo provider.
         cfg = "exec",
         default = Label("@build_bazel_apple_support//tools:coverage_support"),
     ),
+    "_lcov_merger": attr.label(
+        default = configuration_field(
+            fragment = "coverage",
+            name = "output_generator",
+        ),
+        cfg = "exec",
+    ),
 }
 
 def _common_binary_linking_attrs(deps_cfg, product_type):


### PR DESCRIPTION
As of bazel 5.1 this can be used as a late bound attribute https://github.com/bazelbuild/bazel/commit/14d8be0e8ec07aabb6c4497555f712dac5720a5f

This alleviates the concerns from
https://github.com/bazelbuild/rules_apple/pull/691 and allows users to
use this feature, and avoid having to pass `LCOV_MERGER` in the
environment manually