### PR TITLE
Allows for macos JSON lcov exports via a flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,3 +31,10 @@ build --nocheck_visibility
 # here forever.
 build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
 build --strategy=SwiftCompile=local
+
+# Required to avoid missing coverage runner file errors.
+# GitHub Issue: https://github.com/bazelbuild/rules_apple/issues/1128
+coverage --action_env=LCOV_MERGER=/usr/bin/true
+
+# Use llvm-cov instead of gcov (default).
+coverage --experimental_use_llvm_covmap

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -116,9 +116,15 @@ if [[ "${COVERAGE:-}" -eq 1 ]]; then
 fi
 
 XCTESTRUN_ENV=""
+COVERAGE_PRODUCE_JSON=false
 for SINGLE_TEST_ENV in ${TEST_ENV//,/ }; do
   IFS== read key value <<< "$SINGLE_TEST_ENV"
   XCTESTRUN_ENV+="<key>$(escape "$key")</key><string>$(escape "$value")</string>"
+  if [[ "${COVERAGE:-}" -eq 1 ]]; then
+    if [[ "$key" = "COVERAGE_PRODUCE_JSON" && "$value" = "TRUE" ]]; then
+      COVERAGE_PRODUCE_JSON=true
+    fi
+  fi
 done
 
 # Replace the substitution values into the xctestrun file.
@@ -149,8 +155,8 @@ fi
 readonly profdata="$TEST_TMP_DIR/coverage.profdata"
 xcrun llvm-profdata merge "$profraw" --output "$profdata"
 
-readonly error_file="$TEST_TMP_DIR/llvm-cov-error.txt"
-llvm_cov_status=0
+readonly export_error_file="$TEST_TMP_DIR/llvm-cov-export-error.txt"
+llvm_cov_export_status=0
 xcrun llvm-cov \
   export \
   -format lcov \
@@ -160,13 +166,41 @@ xcrun llvm-cov \
   "$test_binary" \
   @"$COVERAGE_MANIFEST" \
   > "$COVERAGE_OUTPUT_FILE" \
-  2> "$error_file" \
-  || llvm_cov_status=$?
+  2> "$export_error_file" \
+  || llvm_cov_export_status=$?
+
+llvm_cov_json_export_status=0
+readonly json_export_error_file="$TEST_TMP_DIR/llvm-cov-json-export-error.txt"
+if [ "$COVERAGE_PRODUCE_JSON" = true ]; then
+  if [[ -n "${TEST_UNDECLARED_OUTPUTS_DIR}" ]]; then
+    OUTPUT_DIR="${TEST_UNDECLARED_OUTPUTS_DIR}"
+    mkdir -p "$OUTPUT_DIR"
+    xcrun llvm-cov \
+      export \
+      -format text \
+      -instr-profile "$profdata" \
+      -ignore-filename-regex='.*external/.+' \
+      -path-equivalence="$ROOT",. \
+      "$test_binary" \
+      @"$COVERAGE_MANIFEST" \
+      > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json"
+        2> "$json_export_error_file" \
+        || llvm_cov_json_export_status=$?
+  fi
+fi
 
 # Error ourselves if lcov outputs warnings, such as if we misconfigure
 # something and the file path of one of the covered files doesn't exist
-if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
+if [[ -s "$export_error_file" || "$llvm_cov_export_status" -ne 0 ]]; then
   echo "error: while exporting coverage report" >&2
-  cat "$error_file" >&2
+  cat "$export_error_file" >&2
   exit 1
+fi
+
+if [ "$COVERAGE_PRODUCE_JSON" = true ]; then
+  if [[ -s "$json_export_error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
+    cat "$json_export_error_file" >&2
+    exit 1
+  fi
 fi

--- a/examples/macos/CommandLineSwift/BUILD
+++ b/examples/macos/CommandLineSwift/BUILD
@@ -11,12 +11,37 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
 )
+load(
+    "@build_bazel_rules_apple//apple:macos.bzl",
+    "macos_unit_test",
+)
 
 licenses(["notice"])
 
 swift_library(
     name = "Sources",
-    srcs = ["Sources/main.swift"],
+    module_name = "Sources",
+    srcs = [
+        "Sources/main.swift",
+        "Sources/Logger.swift"
+    ],
+)
+
+swift_library(
+    name = "SourcesTests",
+    srcs = [
+        "Tests/LoggerTests.swift",
+        "Tests/MockLog.swift"
+    ],
+    deps = [
+        ":Sources"
+    ]
+)
+
+macos_unit_test(
+    name = "SourcesUnitTests",
+    deps = [":SourcesTests"],
+    minimum_os_version = "12.0"
 )
 
 apple_bundle_version(

--- a/examples/macos/CommandLineSwift/Sources/Logger.swift
+++ b/examples/macos/CommandLineSwift/Sources/Logger.swift
@@ -1,0 +1,47 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public protocol Log {
+    func append(_ item: Any, terminator: String)
+}
+
+public extension Log {
+    func append(_ item: Any) {
+        append(item, terminator: "\n")
+    }
+}
+
+public final class LogImp: Log {
+    public init() {}
+
+    public func append(_ item: Any, terminator: String) {
+        print(item, terminator: terminator)
+    }
+}
+
+public final class Logger {
+
+    private let log: Log
+
+    public init(log: Log) {
+        self.log = log
+    }
+
+    func printHelloWorld(bundle: Bundle) {
+        log.append("Hello World from \(bundle.bundleIdentifier ?? "<none>")")
+        log.append("Here is the entire Info.plist dictionary: \(bundle.infoDictionary ?? [:])")
+    }
+}

--- a/examples/macos/CommandLineSwift/Tests/LoggerTests.swift
+++ b/examples/macos/CommandLineSwift/Tests/LoggerTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 The Bazel Authors. All rights reserved.
+// Copyright 2022 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+@testable import Sources
+import XCTest
 
-// Since the Info.plist file gets embedded in the binary, we can access values
-// like the bundle identifier using the NSBundle APIs.
-let bundle = Bundle.main
-let logger: Logger = .init(log: LogImp())
-logger.printHelloWorld(bundle: bundle)
+final class LoggerTests: XCTestCase {
+    var logger: Logger!
+    var log: MockLog!
+
+    override func setUp() {
+        super.setUp()
+        log = .init()
+        logger = Logger(log: log)
+    }
+
+    func testHelloWorld() {
+        logger.printHelloWorld(bundle: Bundle(for: Logger.self))
+        XCTAssertTrue(!log.contents.isEmpty)
+    }
+}

--- a/examples/macos/CommandLineSwift/Tests/MockLog.swift
+++ b/examples/macos/CommandLineSwift/Tests/MockLog.swift
@@ -1,4 +1,4 @@
-// Copyright 2017 The Bazel Authors. All rights reserved.
+// Copyright 2022 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
+@testable import Sources
 
-// Since the Info.plist file gets embedded in the binary, we can access values
-// like the bundle identifier using the NSBundle APIs.
-let bundle = Bundle.main
-let logger: Logger = .init(log: LogImp())
-logger.printHelloWorld(bundle: bundle)
+public final class MockLog: Log {
+
+    public private(set) var contents: String = ""
+
+    public init() {}
+
+    public func append(_ item: Any, terminator: String) {
+        contents += "\(item)\(terminator)"
+    }
+}


### PR DESCRIPTION
Allows JSON coverage results to be created in
`$TEST_UNDECLARED_OUTPUTS_DIR` for macos
when passing `--test_env=COVERAGE_PRODUCE_JSON=TRUE`