### PR TITLE
Bundle Apple frameworks for ios/tvos_unit_test from objc_library runtime_deps

### DIFF
--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -337,6 +337,8 @@ def _apple_test_bundle_impl(ctx):
     if bundle_loader:
         targets_to_avoid.append(bundle_loader)
 
+    embeddable_targets = ctx.attr.deps + getattr(ctx.attr, "frameworks", [])
+
     processor_partials = [
         partials.apple_bundle_info_partial(
             actions = actions,
@@ -380,7 +382,7 @@ def _apple_test_bundle_impl(ctx):
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
-            embeddable_targets = getattr(ctx.attr, "frameworks", []),
+            embeddable_targets = embeddable_targets,
             platform_prerequisites = platform_prerequisites,
         ),
         partials.framework_import_partial(

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -103,6 +103,16 @@ def ios_unit_test_test_suite(name):
     )
 
     archive_contents_test(
+        name = "{}_test_target_bundles_framework_from_objc_library_runtime_deps".format(name),
+        build_type = "simulator",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/fmwk_8_0_minimum.framework/fmwk_8_0_minimum",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_with_fmwk_from_objc_library_runtime_deps",
+        tags = [name],
+    )
+
+    archive_contents_test(
         name = "{}_test_target_bundles_imported_framework".format(name),
         build_type = "simulator",
         contains = [

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1866,6 +1866,23 @@ ios_unit_test(
 )
 
 ios_unit_test(
+    name = "unit_test_with_fmwk_from_objc_library_runtime_deps",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":objc_lib_with_runtime_dep_fmwk",
+        "//test/starlark_tests/resources:objc_test_lib",
+    ],
+)
+
+ios_unit_test(
     name = "unit_test_with_host_importing_same_fmwk",
     families = [
         "iphone",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -357,6 +357,19 @@ tvos_unit_test(
     ],
 )
 
+tvos_unit_test(
+    name = "unit_test_with_fmwk_from_objc_library_runtime_deps",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "9.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":objc_lib_with_runtime_dep_fmwk",
+        "//test/starlark_tests/resources:objc_test_lib",
+    ],
+)
+
 # ---------------------------------------------------------------------------------------
 
 tvos_application(

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+)
+load(
     ":rules/dsyms_test.bzl",
     "dsyms_test",
 )
@@ -69,6 +73,16 @@ def tvos_unit_test_test_suite(name):
             "MinimumOSVersion": "9.0",
             "UIDeviceFamily:0": "3",
         },
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_test_target_bundles_framework_from_objc_library_runtime_deps".format(name),
+        build_type = "simulator",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/fmwk_with_provisioning.framework/fmwk_with_provisioning",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:unit_test_with_fmwk_from_objc_library_runtime_deps",
         tags = [name],
     )
 


### PR DESCRIPTION
Adds support to bundle Apple frameworks propagated from `objc_library`
targets using the `runtime_deps` attribute. Support for `ios_application`
and `tvos_application` was introduced on https://github.com/bazelbuild/rules_apple/commit/1199da04e51c273f5509a9153c32d4d8dd75b336, but adding
support for `ios_unit_test`, and `tvos_unit_test` targets was missed.

PiperOrigin-RevId: 457116795
(cherry picked from commit 889131aca743079cdff68cba27b4987ca301f9bb)