### PR TITLE
Add config_setting for tvos_sim_arm64

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -22,6 +22,7 @@ licenses(["notice"])
         "ios_sim_arm64",
         "tvos_x86_64",
         "tvos_arm64",
+        "tvos_sim_arm64",
         "watchos_i386",
         "watchos_arm64",
         "watchos_armv7k",


### PR DESCRIPTION
Added to bazel here: https://github.com/bazelbuild/bazel/commit/207c31be57b9863f5c1aa17361a4ed68e6eaf041

Just landed in Bazel 5.1