### PR TITLE
if resource_bundles has exclude_directories = false, clonefile fails

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -213,6 +213,9 @@ class Bundler(object):
 
     self._makedirs_safely(os.path.dirname(full_dest))
     if sys.platform == "darwin":
+      # Clonefile will fail if destination already exists
+      if os.path.exists(full_dest):
+        os.remove(full_dest)
       clonefile = _load_clonefile()
       result = clonefile(src.encode(), full_dest.encode(), 0)
       if result != 0:


### PR DESCRIPTION
Bugfix for this PR: https://github.com/bazelbuild/rules_apple/commit/5401fe26c813c0ec0ae8b0e0a00759215c90be43. 

before this PR, we are using `cp -c`, which will overide the destination file if exists. However, the `clonefile` will just fail if the destination exists.

An alternative is to revert to `shutil.copy(src, full_dest)`.

Did some benchmark for copying a tiny file 10000 times in my machine:
- `subprocess.check_output(["/bin/cp", "-c", src, dest])`: 46 seconds
- `subprocess .Popen(['cp', 'x', 'y'], stdout=DEVNULL, stderr=STDOUT)`: 55 seconds
- clonfile: 1.58 seconds
- check exists + remove + clone file: 2.14 seconds
- `shutil.copy`: 4.05 seconds

