### PR TITLE
Specify language = "objc" for Objective-C's use of cc_common.configure_features

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -63,7 +63,8 @@ def _cc_info_with_dependencies(
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        requested_features = features + ["lang_objc"],  # b/210775356
+        language = "objc",
+        requested_features = features,
         unsupported_features = disabled_features,
     )
 


### PR DESCRIPTION
This automatically sets all the features needed for Objective-C, and
allows us to get rid of a bunch of custom starlark code.

PiperOrigin-RevId: 457486535
(cherry picked from commit dd5be9edbc86ffc2c5bfb4d9ac0d28798680a873)