### PR TITLE
Add support to generate Swift static XCFramework

### DIFF
--- a/test/testdata/xcframeworks/BUILD
+++ b/test/testdata/xcframeworks/BUILD
@@ -1,9 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("//test/starlark_tests:common.bzl", "FIXTURE_TAGS")
 load(
     "//test/testdata/xcframeworks:generate_xcframework.bzl",
     "generate_dynamic_xcframework",
     "generate_static_xcframework",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])
 
@@ -91,6 +93,25 @@ generate_static_xcframework(
     },
 )
 
+swift_library(
+    name = "swift_lib_for_static_xcframework",
+    srcs = ["//test/testdata/fmwk:swift_source"],
+    features = [
+        "swift.emit_swiftinterface",
+        "swift.enable_library_evolution",
+    ],
+    generates_header = True,
+    module_name = "swift_lib_for_static_xcframework",
+    tags = FIXTURE_TAGS,
+)
+
+generate_static_xcframework(
+    name = "generated_swift_static_xcframework",
+    platforms = {"ios_simulator": ["x86_64"]},
+    swift_library = ":swift_lib_for_static_xcframework",
+    tags = FIXTURE_TAGS,
+)
+
 bzl_library(
     name = "generate_xcframework_bzl",
     srcs = ["generate_xcframework.bzl"],
@@ -100,5 +121,6 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
+        "@build_bazel_rules_swift//swift",
     ],
 )

--- a/test/testdata/xcframeworks/BUILD
+++ b/test/testdata/xcframeworks/BUILD
@@ -112,6 +112,14 @@ generate_static_xcframework(
     tags = FIXTURE_TAGS,
 )
 
+generate_static_xcframework(
+    name = "generated_swift_static_xcframework_without_swiftmodule",
+    include_module_interface_files = False,
+    platforms = {"ios_simulator": ["x86_64"]},
+    swift_library = ":swift_lib_for_static_xcframework",
+    tags = FIXTURE_TAGS,
+)
+
 bzl_library(
     name = "generate_xcframework_bzl",
     srcs = ["generate_xcframework.bzl"],


### PR DESCRIPTION
This change adds support to generate an XCFramework with a Swift static
library using a `swift_library` target. This only supports a single
platform and architecture for an XCFramework.

PiperOrigin-RevId: 453938469
(cherry picked from commit 0ff924db662c3ddf90c16c042ffbdd4ede0620a8)