### PR TITLE
Disable macOS kernel extension test

### DIFF
--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -23,7 +23,6 @@ load(":macos_bundle_tests.bzl", "macos_bundle_test_suite")
 load(":macos_command_line_application_tests.bzl", "macos_command_line_application_test_suite")
 load(":macos_dylib_tests.bzl", "macos_dylib_test_suite")
 load(":macos_extension_tests.bzl", "macos_extension_test_suite")
-load(":macos_kernel_extension_tests.bzl", "macos_kernel_extension_test_suite")
 load(":macos_quick_look_plugin_tests.bzl", "macos_quick_look_plugin_test_suite")
 load(":macos_ui_test_tests.bzl", "macos_ui_test_test_suite")
 load(":macos_unit_test_tests.bzl", "macos_unit_test_test_suite")
@@ -93,7 +92,8 @@ macos_dylib_test_suite(name = "macos_dylib")
 
 macos_extension_test_suite(name = "macos_extension")
 
-macos_kernel_extension_test_suite(name = "macos_kernel_extension")
+# TODO: Re-enable once it works on M1s with the public crosstool.
+# macos_kernel_extension_test_suite(name = "macos_kernel_extension")
 
 macos_quick_look_plugin_test_suite(name = "macos_quick_look_plugin")
 


### PR DESCRIPTION
This fails on M1 machines because the linker is getting `-lSystem` from
clang when it shouldn't be. I don't why know it passes on CI. But I
doubt there's much public usage of this so we can punt for now.