### PR TITLE
Add sim_arm64 to ios_multi_cpus in tests

### DIFF
--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -24,7 +24,7 @@ COMPILATION_MODE_OPTIONS = ["--compilation_mode opt"]
 # TODO(b/35091927): Here and below, switch to Bitcode mode "embedded".
 IOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=arm64,armv7"]
 IOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [
-    "--ios_multi_cpus=i386,x86_64",
+    "--ios_multi_cpus=i386,x86_64,sim_arm64",
 ]
 
 IOS_CONFIGURATIONS = {
@@ -45,7 +45,7 @@ IOS_64BIT_SIMULATOR_FAT_DEVICE_CONFIGURATIONS = {
     # "device_bitcode": IOS_DEVICE_OPTIONS + [
     #    "--apple_bitcode=embedded_markers",
     #],
-    "simulator": COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=x86_64"],
+    "simulator": COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=x86_64,sim_arm64"],
 }
 
 IOS_TEST_CONFIGURATIONS = {


### PR DESCRIPTION
This makes it so whatever host arch we're running on there is a matching
slice. We cannot remove this flag and just take the default because test
implementations depend on parsing the ios_multi_cpus flag to get the
archs. Without this tests that try to actually run fail on M1 machines
because they were built for x86_64.