### PR TITLE
Remove LCOV_MERGER

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,9 +17,5 @@ test --build_tests_only
 # visibility and symbol import issues are resolved.
 build --nocheck_visibility
 
-# Required to avoid missing coverage runner file errors.
-# GitHub Issue: https://github.com/bazelbuild/rules_apple/issues/1128
-coverage --action_env=LCOV_MERGER=/usr/bin/true
-
 # Use llvm-cov instead of gcov (default).
 coverage --experimental_use_llvm_covmap

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -449,8 +449,6 @@ function do_action() {
       # Explicitly pass these flags to ensure the external testing infrastructure
       # matches the internal one.
       "--incompatible_merge_genfiles_directory"
-      # TODO: Remove this once we can use the late bound coverage attribute
-      "--test_env=LCOV_MERGER=/usr/bin/true"
   )
 
   local bazel_version="$(bazel --version)"


### PR DESCRIPTION
We now set the related attribute instead https://github.com/bazelbuild/rules_apple/pull/1388