### PR TITLE
Fix codesign output format in tests

### DIFF
--- a/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
@@ -23,7 +23,7 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign -d --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi

--- a/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
@@ -23,7 +23,7 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign -d --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi


### PR DESCRIPTION
I'm not sure if it's OS version, Xcode version, or M1, but the default
output for this case is no longer xml which is what the tests were
expecting.