### PR TITLE
Generate Swift source for CoreML models

### DIFF
--- a/apple/internal/resource_actions.bzl
+++ b/apple/internal/resource_actions.bzl
@@ -41,7 +41,7 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:mlmodel.bzl",
     _compile_mlmodel = "compile_mlmodel",
-    _generate_objc_mlmodel_sources = "generate_objc_mlmodel_sources",
+    _generate_mlmodel_sources = "generate_mlmodel_sources",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:plist.bzl",
@@ -72,7 +72,7 @@ resource_actions = struct(
     copy_png = _copy_png,
     generate_datamodels = _generate_datamodels,
     generate_intent_classes_sources = _generate_intent_classes_sources,
-    generate_objc_mlmodel_sources = _generate_objc_mlmodel_sources,
+    generate_mlmodel_sources = _generate_mlmodel_sources,
     link_storyboards = _link_storyboards,
     merge_resource_infoplists = _merge_resource_infoplists,
     merge_root_infoplists = _merge_root_infoplists,

--- a/apple/internal/resource_actions/mlmodel.bzl
+++ b/apple/internal/resource_actions/mlmodel.bzl
@@ -63,40 +63,59 @@ def compile_mlmodel(
         xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
-def generate_objc_mlmodel_sources(
+def generate_mlmodel_sources(
         *,
         actions,
         input_file,
-        output_source,
-        output_header,
+        swift_output_src,
+        objc_output_src,
+        objc_output_hdr,
+        language,
         platform_prerequisites,
         resolved_xctoolrunner):
     """Creates an action that generates sources for an mlmodel file.
 
     Args:
       actions: The actions provider from `ctx.actions`.
-      input_file: The png file to be copied.
-      output_source: The file reference for the generated ObjC source.
-      output_header: The file reference for the generated ObjC header.
+      input_file: The input mlmodel file.
+      swift_output_src: The output file when generating Swift sources.
+      objc_output_src: The output source file when generating Obj-C.
+      objc_output_hdr: The output header file when generating Obj-C.
+      language: Language of generated classes ("Objective-C", "Swift").
       platform_prerequisites: Struct containing information on the platform being targeted.
       resolved_xctoolrunner: A struct referencing the resolved wrapper for "xcrun" tools.
     """
-    args = [
+
+    is_swift = language == "Swift"
+
+    arguments = [
         "coremlc",
         "generate",
         xctoolrunner.prefixed_path(input_file.path),
-        output_source.dirname,
     ]
+
+    outputs = []
+    if is_swift:
+        arguments += [
+            "--public-access",
+            "--language",
+            "Swift",
+            swift_output_src.dirname,
+        ]
+        outputs = [swift_output_src]
+    else:
+        arguments.append(objc_output_src.dirname)
+        outputs = [objc_output_src, objc_output_hdr]
 
     apple_support.run(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
-        arguments = args,
+        arguments = arguments,
         executable = resolved_xctoolrunner.executable,
         inputs = depset([input_file], transitive = [resolved_xctoolrunner.inputs]),
         input_manifests = resolved_xctoolrunner.input_manifests,
         mnemonic = "MlmodelGenerate",
-        outputs = [output_source, output_header],
+        outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,
         xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -31,10 +31,6 @@ load(
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
-    "swift_support",
-)
-load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
@@ -48,14 +44,22 @@ def _apple_core_ml_library_impl(ctx):
     actions = ctx.actions
     basename = paths.replace_extension(ctx.file.mlmodel.basename, "")
 
-    deps = getattr(ctx.attr, "deps", None)
-    uses_swift = swift_support.uses_swift(deps) if deps else False
+    is_swift = ctx.attr.language == "Swift"
 
-    coremlc_source = actions.declare_file(
-        "{}.m".format(basename),
-        sibling = ctx.outputs.source,
-    )
-    coremlc_header = actions.declare_file("{}.h".format(basename), sibling = coremlc_source)
+    if is_swift and not ctx.attr.swift_source:
+        fail("Attribute `swift_source` is mandatory when generating Swift.")
+    if not is_swift and (not ctx.attr.objc_header or not ctx.attr.objc_source):
+        fail("Attributes `objc_header` and `objc_source` are mandatory when generating Objective-C.")
+
+    swift_output_src = None
+    objc_output_src = None
+    objc_output_hdr = None
+
+    if is_swift:
+        swift_output_src = actions.declare_file("{}.swift".format(basename))
+    else:
+        objc_output_src = actions.declare_file("{}.m".format(basename))
+        objc_output_hdr = actions.declare_file("{}.h".format(basename))
 
     # TODO(b/168721966): Consider if an aspect could be used to generate mlmodel sources. This
     # would be similar to how we are planning to use the resource aspect with the
@@ -71,7 +75,7 @@ def _apple_core_ml_library_impl(ctx):
         features = ctx.features,
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
-        uses_swift = uses_swift,
+        uses_swift = is_swift,
         xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
@@ -80,32 +84,38 @@ def _apple_core_ml_library_impl(ctx):
 
     # coremlc doesn't have any configuration on the name of the generated source files, it uses the
     # basename of the mlmodel file instead, so we need to expect those files as outputs.
-    resource_actions.generate_objc_mlmodel_sources(
+    resource_actions.generate_mlmodel_sources(
         actions = actions,
+        language = ctx.attr.language,
         input_file = ctx.file.mlmodel,
-        output_source = coremlc_source,
-        output_header = coremlc_header,
+        swift_output_src = swift_output_src,
+        objc_output_src = objc_output_src,
+        objc_output_hdr = objc_output_hdr,
         platform_prerequisites = platform_prerequisites,
         resolved_xctoolrunner = apple_toolchain_info.resolved_xctoolrunner,
     )
 
-    # But we would like our ObjC clients to use <target_name>.h instead, so we create that header
-    # too and import the coremlc header.
-    public_header = actions.declare_file("{}.h".format(ctx.attr.header_name))
+    if is_swift:
+        actions.symlink(target_file = swift_output_src, output = ctx.outputs.swift_source)
+        return [
+            DefaultInfo(files = depset([swift_output_src])),
+        ]
+
     actions.write(
-        public_header,
-        "#import \"{}\"".format(coremlc_header.path),
+        ctx.outputs.objc_public_header,
+        "#import \"{}\"".format(objc_output_hdr.path),
     )
 
-    # In order to reference the source file from the macro context, we need to have an implicit
-    # output, but those can only reference the name of the target, so we need to symlink the coremlc
-    # source into the implicit output. We don't want to do this for the headers since we would like
-    # the header to be named as the objc_library target and not the target for this rule.
-    actions.symlink(target_file = coremlc_source, output = ctx.outputs.source)
+    actions.symlink(target_file = objc_output_hdr, output = ctx.outputs.objc_header)
+    actions.symlink(target_file = objc_output_src, output = ctx.outputs.objc_source)
 
     # This rule returns the headers as its outputs so that they can be referenced in the hdrs of the
     # underlying objc_library.
-    return [DefaultInfo(files = depset([public_header, coremlc_header]))]
+    return [
+        DefaultInfo(
+            files = depset([ctx.outputs.objc_public_header, objc_output_hdr, objc_output_src, ctx.outputs.objc_header, ctx.outputs.objc_source]),
+        ),
+    ]
 
 apple_core_ml_library = rule(
     implementation = _apple_core_ml_library_impl,
@@ -118,9 +128,22 @@ Label to a single `.mlmodel` file or `.mlpackage` bundle from which to generate 
 into mlmodelc files.
 """,
         ),
-        "header_name": attr.string(
+        "language": attr.string(
             mandatory = True,
-            doc = "Private attribute to configure the ObjC header name to be exported.",
+            values = ["Objective-C", "Swift"],
+            doc = "Language of generated classes (\"Objective-C\", \"Swift\")",
+        ),
+        "swift_source": attr.output(
+            doc = "Name of the output file (only when using Swift).",
+        ),
+        "objc_source": attr.output(
+            doc = "Name of the implementation file (only when using Objective-C).",
+        ),
+        "objc_header": attr.output(
+            doc = "Name of the header file (only when using Objective-C).",
+        ),
+        "objc_public_header": attr.output(
+            doc = "Name of the public header file (only when using Objective-C).",
         ),
         "_toolchain": attr.label(
             default = Label("@build_bazel_rules_apple//apple/internal:toolchain_support"),
@@ -129,9 +152,6 @@ into mlmodelc files.
     }),
     output_to_genfiles = True,
     fragments = ["apple"],
-    outputs = {
-        "source": "%{name}.m",
-    },
     doc = """
 This rule takes a single mlmodel file or mlpackage bundle and creates a target that can be added
 as a dependency from objc_library or swift_library targets. For Swift, just import like any other
@@ -154,8 +174,5 @@ as `#import my/package/MyModel.h`.
 
 This rule will also compile the `mlmodel` into an `mlmodelc` and propagate it
 upstream so that it is packaged as a resource inside the top level bundle.
-
-This rule currently only returns an ObjC interface since the Swift generated files do not have the
-necessary public interfaces to export its symbols outside of the module.
 """,
 )

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -31,6 +31,10 @@ load(
     "platform_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "swift_support",
+)
+load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
@@ -45,6 +49,9 @@ def _apple_core_ml_library_impl(ctx):
     basename = paths.replace_extension(ctx.file.mlmodel.basename, "")
 
     is_swift = ctx.attr.language == "Swift"
+
+    deps = getattr(ctx.attr, "deps", None)
+    uses_swift = is_swift or (swift_support.uses_swift(deps) if deps else False)
 
     if is_swift and not ctx.attr.swift_source:
         fail("Attribute `swift_source` is mandatory when generating Swift.")
@@ -75,7 +82,7 @@ def _apple_core_ml_library_impl(ctx):
         features = ctx.features,
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
-        uses_swift = is_swift,
+        uses_swift = uses_swift,
         xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )

--- a/doc/rules-resources.md
+++ b/doc/rules-resources.md
@@ -147,6 +147,26 @@ Macro to orchestrate an objc_library with generated sources for intentdefiniton 
 | <a id="objc_intent_library-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
+<a id="#swift_apple_core_ml_library"></a>
+
+## swift_apple_core_ml_library
+
+<pre>
+swift_apple_core_ml_library(<a href="#swift_apple_core_ml_library-name">name</a>, <a href="#swift_apple_core_ml_library-mlmodel">mlmodel</a>, <a href="#swift_apple_core_ml_library-kwargs">kwargs</a>)
+</pre>
+
+Macro to orchestrate a swift_library with generated sources for mlmodel files.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_apple_core_ml_library-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="swift_apple_core_ml_library-mlmodel"></a>mlmodel |  <p align="center"> - </p>   |  none |
+| <a id="swift_apple_core_ml_library-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <a id="#swift_intent_library"></a>
 
 ## swift_intent_library

--- a/test/apple_core_ml_library_package_test.sh
+++ b/test/apple_core_ml_library_package_test.sh
@@ -30,7 +30,11 @@ function tear_down() {
 function create_common_files() {
   cat > app/BUILD <<EOF
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
-load("@build_bazel_rules_apple//apple:resources.bzl", "apple_core_ml_library")
+load(
+    "@build_bazel_rules_apple//apple:resources.bzl",
+    "apple_core_ml_library",
+    "swift_apple_core_ml_library",
+)
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 objc_library(
@@ -48,14 +52,16 @@ objc_library(
 swift_library(
     name = "swift_lib",
     srcs = ["swift_lib.swift"],
-    # Apple's generated code triggers this warning, so we need to disable it,
-    # smh.
-    copts = ["-Xcc", "-Wno-nullability"],
-    deps = [":SampleCoreML"],
+    deps = [":SampleSwiftCoreML"],
 )
 
 apple_core_ml_library(
     name = "SampleCoreML",
+    mlmodel = "@build_bazel_rules_apple//test/testdata/resources:sample.mlpackage",
+)
+
+swift_apple_core_ml_library(
+    name = "SampleSwiftCoreML",
     mlmodel = "@build_bazel_rules_apple//test/testdata/resources:sample.mlpackage",
 )
 
@@ -91,7 +97,7 @@ EOF
 
   cat > app/swift_lib.swift <<EOF
 import Foundation
-import app_SampleCoreML
+import app_SampleSwiftCoreML
 
 public struct SwiftLib {
   public var mySample = sample()

--- a/test/apple_core_ml_library_test.sh
+++ b/test/apple_core_ml_library_test.sh
@@ -30,7 +30,11 @@ function tear_down() {
 function create_common_files() {
   cat > app/BUILD <<EOF
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
-load("@build_bazel_rules_apple//apple:resources.bzl", "apple_core_ml_library")
+load(
+    "@build_bazel_rules_apple//apple:resources.bzl",
+    "apple_core_ml_library",
+    "swift_apple_core_ml_library",
+)
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 objc_library(
@@ -48,14 +52,16 @@ objc_library(
 swift_library(
     name = "swift_lib",
     srcs = ["swift_lib.swift"],
-    # Apple's generated code triggers this warning, so we need to disable it,
-    # smh.
-    copts = ["-Xcc", "-Wno-nullability"],
-    deps = [":SampleCoreML"],
+    deps = [":SampleSwiftCoreML"],
 )
 
 apple_core_ml_library(
     name = "SampleCoreML",
+    mlmodel = "@build_bazel_rules_apple//test/testdata/resources:sample.mlmodel",
+)
+
+swift_apple_core_ml_library(
+    name = "SampleSwiftCoreML",
     mlmodel = "@build_bazel_rules_apple//test/testdata/resources:sample.mlmodel",
 )
 
@@ -91,7 +97,7 @@ EOF
 
   cat > app/swift_lib.swift <<EOF
 import Foundation
-import app_SampleCoreML
+import app_SampleSwiftCoreML
 
 public struct SwiftLib {
   public var mySample = sample()


### PR DESCRIPTION
Implementation of #1418

> I noticed that the `coremlc generate` subcommand now — at least as of version 1127.100.30, which comes bundled with Xcode 13.3 — supports generating Swift source files with the public access modifiers (`--public-access`):
> 
> <details>
> <summary>Output from <code>xcrun coremlc generate --help</code></summary>
> 
> ```
> $ xcrun coremlc generate --help
> usage: coremlc <command> <inputdocument> <outputpath> [options ...]
> 
> Examples:
> 
> [...]
> 
> Commands:
> 
> [...]
> 
>    generate <model.{mlmodel,mlpackage}> </desired/path/to/output/directory>
>       Generate source code interface for supplied CoreML .mlmodel or .mlpackage with the following options:
>       --outputpath </desired/path/to/output/directory> : where to place the generated interface files.
>       --language <Swift|Objective-C> : interface language.
>       --swift-version x.y : generated interface requires Swift version x.y (swift only).
>       --public-access : classes and members get public access specifier (swift only).
>       --globalmodule : generate objc compatible model classes (swift only).
>       --sdkroot : filename base for System/Library/CoreServices/SystemVersion.plist (internal, swift only). Requires --platform.
>       --platform <macos|ios|watchos|tvos|maccatalyst> : check mlmodel version compatability for this platform.
>       --deployment-target xx.yy.zz : check mlmodel version compatability for this version.
>       --container <bundle-resources|swift-package> : code generation variants (internal).
>       --no-documentation : suppress inline documentation.
>       --dry-run : don't write generated code to output directory.
> 
> [...]
> ```
> </details>
> 
> As for implementing this, and because naming is one of the two most difficult problems in programming (along with cache invalidation and off-by-one errors), I see that there is are `objc_intent_library` and `swift_intent_library` functions (Macros? I'm new to Bazel) in [_apple/resources.bzl_](https://github.com/bazelbuild/rules_apple/blob/a93ad60b28877b0cfa16abafc6bdd3fce0e66c76/apple/resources.bzl).
