### PR TITLE
Rename register_linking_action method from linking_support

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -67,7 +67,7 @@ def _apple_binary_impl(ctx):
         for framework in ctx.attr.weak_sdk_frameworks
     ])
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         bundle_loader = bundle_loader,
         extra_linkopts = extra_linkopts,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -159,7 +159,7 @@ def _ios_application_impl(ctx):
             collections.before_each("-framework", ctx.attr.sdk_frameworks),
         )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,
@@ -448,7 +448,7 @@ def _ios_app_clip_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,
@@ -699,7 +699,7 @@ def _ios_framework_impl(ctx):
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         # Frameworks do not have entitlements.
@@ -921,7 +921,7 @@ def _ios_extension_impl(ctx):
             collections.before_each("-framework", ctx.attr.sdk_frameworks),
         )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,
@@ -1164,7 +1164,7 @@ def _ios_dynamic_framework_impl(ctx):
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         # Frameworks do not have entitlements.
@@ -1652,7 +1652,7 @@ def _ios_imessage_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -68,7 +68,7 @@ def _parse_platform_key(key):
     arch, _, environment = rest.rpartition("_")
     return struct(platform = platform, arch = arch, environment = environment)
 
-def _register_linking_action(
+def _register_binary_linking_action(
         ctx,
         *,
         avoid_deps = [],
@@ -218,6 +218,6 @@ def _lipo_or_symlink_inputs(actions, inputs, output, apple_fragment, xcode_confi
 linking_support = struct(
     lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     parse_platform_key = _parse_platform_key,
-    register_linking_action = _register_linking_action,
+    register_binary_linking_action = _register_binary_linking_action,
     sectcreate_objc_provider = _sectcreate_objc_provider,
 )

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -133,7 +133,7 @@ def _macos_application_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         platform_prerequisites = platform_prerequisites,
@@ -367,7 +367,7 @@ def _macos_bundle_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         bundle_loader = ctx.attr.bundle_loader,
         entitlements = linking_entitlements,
@@ -558,7 +558,7 @@ def _macos_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         platform_prerequisites = platform_prerequisites,
@@ -765,7 +765,7 @@ def _macos_quick_look_plugin_impl(ctx):
         "-install_name",
         "\"/Library/Frameworks/{0}.qlgenerator/{0}\"".format(ctx.attr.bundle_name),
     ]
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         extra_linkopts = extra_linkopts,
@@ -960,7 +960,7 @@ def _macos_kernel_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         platform_prerequisites = platform_prerequisites,
@@ -1151,7 +1151,7 @@ def _macos_spotlight_importer_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         platform_prerequisites = platform_prerequisites,
@@ -1340,7 +1340,7 @@ def _macos_xpc_service_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         platform_prerequisites = platform_prerequisites,
@@ -1512,7 +1512,7 @@ def _macos_command_line_application_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     rule_descriptor = rule_support.rule_descriptor(ctx)
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         # Command-line applications do not have entitlements.
         entitlements = None,
@@ -1607,7 +1607,7 @@ def _macos_dylib_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     rule_descriptor = rule_support.rule_descriptor(ctx)
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         # Dynamic libraries do not have entitlements.
         entitlements = None,

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -301,7 +301,7 @@ def _apple_test_bundle_impl(ctx):
     else:
         bundle_loader = None
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = getattr(ctx.attr, "frameworks", []),
         bundle_loader = bundle_loader,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -142,7 +142,7 @@ def _tvos_application_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,
@@ -393,7 +393,7 @@ def _tvos_dynamic_framework_impl(ctx):
             bundle_name + rule_descriptor.bundle_extension,
         ]
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         # Frameworks do not have entitlements.
@@ -596,7 +596,7 @@ def _tvos_framework_impl(ctx):
         res_attrs = ["resources"],
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         # Frameworks do not have entitlements.
@@ -807,7 +807,7 @@ def _tvos_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = linking_entitlements,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -155,7 +155,7 @@ def _watchos_dynamic_framework_impl(ctx):
     if ctx.attr.extension_safe:
         extra_linkopts.append("-fapplication-extension")
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         # Frameworks do not have entitlements.
@@ -596,7 +596,7 @@ def _watchos_extension_impl(ctx):
     else:
         extra_linkopts = []
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = linking_entitlements,
         extra_linkopts = extra_linkopts,

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -103,7 +103,7 @@ def _lipoed_link_outputs_by_framework(
         apple_fragment: An Apple fragment (ctx.fragments.apple).
         label_name: Name of the target being built.
         link_result_outputs: The list of outputs from the struct returned by
-            `linking_support.register_linking_action`.
+            `linking_support.register_binary_linking_action`.
         xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
 
     Returns:
@@ -430,7 +430,7 @@ def _apple_xcframework_impl(ctx):
         if framework_type != "dynamic":
             fail("Unsupported framework_type found: " + framework_type)
 
-    link_result = linking_support.register_linking_action(
+    link_result = linking_support.register_binary_linking_action(
         ctx,
         # Frameworks do not have entitlements.
         entitlements = None,


### PR DESCRIPTION
PiperOrigin-RevId: 435370890
(cherry picked from commit b881ce455f00d5da43cdbcd4974e95eca8812afc)