### PR TITLE
Silence mapc output

### DIFF
--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -369,8 +369,7 @@ def mapc(_, toolargs):
   xcrunargs += toolargs
 
   return_code, _, _ = execute.execute_and_filter_output(
-      xcrunargs,
-      print_output=True)
+      xcrunargs)
   return return_code
 
 


### PR DESCRIPTION
This outputs a ton of info even in successful cases and makes tests very
hard to skim. This still prints in the case it fails.