### PR TITLE
Fix import style in static xcframeworks

### DIFF
--- a/apple/internal/partials/framework_header_modulemap.bzl
+++ b/apple/internal/partials/framework_header_modulemap.bzl
@@ -105,7 +105,7 @@ def _create_modulemap(
     )
     actions.write(output = output, content = content)
 
-def _create_umbrella_header(actions, output, bundle_name, headers):
+def _create_umbrella_header(actions, output, bundle_name, headers, framework_imports):
     """Creates an umbrella header that imports a list of other headers.
 
     Args:
@@ -113,8 +113,12 @@ def _create_umbrella_header(actions, output, bundle_name, headers):
       output: A declared `File` to which the umbrella header will be written.
       bundle_name: The name of the output bundle.
       headers: A list of header files to be imported by the umbrella header.
+      framework_imports: Whether to import with the framework style or directly quoted.
     """
-    import_lines = ["#import <%s/%s>" % (bundle_name, f.basename) for f in headers]
+    if framework_imports:
+        import_lines = ["#import <%s/%s>" % (bundle_name, f.basename) for f in headers]
+    else:
+        import_lines = ['#import "%s"' % f.basename for f in headers]
     content = "\n".join(import_lines) + "\n"
     actions.write(output = output, content = content)
 
@@ -151,6 +155,7 @@ def _framework_header_modulemap_partial_impl(
             umbrella_header_file,
             bundle_name,
             sorted(hdrs),
+            framework_modulemap,
         )
 
         # Don't bundle the umbrella header if there is only one public header

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -660,7 +660,7 @@ swift_library(
 genrule(
     name = "swift_importing_imported_xcfw_bundling_static_fmwks",
     outs = ["swift_importing_imported_xcfw_bundling_static_fmwks.swift"],
-    cmd = "echo 'import ios_xcframework_bundling_static_fmwks' > $@",
+    cmd = "echo 'import ios_static_xcframework' > $@",
     tags = FIXTURE_TAGS,
 )
 

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -418,6 +418,7 @@ genrule(
             file,
         )
         for file in [
+            "Headers/ios_static_xcframework.h",
             "Headers/shared.h",
             "Modules/module.modulemap",
             "ios_xcframework_bundling_static_fmwks",
@@ -456,15 +457,11 @@ do
   framework_dir="$$platform_dir/$$xcframework_name.framework"
   mkdir -p "$$framework_dir"
   mv "$$platform_dir/ios_static_xcframework"*.a "$$framework_dir/$$xcframework_name"
-  mv "$$platform_dir/Headers" "$$framework_dir/"
-
   modules_dir="$$framework_dir/Modules"
   mkdir -p "$$modules_dir"
-  cat > "$$modules_dir/module.modulemap" << EOF
-module ios_xcframework_bundling_static_fmwks {
-  umbrella "Headers"
-}
-EOF
+  mv "$$platform_dir/Headers/module.modulemap" "$$modules_dir/"
+  sed -i "" "s/^module/framework module/g" "$$modules_dir/module.modulemap"
+  mv "$$platform_dir/Headers" "$$framework_dir/"
 done
 """,
 )


### PR DESCRIPTION
Currently the apple_static_xcframework rule produces a xcframework that
contains a static library and headers. The import style that was used
previously doesn't support that case, so they were not consumable via
Xcode, or our import rule. Now in the case that we use a non-framework
modulemap file, we also use quoted headers.