### PR TITLE
Don't pass path of `swift-5.0` stdlib to `swift-stdlib-tool` when not neeeded

### DIFF
--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -65,13 +65,19 @@ File object that represents a directory containing the Swift dylibs to package f
 # Swift dylibs with the application. The first cutoff point was when the
 # platforms bundled the standard libraries, the second was when they started
 # bundling the Concurrency library. There may be future libraries that require
-# us to continue bumping these values. The tool is smart enough only to bundle
-# those libraries required by the minimum OS version of the scanned binaries.
+# us to continue bumping these values.
 #
 # Values are the first version where bundling is no longer required and should
 # correspond with the Swift compilers values for these which is the source of
 # truth https://github.com/apple/swift/blob/998d3518938bd7229e7c5e7b66088d0501c02051/lib/Basic/Platform.cpp#L82-L105
 _MIN_OS_PLATFORM_SWIFT_PRESENCE = {
+    "ios": apple_common.dotted_version("12.2"),
+    "macos": apple_common.dotted_version("10.14.4"),
+    "tvos": apple_common.dotted_version("12.2"),
+    "watchos": apple_common.dotted_version("5.2"),
+}
+
+_MIN_OS_PLATFORM_SWIFT_CONCURRENCY_PRESENCE = {
     "ios": apple_common.dotted_version("15.0"),
     "macos": apple_common.dotted_version("12.0"),
     "tvos": apple_common.dotted_version("15.0"),
@@ -86,7 +92,8 @@ def _swift_dylib_action(
         platform_name,
         platform_prerequisites,
         resolved_swift_stdlib_tool,
-        strip_bitcode):
+        strip_bitcode,
+        swift_dylibs_paths):
     """Registers a swift-stlib-tool action to gather Swift dylibs to bundle."""
     swift_stdlib_tool_args = [
         "--platform",
@@ -94,6 +101,11 @@ def _swift_dylib_action(
         "--output_path",
         output_dir.path,
     ]
+    for x in swift_dylibs_paths:
+        swift_stdlib_tool_args.extend([
+            "--swift_dylibs_path",
+            x,
+        ])
     for x in binary_files:
         swift_stdlib_tool_args.extend([
             "--binary",
@@ -142,14 +154,20 @@ def _swift_dylibs_partial_impl(
         transitive_swift_support_files.extend(provider.swift_support_files)
 
     direct_binaries = []
+    target_min_os = apple_common.dotted_version(platform_prerequisites.minimum_os)
     if binary_artifact and platform_prerequisites.uses_swift:
-        target_min_os = apple_common.dotted_version(platform_prerequisites.minimum_os)
-        swift_min_os = _MIN_OS_PLATFORM_SWIFT_PRESENCE[str(platform_prerequisites.platform_type)]
+        swift_concurrency_min_os = _MIN_OS_PLATFORM_SWIFT_CONCURRENCY_PRESENCE[str(platform_prerequisites.platform_type)]
 
         # Only check this binary for Swift dylibs if the minimum OS version is lower than the
         # minimum OS version under which Swift dylibs are already packaged with the OS.
-        if target_min_os < swift_min_os:
+        if target_min_os < swift_concurrency_min_os:
             direct_binaries.append(binary_artifact)
+
+    swift_min_os = _MIN_OS_PLATFORM_SWIFT_PRESENCE[str(platform_prerequisites.platform_type)]
+    swift_dylibs_path_prefix = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-"
+    swift_dylibs_paths = [swift_dylibs_path_prefix + "5.5"]
+    if target_min_os < swift_min_os:
+        swift_dylibs_paths.append(swift_dylibs_path_prefix + "5.0")
 
     transitive_binaries = depset(
         direct = direct_binaries,
@@ -185,6 +203,7 @@ def _swift_dylibs_partial_impl(
                 platform_prerequisites = platform_prerequisites,
                 resolved_swift_stdlib_tool = apple_toolchain_info.resolved_swift_stdlib_tool,
                 strip_bitcode = strip_bitcode,
+                swift_dylibs_paths = swift_dylibs_paths,
             )
 
             bundle_files.append((processor.location.framework, None, depset([output_dir])))
@@ -208,6 +227,7 @@ def _swift_dylibs_partial_impl(
                         platform_prerequisites = platform_prerequisites,
                         resolved_swift_stdlib_tool = apple_toolchain_info.resolved_swift_stdlib_tool,
                         strip_bitcode = False,
+                        swift_dylibs_paths = swift_dylibs_paths,
                     )
                 else:
                     # When not building with bitcode, we can reuse Swift dylibs

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -25,15 +25,16 @@ from build_bazel_rules_apple.tools.wrapper_common import execute
 from build_bazel_rules_apple.tools.wrapper_common import lipo
 
 
-def _copy_swift_stdlibs(binaries_to_scan, sdk_platform, destination_path):
+def _copy_swift_stdlibs(binaries_to_scan, swift_dylibs_paths, sdk_platform,
+                        destination_path):
   """Copies the Swift stdlibs required by the binaries to the destination."""
   # Rely on the swift-stdlib-tool to determine the subset of Swift stdlibs that
   # these binaries require.
   developer_dir = os.environ["DEVELOPER_DIR"]
-  swift_dylibs_root = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-*"
-  swift_library_dir_pattern = os.path.join(developer_dir, swift_dylibs_root,
-                                           sdk_platform)
-  swift_library_dirs = glob.glob(swift_library_dir_pattern)
+  swift_library_dirs = [
+    os.path.join(developer_dir, x, sdk_platform)
+    for x in swift_dylibs_paths
+  ]
 
   cmd = [
       "xcrun", "swift-stdlib-tool", "--copy", "--platform", sdk_platform,
@@ -92,6 +93,11 @@ def main():
       "'iphoneos'"
   )
   parser.add_argument(
+      "--swift_dylibs_path", action="append", type=str, required=True,
+      help="path relative from the developer directory to find the Swift "
+      "standard libraries, independent of platform"
+  )
+  parser.add_argument(
       "--strip_bitcode", action="store_true", default=False, help="strip "
       "bitcode from the Swift support libraries"
   )
@@ -105,7 +111,8 @@ def main():
   temp_path = tempfile.mkdtemp(prefix="swift_stdlib_tool.XXXXXX")
 
   # Use the binaries to copy only the Swift stdlibs we need for this app.
-  _copy_swift_stdlibs(args.binary, args.platform, temp_path)
+  _copy_swift_stdlibs(args.binary, args.swift_dylibs_path, args.platform,
+                      temp_path)
 
   # Determine the binary slices we need to strip with lipo.
   target_archs, _ = lipo.find_archs_for_binaries(args.binary)

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -32,8 +32,8 @@ def _copy_swift_stdlibs(binaries_to_scan, swift_dylibs_paths, sdk_platform,
   # these binaries require.
   developer_dir = os.environ["DEVELOPER_DIR"]
   swift_library_dirs = [
-    os.path.join(developer_dir, x, sdk_platform)
-    for x in swift_dylibs_paths
+    os.path.join(developer_dir, dylibs_path, sdk_platform)
+    for dylibs_path in swift_dylibs_paths
   ]
 
   cmd = [


### PR DESCRIPTION
Workaround for https://bugs.swift.org/browse/SR-16010:
`libswift_Concurrency.dylib` bundled with Xcode 13.3 refenrences
`@rpath/libswiftCore.dylib` instead of `/usr/lib/libswiftCore.dylib`,
which causes `libswiftCore.dylib` to unnecessarily get copied into the
product bundle.

Fixes https://github.com/bazelbuild/rules_apple/issues/1397.