### PR TITLE
Add compression for xcframework archives

### DIFF
--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -439,6 +439,7 @@ def _create_xcframework_bundle(
         bundle_merge_zips = framework_archive_merge_zips,
         bundle_path = bundle_name + ".xcframework",
         output = output_archive.path,
+        compress = True,
     )
     actions.write(
         output = bundletool_control_file,


### PR DESCRIPTION
Previously all zips created by bundletool would not compress their
contents. For envoy-mobile the uncompressed zip is ~2.3gb where the
compressed zip is ~434mbs. Since this rule is always meant for
distribution, I think compressing their outputs is worth the extra CPU
time.

ios_static_framework gets compression through a different codepath since
it relies on the processor to create the zip instead.