### PR TITLE
Introduce xcframework_processor_tool for XCFramework imports.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -31,6 +31,7 @@ apple_mac_tools_toolchain(
     # should be considered an implementation detail of the rules and
     # not used by other things.
     visibility = ["//visibility:public"],
+    xcframework_processor_tool = "//tools/xcframework_processor_tool",
     xctoolrunner = "//tools/xctoolrunner",
 )
 
@@ -106,12 +107,15 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
+        ":apple_toolchains",
         ":cc_toolchain_info_support",
         ":framework_import_support",
+        ":intermediates",
         ":rule_factory",
         "//apple:providers",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
+        "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_rules_swift//swift",
     ],
 )

--- a/apple/internal/apple_toolchains.bzl
+++ b/apple/internal/apple_toolchains.bzl
@@ -72,6 +72,10 @@ provisioning profile.
 A `struct` from `ctx.resolve_tools` referencing a tool that copies and lipos Swift stdlibs required
 for the target to run.
 """,
+        "resolved_xcframework_processor_tool": """\
+A `struct` from `ctx.resolve_tools` referencing a tool that extracts and copies an XCFramework
+library for a target triplet.
+""",
         "resolved_xctoolrunner": """\
 A `struct` from `ctx.resolve_tools` referencing a tool that acts as a wrapper for xcrun actions.
 """,
@@ -172,6 +176,10 @@ def _apple_mac_tools_toolchain_impl(ctx):
                 attr_name = "swift_stdlib_tool",
                 rule_ctx = ctx,
             ),
+            resolved_xcframework_processor_tool = _resolve_tools_for_executable(
+                attr_name = "xcframework_processor_tool",
+                rule_ctx = ctx,
+            ),
             resolved_xctoolrunner = _resolve_tools_for_executable(
                 attr_name = "xctoolrunner",
                 rule_ctx = ctx,
@@ -259,6 +267,14 @@ A `File` referencing a tool that extracts entitlements from a provisioning profi
             executable = True,
             doc = """
 A `File` referencing a tool that copies and lipos Swift stdlibs required for the target to run.
+""",
+        ),
+        "xcframework_processor_tool": attr.label(
+            cfg = "exec",
+            executable = True,
+            doc = """
+A `File` referencing a tool that extracts and copies an XCFramework library for a given target
+triplet.
 """,
         ),
         "xctoolrunner": attr.label(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -14,6 +14,11 @@
 
 """Implementation of XCFramework import rules."""
 
+load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load(
+    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "AppleMacToolsToolchainInfo",
+)
 load(
     "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
     "cc_toolchain_info_support",
@@ -22,6 +27,7 @@ load(
     "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
+load("@build_bazel_rules_apple//apple/internal:intermediates.bzl", "intermediates")
 load("@build_bazel_rules_apple//apple/internal:rule_factory.bzl", "rule_factory")
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_clang_module_aspect")
@@ -88,7 +94,16 @@ def _classify_xcframework_imports(config_vars, xcframework_imports):
         info_plist = info_plist,
     )
 
-def _get_xcframework_library(*, target_triplet, xcframework):
+def _get_xcframework_library(
+        *,
+        actions,
+        apple_fragment,
+        apple_mac_toolchain_info,
+        label,
+        parse_xcframework_info_plist = False,
+        target_triplet,
+        xcframework,
+        xcode_config):
     """Returns a processed XCFramework library for a given platform.
 
     Imported XCFramework files are processed through files path parsing, infering the effective
@@ -96,8 +111,16 @@ def _get_xcframework_library(*, target_triplet, xcframework):
     XCFramework library identifiers.
 
     Args:
+        actions: The actions provider from `ctx.actions`.
+        apple_fragment: An Apple fragment (ctx.fragments.apple).
+        apple_mac_toolchain_info: An AppleMacToolsToolchainInfo provider.
+        label: Label of the target being built.
+        parse_xcframework_info_plist: Boolean to indicate if XCFramework library inferrence should
+            be done parsing the XCFramework Info.plist file via the execution-phase tool
+            xcframework_processor_tool.py.
         target_triplet: Struct referring a Clang target triplet.
         xcframework: Struct containing imported XCFramework details.
+        xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
 
     Returns:
         A struct containing processed XCFramework files:
@@ -114,21 +137,25 @@ def _get_xcframework_library(*, target_triplet, xcframework):
                 be either a single tree artifact or a list of regular artifacts.
             swift_module_map: File referencing the XCFramework library modulemap file.
     """
-
-    xcframework_library = _get_xcframework_library_from_paths(
-        target_triplet = target_triplet,
-        xcframework = xcframework,
-    )
-
-    if not xcframework_library:
-        fail(
-            "Could not infer XCFramework library for the following target triplet:",
-            "\n\t- platform: %s" % target_triplet.os,
-            "\n\t- architecture: %s" % target_triplet.architecture,
-            "\n\t- environment: %s" % target_triplet.environment,
+    xcframework_library = None
+    if not parse_xcframework_info_plist:
+        xcframework_library = _get_xcframework_library_from_paths(
+            target_triplet = target_triplet,
+            xcframework = xcframework,
         )
 
-    return xcframework_library
+    if xcframework_library:
+        return xcframework_library
+
+    return _get_xcframework_library_with_xcframework_processor(
+        actions = actions,
+        apple_fragment = apple_fragment,
+        apple_mac_toolchain_info = apple_mac_toolchain_info,
+        label = label,
+        target_triplet = target_triplet,
+        xcframework = xcframework,
+        xcode_config = xcode_config,
+    )
 
 def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
     """Infer XCFramework library for the target platform, architecture based on paths.
@@ -178,6 +205,127 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
         swiftmodule = swiftmodules,
     )
 
+def _get_xcframework_library_with_xcframework_processor(
+        *,
+        actions,
+        apple_fragment,
+        apple_mac_toolchain_info,
+        label,
+        target_triplet,
+        xcframework,
+        xcode_config):
+    """Register action to copy the XCFramework library for the target platform, architecture.
+
+    The registered action leverages the xcframework_processor tool to copy the effective XCFramework
+    library required for the target being built based on platform, and architecture being targeted.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        apple_fragment: An Apple fragment (ctx.fragments.apple).
+        apple_mac_toolchain_info: An AppleMacToolsToolchainInfo provider.
+        label: Label of the target being built.
+        target_triplet: Struct referring a Clang target triplet.
+        xcframework: Struct containing imported XCFramework details.
+        xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
+    Returns:
+        A struct containing processed XCFramework files. See _get_xcframework_library.
+    """
+    intermediates_common = {
+        "actions": actions,
+        "target_name": label.name,
+        "output_discriminator": "",
+    }
+
+    library_suffix = ".framework" if xcframework.bundle_type == _BUNDLE_TYPE.frameworks else ""
+    library_path = xcframework.bundle_name + library_suffix
+
+    library_dir = intermediates.directory(dir_name = library_path, **intermediates_common)
+    framework_imports_dir = intermediates.directory(
+        dir_name = paths.join("framework_imports", library_path),
+        **intermediates_common
+    )
+
+    # The folowing artifacts are declared here to be used later on as inputs for different
+    # providers; but not added as arguments to the xcframework_processor tool because it's
+    # not really needed if you add the target directory for the copied .framework bundle.
+    binary = intermediates.file(
+        file_name = paths.join(library_path, xcframework.bundle_name),
+        **intermediates_common
+    )
+    headers_dir = intermediates.directory(
+        dir_name = paths.join(library_path, "Headers"),
+        **intermediates_common
+    )
+    modulemap_dir_path = paths.join(library_path, "Modules")
+    modulemap_dir = intermediates.directory(
+        dir_name = paths.join(modulemap_dir_path),
+        **intermediates_common
+    )
+    module_map_file = intermediates.file(
+        file_name = paths.join(modulemap_dir_path, "module.modulemap"),
+        **intermediates_common
+    )
+
+    args = actions.args()
+    args.add("--bundle_name", xcframework.bundle_name)
+    args.add("--info_plist", xcframework.info_plist.path)
+
+    args.add("--platform", target_triplet.os)
+    args.add("--architecture", target_triplet.architecture)
+    args.add("--environment", target_triplet.environment)
+
+    files_by_category = xcframework.files_by_category
+    args.add_all(files_by_category.binary_imports, before_each = "--binary_file")
+    args.add_all(files_by_category.bundling_imports, before_each = "--bundle_file")
+    args.add_all(files_by_category.header_imports, before_each = "--header_file")
+    args.add_all(files_by_category.module_map_imports, before_each = "--modulemap_file")
+
+    args.add("--binary", binary.path)
+    args.add("--library_dir", library_dir.path)
+    args.add("--framework_imports_dir", framework_imports_dir.path)
+
+    inputs = []
+    inputs.extend(xcframework.files)
+    inputs.append(xcframework.info_plist)
+
+    outputs = [
+        binary,
+        framework_imports_dir,
+        headers_dir,
+        library_dir,
+        module_map_file,
+        modulemap_dir,
+    ]
+
+    xcframework_processor_tool = apple_mac_toolchain_info.resolved_xcframework_processor_tool
+
+    apple_support.run(
+        actions = actions,
+        apple_fragment = apple_fragment,
+        arguments = [args],
+        executable = xcframework_processor_tool.executable,
+        inputs = depset(
+            inputs,
+            transitive = [xcframework_processor_tool.inputs],
+        ),
+        input_manifests = xcframework_processor_tool.input_manifests,
+        mnemonic = "ProcessXCFrameworkFiles",
+        outputs = outputs,
+        xcode_config = xcode_config,
+    )
+
+    return struct(
+        binary = binary,
+        framework_dirs = [library_dir.path],
+        framework_files = [library_dir],
+        framework_imports = [framework_imports_dir],
+        framework_includes = [library_dir.dirname],
+        headers = [headers_dir],
+        module_maps = [modulemap_dir],
+        swift_module_map = module_map_file,
+        swiftmodule = [],
+    )
+
 def _get_library_identifier(
         *,
         binary_imports,
@@ -223,6 +371,8 @@ def _get_library_identifier(
 def _apple_dynamic_xcframework_import_impl(ctx):
     """Implementation for the apple_dynamic_framework_import rule."""
     actions = ctx.actions
+    apple_fragment = ctx.fragments.apple
+    apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     cc_toolchain = find_cpp_toolchain(ctx)
     deps = ctx.attr.deps
     disabled_features = ctx.disabled_features
@@ -230,6 +380,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     grep_includes = ctx.file._grep_includes
     label = ctx.label
     xcframework_imports = ctx.files.xcframework_imports
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
     xcframework = _classify_xcframework_imports(ctx.var, xcframework_imports)
     target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
@@ -238,8 +389,14 @@ def _apple_dynamic_xcframework_import_impl(ctx):
         fail("Importing XCFrameworks with dynamic libraries is not supported.")
 
     xcframework_library = _get_xcframework_library(
+        actions = actions,
+        apple_fragment = apple_fragment,
+        apple_mac_toolchain_info = apple_mac_toolchain_info,
+        label = label,
+        parse_xcframework_info_plist = "apple.parse_xcframework_info_plist" in features,
         target_triplet = target_triplet,
         xcframework = xcframework,
+        xcode_config = xcode_config,
     )
 
     providers = []
@@ -364,7 +521,7 @@ Unnecssary and ignored, will be removed in the future.
             ),
         },
     ),
-    fragments = ["cpp"],
+    fragments = ["apple", "cpp"],
     provides = [
         AppleFrameworkImportInfo,
         CcInfo,

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -36,7 +36,7 @@ def _cc_info_with_dependencies(
         grep_includes,
         header_imports,
         label,
-        swiftmodule_imports,
+        swiftmodule_imports = [],
         includes = [],
         is_framework = True):
     """Returns a new CcInfo which includes transitive Cc dependencies.

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -111,6 +111,14 @@ def _framework_import_partial_impl(
         if not framework_binaries_by_framework.get(framework_basename):
             framework_binaries_by_framework[framework_basename] = []
 
+        # Check if file is a tree artifact to treat as bundle files.
+        # XCFramework import rules forward tree artifacts when using the
+        # xcframework_processor_tool, since the effective XCFramework library
+        # files are not known during analysis phase.
+        if file.is_directory:
+            files_by_framework[framework_basename].append(file)
+            continue
+
         # Check if this file is a binary to slice and code sign.
         framework_relative_path = paths.relativize(file.short_path, framework_path)
 
@@ -119,12 +127,11 @@ def _framework_import_partial_impl(
         if framework_relative_dir:
             parent_dir = paths.join(parent_dir, framework_relative_dir)
 
+        # Classify if it's a file to bundle or framework binary
         if paths.replace_extension(parent_dir, "") == file.basename:
             framework_binaries_by_framework[framework_basename].append(file)
-            continue
-
-        # Treat the rest as files to copy into the bundle.
-        files_by_framework[framework_basename].append(file)
+        else:
+            files_by_framework[framework_basename].append(file)
 
     for framework_basename in files_by_framework.keys():
         # Create a temporary path for intermediate files and the anticipated zip output.
@@ -140,11 +147,12 @@ def _framework_import_partial_impl(
         # Pass through all binaries, files, and relevant info as args.
         args = actions.args()
 
-        for framework_binary in framework_binaries_by_framework[framework_basename]:
-            args.add("--framework_binary", framework_binary.path)
+        args.add_all(
+            framework_binaries_by_framework[framework_basename],
+            before_each = "--framework_binary",
+        )
 
-        for build_arch in build_archs_found:
-            args.add("--slice", build_arch)
+        args.add_all(build_archs_found, before_each = "--slice")
 
         if bitcode_support.bitcode_mode_string(platform_prerequisites.apple_fragment) == "none":
             args.add("--strip_bitcode")
@@ -153,8 +161,7 @@ def _framework_import_partial_impl(
 
         args.add("--temp_path", temp_framework_bundle_path)
 
-        for file in files_by_framework[framework_basename]:
-            args.add("--framework_file", file.path)
+        args.add_all(files_by_framework[framework_basename], before_each = "--framework_file")
 
         codesign_args = codesigning_support.codesigning_args(
             entitlements = None,
@@ -170,14 +177,14 @@ def _framework_import_partial_impl(
         resolved_codesigningtool = apple_mac_toolchain_info.resolved_codesigningtool
         resolved_imported_dynamic_framework_processor = apple_mac_toolchain_info.resolved_imported_dynamic_framework_processor
 
-        # Inputs of action are all the framework files, plus binaries needed for identifying the
-        # current build's preferred architecture, plus a generated list of those binaries to prune
-        # their dependencies so that future changes to the app/extension/framework binaries do not
-        # force this action to re-run on incremental builds, plus the top-level target's
-        # provisioning profile if the current build targets real devices.
-        input_files = files_by_framework[framework_basename] + framework_binaries_by_framework[framework_basename]
-
         execution_requirements = {}
+
+        # Inputs of action are all the framework files, plus binaries needed for identifying the
+        # current build's preferred architecture, and the provisioning profile if specified.
+        input_files = (
+            files_by_framework[framework_basename] +
+            framework_binaries_by_framework[framework_basename]
+        )
         if provisioning_profile:
             input_files.append(provisioning_profile)
             execution_requirements = {"no-sandbox": "1"}

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -143,6 +143,27 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify ios_application bundles Framework files when using xcframework_processor_tool.
+    archive_contents_test(
+        name = "{}_contains_imported_xcframework_framework_files_with_xcframework_import_tool".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Modules/",
+        ],
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = [
+            "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
+        ],
+        target_features = ["apple.parse_xcframework_info_plist"],
+        tags = [name],
+    )
+
     # Verify importing XCFramework with dynamic libraries (i.e. not Apple frameworks) fails.
     analysis_failure_message_test(
         name = "{}_fails_importing_xcframework_with_libraries_test".format(name),

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,6 +17,7 @@ filegroup(
         "//tools/swift_stdlib_tool:for_bazel_tests",
         "//tools/versiontool:for_bazel_tests",
         "//tools/wrapper_common:for_bazel_tests",
+        "//tools/xcframework_processor_tool:for_bazel_tests",
         "//tools/xctoolrunner:for_bazel_tests",
         "//tools/imported_dynamic_framework_processor:for_bazel_tests",
     ],

--- a/tools/xcframework_processor_tool/BUILD
+++ b/tools/xcframework_processor_tool/BUILD
@@ -1,0 +1,38 @@
+licenses(["notice"])
+
+py_binary(
+    name = "xcframework_processor_tool",
+    srcs = ["xcframework_processor_tool.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [":xcframework_processor_tool_lib"],
+)
+
+py_library(
+    name = "xcframework_processor_tool_lib",
+    srcs = ["xcframework_processor_tool.py"],
+    srcs_version = "PY3",
+    visibility = [
+        "//tools:__subpackages__",
+    ],
+)
+
+py_test(
+    name = "xcframework_processor_tool_test",
+    srcs = ["xcframework_processor_tool_test.py"],
+    python_version = "PY3",
+    deps = [":xcframework_processor_tool_lib"],
+)
+
+# Consumed by bazel tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = [
+        "//tools:__pkg__",
+    ],
+)

--- a/tools/xcframework_processor_tool/xcframework_processor_tool.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool.py
@@ -143,7 +143,7 @@ def _get_library_from_plist(
   library for the given target triplet (platform, architecture, environment).
 
   Args:
-    architecture: Target Apple architecture (e.g. x864_64, arm64).
+    architecture: Target Apple architecture (e.g. x86_64, arm64).
     environment: Target Apple environment (e.g. device, simulator).
     info_plist: Parsed XCFramework Info.plist file contents.
     platform: Target Apple platform (e.g. macos, ios).

--- a/tools/xcframework_processor_tool/xcframework_processor_tool.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool.py
@@ -57,7 +57,7 @@ def _create_args_parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(description="xcframework tool")
 
   value_args = {
-      "architecture": "Target Apple architecture (e.g. x864_64, arm64).",
+      "architecture": "Target Apple architecture (e.g. x86_64, arm64).",
       "binary": "Bazel declared file for XCFramework binary file.",
       "bundle_name": "The XCFramework bundle name (i.e. name.xcframework).",
       "environment": "Target Apple environment (e.g. device, simulator).",

--- a/tools/xcframework_processor_tool/xcframework_processor_tool.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool.py
@@ -1,0 +1,285 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Execution-phase XCFramework processing tool.
+
+The XCFramework processor tool is an execution-phase time tool inspecting an
+XCFramework bundle defined by the embedded Info.plist file containing
+XCFramework library definitions.
+
+This script takes an analysis time defined target triplet (platform,
+architecture, and environment), previously classified XCFramework file paths
+(i.e. headers, module maps, binaries), and Bazel declared files and directories
+to copy the effective XCFramework library files to a desired output location.
+
+An XCFramework Info.plist file defines each XCFramework library with the
+following information:
+
+  - LibraryIdentifier:
+      References relative directory containing an Apple framework or library.
+  - LibraryPath:
+      References relative path to a framework bundle, or library.
+  - HeadersPath:
+      References (if available) a relative directory containing
+      Objective-C(++)/Swift interface files.
+  - BitcodeSymbolMapsPath:
+      References (if available) a relative directory containing bitcode symbol
+      map files.
+  - SupportedArchitectures:
+      List of supported architectures by library.
+  - SupportedPlatforms:
+      List of supported platforms by the library.
+  - SupportedPlatformVariant:
+      List of supported platform variants (e.g. simulator) if available.
+"""
+
+import argparse
+import os
+import plistlib
+import shutil
+import sys
+from typing import Any, Dict, List
+
+
+def _create_args_parser() -> argparse.ArgumentParser:
+  """Create parser and return parsed arguments."""
+  parser = argparse.ArgumentParser(description="xcframework tool")
+
+  value_args = {
+      "architecture": "Target Apple architecture (e.g. x864_64, arm64).",
+      "binary": "Bazel declared file for XCFramework binary file.",
+      "bundle_name": "The XCFramework bundle name (i.e. name.xcframework).",
+      "environment": "Target Apple environment (e.g. device, simulator).",
+      "library_dir": "Bazel declared directory for copied XCFramework files.",
+      "framework_imports_dir":
+          "Bazel declared directory for XCFramework bundle files.",
+      "info_plist": "XCFramework Info.plist file.",
+      "platform": "Target Apple platform (e.g. macos, ios).",
+  }
+  for arg_name, arg_help in value_args.items():
+    parser.add_argument(
+        f"--{arg_name}",
+        type=str,
+        required=True,
+        action="store",
+        help=arg_help)
+
+  list_args = {
+      "binary_file": "Imported XCFramework binary file path.",
+      "header_file": "Imported XCFramework header file path.",
+  }
+  for arg_name, arg_help in list_args.items():
+    parser.add_argument(
+        f"--{arg_name}",
+        type=str,
+        required=True,
+        action="append",
+        help=arg_help,
+        dest=f"{arg_name}s",
+    )
+
+  optional_list_args = {
+      "bundle_file": "Imported XCFramework bundle file path.",
+      "modulemap_file": "Imported XCFramework modulemap file path.",
+      "swiftmodule_file": "Imported XCFramework Swift module file path.",
+  }
+  for arg_name, arg_help in optional_list_args.items():
+    parser.add_argument(
+        f"--{arg_name}",
+        type=str,
+        required=False,
+        action="append",
+        help=arg_help,
+        dest=f"{arg_name}s",
+    )
+
+  return parser
+
+
+def _get_plist_dict(info_plist_path: str) -> Dict[str, Any]:
+  """Returns dictionary from XCFramework Info.plist file content.
+
+  Args:
+    info_plist_path: XCFramework Info.plist file path to read from.
+  Returns:
+    Dictionary of parsed Info.plist contents.
+  Raises:
+    ValueError - if file does not contain XCFrameworkFormatVersion key.
+  """
+  with open(info_plist_path, "rb") as info_plist_file:
+    info_plist_dict = plistlib.load(info_plist_file)
+    if "XCFrameworkFormatVersion" not in info_plist_dict:
+      raise ValueError(f"""
+Info.plist file does not contain key: 'XCFrameworkFormatVersion'. Contents:
+
+{info_plist_dict}
+
+Is it an XCFramework Info.plist file?
+""")
+
+    return info_plist_dict
+
+
+def _get_library_from_plist(
+    *,
+    architecture: str,
+    environment: str,
+    info_plist: Dict[str, Any],
+    platform: str) -> Dict[str, Any]:
+  """Returns an XCFramework library definition from XCFramework Info.plist file.
+
+  Traverse XCFramework Info.plist libraries definitions to find a supported
+  library for the given target triplet (platform, architecture, environment).
+
+  Args:
+    architecture: Target Apple architecture (e.g. x864_64, arm64).
+    environment: Target Apple environment (e.g. device, simulator).
+    info_plist: Parsed XCFramework Info.plist file contents.
+    platform: Target Apple platform (e.g. macos, ios).
+  Returns:
+    Info.plist dictionary referencing target XCFramework library.
+  Raises:
+    ValueError - if no XCFramework library supporting target triplet is found.
+  """
+  available_libraries = info_plist.get("AvailableLibraries", [])
+  for library in available_libraries:
+    supported_platform = library.get("SupportedPlatform", [])
+    if platform != supported_platform:
+      continue
+
+    supported_environment = library.get("SupportedPlatformVariant", [])
+    if environment == "device" and supported_environment:
+      continue
+    if (environment != "device"
+        and environment != supported_environment):
+      continue
+
+    supported_architectures = library.get("SupportedArchitectures", [])
+    if architecture not in supported_architectures:
+      continue
+
+    return library
+
+  library_identifiers = [
+      library.get("LibraryIdentifier")
+      for library in available_libraries
+  ]
+  raise ValueError(f"""
+Imported XCFramework does not support the following platform:
+  - platform: {platform}
+  - architecture: {architecture}
+  - environment: {environment}
+
+Supported platforms: {library_identifiers}
+""")
+
+
+def _copy_xcframework_files(
+    *,
+    executable: bool = False,
+    library_identifier: str,
+    output_directories: List[str],
+    xcframework_files: List[str]) -> None:
+  """Copies XCFramework files filtered by library identifier to a directory.
+
+  Args:
+    executable: Indicates whether or not the file(s) should be made executable.
+    library_identifier: XCFramework library identifier to filter files with.
+    output_directories: List of directory paths to copy files to.
+    xcframework_files: List of XCFramework files to filter by library identifier
+      and copy files from.
+  """
+  if not xcframework_files:
+    return
+
+  library_files = [
+      f
+      for f in xcframework_files
+      if f"/{library_identifier}/" in f
+  ]
+
+  # This path will reference the following path:
+  #   a) For framework based XCFramework -> the .framework directory.
+  #   b) For library based XCFramework -> the library identifier directory.
+  library_dir_path = os.path.commonpath(library_files)
+
+  for library_file in library_files:
+    rel_path = os.path.relpath(library_file, start=library_dir_path)
+    for output_directory in output_directories:
+      dest_path = os.path.join(output_directory, rel_path)
+      os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+      dest_file_path = shutil.copy2(library_file, dest_path)
+      os.chmod(dest_file_path, 0o755 if executable else 0o644)
+
+
+def main() -> int:
+  args_parser = _create_args_parser()
+  args = args_parser.parse_args()
+
+  bundle_name = args.bundle_name
+  info_plist = _get_plist_dict(args.info_plist)
+  xcframework_library = _get_library_from_plist(
+      architecture=args.architecture,
+      environment=args.environment,
+      info_plist=info_plist,
+      platform=args.platform,
+  )
+
+  library_identifier = xcframework_library.get("LibraryIdentifier")
+
+  # Bundle files are copied to two different directories due the following:
+  #
+  # - library_dir: This directory will hold the inferred Apple framework, and
+  #     it's propagated to the AppleDynamicFrameworkInfo provider. This
+  #     provider is responsible of propagation linking information to
+  #     top-level targets (e.g. ios_application, objc_library).
+  #
+  # - framework_imports_dir: This directory will hold Apple framework files
+  #     that are bundable at top-level targets (e.g. ios_application).
+  #     This directory is propagated to the AppleFrameworkImportInfo provider
+  #     as a tree-artifact containing all files to be bundled, and gets
+  #     processed by the framework_import partial.
+  _copy_xcframework_files(
+      library_identifier=library_identifier,
+      output_directories=[args.library_dir, args.framework_imports_dir],
+      xcframework_files=args.bundle_files)
+
+  _copy_xcframework_files(
+      executable=True,
+      library_identifier=library_identifier,
+      output_directories=[args.library_dir],
+      xcframework_files=args.binary_files)
+
+  headers_dir = os.path.join(args.library_dir, "Headers")
+  _copy_xcframework_files(
+      library_identifier=library_identifier,
+      output_directories=[headers_dir],
+      xcframework_files=args.header_files)
+
+  modules_dir = os.path.join(args.library_dir, "Modules")
+  _copy_xcframework_files(
+      library_identifier=library_identifier,
+      output_directories=[modules_dir],
+      xcframework_files=args.modulemap_files)
+
+  swiftmodule_dir = os.path.join(modules_dir, f"{bundle_name}.swiftmodule")
+  _copy_xcframework_files(
+      library_identifier=library_identifier,
+      output_directories=[swiftmodule_dir],
+      xcframework_files=args.swiftmodule_files)
+
+  return 0
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
@@ -1,0 +1,151 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for xcframework_processor_tool."""
+
+import os
+import plistlib
+import tempfile
+import unittest
+from unittest import mock
+
+from build_bazel_rules_apple.tools.xcframework_processor_tool import xcframework_processor_tool
+
+
+_MOCK_XCFRAMEWORK_INFO_PLIST = {
+    "AvailableLibraries": [
+        {
+            "LibraryIdentifier": "ios-arm64",
+            "LibraryPath": "MyFramework.framework",
+            "SupportedArchitectures": ["arm64"],
+            "SupportedPlatform": "ios"
+        },
+        {
+            "LibraryIdentifier": "ios-arm64_x86_64-simulator",
+            "LibraryPath": "MyFramework.framework",
+            "SupportedArchitectures": ["arm64", "x86_64"],
+            "SupportedPlatform": "ios",
+            "SupportedPlatformVariant": "simulator"
+        },
+        {
+            "LibraryIdentifier": "watchos-i386-simulator",
+            "LibraryPath": "MyFramework.framework",
+            "SupportedArchitectures": ["i386"],
+            "SupportedPlatform": "watchos",
+            "SupportedPlatformVariant": "device"
+        }
+    ],
+    "CFBundlePackageType": "XFWK",
+    "XCFrameworkFormatVersion": "1.0"
+}
+
+
+class XcframeworkProcessorToolTest(unittest.TestCase):
+
+  def test_get_library_from_plist_with_unsupported_platform(self):
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Imported XCFramework does not support the following platform.*"):
+      xcframework_processor_tool._get_library_from_plist(
+          info_plist=_MOCK_XCFRAMEWORK_INFO_PLIST,
+          platform="tvos",
+          architecture="arm64",
+          environment="device",
+      )
+
+  def test_get_library_from_plist_with_unsupported_architecture(self):
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Imported XCFramework does not support the following platform.*"):
+      xcframework_processor_tool._get_library_from_plist(
+          info_plist=_MOCK_XCFRAMEWORK_INFO_PLIST,
+          platform="ios",
+          architecture="armv7",
+          environment="device",
+      )
+
+  def test_get_library_from_plist_with_unsupported_platform_variant(self):
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Imported XCFramework does not support the following platform.*"):
+      xcframework_processor_tool._get_library_from_plist(
+          info_plist=_MOCK_XCFRAMEWORK_INFO_PLIST,
+          platform="watchos",
+          architecture="i386",
+          environment="simulator",
+      )
+
+  def test_get_library_from_plist_with_supported_target_triplet(self):
+    xcframework_library = xcframework_processor_tool._get_library_from_plist(
+        info_plist=_MOCK_XCFRAMEWORK_INFO_PLIST,
+        platform="ios",
+        architecture="arm64",
+        environment="simulator",
+    )
+    self.assertIsInstance(xcframework_library, dict)
+
+    expected_xcframework_library = {
+        "LibraryIdentifier": "ios-arm64_x86_64-simulator",
+        "LibraryPath": "MyFramework.framework",
+        "SupportedArchitectures": ["arm64", "x86_64"],
+        "SupportedPlatform": "ios",
+        "SupportedPlatformVariant": "simulator"
+    }
+    self.assertDictEqual(xcframework_library, expected_xcframework_library)
+
+  def test_tool_raises_error_with_invalid_info_plist(self):
+    info_plist_fp = tempfile.NamedTemporaryFile(delete=False)
+    self.addCleanup(lambda: os.unlink(info_plist_fp.name))
+
+    with info_plist_fp:
+      invalid_plist_content = {"Foo": "Bar"}
+      plistlib.dump(invalid_plist_content, info_plist_fp)
+
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Info.plist file does not contain key: 'XCFrameworkFormatVersion'.*"):
+      xcframework_processor_tool._get_plist_dict(
+          info_plist_path=info_plist_fp.name)
+
+  @mock.patch("os.makedirs")
+  @mock.patch("shutil.copy2")
+  def test_copy_xcframework_files_filtering_and_mock_calls(
+      self, mock_copy, mock_mkdirs):
+    xcframework_processor_tool._copy_xcframework_files(
+        library_identifier="ios-arm64",
+        output_directories=["/path/to/bazel/declared/directory/"],
+        xcframework_files=[
+            "/path/to/imported.xcframework/ios-arm64/libstatic.a",
+            "/path/to/imported.xcframework/ios-arm64/Headers/umbrella.h",
+            "/path/to/imported.xcframework/ios-arm64_x86_64/libstatic.a",
+            "/path/to/imported.xcframework/ios-arm64_x86_64/Headers/umbrella.h",
+            "/path/to/imported.xcframework/watchos-i386/libstatic.a",
+            "/path/to/imported.xcframework/watchos-i386/Headers/umbrella.h",
+        ])
+
+    expected_mkdirs_calls = [
+        mock.call("/path/to/bazel/declared/directory", exist_ok=True),
+        mock.call("/path/to/bazel/declared/directory/Headers", exist_ok=True),
+    ]
+    mock_mkdirs.assert_has_calls(expected_mkdirs_calls, any_order=True)
+    expected_copy_calls = [
+        mock.call("/path/to/imported.xcframework/ios-arm64/libstatic.a",
+                  "/path/to/bazel/declared/directory/libstatic.a"),
+        mock.call("/path/to/imported.xcframework/ios-arm64/Headers/umbrella.h",
+                  "/path/to/bazel/declared/directory/Headers/umbrella.h")
+    ]
+    mock_copy.assert_has_calls(expected_copy_calls, any_order=True)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
The following Python tool is an execution phase tool to inspect third-party
imported XCFrameworks. Instead of inferring the effective (target triplet)
XCFramework library based on import file paths, this tool reads an XCFramework
Info.plist file as source of truth.

PiperOrigin-RevId: 452862632
(cherry picked from commit 5d40eb6dd477fa11942fe3ff00cf44ef26c5d722)