### PR TITLE
Add CcInfo to rules that may be inputs to objc_library

### DIFF
--- a/apple/internal/resource_rules/apple_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_resource_bundle.bzl
@@ -27,6 +27,7 @@ def _apple_resource_bundle_impl(_ctx):
     return [
         # TODO(b/122578556): Remove this ObjC provider instance.
         apple_common.new_objc_provider(),
+        CcInfo(),
         AppleResourceBundleInfo(),
     ]
 


### PR DESCRIPTION
We are changing the mandatory provider for objc_library to CcInfo.
The empty CcInfo() is needed in place of
apple_common.new_objc_provider(), which we will remove after the
change is rolled out.

PiperOrigin-RevId: 450465622
(cherry picked from commit e21eb921977fa908618bd2cd9caf009496f01390)