### PR TITLE
Silently drop 32 bit iOS architectures requested for apple_static_library when the minimum OS version is greater than or equal to 11.0, if the archs are provided via --ios_multi_cpus.

### DIFF
--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -192,6 +192,79 @@ def apple_static_library_test_suite(name):
         tags = [name],
     )
 
+    # Test that the output binary quietly omits the 32 bit iOS slice when built for a minimum OS
+    # that does not support 32 bit architectures.
+    binary_contents_test(
+        name = "{}_ios_binary_contents_dropping_32_bit_device_archs_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_os14",
+        cpus = {
+            "ios_multi_cpus": ["armv7", "armv7s", "arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_not_contains_architectures = ["armv7", "armv7s"],
+        tags = [name],
+    )
+
+    # Test that the iOS output binary still contains the 64 bit Arm slice when built for
+    # a minimum OS that does not support 32 bit architectures.
+    binary_contents_test(
+        name = "{}_ios_binary_contents_retains_arm64_when_dropping_32_bit_device_archs_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_os14",
+        cpus = {
+            "ios_multi_cpus": ["armv7", "armv7s", "arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION"],
+        tags = [name],
+    )
+
+    # Test that the output binary quietly omits the 32 bit iOS slice when built for a minimum OS
+    # that does not support 32 bit architectures.
+    binary_contents_test(
+        name = "{}_ios_binary_contents_dropping_32_bit_simulator_archs_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_os14",
+        cpus = {
+            "ios_multi_cpus": ["i386", "x86_64", "sim_arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_not_contains_architectures = ["i386"],
+        tags = [name],
+    )
+
+    # Test that the iOS output binary still contains the 64 bit Intel simulator slice when built for
+    # a minimum OS that does not support 32 bit architectures.
+    binary_contents_test(
+        name = "{}_ios_binary_contents_retains_x86_64_when_dropping_32_bit_simulator_archs_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_os14",
+        cpus = {
+            "ios_multi_cpus": ["i386", "x86_64", "sim_arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "x86_64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION"],
+        tags = [name],
+    )
+
+    # Test that the iOS output binary still contains the 64 bit Arm simulator slice when built for
+    # a minimum OS that does not support 32 bit architectures.
+    binary_contents_test(
+        name = "{}_ios_binary_contents_retains_arm64_when_dropping_32_bit_simulator_archs_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_os14",
+        cpus = {
+            "ios_multi_cpus": ["i386", "x86_64", "sim_arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION"],
+        tags = [name],
+    )
+
     # Test that the output binary is identified as watchOS simulator (PLATFORM_WATCHOSSIMULATOR) via
     # the Mach-O load command LC_BUILD_VERSION for an Intel binary.
     binary_contents_test(

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -192,7 +192,6 @@ def archive_contents_test(
         **kwargs
     )
 
-# TODO(nglevin): Extend for usages required of macos_command_line_application tests.
 def binary_contents_test(
         name,
         build_type,
@@ -200,6 +199,7 @@ def binary_contents_test(
         binary_test_file,
         binary_test_architecture = "",
         binary_contains_symbols = [],
+        binary_not_contains_architectures = [],
         binary_not_contains_symbols = [],
         binary_contains_file_info = [],
         macho_load_commands_contain = [],
@@ -215,9 +215,11 @@ def binary_contents_test(
         target_under_test: The Apple binary target whose contents are to be verified.
         binary_test_file: The binary file to test.
         binary_test_architecture: Optional, The architecture to use from `binary_test_file` for
-            symbol tests (see next two Args).
+            symbol tests.
         binary_contains_symbols: Optional, A list of symbols that should appear in the binary file
             specified in `binary_test_file`.
+        binary_not_contains_architectures: Optional. A list of architectures to verify do not exist
+            within `binary_test_file`.
         binary_not_contains_symbols: Optional, A list of symbols that should not appear in the
             binary file specified in `binary_test_file`.
         binary_contains_file_info: Optional, A list of strings that should appear as substrings of
@@ -248,6 +250,19 @@ def binary_contents_test(
         fail("Need at least one of (binary_contains_symbols, binary_not_contains_symbols, " +
              "macho_load_commands_contain, macho_load_commands_not_contain) when specifying " +
              "binary_test_architecture")
+    elif binary_test_file and not any([
+        binary_contains_symbols,
+        binary_not_contains_architectures,
+        binary_contains_file_info,
+        binary_not_contains_symbols,
+        macho_load_commands_contain,
+        macho_load_commands_not_contain,
+        plist_section_name,
+    ]):
+        fail("Need at least one of (binary_contains_symbols, binary_not_contains_architectures, " +
+             "binary_not_contains_symbols, binary_contains_file_info, " +
+             "macho_load_commands_contain, macho_load_commands_not_contain, plist_section_name) " +
+             "when specifying binary_test_file")
 
     if not any([binary_test_file, embedded_plist_test_values]):
         fail("There are no tests for the binary")
@@ -266,6 +281,7 @@ def binary_contents_test(
             "BINARY_TEST_FILE": [binary_test_file],
             "BINARY_TEST_ARCHITECTURE": [binary_test_architecture],
             "BINARY_CONTAINS_SYMBOLS": binary_contains_symbols,
+            "BINARY_NOT_CONTAINS_ARCHITECTURES": binary_not_contains_architectures,
             "BINARY_NOT_CONTAINS_SYMBOLS": binary_not_contains_symbols,
             "BINARY_CONTAINS_FILE_INFO": binary_contains_file_info,
             "MACHO_LOAD_COMMANDS_CONTAIN": macho_load_commands_contain,


### PR DESCRIPTION
This cannot be done at the transition level for --platforms or --apple_platforms, and can only be done at the rule level.

PiperOrigin-RevId: 459826894
(cherry picked from commit 41f791b924a8981a84777738d628a3b3aa9b8998)