### PR TITLE
Add testonly to Buttons tests, test runner test libraries

### DIFF
--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -55,6 +55,7 @@ swift_library(
 
 swift_library(
     name = "ButtonsTestsLib",
+    testonly = True,
     srcs = [
         "ButtonsTests/ButtonsTests.swift",
     ],
@@ -66,6 +67,7 @@ swift_library(
 
 swift_library(
     name = "ButtonsUITestsLib",
+    testonly = True,
     srcs = [
         "ButtonsUITests/ButtonsUITests.swift",
     ],

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -213,6 +213,7 @@ ios_ui_test(
 
 swift_library(
     name = "pass_ui_swift_test_lib",
+    testonly = True,
     srcs = ["pass_ui_test.swift"],
 )
 

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -220,6 +220,7 @@ ios_unit_test(
 
 swift_library(
     name = "pass_unit_swift_test_lib",
+    testonly = True,
     srcs = ["pass_unit_test.swift"],
 )
 


### PR DESCRIPTION
Discovered integrating https://github.com/bazelbuild/rules_swift/pull/847, with fixes for https://github.com/bazelbuild/rules_swift/pull/840

Adds `testonly` to Swift libraries that need to link XCTest.