### PR TITLE
Fix rpath for application extensions

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -272,7 +272,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -287,8 +289,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),
@@ -327,7 +331,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.messages_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -465,7 +471,10 @@ _RULE_TYPE_DESCRIPTORS = {
             rpaths = [
                 # Extension binaries live in
                 # Application.app/Contents/PlugIns/Extension.appex/Contents/MacOS/Extension
-                # Frameworks are packaged in Application.app/Contents/Frameworks
+                # Frameworks are packaged in
+                # Application.app/Contents/PlugIns/Extension.appex/Contents/Frameworks
+                # or Application.app/Contents/Frameworks
+                "@executable_path/../Frameworks",
                 "@executable_path/../../../../Frameworks",
             ],
         ),
@@ -640,7 +649,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -654,8 +665,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),
@@ -744,7 +757,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.watch2_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -758,8 +773,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -156,6 +156,18 @@ def ios_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
+        tags = [name],
+    )
+
     entry_point_test(
         name = "{}_entry_point_nsextensionmain_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -16,6 +16,7 @@
 
 load(
     ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
     "entry_point_test",
 )
 
@@ -29,6 +30,18 @@ def macos_extension_test_suite(name):
         name = "{}_entry_point_nsextensionmain_test".format(name),
         build_type = "simulator",
         entry_point = "_NSExtensionMain",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ext",
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/MacOS/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/../Frameworks (offset 12)",
+            "path @executable_path/../../../../Frameworks (offset 12)",
+        ],
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ext",
         tags = [name],
     )

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -100,6 +100,18 @@ def tvos_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -183,6 +183,18 @@ def watchos_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],


### PR DESCRIPTION
We sometimes bundle frameworks for application extensions next to the extensions themselves. Our current rpath didn't reflect that possibility. This change adjusts the rpaths to match what Xcode sets, and fixes our current bug.

(cherry picked from commit e773dd491a93be4617128d7c1fb8bfa6d3c4d10a)