### PR TITLE
Expose `infoplist` on `AppleBinaryInfo`

### DIFF
--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -48,6 +48,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfoplistInfo",
     "AppleBundleVersionInfo",
     "AppleSupportToolchainInfo",
 )
@@ -122,6 +123,7 @@ def _macos_binary_infoplist_impl(ctx):
             "__info_plist",
             merged_infoplist,
         ),
+        AppleBinaryInfoplistInfo(infoplist = merged_infoplist),
     ]
 
 macos_binary_infoplist = rule(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -77,6 +77,7 @@ load(
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBinaryInfo",
+    "AppleBinaryInfoplistInfo",
     "AppleSupportToolchainInfo",
     "MacosApplicationBundleInfo",
     "MacosBundleBundleInfo",
@@ -1588,9 +1589,19 @@ def _macos_command_line_application_impl(ctx):
         rule_descriptor = rule_descriptor,
     )
 
+    infoplists = [
+        x[AppleBinaryInfoplistInfo].infoplist
+        for x in getattr(ctx.attr, "deps", [])
+        if AppleBinaryInfoplistInfo in x
+    ]
+
+    # There should only be one `AppleBinaryInfoplistInfo` providing dep
+    infoplist = infoplists[0] if infoplists else None
+
     return [
         AppleBinaryInfo(
             binary = output_file,
+            infoplist = infoplist,
             product_type = rule_descriptor.product_type,
         ),
         DefaultInfo(
@@ -1687,9 +1698,19 @@ def _macos_dylib_impl(ctx):
         rule_descriptor = rule_descriptor,
     )
 
+    infoplists = [
+        x[AppleBinaryInfoplistInfo].infoplist
+        for x in getattr(ctx.attr, "deps", [])
+        if AppleBinaryInfoplistInfo in x
+    ]
+
+    # There should only be one `AppleBinaryInfoplistInfo` providing dep
+    infoplist = infoplists[0] if infoplists else None
+
     return [
         AppleBinaryInfo(
             binary = output_file,
+            infoplist = infoplist,
             product_type = rule_descriptor.product_type,
         ),
         DefaultInfo(files = depset(transitive = [

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -109,9 +109,24 @@ specific to any particular binary type.
         "binary": """
 `File`. The binary (executable, dynamic library, etc.) file that the target represents.
 """,
+        "infoplist": """
+`File`. The complete (binary-formatted) `Info.plist` embedded in the binary.
+""",
         "product_type": """
 `string`. The dot-separated product type identifier associated with the binary (for example,
 `com.apple.product-type.tool`).
+""",
+    },
+)
+
+AppleBinaryInfoplistInfo = provider(
+    doc = """
+Provides information about the Info.plist that was linked into an Apple binary
+target.
+""",
+    fields = {
+        "infoplist": """
+`File`. The complete (binary-formatted) `Info.plist` embedded in the binary.
 """,
     },
 )

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -18,7 +18,7 @@ relevant information that they need.
 ## AppleBinaryInfo
 
 <pre>
-AppleBinaryInfo(<a href="#AppleBinaryInfo-binary">binary</a>, <a href="#AppleBinaryInfo-product_type">product_type</a>)
+AppleBinaryInfo(<a href="#AppleBinaryInfo-binary">binary</a>, <a href="#AppleBinaryInfo-infoplist">infoplist</a>, <a href="#AppleBinaryInfo-product_type">product_type</a>)
 </pre>
 
 
@@ -34,7 +34,29 @@ specific to any particular binary type.
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="AppleBinaryInfo-binary"></a>binary |  <code>File</code>. The binary (executable, dynamic library, etc.) file that the target represents.    |
+| <a id="AppleBinaryInfo-infoplist"></a>infoplist |  <code>File</code>. The complete (binary-formatted) <code>Info.plist</code> embedded in the binary.    |
 | <a id="AppleBinaryInfo-product_type"></a>product_type |  <code>string</code>. The dot-separated product type identifier associated with the binary (for example, <code>com.apple.product-type.tool</code>).    |
+
+
+<a id="#AppleBinaryInfoplistInfo"></a>
+
+## AppleBinaryInfoplistInfo
+
+<pre>
+AppleBinaryInfoplistInfo(<a href="#AppleBinaryInfoplistInfo-infoplist">infoplist</a>)
+</pre>
+
+
+Provides information about the Info.plist that was linked into an Apple binary
+target.
+
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="AppleBinaryInfoplistInfo-infoplist"></a>infoplist |  <code>File</code>. The complete (binary-formatted) <code>Info.plist</code> embedded in the binary.    |
 
 
 <a id="#AppleBundleInfo"></a>

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -26,6 +26,10 @@ load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
+load(
+    ":rules/infoplist_contents_test.bzl",
+    "infoplist_contents_test",
+)
 
 def macos_command_line_application_test_suite(name):
     """Test suite for macos_command_line_application.
@@ -140,6 +144,29 @@ def macos_command_line_application_test_suite(name):
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
         expected_dsyms = ["cmd_app_basic"],
+        tags = [name],
+    )
+
+    infoplist_contents_test(
+        name = "{}_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_info_plists",
+        expected_values = {
+            "AnotherKey": "AnotherValue",
+            "BuildMachineOSBuild": "*",
+            "CFBundleIdentifier": "com.google.example",
+            "CFBundleName": "cmd_app_info_plists",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleSupportedPlatforms:0": "MacOSX",
+            "CFBundleVersion": "1.0",
+            "DTPlatformVersion": "*",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTXcode": "*",
+            "DTXcodeBuild": "*",
+            "DTPlatformName": "macosx",
+            "DTSDKBuild": "*",
+            "DTSDKName": "macosx*",
+            "LSMinimumSystemVersion": "10.11",
+        },
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_dylib_tests.bzl
+++ b/test/starlark_tests/macos_dylib_tests.bzl
@@ -27,6 +27,10 @@ load(
     "dsyms_test",
 )
 load(
+    ":rules/infoplist_contents_test.bzl",
+    "infoplist_contents_test",
+)
+load(
     ":rules/output_group_test.bzl",
     "output_group_test",
 )
@@ -83,6 +87,28 @@ def macos_dylib_test_suite(name):
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
         expected_dsyms = ["dylib"],
+        tags = [name],
+    )
+
+    infoplist_contents_test(
+        name = "{}_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
+        expected_values = {
+            "BuildMachineOSBuild": "*",
+            "CFBundleIdentifier": "com.google.example",
+            "CFBundleName": "dylib",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleSupportedPlatforms:0": "MacOSX",
+            "CFBundleVersion": "1.0",
+            "DTPlatformVersion": "*",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTXcode": "*",
+            "DTXcodeBuild": "*",
+            "DTPlatformName": "macosx",
+            "DTSDKBuild": "*",
+            "DTSDKName": "macosx*",
+            "LSMinimumSystemVersion": "10.11",
+        },
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/infoplist_contents_test.bzl
+++ b/test/starlark_tests/rules/infoplist_contents_test.bzl
@@ -27,16 +27,20 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfo",
     "AppleBundleInfo",
 )
 
 def _infoplist_contents_test_impl(ctx):
     """Implementation of the plist_contents_test rule."""
     target_under_test = ctx.attr.target_under_test[0]
-    if not AppleBundleInfo in target_under_test:
-        fail(("Target %s does not provide AppleBundleInfo") % target_under_test.label)
+    if AppleBundleInfo in target_under_test:
+        plist_file = target_under_test[AppleBundleInfo].infoplist
+    elif AppleBinaryInfo in target_under_test:
+        plist_file = target_under_test[AppleBinaryInfo].infoplist
+    else:
+        fail(("Target %s does not provide AppleBundleInfo or AppleBinaryInfo") % target_under_test.label)
 
-    plist_file = target_under_test[AppleBundleInfo].infoplist
     plist_path = plist_file.short_path
 
     test_lines = [
@@ -132,10 +136,17 @@ https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode
 If true, generates .dSYM debug symbol bundles for the target(s) under test.
 """,
         ),
+        "macos_cpus": attr.string_list(
+            default = ["x86_64"],
+            doc = """
+List of MacOS CPU's to use for test under target.
+https://docs.bazel.build/versions/main/command-line-reference.html#flag--macos_cpus
+""",
+        ),
         "target_under_test": attr.label(
             cfg = apple_verification_transition,
             doc = "Target containing an Info.plist file to verify.",
-            providers = [AppleBundleInfo],
+            providers = [[AppleBinaryInfo], [AppleBundleInfo]],
             mandatory = True,
         ),
         "expected_values": attr.string_dict(


### PR DESCRIPTION
This makes it easier to know what Info.plist embedded into the binary, if any at all. This mirrors the information exposed on `AppleBundleInfo`.