### PR TITLE
Split doc tests into separate CI job

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,7 +8,6 @@ x_defaults:
     - "tools/..."
     - "test/..."
     test_targets:
-    - "doc/..."
     - "tools/..."
     - "test/..."
     - "examples/..."
@@ -55,5 +54,12 @@ tasks:
     # has landed on them breaking this project.
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
+
+  doc_tests:
+    name: "Latest Bazel"
+    bazel: latest
+    platform: ubuntu2004
+    test_targets:
+    - "doc/..."
 
 buildifier: latest


### PR DESCRIPTION
This is useful to be able to get a birds eye view of if your changes
failed for docs or for actual breakages