### PR TITLE
Enable sandboxing for swift builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,5 +17,10 @@ test --build_tests_only
 # visibility and symbol import issues are resolved.
 build --nocheck_visibility
 
+# Disable the worker, which has sandboxing disabled by default, which can hide
+# issues with non-hermetic bugs.
+build --spawn_strategy=sandboxed,local
+build --worker_sandboxing=true
+
 # Use llvm-cov instead of gcov (default).
 coverage --experimental_use_llvm_covmap


### PR DESCRIPTION
I discovered an issue in the rules where we were relying on the fact
that persistent workers, which rules_swift uses, disable the sandbox by
default. Disabling workers in these rules shouldn't hurt anything since
we don't rely on the incremental compilation performance benefits.