### PR TITLE
Fix the generated modulemaps for apple_static_xcframeworks.

### DIFF
--- a/apple/internal/partials/swift_framework.bzl
+++ b/apple/internal/partials/swift_framework.bzl
@@ -36,6 +36,7 @@ def _swift_framework_partial_impl(
         actions,
         avoid_deps,
         bundle_name,
+        framework_modulemap,
         label_name,
         output_discriminator,
         swift_infos):
@@ -104,6 +105,7 @@ issue with a reproducible error case.
 
         modulemap = swift_info_support.declare_modulemap(
             actions = actions,
+            framework_modulemap = framework_modulemap,
             label_name = label_name,
             output_discriminator = output_discriminator,
             module_name = expected_module_name,
@@ -117,6 +119,7 @@ def swift_framework_partial(
         actions,
         avoid_deps = [],
         bundle_name,
+        framework_modulemap = True,
         label_name,
         output_discriminator = None,
         swift_infos):
@@ -129,6 +132,8 @@ def swift_framework_partial(
         actions: The actions provider from `ctx.actions`.
         avoid_deps: A list of library targets with modules to avoid, if specified.
         bundle_name: The name of the output bundle.
+        framework_modulemap: Boolean to indicate if the generated modulemap should be for a
+            framework instead of a library or a generic module. Defaults to `True`.
         label_name: Name of the target being built.
         output_discriminator: A string to differentiate between different target intermediate files
             or `None`.
@@ -144,6 +149,7 @@ def swift_framework_partial(
         actions = actions,
         avoid_deps = avoid_deps,
         bundle_name = bundle_name,
+        framework_modulemap = framework_modulemap,
         label_name = label_name,
         output_discriminator = output_discriminator,
         swift_infos = swift_infos,

--- a/apple/internal/partials/swift_static_framework.bzl
+++ b/apple/internal/partials/swift_static_framework.bzl
@@ -86,6 +86,7 @@ def _swift_static_framework_partial_impl(
         modulemap = swift_info_support.declare_modulemap(
             actions = actions,
             label_name = label_name,
+            framework_modulemap = True,
             output_discriminator = output_discriminator,
             module_name = expected_module_name,
         )

--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -93,18 +93,34 @@ Please file an issue with a reproducible error case.\
 
     return swift_module
 
-def _modulemap_contents(*, module_name):
-    """Returns the contents for the modulemap file for a Swift framework."""
+def _modulemap_contents(
+        *,
+        framework_modulemap,
+        module_name):
+    """Returns the contents for the modulemap file for a Swift framework.
+
+    Args:
+        framework_modulemap: Boolean to indicate if the generated modulemap should be for a
+            framework instead of a library or a generic module.
+        module_name: The name of the Swift module.
+
+    Returns:
+        A string representing a generated modulemap.
+    """
     return """\
-framework module {module_name} {{
+{module_with_qualifier} {module_name} {{
   header "{module_name}.h"
   requires objc
 }}
-""".format(module_name = module_name)
+""".format(
+        module_with_qualifier = "framework module" if framework_modulemap else "module",
+        module_name = module_name,
+    )
 
 def _declare_modulemap(
         *,
         actions,
+        framework_modulemap,
         label_name,
         module_name,
         output_discriminator):
@@ -112,6 +128,8 @@ def _declare_modulemap(
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        framework_modulemap: Boolean to indicate if the generated modulemap should be for a
+            framework instead of a library or a generic module.
         label_name: Name of the target being built.
         module_name: The name of the Swift module.
         output_discriminator: A string to differentiate between different target intermediate files
@@ -126,7 +144,10 @@ def _declare_modulemap(
         output_discriminator = output_discriminator,
         file_name = "module.modulemap",
     )
-    actions.write(modulemap, _modulemap_contents(module_name = module_name))
+    actions.write(modulemap, _modulemap_contents(
+        framework_modulemap = framework_modulemap,
+        module_name = module_name,
+    ))
     return modulemap
 
 def _declare_generated_header(

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -972,6 +972,7 @@ def _apple_static_xcframework_impl(ctx):
                     actions = actions,
                     avoid_deps = ctx.attr.avoid_deps,
                     bundle_name = bundle_name,
+                    framework_modulemap = False,
                     label_name = label.name,
                     output_discriminator = library_identifier,
                     swift_infos = link_output.swift_infos,
@@ -990,6 +991,7 @@ def _apple_static_xcframework_impl(ctx):
             interface_artifacts = partial.call(partials.framework_header_modulemap_partial(
                 actions = actions,
                 bundle_name = bundle_name,
+                framework_modulemap = False,
                 hdrs = ctx.files.public_hdrs,
                 label_name = label.name,
                 output_discriminator = library_identifier,

--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -93,7 +93,7 @@ def apple_static_xcframework_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcfmwk_with_objc_sdk_dylibs_and_and_sdk_frameworks",
         text_test_file = "$BUNDLE_ROOT/ios-arm64/Headers/module.modulemap",
         text_test_values = [
-            "framework module ios_static_xcfmwk_with_objc_sdk_dylibs_and_and_sdk_frameworks",
+            "module ios_static_xcfmwk_with_objc_sdk_dylibs_and_and_sdk_frameworks",
             "umbrella header \"ios_static_xcfmwk_with_objc_sdk_dylibs_and_and_sdk_frameworks.h\"",
             "link \"c++\"",
             "link \"sqlite3\"",
@@ -229,7 +229,7 @@ def apple_static_xcframework_test_suite(name):
         ],
         text_test_file = "$BUNDLE_ROOT/ios-arm64/Headers/module.modulemap",
         text_test_values = [
-            "framework module ios_static_xcfmwk_with_custom_bundle_name",
+            "module ios_static_xcfmwk_with_custom_bundle_name",
             "header \"ios_static_xcfmwk_with_custom_bundle_name.h\"",
             "requires objc",
         ],


### PR DESCRIPTION
These should lead with "module" instead of "framework module", otherwise they will not be recognized by Xcode.

PiperOrigin-RevId: 447789489
(cherry picked from commit b79745de0abeda0d3e3be58f0c2611bf80b3a5a9)