### PR TITLE
Fix dSYM filename in case custom executable names are used

### DIFF
--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -61,15 +61,23 @@ def _dsyms_test_impl(ctx):
         for x in ctx.attr.expected_dsyms
     ]
 
-    expected_binaries = []
-    expected_binaries.extend([
-        "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}".format(
-            package,
-            x,
-            paths.split_extension(x)[0],
-        )
-        for x in ctx.attr.expected_dsyms
-    ])
+    if ctx.attr.expected_binaries:
+        expected_binaries = [
+            "{0}/{1}".format(
+                package,
+                x,
+            )
+            for x in ctx.attr.expected_binaries
+        ]
+    else:
+        expected_binaries = [
+            "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}".format(
+                package,
+                x,
+                paths.split_extension(x)[0],
+            )
+            for x in ctx.attr.expected_dsyms
+        ]
 
     workspace = target_under_test.label.workspace_name
     if workspace != "":


### PR DESCRIPTION
Fixes the dSYM filename in case a custom executable name is used, like this:
- before this fix `bundle_name.app.dSYM/bundle_name`;
- after this fix `bundle_name.app.dSYM/executable_name`.

Changes in the code:
- Fixed the filename by using the executable name instead of the bundle name when it's specified (i.e. use the value returned by `bundling_support.executable_name`).
- Fixed the dSYM test `ios_application_custom_executable_name_dsyms_test` to support custom executable names. (Basically a revert, the last commits made this test ignore the custom executable name argument.)
