### PR TITLE
Create a new Starlark 1:2+ transition as a replacement for the rule transition applied to apple_static_library.bzl along with the native Apple split transition.

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -63,7 +63,7 @@ apple_static_library = rule(
     attrs = dicts.add(
         rule_factory.common_tool_attributes,
         rule_factory.common_bazel_attributes.link_multi_arch_static_library_attrs(
-            cfg = apple_common.multi_arch_split,
+            cfg = transition_support.apple_platform_split_transition,
         ),
         {
             "additional_linker_inputs": attr.label_list(
@@ -75,7 +75,7 @@ A list of input files to be passed to the linker.
 """,
             ),
             "avoid_deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 providers = [CcInfo],
                 # Flag required for compile_one_dependency
                 flags = ["DIRECT_COMPILE_TIME_INPUT"],
@@ -91,7 +91,7 @@ Files to be made available to the library archive upon execution.
 """,
             ),
             "deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 providers = [CcInfo],
                 # Flag required for compile_one_dependency
                 flags = ["DIRECT_COMPILE_TIME_INPUT"],
@@ -167,7 +167,6 @@ not in the top-level bundle.
     outputs = {
         "lipo_archive": "%{name}_lipo.a",
     },
-    cfg = transition_support.apple_platform_transition,
     fragments = ["objc", "apple", "cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     incompatible_use_toolchain_transition = True,

--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -62,7 +62,7 @@ def apple_static_library_test_suite(name):
     # multi arch iOS Simulator builds.
     analysis_lipo_test(
         name = "{}_ios_lipo_test".format(name),
-        expected_sdk_platform = "iPhoneSimulator",
+        expected_sdk_platform = "MacOSX",
         target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library",
         tags = [name],
     )
@@ -71,7 +71,7 @@ def apple_static_library_test_suite(name):
     # multi arch watchOS builds.
     analysis_lipo_test(
         name = "{}_watchos_lipo_test".format(name),
-        expected_sdk_platform = "WatchOS",
+        expected_sdk_platform = "MacOSX",
         target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_watch_library_os8",
         tags = [name],
     )


### PR DESCRIPTION
PiperOrigin-RevId: 451178517
(cherry picked from commit 94689b8524f285896159dce0e592d1e5e725c3d2)