### PR TITLE
Use the executable name as dSYM filename

### DIFF
--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -281,7 +281,7 @@ def _debug_symbols_partial_impl(
         if _AppleDebugInfo in x
     ]
 
-    debug_output_filename = bundle_name
+    debug_output_filename = executable_name
     if debug_discriminator:
         debug_output_filename += "_" + debug_discriminator
 


### PR DESCRIPTION
Use the executable name returned by `bundling_support.executable_name` (i.e. a custom executable name provided by the user, or the bundle name) as output filename.