### PR TITLE
Improve the error handling of archive_contents_test's underlying shell script.

### DIFF
--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -euo pipefail
 
 newline=$'\n'
 
@@ -272,7 +272,8 @@ if [[ -n "${NOT_CONTAINS-}" ]]; then
     something_tested=true
     expanded_path=$(eval echo "$path")
     if [[ -e $expanded_path ]]; then
-      fail "Archive did contain \"$expanded_path\""
+      fail "Archive did contain \"$expanded_path\"" \
+        "contents were:$newline$(find $ARCHIVE_ROOT)"
     fi
   done
 fi


### PR DESCRIPTION
PiperOrigin-RevId: 432450484
(cherry picked from commit e21dc2107429444a99e2f3b3d5ae040a97451841)