### PR TITLE
Stop passing `xcode_path_wrapper`.

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -71,7 +71,6 @@ def _platform_prerequisites_for_aspect(target, aspect_ctx):
         objc_fragment = None,
         platform_type_string = str(aspect_ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = uses_swift,
-        xcode_path_wrapper = aspect_ctx.executable._xcode_path_wrapper,
         xcode_version_config = aspect_ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -552,7 +552,6 @@ def _generate_codesigning_dossier_action(
         progress_message = progress_message,
         tools = [resolved_codesigning_dossier_tool.executable],
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
 def _post_process_and_sign_archive_action(

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -183,7 +183,6 @@ def _extract_signing_info(
             mnemonic = "ExtractFromProvisioningProfile",
             outputs = outputs,
             xcode_config = platform_prerequisites.xcode_version_config,
-            xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
         )
 
     return struct(

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -47,7 +47,6 @@ def _environment_plist_impl(ctx):
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = False,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
     platform = platform_prerequisites.platform

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -205,7 +205,6 @@ def _framework_import_partial_impl(
             outputs = [framework_zip],
             tools = [resolved_codesigningtool.executable],
             xcode_config = platform_prerequisites.xcode_version_config,
-            xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
         )
 
         bundle_zips.append(

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -125,7 +125,6 @@ def _swift_dylib_action(
         mnemonic = "SwiftStdlibCopy",
         outputs = [output_dir],
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
 def _target_platform_is_arm_simulator(platform_prerequisites):

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -78,7 +78,6 @@ def _platform_prerequisites(
         objc_fragment,
         platform_type_string,
         uses_swift,
-        xcode_path_wrapper,
         xcode_version_config):
     """Returns a struct containing information on the platform being targeted.
 
@@ -94,8 +93,6 @@ def _platform_prerequisites(
       objc_fragment: An Objective-C fragment (ctx.fragments.objc), if it is present.
       platform_type_string: The platform type for the current target as a string.
       uses_swift: Boolean value to indicate if this target uses Swift.
-      xcode_path_wrapper: The Xcode path wrapper script. Can be none if and only we don't need to
-          resolve __BAZEL_XCODE_SDKROOT__ and other placeholders in environment arguments.
       xcode_version_config: The `apple_common.XcodeVersionConfig` provider from the current context.
 
     Returns:
@@ -135,7 +132,6 @@ def _platform_prerequisites(
         platform_type = platform_type_attr,
         sdk_version = sdk_version,
         uses_swift = uses_swift,
-        xcode_path_wrapper = xcode_path_wrapper,
         xcode_version_config = xcode_version_config,
     )
 
@@ -168,7 +164,6 @@ def _platform_prerequisites_from_rule_ctx(ctx):
         objc_fragment = ctx.fragments.objc,
         platform_type_string = ctx.attr.platform_type,
         uses_swift = uses_swift,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -440,7 +440,6 @@ def _bundle_partial_outputs_files(
             progress_message = "Bundling, processing and signing %s" % label_name,
             tools = bundling_tools,
             xcode_config = platform_prerequisites.xcode_version_config,
-            xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
             **action_args
         )
     else:

--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -108,5 +108,4 @@ def generate_intent_classes_sources(
         mnemonic = "IntentGenerate",
         outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )

--- a/apple/internal/resource_actions/mlmodel.bzl
+++ b/apple/internal/resource_actions/mlmodel.bzl
@@ -60,7 +60,6 @@ def compile_mlmodel(
         mnemonic = "MlmodelCompile",
         outputs = [output_bundle, output_plist],
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
 def generate_mlmodel_sources(
@@ -117,5 +116,4 @@ def generate_mlmodel_sources(
         mnemonic = "MlmodelGenerate",
         outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -73,7 +73,6 @@ def plisttool_action(
         mnemonic = mnemonic,
         outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )
 
 def compile_plist(*, actions, input_file, output_file, platform_prerequisites):

--- a/apple/internal/resource_actions/png.bzl
+++ b/apple/internal/resource_actions/png.bzl
@@ -54,5 +54,4 @@ def copy_png(*, actions, input_file, output_file, platform_prerequisites):
         mnemonic = "CopyPng",
         outputs = [output_file],
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )

--- a/apple/internal/resource_actions/texture_atlas.bzl
+++ b/apple/internal/resource_actions/texture_atlas.bzl
@@ -48,5 +48,4 @@ def compile_texture_atlas(
         mnemonic = "CompileTextureAtlas",
         outputs = [output_dir],
         xcode_config = platform_prerequisites.xcode_version_config,
-        xcode_path_wrapper = platform_prerequisites.xcode_path_wrapper,
     )

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -66,7 +66,6 @@ def _apple_core_data_model_impl(ctx):
             ctx.fragments.apple.single_arch_platform.platform_type,
         ),
         uses_swift = True,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config =
             ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -83,7 +83,6 @@ def _apple_core_ml_library_impl(ctx):
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = uses_swift,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -66,7 +66,6 @@ def _apple_intent_library_impl(ctx):
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = False,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
     )
 

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -334,8 +334,7 @@ def _create_xcframework_root_infoplist(
         available_libraries,
         resolved_plisttool,
         rule_label,
-        xcode_config,
-        xcode_path_wrapper):
+        xcode_config):
     """Generates a root Info.plist for a given XCFramework.
 
      Args:
@@ -346,7 +345,6 @@ def _create_xcframework_root_infoplist(
         resolved_plisttool: A struct referencing the resolved plist tool.
         rule_label: The label of the target being analyzed.
         xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
-        xcode_path_wrapper: The Xcode path wrapper script.
 
     Returns:
         A `File` representing a root Info.plist to be embedded within an XCFramework bundle.
@@ -389,7 +387,6 @@ def _create_xcframework_root_infoplist(
         mnemonic = "CreateXCFrameworkRootInfoPlist",
         outputs = [root_info_plist],
         xcode_config = xcode_config,
-        xcode_path_wrapper = xcode_path_wrapper,
     )
     return root_info_plist
 
@@ -546,7 +543,6 @@ def _apple_xcframework_impl(ctx):
             objc_fragment = ctx.fragments.objc,
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
-            xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
         )
 
@@ -740,7 +736,6 @@ def _apple_xcframework_impl(ctx):
         resolved_plisttool = apple_toolchain_info.resolved_plisttool,
         rule_label = label,
         xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
     )
 
     _create_xcframework_bundle(
@@ -1042,7 +1037,6 @@ def _apple_static_xcframework_impl(ctx):
         resolved_plisttool = apple_toolchain_info.resolved_plisttool,
         rule_label = label,
         xcode_config = xcode_config,
-        xcode_path_wrapper = ctx.executable._xcode_path_wrapper,
     )
 
     _create_xcframework_bundle(


### PR DESCRIPTION
No `apple_support.run()` actions make use of `xcode_path_resolve_level`, so
there is no need to collect/propagate the wrapper.

RELEASE_NOTES: None
PiperOrigin-RevId: 445179102

(cherry picked from commit 11075b1bbfaf4481d5cbfb47d009a6aaa8ae450c)