### PR TITLE
Remove the `toolchain` field from `SwiftUsageInfo`.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -599,7 +599,7 @@ def _common_static_framework_import_impl(ctx, is_xcframework):
 
     if swiftmodule_imports:
         toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
-        providers.append(SwiftUsageInfo(toolchain = toolchain))
+        providers.append(SwiftUsageInfo())
 
         # The Swift toolchain propagates Swift-specific linker flags (e.g.,
         # library/framework search paths) as an implicit dependency. In the


### PR DESCRIPTION
It's no longer used anywhere and may interfere with toolchainification. It was previously used to retrieve the toolchain from which linker flags should be retrieved, but those are now passed via an implicit dependency.

PiperOrigin-RevId: 439394121
(cherry picked from commit 8cdee21cc02731a4223f6c815adf74616f7aa8d2)