### PR TITLE
Use `LLVM_PROFILE_FILE` from env if exist

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -105,12 +105,24 @@ else
   TEST_ENV="TEST_SRCDIR=$TEST_SRCDIR"
 fi
 
-readonly profraw="$TMP_DIR/coverage.profraw"
+# default profraw
+profraw="$TMP_DIR/coverage.profraw"
+# check if LLVM_PROFILE_FILE has been set on --test_env, if exist, will use the given path instead
+IFS=',' read -ra ENV <<< "$TEST_ENV"
+for i in "${ENV[@]}"; do
+  IFS='=' read -ra VALUE <<< "$i"
+  for j in "${VALUE[@]}"; do
+    if [ "$j" == "LLVM_PROFILE_FILE" ]; then
+      profraw="${VALUE[1]}"
+      break
+    fi
+  done
+done
+
 if [[ "${COVERAGE:-}" -eq 1 ]]; then
   readonly profile_env="LLVM_PROFILE_FILE=$profraw"
   TEST_ENV="$TEST_ENV,$profile_env"
 fi
-
 # Converts the test env string to json format and addes it into launch
 # options string.
 TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) "\":\"" substr($i, d+1); }}')


### PR DESCRIPTION
recently there're changes to generate coverage data automatically if requested on `ios_unit_test`
add an option to use `LLVM_PROFILE_FILE` given from `--test_env`

if none, will use $TMP_DIR instead
