### PR TITLE
Rename swift_library instances used for testing ios_static_framework to better indicate that they can be used to test any SDK framework/library rule.

### DIFF
--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -38,15 +38,15 @@ def ios_static_framework_test_suite(name):
         compilation_mode = "opt",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:static_fmwk_with_swift_and_avoid_deps",
         contains = [
-            "$BUNDLE_ROOT/Modules/StaticFmwkUpperLib.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/StaticFmwkUpperLib.swiftmodule/x86_64.swiftinterface",
+            "$BUNDLE_ROOT/Modules/SwiftFmwkUpperLib.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/SwiftFmwkUpperLib.swiftmodule/x86_64.swiftinterface",
         ],
-        binary_test_file = "$BUNDLE_ROOT/StaticFmwkUpperLib",
+        binary_test_file = "$BUNDLE_ROOT/SwiftFmwkUpperLib",
         binary_test_architecture = "x86_64",
-        binary_contains_symbols = ["_$s18StaticFmwkUpperLib5DummyVMf"],
+        binary_contains_symbols = ["_$s17SwiftFmwkUpperLib5DummyVMn"],
         binary_not_contains_symbols = [
-            "_$s18StaticFmwkLowerLib5DummyVMf",
-            "_$s19StaticFmwkLowestLib5DummyVMf",
+            "_$s17SwiftFmwkLowerLib5DummyVMn",
+            "_$s18SwiftFmwkLowestLib5DummyVMn",
         ],
         tags = [name],
     )
@@ -104,10 +104,10 @@ def ios_static_framework_test_suite(name):
         compilation_mode = "opt",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:static_framework_with_generated_header",
         contains = [
-            "$BUNDLE_ROOT/Headers/StaticFmwkWithGenHeader.h",
+            "$BUNDLE_ROOT/Headers/SwiftFmwkWithGenHeader.h",
             "$BUNDLE_ROOT/Modules/module.modulemap",
-            "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/StaticFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+            "$BUNDLE_ROOT/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2267,19 +2267,19 @@ ios_dynamic_framework(
 
 ios_static_framework(
     name = "static_fmwk_with_swift_and_avoid_deps",
-    avoid_deps = [":StaticFmwkLowerLib"],
-    bundle_name = "StaticFmwkUpperLib",
+    avoid_deps = [":SwiftFmwkLowerLib"],
+    bundle_name = "SwiftFmwkUpperLib",
     minimum_os_version = "8.0",
     tags = FIXTURE_TAGS,
-    deps = [":StaticFmwkUpperLib"],
+    deps = [":SwiftFmwkUpperLib"],
 )
 
 ios_static_framework(
     name = "static_framework_with_generated_header",
-    bundle_name = "StaticFmwkWithGenHeader",
+    bundle_name = "SwiftFmwkWithGenHeader",
     minimum_os_version = "8.0",
     tags = FIXTURE_TAGS,
-    deps = [":StaticFmwkWithGenHeader"],
+    deps = [":SwiftFmwkWithGenHeader"],
 )
 
 genrule(
@@ -2289,33 +2289,33 @@ genrule(
 )
 
 swift_library(
-    name = "StaticFmwkUpperLib",
+    name = "SwiftFmwkUpperLib",
     srcs = ["Dummy.swift"],
-    module_name = "StaticFmwkUpperLib",
+    module_name = "SwiftFmwkUpperLib",
     tags = FIXTURE_TAGS,
-    deps = [":StaticFmwkLowerLib"],
+    deps = [":SwiftFmwkLowerLib"],
 )
 
 swift_library(
-    name = "StaticFmwkLowerLib",
+    name = "SwiftFmwkLowerLib",
     srcs = ["Dummy.swift"],
-    module_name = "StaticFmwkLowerLib",
+    module_name = "SwiftFmwkLowerLib",
     tags = FIXTURE_TAGS,
-    deps = [":StaticFmwkLowestLib"],
+    deps = [":SwiftFmwkLowestLib"],
 )
 
 swift_library(
-    name = "StaticFmwkLowestLib",
+    name = "SwiftFmwkLowestLib",
     srcs = ["Dummy.swift"],
-    module_name = "StaticFmwkLowestLib",
+    module_name = "SwiftFmwkLowestLib",
     tags = FIXTURE_TAGS,
 )
 
 swift_library(
-    name = "StaticFmwkWithGenHeader",
+    name = "SwiftFmwkWithGenHeader",
     srcs = ["Dummy.swift"],
     generates_header = True,
-    module_name = "StaticFmwkWithGenHeader",
+    module_name = "SwiftFmwkWithGenHeader",
     tags = FIXTURE_TAGS,
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 432487955
(cherry picked from commit 082272ce476a675af0106587c03bc478322096e8)