### PR TITLE
Introduce the `swift_common.get_toolchain` helper function.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -57,7 +57,6 @@ load(
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
-    "SwiftToolchainInfo",
     "SwiftUsageInfo",
     "swift_clang_module_aspect",
     "swift_common",
@@ -598,7 +597,7 @@ def _common_static_framework_import_impl(ctx, is_xcframework):
     additional_cc_infos = []
 
     if swiftmodule_imports:
-        toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+        toolchain = swift_common.get_toolchain(ctx)
         providers.append(SwiftUsageInfo())
 
         # The Swift toolchain propagates Swift-specific linker flags (e.g.,


### PR DESCRIPTION
This is change 1 of _N_ to migrate the Swift build rules to use new-style Bazel toolchains. This change:

*   Updates the toolchain configuration rules to wrap the `SwiftToolchainInfo` provider in `platform_common.ToolchainInfo`, for future use by `toolchain()` rules.
*   Funnels all toolchain access through a new `swift_toolchain.get_toolchain()` function that looks up the toolchain using `ctx.toolchains`, falling back to the implicit attribute.

Since `ctx.toolchains` isn't defined yet, the second change is a no-op but it simplifies future parts of the migration.

PiperOrigin-RevId: 439638938
(cherry picked from commit 73b248d8ac1b4b679a411d2785bdef323c923f0e)