### PR TITLE
Remove obsolete Objc provider module map field.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -374,7 +374,6 @@ def _common_dynamic_framework_import_impl(ctx, is_xcframework):
     objc_provider = framework_import_support.objc_provider_with_dependencies(
         additional_objc_providers = transitive_objc_providers,
         dynamic_framework_file = depset([] if ctx.attr.bundle_only else framework_imports_by_category.binary_imports),
-        module_map = framework_imports_by_category.module_map_imports,
     )
     providers.append(objc_provider)
 
@@ -523,7 +522,6 @@ def _common_static_framework_import_impl(ctx, is_xcframework):
             additional_objc_provider_fields = additional_objc_provider_fields,
             additional_objc_providers = additional_objc_providers,
             alwayslink = alwayslink,
-            module_map = framework_imports_by_category.module_map_imports,
             sdk_dylib = sdk_dylibs,
             sdk_framework = sdk_frameworks,
             static_framework_file = static_framework_file,

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -212,7 +212,6 @@ def _objc_provider_with_dependencies(
         additional_objc_providers = [],
         alwayslink = False,
         dynamic_framework_file = None,
-        module_map,
         sdk_dylib = None,
         sdk_framework = None,
         static_framework_file = None,
@@ -225,7 +224,6 @@ def _objc_provider_with_dependencies(
         alwayslink: Boolean to indicate if force_load_library should be set with the static
             framework file.
         dynamic_framework_file: File referencing a framework dynamic library.
-        module_map: File referencing imported framework module map.
         sdk_dylib: List of Apple SDK dylibs to link. Defaults to None.
         sdk_framework: List of Apple SDK frameworks to link. Defaults to None.
         static_framework_file: File referencing a framework static library.
@@ -245,8 +243,6 @@ def _objc_provider_with_dependencies(
         if alwayslink:
             objc_provider_fields["force_load_library"] = depset(static_framework_file)
 
-    if module_map:
-        objc_provider_fields["module_map"] = depset(module_map)
     if sdk_dylib:
         objc_provider_fields["sdk_dylib"] = depset(sdk_dylib)
     if sdk_framework:


### PR DESCRIPTION
PiperOrigin-RevId: 451437302
(cherry picked from commit 5d7d31d739a05bd3fd64b24b7ae56c13cd8453e2)