### PR TITLE
Take upstream apple_dynamic_xcframework_import rule

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -37,6 +37,7 @@ bzl_library(
     deps = [
         "//apple/internal:apple_framework_import",
         "//apple/internal:apple_universal_binary",
+        "//apple/internal:apple_xcframework_import",
         "//apple/internal:xcframework_rules",
     ],
 )

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -21,9 +21,12 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
     _apple_dynamic_framework_import = "apple_dynamic_framework_import",
-    _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
     _apple_static_framework_import = "apple_static_framework_import",
     _apple_static_xcframework_import = "apple_static_xcframework_import",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
+    _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_universal_binary.bzl",

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -99,6 +99,23 @@ bzl_library(
 )
 
 bzl_library(
+    name = "apple_xcframework_import",
+    srcs = ["apple_xcframework_import.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        ":cc_toolchain_info_support",
+        ":framework_import_support",
+        ":rule_factory",
+        "//apple:providers",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
     name = "bundle_package_type",
     srcs = ["bundle_package_type.bzl"],
     visibility = [
@@ -120,6 +137,14 @@ bzl_library(
 bzl_library(
     name = "cc_info_support",
     srcs = ["cc_info_support.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+)
+
+bzl_library(
+    name = "cc_toolchain_info_support",
+    srcs = ["cc_toolchain_info_support.bzl"],
     visibility = [
         "//apple:__subpackages__",
     ],

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -391,6 +391,7 @@ def _common_dynamic_framework_import_impl(ctx, is_xcframework):
         grep_includes = grep_includes,
         header_imports = framework_imports_by_category.header_imports,
         label = label,
+        swiftmodule_imports = framework_imports_by_category.swift_module_imports,
     )
     providers.append(cc_info)
 
@@ -558,6 +559,7 @@ def _common_static_framework_import_impl(ctx, is_xcframework):
             grep_includes = grep_includes,
             header_imports = framework_imports_by_category.header_imports,
             label = label,
+            swiftmodule_imports = framework_imports_by_category.swift_module_imports,
         ),
     )
 

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -1,0 +1,345 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of XCFramework import rules."""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
+    "cc_toolchain_info_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "framework_import_support",
+)
+load("@build_bazel_rules_apple//apple/internal:rule_factory.bzl", "rule_factory")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_clang_module_aspect")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+
+# Currently, XCFramework bundles can contain Apple frameworks or libraries.
+# This defines an _enum_ to identify an imported XCFramework bundle type.
+_BUNDLE_TYPE = struct(frameworks = 1, libraries = 2)
+
+def _classify_xcframework_imports(xcframework_imports):
+    """Classifies XCFramework files for later processing.
+
+    Args:
+        xcframework_imports: List of File for an imported Apple XCFramework.
+    Returns:
+        A struct containing xcframework import files information:
+            - bundle_name: The XCFramework bundle name infered by filepaths.
+            - bundle_type: The XCFramework bundle type (frameworks or libraries).
+            - files: The XCFramework import files.
+            - files_by_category: Classified XCFramework import files.
+            - info_plist: The XCFramework bundle Info.plist file.
+    """
+    info_plist = None
+    bundle_name = None
+
+    framework_files = []
+    xcframework_files = []
+    for file in xcframework_imports:
+        parent_dir_name = paths.basename(file.dirname)
+        is_bundle_root_file = parent_dir_name.endswith(".xcframework")
+
+        if not info_plist and is_bundle_root_file and file.basename == "Info.plist":
+            bundle_name, _ = paths.split_extension(parent_dir_name)
+            info_plist = file
+            continue
+
+        if ".framework/" in file.short_path:
+            framework_files.append(file)
+        else:
+            xcframework_files.append(file)
+
+    if not info_plist:
+        fail("XCFramework import files doesn't include an Info.plist file")
+    if not bundle_name:
+        fail("Could not infer XCFramework bundle name from Info.plist file path")
+
+    if framework_files:
+        files = framework_files
+        bundle_type = _BUNDLE_TYPE.frameworks
+        files_by_category = framework_import_support.classify_framework_imports(files)
+    else:
+        files = xcframework_files
+        bundle_type = _BUNDLE_TYPE.libraries
+        files_by_category = framework_import_support.classify_file_imports(files)
+
+    return struct(
+        bundle_name = bundle_name,
+        bundle_type = bundle_type,
+        files = files,
+        files_by_category = files_by_category,
+        info_plist = info_plist,
+    )
+
+def _get_xcframework_library(*, target_triplet, xcframework):
+    """Returns a processed XCFramework library for a given platform.
+
+    Imported XCFramework files are processed through files path parsing, infering the effective
+    XCFramework library to use based on target platform, and architecture being built matching
+    XCFramework library identifiers.
+
+    Args:
+        target_triplet: Struct referring a Clang target triplet.
+        xcframework: Struct containing imported XCFramework details.
+
+    Returns:
+        A struct containing processed XCFramework files:
+            binary: File referencing the XCFramework library binary.
+            framework_dirs: List of strings referencing framework (.framework) directories.
+            framework_files: List of File referencing all XCFramework framework files.
+            framework_imports: List of File referencing XCFramework library files to be bundled
+                by a top-level target (ios_application) consuming the target being built.
+            framework_includes: List of strings referencing parent directories for framework
+                bundles.
+            headers: List of File referencing XCFramework library header files. This can be either
+                a single tree artifact or a list of regular artifacts.
+            module_maps: List of File referencing XCFramework library module map files. This can
+                be either a single tree artifact or a list of regular artifacts.
+            swift_module_map: File referencing the XCFramework library modulemap file.
+    """
+
+    xcframework_library = _get_xcframework_library_from_paths(
+        target_triplet = target_triplet,
+        xcframework = xcframework,
+    )
+
+    if not xcframework_library:
+        fail(
+            "Could not infer XCFramework library for the following target triplet:",
+            "\n\t- platform: %s" % target_triplet.os,
+            "\n\t- architecture: %s" % target_triplet.architecture,
+            "\n\t- environment: %s" % target_triplet.environment,
+        )
+
+    return xcframework_library
+
+def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
+    """Infer XCFramework library for the target platform, architecture based on paths.
+
+    Args:
+        target_triplet: Struct referring a Clang target triplet.
+        xcframework: Struct containing imported XCFramework details.
+    Returns:
+        A struct containing processed XCFramework files. See _get_xcframework_library.
+    """
+    library_identifier = _get_library_identifier(
+        binary_imports = xcframework.files_by_category.binary_imports,
+        bundle_type = xcframework.bundle_type,
+        target_architecture = target_triplet.architecture,
+        target_environment = target_triplet.environment,
+        target_platform = target_triplet.os,
+    )
+
+    if not library_identifier:
+        return None
+
+    files = xcframework.files_by_category
+    binaries = [f for f in files.binary_imports if library_identifier in f.short_path]
+    framework_imports = [f for f in files.bundling_imports if library_identifier in f.short_path]
+    headers = [f for f in files.header_imports if library_identifier in f.short_path]
+    module_maps = [f for f in files.module_map_imports if library_identifier in f.short_path]
+    swiftmodules = [
+        f
+        for f in files.swift_module_imports
+        if library_identifier in f.short_path and
+           f.basename.startswith(target_triplet.architecture)
+    ]
+
+    framework_dirs = [f.dirname for f in binaries]
+    framework_includes = [paths.dirname(f) for f in framework_dirs]
+    framework_files = [f for f in xcframework.files if library_identifier in f.short_path]
+
+    return struct(
+        binary = binaries[0],
+        framework_dirs = framework_dirs,
+        framework_files = framework_files,
+        framework_imports = framework_imports,
+        framework_includes = framework_includes,
+        headers = headers,
+        module_maps = module_maps,
+        swift_module_map = module_maps[0] if module_maps else None,
+        swiftmodule = swiftmodules,
+    )
+
+def _get_library_identifier(
+        *,
+        binary_imports,
+        bundle_type,
+        target_architecture,
+        target_environment,
+        target_platform):
+    """Returns an XCFramework library identifier for a given target triplet based on import files.
+
+    Args:
+        binary_imports: List of files referencing XCFramework binaries.
+        bundle_type: The XCFramework bundle type (frameworks or libraries).
+        target_architecture: The target Apple architecture for the target being built (e.g. x86_64,
+            arm64).
+        target_environment: The target Apple environment for the target being built (e.g. simulator,
+            device).
+        target_platform: The target Apple platform for the target being built (e.g. macos, ios).
+    Returns:
+        A string for a XCFramework library identifier.
+    """
+    if bundle_type == _BUNDLE_TYPE.frameworks:
+        library_identifiers = [paths.basename(paths.dirname(f.dirname)) for f in binary_imports]
+    elif bundle_type == _BUNDLE_TYPE.libraries:
+        library_identifiers = [paths.basename(f.dirname) for f in binary_imports]
+    else:
+        fail("Unrecognized XCFramework bundle type: %s" % bundle_type)
+
+    for library_identifier in library_identifiers:
+        platform, _, architectures_environment = library_identifier.partition("-")
+        if platform != target_platform:
+            continue
+
+        if target_architecture not in architectures_environment:
+            continue
+
+        if target_environment == "simulator" and not library_identifier.endswith("-simulator"):
+            continue
+
+        return library_identifier
+
+    return None
+
+def _apple_dynamic_xcframework_import_impl(ctx):
+    """Implementation for the apple_dynamic_framework_import rule."""
+    actions = ctx.actions
+    cc_toolchain = find_cpp_toolchain(ctx)
+    deps = ctx.attr.deps
+    disabled_features = ctx.disabled_features
+    features = ctx.features
+    grep_includes = ctx.file._grep_includes
+    label = ctx.label
+    xcframework_imports = ctx.files.xcframework_imports
+
+    xcframework = _classify_xcframework_imports(xcframework_imports)
+    target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
+
+    if xcframework.bundle_type == _BUNDLE_TYPE.libraries:
+        fail("Importing XCFrameworks with dynamic libraries is not supported.")
+
+    xcframework_library = _get_xcframework_library(
+        target_triplet = target_triplet,
+        xcframework = xcframework,
+    )
+
+    providers = []
+
+    # Create AppleFrameworkImportInfo provider
+    apple_framework_import_info = framework_import_support.framework_import_info_with_dependencies(
+        build_archs = [target_triplet.architecture],
+        deps = deps,
+        framework_imports = [xcframework_library.binary] +
+                            xcframework_library.framework_imports,
+    )
+    providers.append(apple_framework_import_info)
+
+    # Create Objc provider
+    objc_provider = framework_import_support.objc_provider_with_dependencies(
+        additional_objc_providers = [
+            dep[apple_common.Objc]
+            for dep in deps
+            if apple_common.Objc in dep
+        ],
+        dynamic_framework_file = depset([xcframework_library.binary]),
+    )
+    providers.append(objc_provider)
+
+    # Create CcInfo provider
+    cc_info = framework_import_support.cc_info_with_dependencies(
+        actions = actions,
+        cc_toolchain = cc_toolchain,
+        ctx = ctx,
+        deps = deps,
+        disabled_features = disabled_features,
+        features = features,
+        framework_includes = xcframework_library.framework_includes,
+        grep_includes = grep_includes,
+        header_imports = xcframework_library.headers,
+        label = label,
+        swiftmodule_imports = xcframework_library.swiftmodule,
+    )
+    providers.append(cc_info)
+
+    # Create AppleDynamicFrameworkInfo provider
+    apple_dynamic_framework_info = apple_common.new_dynamic_framework_provider(
+        objc = objc_provider,
+        framework_dirs = depset(xcframework_library.framework_dirs),
+        framework_files = depset(xcframework_library.framework_files),
+    )
+    providers.append(apple_dynamic_framework_info)
+
+    # Create _SwiftInteropInfo provider if applicable
+    swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+        deps = deps,
+        module_name = xcframework.bundle_name,
+        module_map_imports = [xcframework_library.swift_module_map],
+    )
+    if swift_interop_info:
+        providers.append(swift_interop_info)
+
+    return providers
+
+apple_dynamic_xcframework_import = rule(
+    doc = """
+This rule encapsulates an already-built XCFramework. Defined by a list of files in a .xcframework
+directory. apple_xcframework_import targets need to be added as dependencies to library targets
+through the `deps` attribute.
+""",
+    implementation = _apple_dynamic_xcframework_import_impl,
+    attrs = dicts.add(
+        rule_factory.common_tool_attributes,
+        {
+            "xcframework_imports": attr.label_list(
+                allow_empty = False,
+                allow_files = True,
+                mandatory = True,
+                doc = """
+List of files under a .xcframework directory which are provided to Apple based targets that depend
+on this target.
+""",
+            ),
+            "deps": attr.label_list(
+                doc = """
+List of targets that are dependencies of the target being built, which will provide headers and be
+linked into that target.
+""",
+                providers = [
+                    [apple_common.Objc, CcInfo],
+                    [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
+                ],
+                aspects = [swift_clang_module_aspect],
+            ),
+            "_cc_toolchain": attr.label(
+                default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+                doc = "The C++ toolchain to use.",
+            ),
+        },
+    ),
+    fragments = ["cpp"],
+    provides = [
+        AppleFrameworkImportInfo,
+        CcInfo,
+        apple_common.AppleDynamicFramework,
+        apple_common.Objc,
+    ],
+    toolchains = use_cpp_toolchain(),
+)

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -353,6 +353,11 @@ Avoid linking the dynamic framework, but still include it in the app. This is us
 to manually dlopen the framework at runtime.
 """,
             ),
+            "library_identifiers": attr.string_dict(
+                doc = """
+Unnecssary and ignored, will be removed in the future.
+""",
+            ),
             "_cc_toolchain": attr.label(
                 default = "@bazel_tools//tools/cpp:current_cc_toolchain",
                 doc = "The C++ toolchain to use.",

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -304,6 +304,23 @@ apple_dynamic_xcframework_import = rule(
 This rule encapsulates an already-built XCFramework. Defined by a list of files in a .xcframework
 directory. apple_xcframework_import targets need to be added as dependencies to library targets
 through the `deps` attribute.
+
+### Example
+
+```bzl
+apple_dynamic_xcframework_import(
+    name = "my_dynamic_xcframework",
+    xcframework_imports = glob(["my_dynamic_framework.xcframework/**"]),
+)
+
+objc_library(
+    name = "foo_lib",
+    ...,
+    deps = [
+        ":my_dynamic_xcframework",
+    ],
+)
+```
 """,
     implementation = _apple_dynamic_xcframework_import_impl,
     attrs = dicts.add(

--- a/apple/internal/cc_toolchain_info_support.bzl
+++ b/apple/internal/cc_toolchain_info_support.bzl
@@ -1,0 +1,63 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support methods for handling CcToolchainInfo providers."""
+
+def _get_apple_clang_triplet(cc_toolchain):
+    """Parses and performs normalization on Clang target triplet string reference.
+
+    The C++ ToolchainInfo provider `target_gnu_system_name` field references an LLVM target triple.
+    This support method parses this target triplet and normalizes information for Apple targets.
+
+    See: https://clang.llvm.org/docs/CrossCompilation.html#target-triple
+
+    Args:
+        cc_toolchain: CcToolchainInfo provider.
+    Returns:
+        A normalized Clang target triplet struct for Apple targets.
+    """
+    components = cc_toolchain.target_gnu_system_name.split("-")
+    raw_triplet = struct(
+        architecture = components[0],
+        vendor = components[1],
+        os = components[2],
+        environment = components[3] if len(components) > 3 else None,
+    )
+
+    if raw_triplet.vendor != "apple":
+        return raw_triplet
+
+    environment = "device" if (raw_triplet.environment == None) else "simulator"
+
+    # strip version from Apple platforms
+    os = raw_triplet.os
+    for index in range(len(raw_triplet.os)):
+        if raw_triplet.os[index].isdigit():
+            os = raw_triplet.os[:index]
+            break
+
+    # normalize MacOS names
+    if os in ("macos", "macosx", "darwin"):
+        os = "macos"
+
+    return struct(
+        architecture = raw_triplet.architecture,
+        vendor = raw_triplet.vendor,
+        os = os,
+        environment = environment,
+    )
+
+cc_toolchain_info_support = struct(
+    get_apple_clang_triplet = _get_apple_clang_triplet,
+)

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -36,6 +36,7 @@ def _cc_info_with_dependencies(
         grep_includes,
         header_imports,
         label,
+        swiftmodule_imports,
         includes = [],
         is_framework = True):
     """Returns a new CcInfo which includes transitive Cc dependencies.
@@ -52,6 +53,8 @@ def _cc_info_with_dependencies(
         grep_includes: File reference to grep_includes binary required by cc_common APIs.
         header_imports: List of imported header files.
         label: Label of the target being built.
+        swiftmodule_imports: List of imported Swift module files to include during build phase,
+            but aren't processed in any way.
         includes: List of include search paths.
         is_framework: Whether the target is a framework vs library.
     Returns:
@@ -67,12 +70,15 @@ def _cc_info_with_dependencies(
         unsupported_features = disabled_features,
     )
 
+    public_hdrs = []
+    public_hdrs.extend(header_imports)
+    public_hdrs.extend(swiftmodule_imports)
     (compilation_context, _compilation_outputs) = cc_common.compile(
         name = label.name,
         actions = actions,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
-        public_hdrs = header_imports,
+        public_hdrs = public_hdrs,
         includes = includes,
         framework_includes = framework_includes if is_framework else [],
         compilation_contexts = dep_compilation_contexts,
@@ -90,37 +96,27 @@ def _cc_info_with_dependencies(
         linking_context = linking_context,
     )
 
-def _classify_framework_imports(config_vars, framework_imports):
-    """Classify a list of framework files.
+def _classify_file_imports(config_vars, import_files):
+    """Classifies a list of imported files based on extension, and paths.
+
+    This support method is used to classify import files for Apple frameworks and XCFrameworks.
+    Any file that does not match any known extension will be added to an unknown_imports bucket.
 
     Args:
-        config_vars: A dictionary (String to String) of configuration variables. Can be from ctx.var.
-        framework_imports: List of File for an imported Apple framework.
+        config_vars: A dictionary of configuration variables from ctx.var.
+        import_files: List of File to classify.
     Returns:
-        A struct containing classified framework import files by categories:
-            - bundle_name: The framework bundle name infered by filepaths.
-            - binary_imports: Apple framework binary imports.
-            - bundling_imports: Apple framework bundle imports.
-            - header_imports: Apple framework header imports.
-            - module_map_imports: Apple framework modulemap imports.
-            - swift_module_imports: Apple framework swiftmodule imports.
+        A struct containing classified import files by categories:
+            - header_imports: Objective-C(++) header imports.
+            - module_map_imports: Clang modulemap imports.
+            - swift_module_imports: Swift module imports.
+            - unknown_imports: Unclassified imports.
     """
-    bundle_name = None
-    binary_imports = []
-    bundling_imports = []
+    unknown_imports = []
     header_imports = []
     module_map_imports = []
     swift_module_imports = []
-    for file in framework_imports:
-        # Directory matching
-        parent_dir_name = paths.basename(file.dirname)
-        is_bundle_root_file = parent_dir_name.endswith(".framework")
-        if is_bundle_root_file:
-            bundle_name, _ = paths.split_extension(parent_dir_name)
-            if file.basename == bundle_name:
-                binary_imports.append(file)
-                continue
-
+    for file in import_files:
         # Extension matching
         file_extension = file.extension
         if file_extension == "h":
@@ -144,10 +140,6 @@ def _classify_framework_imports(config_vars, framework_imports):
             module_map_imports.append(file)
             continue
         if file_extension in ["swiftmodule", "swiftinterface"]:
-            # Add Swift's module files to header_imports so
-            # that they are correctly included in the build
-            # by Bazel but they aren't processed in any way
-            header_imports.append(file)
             swift_module_imports.append(file)
             continue
         if file_extension in ["swiftdoc", "swiftsourceinfo"]:
@@ -155,20 +147,64 @@ def _classify_framework_imports(config_vars, framework_imports):
             continue
 
         # Path matching
-        if "Headers" in file.short_path:
+        if "Headers/" in file.short_path:
             header_imports.append(file)
             continue
 
-        # Unknown file type, sending tu bundling (i.e. resources)
+        # Unknown file type, sending to unknown (i.e. resources, Info.plist, etc.)
+        unknown_imports.append(file)
+
+    return struct(
+        header_imports = header_imports,
+        module_map_imports = module_map_imports,
+        swift_module_imports = swift_module_imports,
+        unknown_imports = unknown_imports,
+    )
+
+def _classify_framework_imports(config_vars, framework_imports):
+    """Classify a list of files referencing an Apple framework.
+
+    Args:
+        config_vars: A dictionary (String to String) of configuration variables. Can be from ctx.var.
+        framework_imports: List of File for an imported Apple framework.
+    Returns:
+        A struct containing classified framework import files by categories:
+            - bundle_name: The framework bundle name infered by filepaths.
+            - binary_imports: Apple framework binary imports.
+            - bundling_imports: Apple framework bundle imports.
+            - header_imports: Apple framework header imports.
+            - module_map_imports: Apple framework modulemap imports.
+            - swift_module_imports: Apple framework swiftmodule imports.
+    """
+    framework_imports_by_category = _classify_file_imports(config_vars, framework_imports)
+
+    bundle_name = None
+    bundling_imports = []
+    binary_imports = []
+    for file in framework_imports_by_category.unknown_imports:
+        # Infer framework bundle name and binary
+        parent_dir_name = paths.basename(file.dirname)
+        is_bundle_root_file = parent_dir_name.endswith(".framework")
+        if is_bundle_root_file:
+            bundle_name, _ = paths.split_extension(parent_dir_name)
+            if file.basename == bundle_name:
+                binary_imports.append(file)
+                continue
+
         bundling_imports.append(file)
+
+    if not bundle_name:
+        fail("Could not infer Apple framework name from unclassified framework import files.")
+    if not binary_imports:
+        fail("Could not find Apple framework binary from framework import files.")
 
     return struct(
         bundle_name = bundle_name,
         binary_imports = binary_imports,
         bundling_imports = bundling_imports,
-        header_imports = header_imports,
-        module_map_imports = module_map_imports,
-        swift_module_imports = swift_module_imports,
+        header_imports = framework_imports_by_category.header_imports,
+        module_map_imports = framework_imports_by_category.module_map_imports,
+        swift_module_imports = framework_imports_by_category.swift_module_imports,
     )
 
 def _framework_import_info_with_dependencies(
@@ -269,6 +305,7 @@ def _swift_interop_info_with_dependencies(deps, module_name, module_map_imports)
 
 framework_import_support = struct(
     cc_info_with_dependencies = _cc_info_with_dependencies,
+    classify_file_imports = _classify_file_imports,
     classify_framework_imports = _classify_framework_imports,
     framework_import_info_with_dependencies = _framework_import_info_with_dependencies,
     objc_provider_with_dependencies = _objc_provider_with_dependencies,

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -140,6 +140,10 @@ def _classify_file_imports(config_vars, import_files):
             module_map_imports.append(file)
             continue
         if file_extension in ["swiftmodule", "swiftinterface"]:
+            # Add Swift's module files to header_imports so
+            # that they are correctly included in the build
+            # by Bazel but they aren't processed in any way
+            header_imports.append(file)
             swift_module_imports.append(file)
             continue
         if file_extension in ["swiftdoc", "swiftsourceinfo"]:
@@ -193,10 +197,11 @@ def _classify_framework_imports(config_vars, framework_imports):
 
         bundling_imports.append(file)
 
-    if not bundle_name:
-        fail("Could not infer Apple framework name from unclassified framework import files.")
-    if not binary_imports:
-        fail("Could not find Apple framework binary from framework import files.")
+    # TODO: Enable these checks once static library support works with them
+    # if not bundle_name:
+    #     fail("Could not infer Apple framework name from unclassified framework import files.")
+    # if not binary_imports:
+    #     fail("Could not find Apple framework binary from framework import files.")
 
     return struct(
         bundle_name = bundle_name,
@@ -211,8 +216,8 @@ def _framework_import_info_with_dependencies(
         *,
         build_archs,
         deps,
-        debug_info_binaries,
-        dsyms,
+        debug_info_binaries = [],
+        dsyms = [],
         framework_imports = []):
     """Returns AppleFrameworkImportInfo containing transitive framework imports and build archs.
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -49,7 +49,7 @@ objc_library(
 ## apple_dynamic_xcframework_import
 
 <pre>
-apple_dynamic_xcframework_import(<a href="#apple_dynamic_xcframework_import-name">name</a>, <a href="#apple_dynamic_xcframework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_xcframework_import-deps">deps</a>, <a href="#apple_dynamic_xcframework_import-xcframework_imports">xcframework_imports</a>)
+apple_dynamic_xcframework_import(<a href="#apple_dynamic_xcframework_import-name">name</a>, <a href="#apple_dynamic_xcframework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_xcframework_import-deps">deps</a>, <a href="#apple_dynamic_xcframework_import-library_identifiers">library_identifiers</a>, <a href="#apple_dynamic_xcframework_import-xcframework_imports">xcframework_imports</a>)
 </pre>
 
 
@@ -83,6 +83,7 @@ objc_library(
 | <a id="apple_dynamic_xcframework_import-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="apple_dynamic_xcframework_import-bundle_only"></a>bundle_only |  Avoid linking the dynamic framework, but still include it in the app. This is useful when you want to manually dlopen the framework at runtime.   | Boolean | optional | False |
 | <a id="apple_dynamic_xcframework_import-deps"></a>deps |  List of targets that are dependencies of the target being built, which will provide headers and be linked into that target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="apple_dynamic_xcframework_import-library_identifiers"></a>library_identifiers |  Unnecssary and ignored, will be removed in the future.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="apple_dynamic_xcframework_import-xcframework_imports"></a>xcframework_imports |  List of files under a .xcframework directory which are provided to Apple based targets that depend on this target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -49,18 +49,17 @@ objc_library(
 ## apple_dynamic_xcframework_import
 
 <pre>
-apple_dynamic_xcframework_import(<a href="#apple_dynamic_xcframework_import-name">name</a>, <a href="#apple_dynamic_xcframework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_xcframework_import-deps">deps</a>, <a href="#apple_dynamic_xcframework_import-library_identifiers">library_identifiers</a>, <a href="#apple_dynamic_xcframework_import-xcframework_imports">xcframework_imports</a>)
+apple_dynamic_xcframework_import(<a href="#apple_dynamic_xcframework_import-name">name</a>, <a href="#apple_dynamic_xcframework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_xcframework_import-deps">deps</a>, <a href="#apple_dynamic_xcframework_import-xcframework_imports">xcframework_imports</a>)
 </pre>
 
 
-This rule encapsulates an already-built dynamic XCFramework. It is defined by a
-list of files in exactly one `.xcframework` directory.
-`apple_dynamic_xcframework_import` targets need to be added to library targets
+This rule encapsulates an already-built XCFramework. Defined by a list of files in a .xcframework
+directory. apple_xcframework_import targets need to be added as dependencies to library targets
 through the `deps` attribute.
 
-### Examples
+### Example
 
-```starlark
+```bzl
 apple_dynamic_xcframework_import(
     name = "my_dynamic_xcframework",
     xcframework_imports = glob(["my_dynamic_framework.xcframework/**"]),
@@ -82,10 +81,9 @@ objc_library(
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="apple_dynamic_xcframework_import-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="apple_dynamic_xcframework_import-bundle_only"></a>bundle_only |  Avoid linking the dynamic XCFramework, but still include it in the app. This is useful when you want to manually dlopen the XCFramework at runtime.   | Boolean | optional | False |
-| <a id="apple_dynamic_xcframework_import-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will provide headers (if the importing XCFramework is a dynamic framework) and can be linked into that target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="apple_dynamic_xcframework_import-library_identifiers"></a>library_identifiers |  An optional key-value map of platforms to the corresponding platform IDs (containing all supported architectures), relative to the XCFramework. The identifier keys should be case-insensitive variants of the values in [<code>apple_common.platform</code>](https://docs.bazel.build/versions/5.0.0/skylark/lib/apple_common.html#platform); for example, <code>ios_device</code> or <code>ios_simulator</code>. The identifier values should be case-sensitive variants of values that might be found in the <code>LibraryIdentifier</code> of an <code>Info.plist</code> file in the XCFramework's root; for example, <code>ios-arm64_i386_x86_64-simulator</code> or <code>ios-arm64_armv7</code>.<br><br>Passing this attribute should not be neccessary if the XCFramework follows the standard naming convention (that is, it was created by Xcode or Bazel).   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
-| <a id="apple_dynamic_xcframework_import-xcframework_imports"></a>xcframework_imports |  The list of files under a .xcframework directory which are provided to Apple based targets that depend on this target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="apple_dynamic_xcframework_import-bundle_only"></a>bundle_only |  Avoid linking the dynamic framework, but still include it in the app. This is useful when you want to manually dlopen the framework at runtime.   | Boolean | optional | False |
+| <a id="apple_dynamic_xcframework_import-deps"></a>deps |  List of targets that are dependencies of the target being built, which will provide headers and be linked into that target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
+| <a id="apple_dynamic_xcframework_import-xcframework_imports"></a>xcframework_imports |  List of files under a .xcframework directory which are provided to Apple based targets that depend on this target.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
 <a id="apple_static_framework_import"></a>

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -1,15 +1,16 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":apple_bundle_version_tests.bzl", "apple_bundle_version_test_suite")
 load(":apple_core_data_model_tests.bzl", "apple_core_data_model_test_suite")
+load(":apple_dynamic_xcframework_import_tests.bzl", "apple_dynamic_xcframework_import_test_suite")
 load(":apple_static_library_tests.bzl", "apple_static_library_test_suite")
 load(":apple_static_xcframework_tests.bzl", "apple_static_xcframework_test_suite")
 load(":apple_universal_binary_tests.bzl", "apple_universal_binary_test_suite")
 load(":apple_xcframework_import_tests.bzl", "apple_xcframework_import_test_suite")
 load(":apple_xcframework_tests.bzl", "apple_xcframework_test_suite")
 load(":dtrace_compile_tests.bzl", "dtrace_compile_test_suite")
+load(":ios_app_clip_tests.bzl", "ios_app_clip_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
-load(":ios_app_clip_tests.bzl", "ios_app_clip_test_suite")
 load(":ios_extension_tests.bzl", "ios_extension_test_suite")
 load(":ios_framework_tests.bzl", "ios_framework_test_suite")
 load(":ios_dynamic_framework_tests.bzl", "ios_dynamic_framework_test_suite")
@@ -48,6 +49,8 @@ licenses(["notice"])
 apple_bundle_version_test_suite(name = "apple_bundle_version")
 
 apple_core_data_model_test_suite(name = "apple_core_data_model")
+
+apple_dynamic_xcframework_import_test_suite(name = "apple_dynamic_xcframework_import")
 
 apple_static_library_test_suite(name = "apple_static_library")
 

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -1,0 +1,157 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""apple_dynamic_xcframework_import Starlark tests."""
+
+load(":rules/analysis_failure_message_test.bzl", "analysis_failure_message_test")
+load(":rules/apple_verification_test.bzl", "apple_verification_test")
+load(":rules/common_verification_tests.bzl", "archive_contents_test", "binary_contents_test")
+
+def apple_dynamic_xcframework_import_test_suite(name):
+    """Test suite for apple_dynamic_xcframework_import.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    # Verify ios_application bundles Framework files from imported XCFramework.
+    archive_contents_test(
+        name = "{}_contains_imported_xcframework_framework_files".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Modules/",
+        ],
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = [
+            "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
+        ],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_swift_contains_imported_xcframework_framework_files".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_with_imported_objc_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+            "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Modules/",
+        ],
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = [
+            "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
+        ],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_contains_imported_swift_xcframework_framework_files".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_swift_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Modules/",
+        ],
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = [
+            "name @rpath/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader (offset 24)",
+        ],
+        tags = [name],
+    )
+
+    # Verify the correct XCFramework library was bundled and sliced for the required architecture.
+    binary_contents_test(
+        name = "{}_xcframework_binary_file_info_test_x86_64".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_contains_file_info = ["Mach-O 64-bit dynamically linked shared library x86_64"],
+        tags = [name],
+    )
+    binary_contents_test(
+        name = "{}_xcframework_binary_file_info_test_arm64".format(name),
+        build_type = "simulator",
+        cpus = {"ios_multi_cpus": ["sim_arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_contains_file_info = ["Mach-O 64-bit dynamically linked shared library arm64"],
+        tags = [name],
+    )
+    binary_contents_test(
+        name = "{}_xcframework_binary_file_info_test_fat".format(name),
+        build_type = "simulator",
+        cpus = {
+            "ios_multi_cpus": [
+                "sim_arm64",
+                "x86_64",
+            ],
+        },
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_contains_file_info = [
+            "Mach-O universal binary with 2 architectures: " +
+            "[x86_64:Mach-O 64-bit dynamically linked shared library x86_64] " +
+            "[arm64:Mach-O 64-bit dynamically linked shared library arm64]",
+        ],
+        tags = [name],
+    )
+    binary_contents_test(
+        name = "{}_xcframework_swift_binary_file_info_test_fat".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_swift_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        binary_contains_file_info = ["Mach-O 64-bit dynamically linked shared library x86_64"],
+        tags = [name],
+    )
+
+    # Verify bundled frameworks from imported XCFrameworks are codesigned.
+    apple_verification_test(
+        name = "{}_imported_xcframework_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+    apple_verification_test(
+        name = "{}_imported_swift_xcframework_codesign_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    # Verify importing XCFramework with dynamic libraries (i.e. not Apple frameworks) fails.
+    analysis_failure_message_test(
+        name = "{}_fails_importing_xcframework_with_libraries_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_imported_xcframework_with_libraries",
+        expected_error = "Importing XCFrameworks with dynamic libraries is not supported.",
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -112,9 +112,9 @@ def apple_dynamic_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
         binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
         binary_contains_file_info = [
-            "Mach-O universal binary with 2 architectures: " +
-            "[x86_64:Mach-O 64-bit dynamically linked shared library x86_64] " +
-            "[arm64:Mach-O 64-bit dynamically linked shared library arm64]",
+            "Mach-O universal binary with 2 architectures:",
+            "[x86_64:Mach-O 64-bit dynamically linked shared library x86_64",
+            "[arm64:Mach-O 64-bit dynamically linked shared library arm64",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -639,7 +639,7 @@ swift_library(
     testonly = True,
     srcs = [":swift_importing_imported_dynamic_xcfw"],
     tags = FIXTURE_TAGS,
-    deps = ["//test/starlark_tests/targets_under_test/apple:ios_imported_dynamic_xcframework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:ios_imported_dynamic_xcframework_old"],
 )
 
 genrule(

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -515,6 +515,10 @@ apple_dynamic_xcframework_import(
 
 apple_dynamic_xcframework_import(
     name = "ios_imported_dynamic_xcframework_with_lib_ids",
+    library_identifiers = {
+        "ios_device": "ios-arm64",
+        "ios_simulator": "ios-x86_64-simulator",
+    },
     tags = ["manual"],
     xcframework_imports = [":generated_ios_dynamic_xcframework"],
 )
@@ -528,6 +532,10 @@ apple_static_xcframework_import(
 
 apple_static_xcframework_import(
     name = "ios_imported_static_xcframework_with_lib_ids",
+    library_identifiers = {
+        "ios_device": "ios-arm64",
+        "ios_simulator": "ios-arm64_x86_64-simulator",
+    },
     tags = ["manual"],
     xcframework_imports = [":generated_ios_static_xcframework"],
 )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1103,6 +1103,7 @@ apple_universal_binary(
 apple_dynamic_xcframework_import(
     name = "ios_imported_dynamic_xcframework",
     features = ["-swift.layering_check"],
+    tags = TARGETS_UNDER_TEST_TAGS,
     visibility = ["//visibility:public"],
     xcframework_imports = ["//test/testdata/xcframeworks:generated_dynamic_xcframework_with_headers"],
 )
@@ -1110,6 +1111,7 @@ apple_dynamic_xcframework_import(
 apple_dynamic_xcframework_import(
     name = "ios_imported_swift_dynamic_xcframework",
     features = ["-swift.layering_check"],
+    tags = TARGETS_UNDER_TEST_TAGS,
     visibility = ["//visibility:public"],
     xcframework_imports = [":ios_swift_dynamic_xcframework"],
 )
@@ -1117,6 +1119,7 @@ apple_dynamic_xcframework_import(
 apple_dynamic_xcframework_import(
     name = "ios_imported_swift_dynamic_xcframework_without_swift_files",
     features = ["-swift.layering_check"],
+    tags = TARGETS_UNDER_TEST_TAGS,
     visibility = ["//visibility:public"],
     xcframework_imports = [":ios_swift_dynamic_xcframework_without_swiftmodule"],
 )
@@ -1163,6 +1166,7 @@ genrule(
 
 apple_dynamic_xcframework_import(
     name = "ios_imported_xcframework_with_libraries",
+    tags = TARGETS_UNDER_TEST_TAGS,
     visibility = ["//visibility:public"],
     xcframework_imports = ["//test/testdata/xcframeworks:generated_static_xcframework"],
 )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -508,17 +508,13 @@ unzip -oqq $(execpath :ios_xcframework_bundling_static_fmwks.xcframework.zip) -d
 )
 
 apple_dynamic_xcframework_import(
-    name = "ios_imported_dynamic_xcframework",
+    name = "ios_imported_dynamic_xcframework_old",
     tags = ["manual"],
     xcframework_imports = [":generated_ios_dynamic_xcframework"],
 )
 
 apple_dynamic_xcframework_import(
     name = "ios_imported_dynamic_xcframework_with_lib_ids",
-    library_identifiers = {
-        "ios_device": "ios-arm64",
-        "ios_simulator": "ios-x86_64-simulator",
-    },
     tags = ["manual"],
     xcframework_imports = [":generated_ios_dynamic_xcframework"],
 )
@@ -532,10 +528,6 @@ apple_static_xcframework_import(
 
 apple_static_xcframework_import(
     name = "ios_imported_static_xcframework_with_lib_ids",
-    library_identifiers = {
-        "ios_device": "ios-arm64",
-        "ios_simulator": "ios-arm64_x86_64-simulator",
-    },
     tags = ["manual"],
     xcframework_imports = [":generated_ios_static_xcframework"],
 )
@@ -1103,4 +1095,74 @@ apple_universal_binary(
     minimum_os_version = "11.0",
     platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple XCFramework import tests.
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_dynamic_xcframework",
+    features = ["-swift.layering_check"],
+    visibility = ["//visibility:public"],
+    xcframework_imports = ["//test/testdata/xcframeworks:generated_dynamic_xcframework_with_headers"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_swift_dynamic_xcframework",
+    features = ["-swift.layering_check"],
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":ios_swift_dynamic_xcframework"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_swift_dynamic_xcframework_without_swift_files",
+    features = ["-swift.layering_check"],
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":ios_swift_dynamic_xcframework_without_swiftmodule"],
+)
+
+genrule(
+    name = "ios_swift_dynamic_xcframework",
+    srcs = [":ios_swift_xcframework_with_generated_header.xcframework.zip"],
+    outs = [
+        "SwiftFmwkWithGenHeader.xcframework/Info.plist",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Info.plist",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Info.plist",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+    ],
+    cmd = "unzip -qq $(execpath :ios_swift_xcframework_with_generated_header.xcframework.zip) -d $(RULEDIR)",
+)
+
+genrule(
+    name = "ios_swift_dynamic_xcframework_without_swiftmodule",
+    srcs = [":ios_swift_xcframework_with_generated_header.xcframework.zip"],
+    outs = [
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/Info.plist",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Info.plist",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Info.plist",
+        "ios_swift_dynamic_xcframework_without_swiftmodule/SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+    ],
+    cmd = "unzip -qq $(execpath :ios_swift_xcframework_with_generated_header.xcframework.zip) -d $(RULEDIR)/ios_swift_dynamic_xcframework_without_swiftmodule",
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_xcframework_with_libraries",
+    visibility = ["//visibility:public"],
+    xcframework_imports = ["//test/testdata/xcframeworks:generated_static_xcframework"],
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1521,6 +1521,132 @@ objc_library(
 )
 
 # ---------------------------------------------------------------------------------------
+# Targets for Apple XCFramework import tests.
+
+# Objective-C app with imported Objective-C XCFramework.
+ios_application(
+    name = "app_with_imported_xcframework",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":dynamic_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_xcframework_depending_lib",
+    srcs = ["lib_with_imported_objc_xcframework.m"],
+    tags = FIXTURE_TAGS,
+    deps = ["//test/starlark_tests/targets_under_test/apple:ios_imported_dynamic_xcframework"],
+)
+
+genrule(
+    name = "dynamic_xcframework_depending_lib_file",
+    outs = ["lib_with_imported_objc_xcframework.m"],
+    cmd = """cat > $@ <<EOF
+#import <generated_dynamic_xcframework_with_headers/generated_dynamic_xcframework_with_headers.h>
+
+int main() {
+  SharedClass *sharedClass = [[SharedClass alloc] init];
+  [sharedClass doSomethingShared];
+  return 0;
+}
+EOF
+""",
+)
+
+# Swift app with imported Objective-C XCFramework.
+ios_application(
+    name = "swift_app_with_imported_objc_xcframework",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":dynamic_objc_xcframework_depending_swift_lib",
+        "//test/starlark_tests/resources:swift_main_lib",
+    ],
+)
+
+swift_library(
+    name = "dynamic_objc_xcframework_depending_swift_lib",
+    srcs = ["SwiftWithObjcFramework.swift"],
+    tags = FIXTURE_TAGS,
+    deps = ["//test/starlark_tests/targets_under_test/apple:ios_imported_dynamic_xcframework"],
+)
+
+genrule(
+    name = "swift_with_framework_src",
+    outs = ["SwiftWithObjcFramework.swift"],
+    cmd = """cat > $@ <<EOF
+import generated_dynamic_xcframework_with_headers
+
+func main() {
+  let sc = generated_dynamic_xcframework_with_headers.SharedClass()
+  sc.doSomethingShared()
+}
+EOF
+""",
+)
+
+# Objective-C app with imported Swift XCFramework.
+ios_application(
+    name = "app_with_imported_swift_xcframework",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "11.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":dynamic_swift_xcframework_depending_objc_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_swift_xcframework_depending_objc_lib",
+    srcs = ["ObjcWithFramework.m"],
+    tags = FIXTURE_TAGS,
+    deps = ["//test/starlark_tests/targets_under_test/apple:ios_imported_swift_dynamic_xcframework"],
+)
+
+genrule(
+    name = "objc_with_framework_src",
+    outs = ["ObjcWithFramework.m"],
+    cmd = """cat > $@ <<EOF
+#import <SwiftFmwkWithGenHeader/SwiftFmwkWithGenHeader.h>
+
+int main() {
+  SharedClass *sharedClass = [[SharedClass alloc] init];
+  [sharedClass doSomethingShared];
+  return 0;
+}
+EOF
+""",
+)
+
+# ---------------------------------------------------------------------------------------
 
 ios_imessage_application(
     name = "imessage_app",

--- a/test/testdata/xcframeworks/BUILD
+++ b/test/testdata/xcframeworks/BUILD
@@ -7,6 +7,9 @@ load(
 
 licenses(["notice"])
 
+# TODO(b/232578557): Migrate targets to starlark_tests/
+package(default_visibility = ["//test/starlark_tests:__subpackages__"])
+
 generate_dynamic_xcframework(
     name = "generated_dynamic_xcframework",
     srcs = ["@bazel_tools//tools/objc:objc_dummy.mm"],


### PR DESCRIPTION
This change adds the first version of the XCFramework import rule for
XCFrameworks containing Apple frameworks with dynamic libraries.

PiperOrigin-RevId: 452564946
(cherry picked from commit a973b75ed28298019c146d192357677c36f7bb69)