### PR TITLE
Add tests to assert resources are propagated for framework import rules

### DIFF
--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -115,6 +115,7 @@ def ios_application_test_suite(name):
         contains = [
             "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Info.plist",
             "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/iOSDynamicFramework",
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Resources/iOSDynamicFramework.bundle/Info.plist",
         ],
         not_contains = [
             "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Headers/SharedClass.h",
@@ -140,9 +141,10 @@ def ios_application_test_suite(name):
         tags = [name],
     )
 
-    # Verify ios_application with imported static framework contains symbols for Objective-C/Swift
+    # Verify ios_application with imported static framework contains symbols for Objective-C/Swift,
+    # and resource bundles; but does not bundle the static library.
     archive_contents_test(
-        name = "{}_with_imported_static_fmwk_contains_symbols_and_not_bundles_files".format(name),
+        name = "{}_with_imported_static_fmwk_contains_symbols_and_bundles_resources".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_fmwk",
         binary_test_file = "$BINARY",
@@ -151,6 +153,7 @@ def ios_application_test_suite(name):
             "-[SharedClass doSomethingShared]",
             "_OBJC_CLASS_$_SharedClass",
         ],
+        contains = ["$BUNDLE_ROOT/iOSStaticFramework.bundle/Info.plist"],
         not_contains = ["$BUNDLE_ROOT/Frameworks/iOSStaticFramework.framework"],
         tags = [name],
     )

--- a/test/testdata/fmwk/BUILD
+++ b/test/testdata/fmwk/BUILD
@@ -95,6 +95,7 @@ filegroup(
 generate_import_framework(
     name = "iOSDynamicFramework",
     archs = ["x86_64"],
+    include_resource_bundle = True,
     libtype = "dynamic",
     minimum_os_version = "11.0",
     sdk = "iphonesimulator",
@@ -126,6 +127,7 @@ generate_import_framework(
 generate_import_framework(
     name = "iOSStaticFramework",
     archs = ["x86_64"],
+    include_resource_bundle = True,
     libtype = "static",
     minimum_os_version = "11.0",
     sdk = "iphonesimulator",

--- a/test/testdata/fmwk/generate_framework.bzl
+++ b/test/testdata/fmwk/generate_framework.bzl
@@ -30,12 +30,15 @@ def _generate_import_framework_impl(ctx):
 
     architectures = ctx.attr.archs
     hdrs = ctx.files.hdrs
-    include_module_interface_files = ctx.attr.include_module_interface_files
     libtype = ctx.attr.libtype
     minimum_os_version = ctx.attr.minimum_os_version
     sdk = ctx.attr.sdk
     srcs = ctx.files.src
+
     swift_library_files = ctx.files.swift_library
+
+    include_module_interface_files = ctx.attr.include_module_interface_files
+    include_resource_bundle = ctx.attr.include_resource_bundle
 
     if swift_library_files and len(architectures) > 1:
         fail("Internal error: Can only generate a Swift " +
@@ -111,6 +114,7 @@ def _generate_import_framework_impl(ctx):
         bundle_name = label.name,
         library = library,
         headers = headers,
+        include_resource_bundle = include_resource_bundle,
         module_interfaces = module_interfaces,
     )
 
@@ -148,6 +152,14 @@ Minimum version of the OS corresponding to the SDK that this binary will support
                 "@build_bazel_rules_apple//test/testdata/fmwk:objc_headers",
             ),
             doc = "Header files for the generated framework.",
+        ),
+        "include_resource_bundle": attr.bool(
+            mandatory = False,
+            default = False,
+            doc = """
+Boolean to indicate if the generate framework should include a resource bundle containing an
+Info.plist file to test resource propagation.
+""",
         ),
         "swift_library": attr.label(
             allow_files = True,

--- a/test/testdata/fmwk/generation_support.bzl
+++ b/test/testdata/fmwk/generation_support.bzl
@@ -227,6 +227,7 @@ def _create_framework(
         bundle_name,
         library,
         headers,
+        include_resource_bundle = False,
         module_interfaces = []):
     """Creates an Apple platform framework bundle.
 
@@ -236,6 +237,8 @@ def _create_framework(
         bundle_name: Name of the Framework bundle.
         library: The library for the Framework bundle.
         headers: List of header files for the Framework bundle.
+        include_resource_bundle: Boolean to indicate if a resource bundle should be added to
+            the framework bundle (optional).
         module_interfaces: List of Swift module interface files for the framework bundle (optional).
     Returns:
         List of files for a .framework bundle.
@@ -297,6 +300,12 @@ def _create_framework(
             )
             for interface_file in module_interfaces
         ])
+
+    if include_resource_bundle:
+        resources_path = paths.join(framework_directory, "Resources", bundle_name + ".bundle")
+        resource_file = actions.declare_file(paths.join(resources_path, "Info.plist"))
+        actions.write(output = resource_file, content = "Mock resource bundle")
+        framework_files.append(resource_file)
 
     return framework_files
 


### PR DESCRIPTION
Added tests for both dynamic and static Apple framework import rules to
assert resources are propagated appropiately for both formats:

- Dynamic frameworks: Propagated with the framework bundle.
- Static frameworks: Propagated as resource bundles.

PiperOrigin-RevId: 458529620
(cherry picked from commit df2f33cb6e8f30b7f95a6e47c27b1006e63df469)