### PR TITLE
Add a test to verify that `libswift_Concurrency.dylib` is bundled if app uses Swift Concurrency and targets iOS >= 13 and < 15.

### DIFF
--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -363,6 +363,19 @@ def ios_application_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_libswiftconcurrency_copied_lt_ios_15_0_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_swift_concurrency_dep",
+        tags = [name],
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/libswift_Concurrency.dylib",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
+        ],
+    )
+
     # Tests that the provisioning profile is present when built for device.
     archive_contents_test(
         name = "{}_contains_provisioning_profile_test".format(name),

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -124,6 +124,13 @@ swift_library(
 )
 
 swift_library(
+    name = "swift_concurrency_lib",
+    testonly = True,
+    srcs = ["concurrency.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
     name = "swift_transitive_lib",
     testonly = True,
     srcs = ["Transitives.swift"],

--- a/test/starlark_tests/resources/concurrency.swift
+++ b/test/starlark_tests/resources/concurrency.swift
@@ -1,0 +1,20 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+public func doSomething() async -> String {
+    let task = Task {
+        return "result"
+    }
+    return await task.value
+}

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -492,6 +492,25 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_swift_concurrency_dep",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "13.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:swift_concurrency_lib",
+        "//test/starlark_tests/resources:swift_main_lib",
+    ],
+)
+
 ios_static_framework(
     name = "swift_static_framework",
     bundle_name = "swift_framework_lib",


### PR DESCRIPTION
Also verify that `libswiftCore.dylib` should not get bundled in this
case, which is broken with Xcode 13.3.
