### PR TITLE
Add long format options to codesign commands

### DIFF
--- a/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
@@ -23,7 +23,7 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi

--- a/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/app_clip_entitlements_verifier.sh
@@ -23,7 +23,8 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT" || \
+    codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi

--- a/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
@@ -23,7 +23,7 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi

--- a/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/entitlements_verifier.sh
@@ -23,7 +23,8 @@ if [[ "$BUILD_TYPE" == "simulator" ]]; then
       sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
       -e 'tx' -e 'd' -e ':x' | xxd -r -p > "$TEMP_OUTPUT"
 elif [[ "$BUILD_TYPE" == "device" ]]; then
-  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
+  codesign --display --xml --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT" || \
+    codesign -d --entitlements "$TEMP_OUTPUT" "$BUNDLE_ROOT"
 else
   fail "Unsupported BUILD_TYPE = $BUILD_TYPE for this test"
 fi


### PR DESCRIPTION
Currently a few tests are failing due to codesign returning a different
format for displaying entitlements (vs. xml format). Adding both
`--display`, as well as explicit expected format `--xml` fixes this.

PiperOrigin-RevId: 456839673
(cherry picked from commit 473875c6a344fce0f37fede8858da7ed6a28e75f)