### PR TITLE
Decouple framework_includes from CcInfo provider for framework imports

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -288,9 +288,11 @@ def _objc_provider_with_dependencies(
     return apple_common.new_objc_provider(**objc_provider_fields)
 
 def _cc_info_with_dependencies(
+        *,
         ctx,
         name,
         deps,
+        framework_includes,
         grep_includes,
         header_imports,
         additional_cc_infos = [],
@@ -299,6 +301,7 @@ def _cc_info_with_dependencies(
     """Returns a new CcInfo which includes transitive Cc dependencies."""
     all_cc_infos = [dep[CcInfo] for dep in deps] + additional_cc_infos
     dep_compilation_contexts = [cc_info.compilation_context for cc_info in all_cc_infos]
+
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
@@ -306,14 +309,15 @@ def _cc_info_with_dependencies(
         requested_features = ctx.features + ["lang_objc"],  # b/210775356
         unsupported_features = ctx.disabled_features,
     )
+
     (compilation_context, _compilation_outputs) = cc_common.compile(
         name = name,
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
         public_hdrs = header_imports,
-        framework_includes = _framework_search_paths(header_imports) if is_framework else [],
         includes = includes,
+        framework_includes = framework_includes if is_framework else [],
         compilation_contexts = dep_compilation_contexts,
         language = "objc",
         grep_includes = grep_includes,
@@ -599,11 +603,12 @@ def _common_dynamic_framework_import_impl(ctx, is_xcframework):
 
     # Create CcInfo provider.
     cc_info = _cc_info_with_dependencies(
-        ctx,
-        label.name,
-        deps,
-        grep_includes,
-        framework_imports_by_category.header_imports,
+        ctx = ctx,
+        deps = deps,
+        framework_includes = _framework_search_paths(framework_imports_by_category.header_imports),
+        grep_includes = grep_includes,
+        header_imports = framework_imports_by_category.header_imports,
+        name = label.name,
     )
     providers.append(cc_info)
 
@@ -750,14 +755,17 @@ def _common_static_framework_import_impl(ctx, is_xcframework):
     # Create CcInfo provider.
     providers.append(
         _cc_info_with_dependencies(
-            ctx,
-            label.name,
-            deps,
-            grep_includes,
-            framework_imports_by_category.header_imports,
-            additional_cc_infos,
-            includes,
-            is_framework,
+            additional_cc_infos = additional_cc_infos,
+            ctx = ctx,
+            deps = deps,
+            is_framework = is_framework,
+            includes = includes,
+            framework_includes = _framework_search_paths(
+                framework_imports_by_category.header_imports,
+            ) if is_framework else [],
+            header_imports = framework_imports_by_category.header_imports,
+            name = label.name,
+            grep_includes = grep_includes,
         ),
     )
 


### PR DESCRIPTION
This change decouples `framework_includes` field computing out of the
CcInfo provider creation for framework import rules.

PiperOrigin-RevId: 448537279
(cherry picked from commit d63774374f1907d20fd66922df6e5fd3af9f5a20)