### PR TITLE
Allow for HTML lcov coverage exports via a flag

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -284,3 +284,21 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     exit 1
   fi
 fi
+
+if [[ -n "${COVERAGE_PRODUCE_HTML:-}" ]]; then
+  llvm_cov_html_export_status=0
+  xcrun llvm-cov \
+    show \
+    -format html \
+    -use-color \
+    "${lcov_args[@]}" \
+    @"$COVERAGE_MANIFEST" \
+    > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.html"
+    2> "$error_file" \
+    || llvm_cov_html_export_status=$?
+  if [[ -s "$error_file" || "$llvm_cov_html_export_status" -ne 0 ]]; then
+    echo "error: while exporting html coverage report" >&2
+    cat "$error_file" >&2
+    exit 1
+  fi
+fi

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -287,12 +287,13 @@ fi
 
 if [[ -n "${COVERAGE_PRODUCE_HTML:-}" ]]; then
   llvm_cov_html_export_status=0
+
+  # we couldn't use $COVERAGE_MANIFEST", as it will result an empty html
   xcrun llvm-cov \
     show \
     -format html \
     -use-color \
     "${lcov_args[@]}" \
-    @"$COVERAGE_MANIFEST" \
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.html"
     2> "$error_file" \
     || llvm_cov_html_export_status=$?


### PR DESCRIPTION
extending https://github.com/bazelbuild/rules_apple/pull/1390

Allows HTML coverage results to be created in$TEST_UNDECLARED_OUTPUTS_DIR
when passing --test_env=COVERAGE_PRODUCE_HTML=TRUE