### PR TITLE
Renamed `_environment_plist` implementation function to be consistent

### DIFF
--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -33,7 +33,7 @@ load(
     "dicts",
 )
 
-def _environment_plist(ctx):
+def _environment_plist_impl(ctx):
     # Only need as much platform information as this rule is able to give, for environment plist
     # processing.
     platform_prerequisites = platform_support.platform_prerequisites(
@@ -90,5 +90,5 @@ amount of duplicative work done generating these plists for the same platforms.
 """,
     fragments = ["apple"],
     outputs = {"plist": "%{name}.plist"},
-    implementation = _environment_plist,
+    implementation = _environment_plist_impl,
 )


### PR DESCRIPTION
PiperOrigin-RevId: 438866640
(cherry picked from commit 2b8796b16d4478661c93113c26a071ab286cc53a)