### PR TITLE
Emit resultBundlePath for macos_test_runner.

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -140,7 +140,7 @@ fi
 rm -rf "$TEST_UNDECLARED_OUTPUTS_DIR/test.xcresult"
 xcodebuild test-without-building \
     -destination "platform=macOS" \
-    -resultBundlePath "${TEST_UNDECLARED_OUTPUTS_DIR}/test.xcresult" \
+    -resultBundlePath "$TEST_UNDECLARED_OUTPUTS_DIR/test.xcresult" \
     -xctestrun "$XCTESTRUN"
 
 if [[ "${COVERAGE:-}" -ne 1 ]]; then

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -137,7 +137,7 @@ fi
 # Run xcodebuild with the xctestrun file just created. If the test failed, this
 # command will return non-zero, which is enough to tell bazel that the test
 # failed.
-mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}"
+rm -rf "$TEST_UNDECLARED_OUTPUTS_DIR/test.xcresult"
 xcodebuild test-without-building \
     -destination "platform=macOS" \
     -resultBundlePath "${TEST_UNDECLARED_OUTPUTS_DIR}/test.xcresult" \

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -137,8 +137,10 @@ fi
 # Run xcodebuild with the xctestrun file just created. If the test failed, this
 # command will return non-zero, which is enough to tell bazel that the test
 # failed.
+mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}"
 xcodebuild test-without-building \
     -destination "platform=macOS" \
+    -resultBundlePath "${TEST_UNDECLARED_OUTPUTS_DIR}/test.xcresult" \
     -xctestrun "$XCTESTRUN"
 
 if [[ "${COVERAGE:-}" -ne 1 ]]; then


### PR DESCRIPTION
Supplies a `resultBundlePath` to the macos test runner xcodebuild invocation. This matches the behavior and filename used by the ios test runner.