### PR TITLE
Switch tests to use python3

### DIFF
--- a/test/unittest.bash
+++ b/test/unittest.bash
@@ -675,7 +675,7 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
 else
     function timestamp() {
       # OS X and FreeBSD do not have %N so python is the best we can do
-      python -c 'import time; print(int(round(time.time() * 1000)))'
+      python3 -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 


### PR DESCRIPTION
This otherwise files on macOS 12.3 since there is no default `python`