### PR TITLE
Fix static xcframework import identifier picking issues

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -385,6 +385,8 @@ def _get_library_identifier(
 
         if target_environment == "simulator" and not library_identifier.endswith("-simulator"):
             continue
+        if target_environment != "simulator" and library_identifier.endswith("-simulator"):
+            continue
 
         return library_identifier
 

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -183,20 +183,23 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
     if not library_identifier:
         return None
 
+    def _matches_library(file):
+        return library_identifier in file.short_path.split("/")
+
     files = xcframework.files_by_category
-    binaries = [f for f in files.binary_imports if library_identifier in f.short_path]
-    framework_imports = [f for f in files.bundling_imports if library_identifier in f.short_path]
-    headers = [f for f in files.header_imports if library_identifier in f.short_path]
-    module_maps = [f for f in files.module_map_imports if library_identifier in f.short_path]
+    binaries = [f for f in files.binary_imports if _matches_library(f)]
+    framework_imports = [f for f in files.bundling_imports if _matches_library(f)]
+    headers = [f for f in files.header_imports if _matches_library(f)]
+    module_maps = [f for f in files.module_map_imports if _matches_library(f)]
     swiftmodules = [
         f
         for f in files.swift_module_imports
-        if library_identifier in f.short_path and
+        if _matches_library(f) and
            f.basename.startswith(target_triplet.architecture)
     ]
 
     framework_dirs = [f.dirname for f in binaries]
-    framework_files = [f for f in xcframework.files if library_identifier in f.short_path]
+    framework_files = [f for f in xcframework.files if _matches_library(f)]
 
     includes = []
     framework_includes = []

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -233,6 +233,19 @@ def _command_line_options(
 
     output_dictionary["@build_bazel_rules_swift//swift:emit_swiftinterface"] = emit_swiftinterface
 
+    # Without handling this flag our transition differs from what we get
+    # from bazel when the dependency tree contains a rule inheriting bazel's
+    # built in transitions. This flag should not be used, we can remove this
+    # once https://github.com/bazelbuild/bazel/pull/13872 is merged
+    if platform_type == "ios":
+        output_dictionary["//command_line_option:ios_cpu"] = _cpu_string(
+            cpu = cpu,
+            platform_type = platform_type,
+            settings = settings,
+        )
+    else:
+        output_dictionary["//command_line_option:ios_cpu"] = ""
+
     return output_dictionary
 
 def _xcframework_split_attr_key(*, cpu, environment, platform_type):
@@ -358,6 +371,7 @@ _apple_rule_base_transition_outputs = [
     "//command_line_option:apple_split_cpu",
     "//command_line_option:compiler",
     "//command_line_option:cpu",
+    "//command_line_option:ios_cpu",
     "//command_line_option:crosstool_top",
     "//command_line_option:fission",
     "//command_line_option:grte_top",

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -39,6 +39,20 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_ios_application_with_imported_static_xcframework_includes_symbols_device".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework_with_static_library",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        not_contains = ["$BUNDLE_ROOT/Frameworks/"],
+        tags = [name],
+    )
+
     # Verify ios_application with XCFramework with Swift static library dependency contains
     # Objective-C symbols, doesn't bundle XCFramework, and does bundle Swift standard libraries.
     archive_contents_test(

--- a/test/starlark_tests/apple_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_import_tests.bzl
@@ -66,8 +66,16 @@ def apple_xcframework_import_test_suite(name):
     )
 
     apple_verification_test(
-        name = "{}_xcfmwk_bundling_static_xcfmwks_codesign_test".format(name),
+        name = "{}_xcfmwk_bundling_static_xcfmwks_codesign_test_simulator".format(name),
         build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_static_fmwks",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    apple_verification_test(
+        name = "{}_xcfmwk_bundling_static_xcfmwks_codesign_test_device".format(name),
+        build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_static_fmwks",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
         tags = [name],
@@ -83,8 +91,22 @@ def apple_xcframework_import_test_suite(name):
     )
 
     archive_contents_test(
-        name = "{}_static_xcfw_binary_not_bundled".format(name),
+        name = "{}_static_xcfw_binary_not_bundled_simulator".format(name),
         build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_static_fmwks_with_resources",
+        contains = [
+            "$BUNDLE_ROOT/resource_bundle.bundle/custom_apple_resource_info.out",
+            "$BUNDLE_ROOT/resource_bundle.bundle/Info.plist",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/ios_static_xcframework_with_resources.framework/ios_static_xcframework_with_resources",
+        ],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_static_xcfw_binary_not_bundled_device".format(name),
+        build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_static_fmwks_with_resources",
         contains = [
             "$BUNDLE_ROOT/resource_bundle.bundle/custom_apple_resource_info.out",

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -54,7 +54,7 @@ def _apple_verification_transition_impl(settings, attr):
         })
     else:
         output_dictionary.update({
-            "//command_line_option:ios_multi_cpus": "arm64,armv7",
+            "//command_line_option:ios_multi_cpus": "arm64",
             "//command_line_option:tvos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
         })

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1874,6 +1874,7 @@ ios_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "11.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = FIXTURE_TAGS,
     deps = [
         ":static_xcframework_depending_objc_lib",


### PR DESCRIPTION
Fix xcframework incorrect library identifier picking. There are a few issues being fixed here:

- armv7 can't be included in device tests unless we want to include it in xcframework fixtures, I just removed that since 32 bit usage should be low, and was also partially removed upstream
- added ios_cpu to the default transition, sometimes we get this set from bazel itself, so in the case you have a dependency tree where an ios_application built for device transitively depends on a apple_static_xcframework, you ended up with conflicting actions because of the minor configuration difference. Theoretically people mostly shouldn't have this, but if you want to test a real xcframework that's produced, then you hit this case
- fix library identification where previously it was too aggressive and over including simulator files for device