### PR TITLE
Ensure `[AppleBundleInfo].binary` exists for coverage

### DIFF
--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -65,7 +65,7 @@ def _coverage_files_aspect_impl(target, ctx):
     # embedded in them.
     direct_binaries = []
     transitive_binaries_sets = []
-    if AppleBundleInfo in target:
+    if AppleBundleInfo in target and target[AppleBundleInfo].binary:
         direct_binaries.append(target[AppleBundleInfo].binary)
 
     # Collect dependencies coverage files.


### PR DESCRIPTION
**Summary:**
When `AppleBundleInfo` is created without a `binary`, allow coverage to still be gathered from the other `direct_binaries`. Example that creates the provider with a non-populated/`None` binary:

https://github.com/bazel-ios/rules_ios/blob/57edfbb4205fcfaae82f7c42c32e137d9c77634a/rules/internal/framework_middleman.bzl#L74-L82