### PR TITLE
Move `swift_usage_aspect` and `SwiftUsageInfo` from rules_swift into rules_apple.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -43,6 +43,7 @@ bzl_library(
         ":resources",
         "//apple:providers",
         "//apple:utils",
+        "//apple/internal/aspects:swift_usage_aspect",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:partial",
@@ -394,6 +395,7 @@ bzl_library(
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
         "//apple/internal/aspects:swift_static_framework_aspect",
+        "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/testing:apple_test_bundle_support",
         "//apple/internal/testing:apple_test_rule_support",
         "@bazel_skylib//lib:dicts",
@@ -458,7 +460,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        "@build_bazel_rules_swift//swift",
+        "//apple/internal/aspects:swift_usage_aspect",
     ],
 )
 
@@ -543,6 +545,7 @@ bzl_library(
         ":transition_support",
         "//apple:providers",
         "//apple/internal/aspects:resource_aspect",
+        "//apple/internal/aspects:swift_usage_aspect",
         "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_apple_support//lib:lipo",
         "@build_bazel_rules_swift//swift",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -51,6 +51,10 @@ load(
     "defines",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "SwiftUsageInfo",
+)
+load(
     "@build_bazel_rules_apple//apple:utils.bzl",
     "group_files_by_directory",
 )
@@ -58,7 +62,6 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
     "SwiftToolchainInfo",
-    "SwiftUsageInfo",
     "swift_clang_module_aspect",
     "swift_common",
 )

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -51,6 +51,17 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "swift_usage_aspect",
+    srcs = ["swift_usage_aspect.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",

--- a/apple/internal/aspects/swift_usage_aspect.bzl
+++ b/apple/internal/aspects/swift_usage_aspect.bzl
@@ -1,0 +1,71 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An aspect that collects information about Swift usage among dependencies."""
+
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+
+SwiftUsageInfo = provider(
+    doc = """\
+A provider that indicates that Swift was used by a target or any target that it
+depends on.
+""",
+    fields = {},
+)
+
+def _swift_usage_aspect_impl(target, aspect_ctx):
+    # Targets can directly propagate their own `SwiftUsageInfo` provider. In
+    # those case, this aspect must not propagate a `SwiftUsageInfo`, because
+    # doing so results in a Bazel error.
+    if SwiftUsageInfo in target:
+        return []
+
+    # If the target propagates `SwiftInfo`, then it or something in its
+    # dependencies more than likely uses Swift.
+    if SwiftInfo in target:
+        return [SwiftUsageInfo()]
+
+    # If one of the deps propagates `SwiftUsageInfo` provider, we can
+    # repropagate that information. We currently make the assumption that all
+    # Swift dependencies are built with the same toolchain (as in Bazel
+    # toolchain, not Swift toolchain).
+    for dep in getattr(aspect_ctx.rule.attr, "deps", []):
+        if SwiftUsageInfo in dep:
+            return [dep[SwiftUsageInfo]]
+
+    # Don't propagate the provider at all if the target nor its dependencies use
+    # Swift.
+    return []
+
+swift_usage_aspect = aspect(
+    attr_aspects = ["deps"],
+    doc = """\
+Collects information about how Swift is used in a dependency tree.
+
+When attached to an attribute, this aspect will propagate a `SwiftUsageInfo`
+provider for any target found in that attribute that uses Swift, either directly
+or deeper in its dependency tree. Conversely, if neither a target nor its
+transitive dependencies use Swift, the `SwiftUsageInfo` provider will not be
+propagated.
+
+We use an aspect (as opposed to propagating this information through normal
+providers returned by `swift_library`) because the information is needed if
+Swift is used _anywhere_ in a dependency graph, even as dependencies of other
+language rules that wouldn't know how to propagate the Swift-specific providers.
+""",
+    implementation = _swift_usage_aspect_impl,
+)

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -43,6 +43,10 @@ load(
     "swift_dynamic_framework_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "swift_usage_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
 )
@@ -83,10 +87,6 @@ load(
     "TvosFrameworkBundleInfo",
     "WatchosApplicationBundleInfo",
     "WatchosExtensionBundleInfo",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_usage_aspect",
 )
 load(
     "@bazel_skylib//lib:dicts.bzl",

--- a/apple/internal/swift_support.bzl
+++ b/apple/internal/swift_support.bzl
@@ -15,28 +15,9 @@
 """Support functions for working with Swift."""
 
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
-
-def _swift_usage_info(targets):
-    """Returns the `SwiftUsageInfo` provider for any of the given targets.
-
-    Since all Swift dependencies in the same target configuration should be built
-    with the same toolchain, we can safely just take the first one we see in the
-    given list.
-
-    Args:
-      targets: List of targets to check.
-
-    Returns:
-      The `SwiftUsageInfo` provider for any of the targets in the list, or `None`
-      if none of the targets transitively used Swift.
-    """
-    for x in targets:
-        if SwiftUsageInfo in x:
-            return x[SwiftUsageInfo]
-    return None
 
 def _uses_swift(targets):
     """Returns True if any of the given targets uses Swift.
@@ -47,15 +28,17 @@ def _uses_swift(targets):
     function.
 
     Args:
-      targets: List of targets to check.
+        targets: List of targets to check.
 
     Returns:
-      True if any of the targets directly uses Swift; otherwise, False.
+        True if any of the targets directly uses Swift; otherwise, False.
     """
-    return (_swift_usage_info(targets) != None)
+    for target in targets:
+        if SwiftUsageInfo in target:
+            return True
+    return False
 
 # Define the loadable module that lists the exported symbols in this file.
 swift_support = struct(
-    swift_usage_info = _swift_usage_info,
     uses_swift = _uses_swift,
 )

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -75,6 +75,10 @@ load(
     "apple_resource_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "swift_usage_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleBundleVersionInfo",
@@ -82,11 +86,7 @@ load(
     "AppleSupportToolchainInfo",
     "AppleXcframeworkBundleInfo",
 )
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
-    "swift_usage_aspect",
-)
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 def _group_link_outputs_by_library_identifier(


### PR DESCRIPTION
With the toolchain information removed, this aspect/provider offers a minimal API. The only client is rules_apple, which uses it to determine if Swift support may need to be bundled at all, so it's better that that single client own it, rather than rules_swift try to provide an API that could serve all possible hypothetical clients.

PiperOrigin-RevId: 439577534
(cherry picked from commit 7029c879fba68df038bf0bca522722fe01a9e6ec)