### PR TITLE
Revert xcframework 5.x workarounds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,12 +19,6 @@ tasks:
   macos_latest:
     name: "Latest Bazel"
     bazel: latest
-    build_flags:
-      - --build_tests_only
-      - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
-    test_flags:
-      - --build_tests_only
-      - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
     <<: *common
 
   macos_last_green:
@@ -39,12 +33,6 @@ tasks:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.
     - .bazelci/update_workspace_to_deps_heads.sh
-    build_flags:
-      - --build_tests_only
-      - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
-    test_flags:
-      - --build_tests_only
-      - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
     <<: *common
 
   macos_last_green_head_deps:

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -244,11 +244,8 @@ def _register_static_library_linking_action(ctx):
         *   `output_groups`: A `dict` containing output groups that should be returned in the
             `OutputGroupInfo` provider of the calling rule.
     """
+    linking_outputs = apple_common.link_multi_arch_static_library(ctx = ctx)
 
-    if not getattr(apple_common, "link_multi_arch_static_library", False):
-        fail("static xcframework support requires bazel 6.x+")
-
-    linking_outputs = getattr(apple_common, "link_multi_arch_static_library")(ctx = ctx)
     fat_library = ctx.actions.declare_file("{}_lipo.a".format(ctx.label.name))
 
     _lipo_or_symlink_inputs(

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -1074,11 +1074,7 @@ def _apple_static_xcframework_impl(ctx):
 
 apple_static_xcframework = rule(
     implementation = _apple_static_xcframework_impl,
-    doc = """
-Generates an XCFramework with static libraries for third-party distribution.
-
-NOTE: This is only supported on bazel 6.0+
-""",
+    doc = "Generates an XCFramework with static libraries for third-party distribution.",
     attrs = dicts.add(
         rule_factory.common_tool_attributes,
         rule_factory.common_bazel_attributes.link_multi_arch_static_library_attrs(

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -141,11 +141,7 @@ apple_static_xcframework(<a href="#apple_static_xcframework-name">name</a>, <a h
                          <a href="#apple_static_xcframework-minimum_deployment_os_versions">minimum_deployment_os_versions</a>, <a href="#apple_static_xcframework-minimum_os_versions">minimum_os_versions</a>, <a href="#apple_static_xcframework-public_hdrs">public_hdrs</a>)
 </pre>
 
-
 Generates an XCFramework with static libraries for third-party distribution.
-
-NOTE: This is only supported on bazel 6.0+
-
 
 **ATTRIBUTES**
 


### PR DESCRIPTION
We can land this when we no longer need to support bazel 5.x