### PR TITLE
Use rolling releases for local development

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,1 @@
+rolling


### PR DESCRIPTION
Since we broke 5.x compat for some cases, this is nicer to use so you
can run tests over everything.