### PR TITLE
Use the target triple from the C++ toolchain instead of deriving it from values in the Apple configuration fragment.

### DIFF
--- a/test/ios_framework_import_test.sh
+++ b/test/ios_framework_import_test.sh
@@ -104,6 +104,7 @@ EOF
   do_build ios \
     --compilation_mode=dbg \
     --ios_minimum_os="$IOS_VERSION" \
+    --cpu=ios_x86_64 \
     --apple_platform_type=ios \
     //libraries:iOSSwiftStaticFrameworkLibrary
 


### PR DESCRIPTION
When using `--host_cpu=darwin_x86_64` on an ARM (Apple Silicon) host, the value returned by the Apple configuration fragment is wrong, and we end up compiling Swift for `arm64`. Since the C++ toolchain already has the correct triple verbatim as we want it in the `target_gnu_system_name` field, just use that, and add some generally useful utilities for manipulating the triples and their components.

Note to open-source rules maintainers: This change requires/assumes that your C++ toolchain configuration returns a complete target triple that includes minimum OS version and target environment; for example, `x86_64-apple-ios13.0-simulator`.

PiperOrigin-RevId: 429897884
(cherry picked from commit 88c03c10561effbc438fa65e1d47c76a50d1772d)