### PR TITLE
Add cpus to apple_verification_test

### DIFF
--- a/test/starlark_tests/apple_universal_binary_tests.bzl
+++ b/test/starlark_tests/apple_universal_binary_tests.bzl
@@ -39,7 +39,7 @@ def apple_universal_binary_test_suite(name):
     binary_contents_test(
         name = "{}_x86_binary_contents_test".format(name),
         build_type = "device",
-        macos_cpus = ["x86_64", "arm64"],
+        cpus = {"macos_cpus": ["x86_64", "arm64"]},
         target_under_test = "//test/starlark_tests/targets_under_test/apple:multi_arch_cc_binary",
         binary_test_file = "$BINARY",
         binary_test_architecture = "x86_64",
@@ -51,7 +51,7 @@ def apple_universal_binary_test_suite(name):
     binary_contents_test(
         name = "{}_arm64_binary_contents_test".format(name),
         build_type = "device",
-        macos_cpus = ["x86_64", "arm64"],
+        cpus = {"macos_cpus": ["x86_64", "arm64"]},
         target_under_test = "//test/starlark_tests/targets_under_test/apple:multi_arch_cc_binary",
         binary_test_file = "$BINARY",
         binary_test_architecture = "arm64",
@@ -67,7 +67,7 @@ def apple_universal_binary_test_suite(name):
     binary_contents_test(
         name = "{}_forced_cpus_x86_binary_contents_test".format(name),
         build_type = "device",
-        macos_cpus = ["arm64"],
+        cpus = {"macos_cpus": ["arm64"]},
         target_under_test = "//test/starlark_tests/targets_under_test/apple:multi_arch_forced_cpus_cc_binary",
         binary_test_file = "$BINARY",
         binary_test_architecture = "x86_64",
@@ -79,7 +79,7 @@ def apple_universal_binary_test_suite(name):
     binary_contents_test(
         name = "{}_forced_cpus_arm64_binary_contents_test".format(name),
         build_type = "device",
-        macos_cpus = ["x86_64"],
+        cpus = {"macos_cpus": ["x86_64"]},
         target_under_test = "//test/starlark_tests/targets_under_test/apple:multi_arch_forced_cpus_cc_binary",
         binary_test_file = "$BINARY",
         binary_test_architecture = "arm64",

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -19,7 +19,7 @@ that may change at any time. Please do not depend on this rule.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
     "apple_product_type",
 )  # buildifier: disable=bzl-visibility
 load(
@@ -39,15 +39,9 @@ load(
 def _apple_verification_transition_impl(settings, attr):
     """Implementation of the apple_verification_transition transition."""
 
-    # This was added because this transition is also used by
-    # `infoplist_contents_test` and has no "macos_cpus" attribute.
-    macos_cpus = "x86_64"
-    if hasattr(attr, "macos_cpus"):
-        macos_cpus = ",".join(attr.macos_cpus)
-
     output_dictionary = {
         "//command_line_option:ios_signing_cert_name": "-",
-        "//command_line_option:macos_cpus": macos_cpus,
+        "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
         "//command_line_option:apple_bitcode": attr.apple_bitcode,
         "//command_line_option:apple_generate_dsym": attr.apple_generate_dsym,
@@ -64,12 +58,19 @@ def _apple_verification_transition_impl(settings, attr):
             "//command_line_option:tvos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
         })
+
+    if hasattr(attr, "cpus"):
+        for cpu_option, cpus in attr.cpus.items():
+            command_line_option = "//command_line_option:%s" % cpu_option
+            output_dictionary.update({command_line_option: ",".join(cpus)})
+
     existing_features = settings.get("//command_line_option:features") or []
     if hasattr(attr, "target_features"):
         existing_features.extend(attr.target_features)
     if hasattr(attr, "sanitizer") and attr.sanitizer != "none":
         existing_features.append(attr.sanitizer)
     output_dictionary["//command_line_option:features"] = existing_features
+
     return output_dictionary
 
 apple_verification_transition = transition(
@@ -231,10 +232,10 @@ https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode
 If true, generates .dSYM debug symbol bundles for the target(s) under test.
 """,
         ),
-        "macos_cpus": attr.string_list(
+        "cpus": attr.string_list_dict(
             doc = """
-List of MacOS CPU's to use for test under target.
-https://docs.bazel.build/versions/main/command-line-reference.html#flag--macos_cpus
+Dictionary of command line options cpu flags (e.g. ios_multi_cpus, macos_cpus) and the list of
+cpu's to use for test under target (e.g. {'ios_multi_cpus': ['arm64', 'x86_64']})
 """,
         ),
         "sanitizer": attr.string(


### PR DESCRIPTION
This is a partial cherry pick from
https://github.com/bazelbuild/rules_apple/pull/1447 which we're delaying
merging temporarily until we only support 6.x