### PR TITLE
Remove RULES_SWIFT_BUILD_DUMMY_WORKER

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,17 +17,6 @@ test --build_tests_only
 # visibility and symbol import issues are resolved.
 build --nocheck_visibility
 
-# Disable the Swift compilation worker when running integration tests, since it
-# requires the protobuf dependency, and because Bazel dependency management is
-# awful/non-existent, we can get away with not declaring protobuf's transitive
-# dependencies. This is very much a hack and leaves rules_apple (and dependents)
-# in a very brittle state, but until Bazel provides a better dependency management
-# solution, this is the path of least resistance to get integration tests working.
-# TODO(b/134144964): Formality to track removing this, but we all know it'll be
-# here forever.
-build --define=RULES_SWIFT_BUILD_DUMMY_WORKER=1
-build --strategy=SwiftCompile=local
-
 # Required to avoid missing coverage runner file errors.
 # GitHub Issue: https://github.com/bazelbuild/rules_apple/issues/1128
 coverage --action_env=LCOV_MERGER=/usr/bin/true


### PR DESCRIPTION
Now that the worker uses json instead of protobuf, this is no longer a
concern.