### PR TITLE
Allow no local provisioning profiles

### DIFF
--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -82,8 +82,12 @@ def _local_provisioning_profile(ctx):
     args.add(selected_profile)
     if ctx.attr.team_id:
         args.add("--team_id", ctx.attr.team_id)
-    args.add_all("--local_profiles", ctx.files._local_srcs)
-    args.add_all("--fallback_profiles", ctx.files._fallback_srcs)
+    if ctx.files._local_srcs:
+        args.add_all("--local_profiles", ctx.files._local_srcs)
+    if ctx.files._fallback_srcs:
+        args.add_all("--fallback_profiles", ctx.files._fallback_srcs)
+    if not ctx.files._local_srcs and not ctx.attr._fallback_srcs:
+        fail("Either local or fallback provisioning profiles must exist")
 
     ctx.actions.run(
         executable = ctx.executable._finder,

--- a/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
+++ b/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
@@ -14,13 +14,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--local_profiles",
         nargs="*",
-        required=True,
         help="All local provisioning profiles to search through",
     )
     parser.add_argument(
         "--fallback_profiles",
         nargs="*",
-        required=True,
         help="Fallback provisioning profiles to use if not found locally",
     )
     parser.add_argument(
@@ -81,6 +79,6 @@ if __name__ == "__main__":
         args.name,
         args.team_id,
         args.output,
-        args.local_profiles,
-        args.fallback_profiles,
+        args.local_profiles or [],
+        args.fallback_profiles or [],
     )


### PR DESCRIPTION
On brand new, or CI machines, you might not have local profiles. You
also might not provide fallback profiles if you only want to use this
rule for picking up local profiles. Now both options are supported but
it errors in the case you have neither which is a better error for this
case than if the python script just failed.