### PR TITLE
Remove ios_ prefix from ios_cpu setting

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -242,7 +242,7 @@ def _command_line_options(
             cpu = cpu,
             platform_type = platform_type,
             settings = settings,
-        )
+        )[len("ios_"):]
     else:
         output_dictionary["//command_line_option:ios_cpu"] = ""
 


### PR DESCRIPTION
This was incorrectly set as ios_x86_64 etc, I think it worked in my
initial test because this value is mostly ignored, it failed in an
internal test we have because the value changed from `x86_64` to
`ios_x86_64` from this logic.