### PR TITLE
Use `path` instead of `short_path` in `AppleResourceInfo`

### DIFF
--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -330,7 +330,7 @@ def _infoplists(
             output_discriminator = output_discriminator,
             file_name = paths.join(parent_dir, "Info.plist"),
         )
-        processed_origins[out_plist.short_path] = [f.short_path for f in input_files]
+        processed_origins[out_plist.path] = [f.path for f in input_files]
         resource_actions.merge_resource_infoplists(
             actions = actions,
             bundle_id = bundle_id,
@@ -499,7 +499,7 @@ def _plists_and_strings(
             output_discriminator = output_discriminator,
             file_name = paths.join(parent_dir or "", file.basename),
         )
-        processed_origins[plist_file.short_path] = [file.short_path]
+        processed_origins[plist_file.path] = [file.path]
         resource_actions.compile_plist(
             actions = actions,
             input_file = file,
@@ -551,7 +551,7 @@ def _pngs(
             output_discriminator = output_discriminator,
             file_name = png_path,
         )
-        processed_origins[png_file.short_path] = [file.short_path]
+        processed_origins[png_file.path] = [file.path]
         resource_actions.copy_png(
             actions = actions,
             input_file = file,
@@ -716,7 +716,7 @@ def _noop(
     """Registers files to be bundled as is."""
     processed_origins = {}
     for file in files.to_list():
-        processed_origins[file.short_path] = [file.short_path]
+        processed_origins[file.path] = [file.path]
     return struct(
         files = [(processor.location.resource, parent_dir, files)],
         processed_origins = processed_origins,

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -214,13 +214,14 @@ def _bucketize_data(
         allowed_bucket_set = {k: None for k in allowed_buckets}
 
     for resource in resources:
-        # Local cache of the resource short path since it gets used quite a bit below.
+        # Local cache of the resource path since it gets used quite a bit below.
+        resource_path = resource.path
         resource_short_path = resource.short_path
 
         if owner:
-            owners.append((resource_short_path, owner))
+            owners.append((resource_path, owner))
         else:
-            unowned_resources.append(resource_short_path)
+            unowned_resources.append(resource_path)
 
         if types.is_string(parent_dir_param) or parent_dir_param == None:
             parent = parent_dir_param
@@ -349,11 +350,12 @@ def _bucketize_typed_data(*, bucket_type, owner = None, parent_dir_param = None,
     unowned_resources = []
 
     for resource in resources:
+        resource_path = resource.path
         resource_short_path = resource.short_path
         if owner:
-            owners.append((resource_short_path, owner))
+            owners.append((resource_path, owner))
         else:
-            unowned_resources.append(resource_short_path)
+            unowned_resources.append(resource_path)
 
         if types.is_string(parent_dir_param) or parent_dir_param == None:
             parent = parent_dir_param
@@ -499,9 +501,9 @@ def _process_bucketized_data(
             for _, _, processed_files in result.files:
                 for processed_file in processed_files.to_list():
                     if processing_owner:
-                        bucketized_owners.append((processed_file.short_path, processing_owner))
+                        bucketized_owners.append((processed_file.path, processing_owner))
                     else:
-                        unowned_resources.append(processed_file.short_path)
+                        unowned_resources.append(processed_file.path)
 
     return AppleResourceInfo(
         owners = depset(bucketized_owners),


### PR DESCRIPTION
This is mainly to make `AppleResourceInfo.processed_origins` useful outside of the internal `_deduplication` function. With this change, one can use `processed_origins` to find the resource file behind processed files, such as the original Info.plist uses.

This isn't an API change, since the docs never specify if the paths are short or not, but it's s slight breaking change, if for example someone reimplemented `_deduplicate`. As long as we mention it in the release notes, we should be fine.