### PR TITLE
Reference the rules_apple version of apple_static_library instead of the Bazel Starlark builtin version.

### DIFF
--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -2,6 +2,10 @@ load(
     "//apple:apple_binary.bzl",
     "apple_binary",
 )
+load(
+    "//apple:apple_static_library.bzl",
+    "apple_static_library",
+)
 
 # Public only because these are used by the integration tests from generated
 # workspaces. Please no not depend on them as they can change at any time.


### PR DESCRIPTION
PiperOrigin-RevId: 456286553
(cherry picked from commit 5d6e6fd3b8cd877e172d5fae2900bb7c38104d2f)