### PR TITLE
Removing internal dependencies on the native debug outputs provider in rules_apple.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -168,7 +168,7 @@ def _ios_application_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     if ctx.attr.watch_application:
         embeddable_targets.append(ctx.attr.watch_application)
@@ -209,7 +209,7 @@ def _ios_application_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = embeddable_targets,
             label_name = label.name,
             package_bitcode = True,
@@ -241,9 +241,10 @@ def _ios_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = embeddable_targets,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -300,8 +301,8 @@ def _ios_application_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = embeddable_targets + ctx.attr.deps,
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = ctx.attr.include_symbols_in_bundle,
             platform_prerequisites = platform_prerequisites,
@@ -401,6 +402,8 @@ def _ios_application_impl(ctx):
             binary = binary_artifact,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _ios_app_clip_impl(ctx):
@@ -456,7 +459,7 @@ def _ios_app_clip_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -497,7 +500,7 @@ def _ios_app_clip_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = embeddable_targets,
             label_name = label.name,
             package_bitcode = True,
@@ -530,9 +533,10 @@ def _ios_app_clip_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = embeddable_targets,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -655,6 +659,8 @@ def _ios_app_clip_impl(ctx):
             binary = binary_artifact,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _ios_framework_impl(ctx):
@@ -709,7 +715,7 @@ def _ios_framework_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -744,7 +750,7 @@ def _ios_framework_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -778,9 +784,10 @@ def _ios_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -835,8 +842,8 @@ def _ios_framework_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -871,6 +878,8 @@ def _ios_framework_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _ios_extension_impl(ctx):
@@ -930,7 +939,7 @@ def _ios_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -971,7 +980,7 @@ def _ios_extension_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -1004,9 +1013,10 @@ def _ios_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1049,8 +1059,8 @@ def _ios_extension_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = ctx.attr.frameworks,
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -1101,6 +1111,8 @@ def _ios_extension_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _ios_dynamic_framework_impl(ctx):
@@ -1174,7 +1186,7 @@ def _ios_dynamic_framework_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -1209,7 +1221,7 @@ def _ios_dynamic_framework_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -1228,9 +1240,9 @@ def _ios_dynamic_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1660,7 +1672,7 @@ def _ios_imessage_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -1703,7 +1715,7 @@ def _ios_imessage_extension_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -1736,9 +1748,10 @@ def _ios_imessage_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1821,6 +1834,8 @@ def _ios_imessage_extension_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _ios_sticker_pack_extension_impl(ctx):

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -20,6 +20,38 @@ load(
     "rule_support",
 )
 
+def _debug_outputs_by_architecture(link_outputs):
+    """Returns debug outputs indexed by architecture from `register_binary_linking_action` output.
+
+    Args:
+        link_outputs: The dictionary of linking outputs found from the `outputs` field of
+            `register_binary_linking_action`'s output struct.
+
+    Returns:
+        A `struct` containing three fields:
+
+        *   `bitcode_symbol_maps`: A mapping of architectures to Files representing bitcode symbol
+            maps for each architecture.
+        *   `dsym_binaries`: A mapping of architectures to Files representing dSYM binary outputs
+            for each architecture.
+        *   `linkmaps`: A mapping of architectures to Files representing linkmaps for each
+            architecture.
+    """
+    bitcode_symbol_maps = {}
+    dsym_binaries = {}
+    linkmaps = {}
+
+    for link_output in link_outputs:
+        bitcode_symbol_maps[link_output.architecture] = link_output.bitcode_symbols
+        dsym_binaries[link_output.architecture] = link_output.dsym_binary
+        linkmaps[link_output.architecture] = link_output.linkmap
+
+    return struct(
+        bitcode_symbol_maps = bitcode_symbol_maps,
+        dsym_binaries = dsym_binaries,
+        linkmaps = linkmaps,
+    )
+
 def _sectcreate_objc_provider(segname, sectname, file):
     """Returns an objc provider that propagates a section in a linked binary.
 
@@ -255,6 +287,7 @@ def _lipo_or_symlink_inputs(actions, inputs, output, apple_fragment, xcode_confi
         actions.symlink(target_file = inputs[0], output = output)
 
 linking_support = struct(
+    debug_outputs_by_architecture = _debug_outputs_by_architecture,
     lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     parse_platform_key = _parse_platform_key,
     register_binary_linking_action = _register_binary_linking_action,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -140,7 +140,7 @@ def _macos_application_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     processor_partials = [
         partials.apple_bundle_info_partial(
@@ -188,9 +188,10 @@ def _macos_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = embedded_targets + ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -242,8 +243,8 @@ def _macos_application_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = embedded_targets,
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = ctx.attr.include_symbols_in_bundle,
             platform_prerequisites = platform_prerequisites,
@@ -322,6 +323,8 @@ def _macos_application_impl(ctx):
             binary = binary_artifact,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_bundle_impl(ctx):
@@ -376,7 +379,7 @@ def _macos_bundle_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -432,9 +435,10 @@ def _macos_bundle_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -513,6 +517,8 @@ def _macos_bundle_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_extension_impl(ctx):
@@ -565,7 +571,7 @@ def _macos_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -622,9 +628,10 @@ def _macos_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -662,8 +669,8 @@ def _macos_extension_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = [],
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -716,6 +723,8 @@ def _macos_extension_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_quick_look_plugin_impl(ctx):
@@ -773,7 +782,7 @@ def _macos_quick_look_plugin_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -832,9 +841,10 @@ def _macos_quick_look_plugin_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -872,8 +882,8 @@ def _macos_quick_look_plugin_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = [],
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -919,6 +929,8 @@ def _macos_quick_look_plugin_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_kernel_extension_impl(ctx):
@@ -967,7 +979,7 @@ def _macos_kernel_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -1024,9 +1036,10 @@ def _macos_kernel_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1064,8 +1077,8 @@ def _macos_kernel_extension_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = [],
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -1114,6 +1127,8 @@ def _macos_kernel_extension_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_spotlight_importer_impl(ctx):
@@ -1158,7 +1173,7 @@ def _macos_spotlight_importer_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -1215,9 +1230,10 @@ def _macos_spotlight_importer_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1254,8 +1270,8 @@ def _macos_spotlight_importer_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = [],
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -1303,6 +1319,8 @@ def _macos_spotlight_importer_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_xpc_service_impl(ctx):
@@ -1347,7 +1365,7 @@ def _macos_xpc_service_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -1404,9 +1422,10 @@ def _macos_xpc_service_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.additional_contents.keys(),
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -1443,8 +1462,8 @@ def _macos_xpc_service_impl(ctx):
         partials.apple_symbols_file_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
             dependency_targets = [],
+            dsym_binaries = debug_outputs.dsym_binaries,
             label_name = label.name,
             include_symbols_in_bundle = False,
             platform_prerequisites = platform_prerequisites,
@@ -1493,6 +1512,8 @@ def _macos_xpc_service_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_command_line_application_impl(ctx):
@@ -1520,16 +1541,17 @@ def _macos_command_line_application_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     debug_outputs_partial = partials.debug_symbols_partial(
         actions = actions,
         bin_root_path = bin_root_path,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
-        debug_outputs_provider = debug_outputs_provider,
+        dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
         executable_name = executable_name,
+        linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
         rule_label = label,
     )
@@ -1588,6 +1610,8 @@ def _macos_command_line_application_impl(ctx):
             binary = output_file,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _macos_dylib_impl(ctx):
@@ -1616,16 +1640,17 @@ def _macos_dylib_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     debug_outputs_partial = partials.debug_symbols_partial(
         actions = actions,
         bin_root_path = bin_root_path,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
-        debug_outputs_provider = debug_outputs_provider,
+        dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
         executable_name = executable_name,
+        linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
         rule_label = label,
     )
@@ -1678,6 +1703,8 @@ def _macos_dylib_impl(ctx):
                 {"dylib": depset(direct = [output_file])},
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 macos_application = rule_factory.create_apple_bundling_rule(

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -47,8 +47,8 @@ def _apple_symbols_file_partial_impl(
         *,
         actions,
         binary_artifact,
-        debug_outputs_provider,
         dependency_targets,
+        dsym_binaries,
         label_name,
         output_discriminator,
         include_symbols_in_bundle,
@@ -56,10 +56,10 @@ def _apple_symbols_file_partial_impl(
     """Implementation for the Apple .symbols file processing partial."""
     outputs = []
     if (platform_prerequisites.cpp_fragment.apple_generate_dsym and
-        binary_artifact and debug_outputs_provider):
+        binary_artifact and dsym_binaries):
         inputs = [binary_artifact]
-        for debug_output in debug_outputs_provider.outputs_map.values():
-            inputs.append(debug_output["dsym_binary"])
+        for dsym_binary in dsym_binaries.values():
+            inputs.append(dsym_binary)
         for target in dependency_targets:
             if AppleFrameworkImportInfo in target:
                 inputs.extend(target[AppleFrameworkImportInfo].debug_info_binaries.to_list())
@@ -109,8 +109,8 @@ def apple_symbols_file_partial(
         *,
         actions,
         binary_artifact,
-        debug_outputs_provider,
         dependency_targets = [],
+        dsym_binaries,
         label_name,
         output_discriminator = None,
         include_symbols_in_bundle,
@@ -120,10 +120,10 @@ def apple_symbols_file_partial(
     Args:
       actions: Actions defined for the current build context.
       binary_artifact: The main binary artifact for this target.
-      debug_outputs_provider: The AppleDebugOutputs provider containing the references to the debug
-        outputs of this target's binary.
       dependency_targets: List of targets that should be checked for files that need to be
         bundled.
+      dsym_binaries: A mapping of architectures to Files representing dsym binary outputs for each
+        architecture.
       label_name: Name of the target being built.
       output_discriminator: A string to differentiate between different target intermediate files
           or `None`.
@@ -138,8 +138,8 @@ def apple_symbols_file_partial(
         _apple_symbols_file_partial_impl,
         actions = actions,
         binary_artifact = binary_artifact,
-        debug_outputs_provider = debug_outputs_provider,
         dependency_targets = dependency_targets,
+        dsym_binaries = dsym_binaries,
         include_symbols_in_bundle = include_symbols_in_bundle,
         label_name = label_name,
         output_discriminator = output_discriminator,

--- a/apple/internal/partials/bitcode_symbols.bzl
+++ b/apple/internal/partials/bitcode_symbols.bzl
@@ -43,7 +43,6 @@ def _bitcode_symbols_partial_impl(
         actions,
         binary_artifact,
         bitcode_symbol_maps,
-        debug_outputs_provider,
         dependency_targets,
         label_name,
         output_discriminator,
@@ -56,9 +55,6 @@ def _bitcode_symbols_partial_impl(
     bitcode_symbols = {}
     if bitcode_symbol_maps:
         bitcode_symbols.update(bitcode_symbol_maps)
-    if debug_outputs_provider:
-        for arch in debug_outputs_provider.outputs_map:
-            bitcode_symbols[arch] = debug_outputs_provider.outputs_map[arch].get("bitcode_symbols")
 
     if binary_artifact and bitcode_symbols:
         bitcode_files = []
@@ -124,7 +120,6 @@ def bitcode_symbols_partial(
         actions,
         binary_artifact = None,
         bitcode_symbol_maps = {},
-        debug_outputs_provider = None,
         dependency_targets = [],
         label_name,
         output_discriminator = None,
@@ -137,8 +132,6 @@ def bitcode_symbols_partial(
       binary_artifact: The main binary artifact for this target.
       bitcode_symbol_maps: A mapping of architectures to Files representing bitcode symbol maps for
         each architecture.
-      debug_outputs_provider: The AppleDebugOutputs provider containing the references to the debug
-        outputs of this target's binary.
       dependency_targets: List of targets that should be checked for bitcode files that need to be
         bundled..
       label_name: Name of the target being built
@@ -156,7 +149,6 @@ def bitcode_symbols_partial(
         actions = actions,
         binary_artifact = binary_artifact,
         bitcode_symbol_maps = bitcode_symbol_maps,
-        debug_outputs_provider = debug_outputs_provider,
         dependency_targets = dependency_targets,
         label_name = label_name,
         output_discriminator = output_discriminator,

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -312,7 +312,7 @@ def _apple_test_bundle_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     if hasattr(ctx.attr, "additional_contents"):
         debug_dependencies = ctx.attr.additional_contents.keys()
@@ -361,9 +361,10 @@ def _apple_test_bundle_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = debug_dependencies,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -493,6 +494,8 @@ def _apple_test_bundle_impl(ctx):
                 processor_result.output_groups,
             )
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ])
 
     return providers

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -150,7 +150,7 @@ def _tvos_application_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     processor_partials = [
         partials.app_assets_validation_partial(
@@ -181,7 +181,7 @@ def _tvos_application_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = embeddable_targets,
             label_name = label.name,
             package_bitcode = True,
@@ -213,9 +213,10 @@ def _tvos_application_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = embeddable_targets,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -341,6 +342,8 @@ def _tvos_application_impl(ctx):
             binary = binary_artifact,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _tvos_dynamic_framework_impl(ctx):
@@ -409,7 +412,7 @@ def _tvos_dynamic_framework_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -441,7 +444,7 @@ def _tvos_dynamic_framework_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -460,9 +463,9 @@ def _tvos_dynamic_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -612,7 +615,7 @@ def _tvos_framework_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -644,7 +647,7 @@ def _tvos_framework_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -678,9 +681,10 @@ def _tvos_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -762,6 +766,8 @@ def _tvos_framework_impl(ctx):
             )
         ),
         TvosFrameworkBundleInfo(),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _tvos_extension_impl(ctx):
@@ -815,7 +821,7 @@ def _tvos_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -848,7 +854,7 @@ def _tvos_extension_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -881,9 +887,10 @@ def _tvos_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -969,6 +976,8 @@ def _tvos_extension_impl(ctx):
             binary = binary_artifact,
             objc = link_result.objc,
         ),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _tvos_static_framework_impl(ctx):

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -165,7 +165,7 @@ def _watchos_dynamic_framework_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive_for_embedding = outputs.archive_for_embedding(
         actions = actions,
@@ -200,7 +200,7 @@ def _watchos_dynamic_framework_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.frameworks,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -219,9 +219,9 @@ def _watchos_dynamic_framework_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.frameworks,
-            debug_outputs_provider = debug_outputs_provider,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -604,7 +604,7 @@ def _watchos_extension_impl(ctx):
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
-    debug_outputs_provider = link_result.debug_outputs_provider
+    debug_outputs = linking_support.debug_outputs_by_architecture(link_result.outputs)
 
     archive = outputs.archive(
         actions = actions,
@@ -639,7 +639,7 @@ def _watchos_extension_impl(ctx):
         partials.bitcode_symbols_partial(
             actions = actions,
             binary_artifact = binary_artifact,
-            debug_outputs_provider = debug_outputs_provider,
+            bitcode_symbol_maps = debug_outputs.bitcode_symbol_maps,
             dependency_targets = ctx.attr.extensions,
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
@@ -672,9 +672,10 @@ def _watchos_extension_impl(ctx):
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             debug_dependencies = ctx.attr.extensions,
-            debug_outputs_provider = debug_outputs_provider,
+            dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
             rule_label = label,
         ),
@@ -765,6 +766,8 @@ def _watchos_extension_impl(ctx):
             )
         ),
         WatchosExtensionBundleInfo(),
+        # TODO(b/228856372): Remove when downstream users are migrated off this provider.
+        link_result.debug_outputs_provider,
     ] + processor_result.providers
 
 def _watchos_static_framework_impl(ctx):


### PR DESCRIPTION
PiperOrigin-RevId: 441212884
(cherry picked from commit 4e113b33582a1bc6e1ad7e7e11e45735d75c899c)