### PR TITLE
Migrate ObjcConfiguration usage to equivalent info in CppConfiguration

### DIFF
--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -296,8 +296,7 @@ def _debug_symbols_partial_impl(
                 transitive = [dsym_bundles],
             )
 
-    if platform_prerequisites.objc_fragment:
-        if platform_prerequisites.objc_fragment.generate_linkmap:
+        if platform_prerequisites.cpp_fragment.objc_generate_linkmap:
             linkmaps = _collect_linkmaps(
                 actions = actions,
                 debug_output_filename = debug_output_filename,


### PR DESCRIPTION
We would like to migrate all such usage to CppConfiguration so that we
can delete the info in ObjcConfiguration.

PiperOrigin-RevId: 457500060
(cherry picked from commit 1cddb75cc00ca6a580a77f0e3e22a2827b1f7cb9)