### PR TITLE
Added new rules_factory methods for Bazel linking APIs attributes

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -160,15 +160,6 @@ _J2OBJC_BINARY_LINKING_ATTRS = {
         cfg = apple_common.multi_arch_split,
         default = Label("@bazel_tools//tools/objc:dummy_lib"),
     ),
-    "_j2objc_dead_code_pruner": attr.label(
-        executable = True,
-        # Setting `allow_single_file=True` would be more correct. Unfortunately,
-        # doing so prevents using py_binary as the underlying target because py_binary
-        # produces at least _two_ output files (the executable plus any files in srcs)
-        allow_files = True,
-        cfg = "exec",
-        default = Label("@bazel_tools//tools/objc:j2objc_dead_code_pruner_binary"),
-    ),
 }
 
 _COMMON_TEST_ATTRS = {

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -146,7 +146,7 @@ def _link_multi_arch_binary_attrs(*, cfg = apple_common.multi_arch_split):
             # - `registerLinkActions()` --> `registerBinaryStripAction()`
             # TODO(b/117932394): Remove this attribute once Bazel no longer uses xcrunwrapper.
             "_xcrunwrapper": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 executable = True,
                 default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
             ),

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -113,32 +113,63 @@ _COMMON_ATTRS = dicts.add(
     apple_support.action_required_attrs(),
 )
 
-# Private attributes on rules that perform binary linking.
-_COMMON_BINARY_RULE_ATTRS = dicts.add(
-    {
-        "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
+def _common_linking_api_attrs(*, cfg = apple_common.multi_arch_split):
+    """Returns dictionary of required attributes for Bazel Apple linking API's.
+
+    These rule attributes are required by both Bazel Apple linking API's under apple_common module:
+      - apple_common.link_multi_arch_binary
+      - apple_common.link_multi_arch_static_library
+
+    Args:
+        cfg: Bazel split transition to use on attrs.
+    """
+    return {
         "_child_configuration_dummy": attr.label(
-            cfg = apple_common.multi_arch_split,
+            cfg = cfg,
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
-        # Needed for the J2ObjC processing code that already exists in the implementation of
-        # apple_common.link_multi_arch_binary.
-        "_dummy_lib": attr.label(
-            cfg = apple_common.multi_arch_split,
-            default = Label("@bazel_tools//tools/objc:dummy_lib"),
-        ),
-        # xcrunwrapper is no longer used by rules_apple, but the underlying implementation of
-        # apple_common.link_multi_arch_binary requires this attribute.
-        # TODO(b/117932394): Remove this attribute once Bazel no longer uses xcrunwrapper.
-        "_xcrunwrapper": attr.label(
-            cfg = "exec",
-            executable = True,
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-        ),
-    },
-)
+    }
+
+def _link_multi_arch_binary_attrs(*, cfg = apple_common.multi_arch_split):
+    """Returns dictionary of required attributes for apple_common.link_multi_arch_binary.
+
+    Args:
+        cfg: Bazel split transition to use on attrs.
+    """
+    return dicts.add(
+        _common_linking_api_attrs(cfg = cfg),
+        {
+            # xcrunwrapper is no longer used by rules_apple, but the underlying implementation of
+            # apple_common.link_multi_arch_binary and j2objc_dead_code_pruner require this attribute.
+            # See CompilationSupport.java:
+            # - `registerJ2ObjcDeadCodeRemovalActions()`
+            # - `registerLinkActions()` --> `registerBinaryStripAction()`
+            # TODO(b/117932394): Remove this attribute once Bazel no longer uses xcrunwrapper.
+            "_xcrunwrapper": attr.label(
+                cfg = "host",
+                executable = True,
+                default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
+            ),
+        },
+    )
+
+# Needed for the J2ObjC processing code that already exists in the implementation of
+# apple_common.link_multi_arch_binary.
+_J2OBJC_BINARY_LINKING_ATTRS = {
+    "_dummy_lib": attr.label(
+        cfg = apple_common.multi_arch_split,
+        default = Label("@bazel_tools//tools/objc:dummy_lib"),
+    ),
+    "_j2objc_dead_code_pruner": attr.label(
+        executable = True,
+        # Setting `allow_single_file=True` would be more correct. Unfortunately,
+        # doing so prevents using py_binary as the underlying target because py_binary
+        # produces at least _two_ output files (the executable plus any files in srcs)
+        allow_files = True,
+        cfg = "exec",
+        default = Label("@bazel_tools//tools/objc:j2objc_dead_code_pruner_binary"),
+    ),
+}
 
 _COMMON_TEST_ATTRS = {
     "data": attr.label_list(
@@ -198,8 +229,14 @@ def _common_binary_linking_attrs(deps_cfg, product_type):
 
     return dicts.add(
         _COMMON_ATTRS,
-        _COMMON_BINARY_RULE_ATTRS,
+        _J2OBJC_BINARY_LINKING_ATTRS,
+        _link_multi_arch_binary_attrs(),
         {
+            # This attribute is required by the Clang runtime libraries processing partial.
+            # See utils/clang_rt_dylibs.bzl and partials/clang_rt_dylibs.bzl
+            "_cc_toolchain": attr.label(
+                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            ),
             "exported_symbols_lists": attr.label_list(
                 allow_files = True,
                 doc = """
@@ -1240,6 +1277,9 @@ def _create_apple_test_rule(implementation, doc, platform_type):
     )
 
 rule_factory = struct(
+    common_bazel_attributes = struct(
+        link_multi_arch_binary_attrs = _link_multi_arch_binary_attrs,
+    ),
     common_tool_attributes = dicts.add(
         _COMMON_ATTRS,
         apple_support_toolchain_utils.shared_attrs(),

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -757,25 +757,16 @@ def _apple_xcframework_impl(ctx):
 apple_xcframework = rule(
     attrs = dicts.add(
         rule_factory.common_tool_attributes,
+        rule_factory.common_bazel_attributes.link_multi_arch_binary_attrs(
+            cfg = transition_support.xcframework_transition,
+        ),
         {
             "_allowlist_function_transition": attr.label(
                 default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
             ),
-            "_child_configuration_dummy": attr.label(
-                cfg = transition_support.xcframework_transition,
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-            ),
-            "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-            ),
             "_environment_plist_ios": attr.label(
                 allow_single_file = True,
                 default = "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
-            ),
-            "_xcrunwrapper": attr.label(
-                cfg = "exec",
-                default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-                executable = True,
             ),
             "bundle_id": attr.string(
                 doc = """


### PR DESCRIPTION
Introduces new methods under `rule_factory.bzl` to get a dictionary of
required attributes by Bazel Apple linking API's under `apple_common`.

These methods have the optional `cfg` argument to set a custom split
transition on attributes (defaults to `apple_common.multi_arch_split`).

PiperOrigin-RevId: 434550215
(cherry picked from commit 299b8440ee4788b19c5d6c2539524a70adfba41b)