### PR TITLE
Fix static xcframework import regressions

### DIFF
--- a/test/starlark_tests/apple_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_import_tests.bzl
@@ -22,6 +22,10 @@ load(
     ":rules/apple_verification_test.bzl",
     "apple_verification_test",
 )
+load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+)
 
 def apple_xcframework_import_test_suite(name):
     """Test suite for apple_dynamic_xcframework_import and apple_static_xcframework_import.
@@ -75,6 +79,20 @@ def apple_xcframework_import_test_suite(name):
         name = "{}_static_xcfw_import_ipa_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_xcfmwk",
         expected_outputs = ["app_with_imported_static_xcfmwk.ipa"],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_static_xcfw_binary_not_bundled".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_static_fmwks_with_resources",
+        contains = [
+            "$BUNDLE_ROOT/resource_bundle.bundle/custom_apple_resource_info.out",
+            "$BUNDLE_ROOT/resource_bundle.bundle/Info.plist",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/ios_static_xcframework_with_resources.framework/ios_static_xcframework_with_resources",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -882,6 +882,42 @@ apple_static_xcframework(
     deps = [":fmwk_lib_with_resources"],
 )
 
+genrule(
+    name = "generated_ios_static_xcframework_with_resources",
+    testonly = 1,
+    srcs = [":ios_static_xcframework_with_resources.xcframework.zip"],
+    outs = [
+        "{0}/{1}/{2}/{3}".format(
+            "ios_static_xcframework_with_resources.xcframework",
+            platform_id,
+            "ios_static_xcframework_with_resources.framework",
+            file,
+        )
+        for file in [
+            "Headers/ios_static_xcframework_with_resources.h",
+            "Headers/shared.h",
+            "Modules/module.modulemap",
+            "ios_static_xcframework_with_resources",
+            "resource_bundle.bundle/custom_apple_resource_info.out",
+            "resource_bundle.bundle/Info.plist",
+        ]
+        for platform_id in [
+            "ios-arm64",
+            "ios-arm64_x86_64-simulator",
+        ]
+    ] + ["ios_static_xcframework_with_resources.xcframework/Info.plist"],
+    cmd = """
+unzip -oqq $(execpath :ios_static_xcframework_with_resources.xcframework.zip) -d $(RULEDIR)
+""",
+)
+
+apple_static_xcframework_import(
+    name = "ios_static_xcframework_with_resources_import",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_ios_static_xcframework_with_resources"],
+)
+
 apple_static_xcframework(
     name = "ios_xcframework_bundling_static_fmwks",
     ios = {

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3041,6 +3041,25 @@ ios_application(
 )
 
 ios_application(
+    name = "app_with_imported_xcfmwk_bundling_static_fmwks_with_resources",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+        "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_with_resources_import",
+    ],
+)
+
+ios_application(
     name = "app_with_imported_static_xcfmwk_with_module_map",
     bundle_id = "com.google.example",
     families = [


### PR DESCRIPTION
1. Setting framework_imports resulted in bundling the static framework
   as well as linking it
2. The upstream version didn't handle importing resources from static
   frameworks