### PR TITLE
Apply the same configuration to `resources` as `deps`

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -298,7 +298,7 @@ bundle.
         },
     )
 
-def _get_common_bundling_attributes(rule_descriptor):
+def _get_common_bundling_attributes(deps_cfg, rule_descriptor):
     """Returns a list of dictionaries with attributes common to all bundling rules."""
 
     # TODO(kaipi): Review platform specific wording in the documentation before migrating macOS
@@ -403,6 +403,7 @@ in the bundle.
         "resources": attr.label_list(
             allow_files = True,
             aspects = [apple_resource_aspect],
+            cfg = deps_cfg,
             doc = """
 A list of resources or files bundled with the bundle. The resources will be stored in the
 appropriate resources location within the bundle.
@@ -1208,7 +1209,10 @@ def _create_apple_bundling_rule(
         [
             _COMMON_ATTRS,
             apple_toolchain_utils.shared_attrs(),
-        ] + _get_common_bundling_attributes(rule_descriptor),
+        ] + _get_common_bundling_attributes(
+            deps_cfg = rule_descriptor.deps_cfg,
+            rule_descriptor = rule_descriptor,
+        ),
     )
 
     if rule_descriptor.requires_deps:


### PR DESCRIPTION
This ensures that resources included via a top-level target's `resources` attribute have the same transition applied to them as those included transitively through `deps`'d `data`.

Before this change, a resource bundle included via `resources` has this path for it's generated plist:

```
applebin_ios-ios_sim_arm64-dbg-ST-dd300a2e2c23/bin/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle/Info.plist
```

and this path when included via a dependency:

```
ios-sim_arm64-min15.0-applebin_ios-ios_sim_arm64-dbg-ST-dd300a2e2c23/bin/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle/Info.plist
```

Now both have the same path.