### PR TITLE
Allow for JSON lcov coverage exports via a flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,3 +31,10 @@ build --nocheck_visibility
 # here forever.
 build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
 build --strategy=SwiftCompile=local
+
+# Required to avoid missing coverage runner file errors.
+# GitHub Issue: https://github.com/bazelbuild/rules_apple/issues/1128
+coverage --action_env=LCOV_MERGER=/usr/bin/true
+
+# Use llvm-cov instead of gcov (default).
+coverage --experimental_use_llvm_covmap

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -253,7 +253,7 @@ readonly error_file="$TMP_DIR/llvm-cov-error.txt"
 llvm_cov_status=0
 xcrun llvm-cov \
   export \
-  -format lcov
+  -format lcov \
   "${lcov_args[@]}" \
   @"$COVERAGE_MANIFEST" \
   > "$COVERAGE_OUTPUT_FILE" \
@@ -272,7 +272,7 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
   llvm_cov_json_export_status=0
   xcrun llvm-cov \
     export \
-    -format text
+    -format text \
     "${lcov_args[@]}" \
     @"$COVERAGE_MANIFEST" \
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json"

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -228,7 +228,6 @@ readonly profdata="$TMP_DIR/coverage.profdata"
 xcrun llvm-profdata merge "$profraw" --output "$profdata"
 
 lcov_args=(
-  -format lcov
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
   -path-equivalence="$ROOT",.
@@ -254,6 +253,7 @@ readonly error_file="$TMP_DIR/llvm-cov-error.txt"
 llvm_cov_status=0
 xcrun llvm-cov \
   export \
+  -format lcov
   "${lcov_args[@]}" \
   @"$COVERAGE_MANIFEST" \
   > "$COVERAGE_OUTPUT_FILE" \
@@ -268,17 +268,11 @@ if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
   exit 1
 fi
 
-llvm_cov_json_export_status=0
-if [[ "$TEST_ENV" =~ "COVERAGE_PRODUCE_JSON" ]]; then
-  mkdir -p "$TEST_UNDECLARED_OUTPUTS_DIR"
-  lcov_args=(
-    -format text
-    -instr-profile "$profdata"
-    -ignore-filename-regex='.*external/.+'
-    -path-equivalence="$ROOT",.
-  )
+if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
+  llvm_cov_json_export_status=0
   xcrun llvm-cov \
     export \
+    -format text
     "${lcov_args[@]}" \
     @"$COVERAGE_MANIFEST" \
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json"

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -129,7 +129,7 @@ fi
 
 # Use the TESTBRIDGE_TEST_ONLY environment variable set by Bazel's --test_filter
 # flag to set tests_to_run value in ios_test_runner's launch_options.
-# Any test prefixed with '-' will be passed to "skip_tests". Otherwise the tests 
+# Any test prefixed with '-' will be passed to "skip_tests". Otherwise the tests
 # is passed to "tests_to_run"
 if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
@@ -266,4 +266,27 @@ if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
   echo "error: while exporting coverage report" >&2
   cat "$error_file" >&2
   exit 1
+fi
+
+llvm_cov_json_export_status=0
+if [[ "$TEST_ENV" =~ "COVERAGE_PRODUCE_JSON" ]]; then
+  mkdir -p "$TEST_UNDECLARED_OUTPUTS_DIR"
+  lcov_args=(
+    -format text
+    -instr-profile "$profdata"
+    -ignore-filename-regex='.*external/.+'
+    -path-equivalence="$ROOT",.
+  )
+  xcrun llvm-cov \
+    export \
+    "${lcov_args[@]}" \
+    @"$COVERAGE_MANIFEST" \
+    > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json"
+    2> "$error_file" \
+    || llvm_cov_json_export_status=$?
+  if [[ -s "$error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
+    cat "$error_file" >&2
+    exit 1
+  fi
 fi

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -169,9 +169,8 @@ function test_standalone_unit_test_coverage() {
 function test_standalone_unit_test_coverage_json() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
-  cd "test-testlogs/app/standalone_test/test.outputs" || fail "Should unzip"
-  unzip "outputs.zip"
-  assert_contains "\"name\":\"SharedLogic.m:-\[SharedLogic doSomething\]\"" "coverage.json"
+  unzip_single_file "test-testlogs/app/standalone_test/test.outputs/outputs.zip" coverage.json \
+      grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
 }
 
 function test_hosted_unit_test_coverage() {

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -166,6 +166,14 @@ function test_standalone_unit_test_coverage() {
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
 }
 
+function test_standalone_unit_test_coverage_json() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
+  cd "test-testlogs/app/standalone_test/test.outputs" || fail "Should unzip"
+  unzip "outputs.zip"
+  assert_contains "\"name\":\"SharedLogic.m:-\[SharedLogic doSomething\]\"" "coverage.json"
+}
+
 function test_hosted_unit_test_coverage() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"


### PR DESCRIPTION
Allows JSON coverage results to be created in
`$TEST_UNDECLARED_OUTPUTS_DIR` 
when passing `--test_env=COVERAGE_PRODUCE_JSON=TRUE`