### PR TITLE
Add long format options to (llvm-)objdump commands

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -536,7 +536,7 @@ function print_debug_entitlements() {
   # look like hex), then runs it through `xxd` to turn the hex into ASCII.
   # The results should be the entitlements plist text, which we can compare
   # against.
-  xcrun llvm-objdump -macho -section=__TEXT,__entitlements "$binary" | \
+  xcrun llvm-objdump --macho --section=__TEXT,__entitlements "$binary" | \
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
           -e 'tx' -e 'd' -e ':x' | xxd -r -p
 }
@@ -608,7 +608,7 @@ function assert_objdump_contains() {
   local symbol_regexp="$3"
 
   [[ -f "$path" ]] || fail "$path does not exist"
-  local contents=$(objdump -t -macho -arch="$arch" "$path" | grep -v "*UND*")
+  local contents=$(objdump -t --macho --arch="$arch" "$path" | grep -v "*UND*")
   echo "$contents" | grep -e "$symbol_regexp" >& /dev/null && return 0
   fail "Expected binary '$path' to contain '$symbol_regexp' but it did not." \
       "contents were: $contents"
@@ -624,7 +624,7 @@ function assert_objdump_not_contains() {
   local symbol_regexp="$3"
 
   [[ -f "$path" ]] || fail "$path does not exist"
-  local contents=$(objdump -t -macho -arch="$arch" "$path" | grep -v "*UND*")
+  local contents=$(objdump -t --macho --arch="$arch" "$path" | grep -v "*UND*")
   echo "$contents" | grep -e "$symbol_regexp" >& /dev/null || return 0
   fail "Expected binary '$path' to not contain '$symbol_regexp' but it did."  \
       "contents were: $contents"

--- a/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
@@ -19,7 +19,7 @@ set -eu
 TEMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/codesign_output.XXXXXX")"
 
 if [[ "$BUILD_TYPE" == "simulator" ]]; then
-  xcrun llvm-objdump -macho -section=__TEXT,__entitlements "$BINARY" | \
+  xcrun llvm-objdump --macho --section=__TEXT,__entitlements "$BINARY" | \
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -108,7 +108,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
 
     # Filter out undefined symbols from the objdump mach-o symbol output and
     # return the rightmost value; these binary symbols will not have spaces.
-    IFS=$'\n' actual_symbols=($(objdump -t -macho -arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
+    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_CONTAINS_SYMBOLS[@]}"
       do

--- a/test/starlark_tests/verifier_scripts/binary_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/binary_contents_test.sh
@@ -50,7 +50,7 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
 
     # Filter out undefined symbols from the objdump mach-o symbol output and
     # return the rightmost value; these binary symbols will not have spaces.
-    IFS=$'\n' actual_symbols=($(objdump -t -macho -arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
+    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_CONTAINS_SYMBOLS[@]}"
       do

--- a/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
@@ -19,7 +19,7 @@ set -eu
 TEMP_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/codesign_output.XXXXXX")"
 
 if [[ "$BUILD_TYPE" == "simulator" ]]; then
-  xcrun llvm-objdump -macho -section=__TEXT,__entitlements "$BINARY" | \
+  xcrun llvm-objdump --macho --section=__TEXT,__entitlements "$BINARY" | \
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then

--- a/test/starlark_tests/verifier_scripts/entry_point_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/entry_point_verifier.sh
@@ -42,7 +42,7 @@ while read -r line ; do
     entryoff="${BASH_REMATCH[1]}"
     break
   fi
-done < <(xcrun llvm-objdump -macho --private-headers "$BINARY")
+done < <(xcrun llvm-objdump --macho --private-headers "$BINARY")
 
 # Fail if we didn't get a valid entryoff; something must have gone wrong
 # earlier.

--- a/tools/clangrttool/clangrttool.py
+++ b/tools/clangrttool/clangrttool.py
@@ -106,10 +106,11 @@ class ClangRuntimeTool(object):
     return rpath, libs
 
   def run(self):
-    objdump_output = subprocess.check_output([
-        "xcrun", "llvm-objdump", "-macho", "-private-headers", "-non-verbose",
-        binary_path
-    ],
+    objdump_args = [
+        "xcrun", "llvm-objdump", "--macho", "--private-headers",
+        "--non-verbose", binary_path
+    ]
+    objdump_output = subprocess.check_output(objdump_args,
                                              encoding="utf8",
                                              errors="replace")
     objdump_output = [x.strip() for x in objdump_output.splitlines()]


### PR DESCRIPTION
PiperOrigin-RevId: 453249682
(cherry picked from commit edf54171b11df8aa72ef878678ef09954771ada6)

Fixes https://github.com/bazelbuild/rules_apple/issues/1493