### PR TITLE
Add swift_clang_module_aspect to apple_static_xcframework_import deps

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -726,6 +726,7 @@ linked into that target.
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],
+                aspects = [swift_clang_module_aspect],
             ),
             "has_swift": attr.bool(
                 doc = """

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -23,6 +23,15 @@ def apple_static_xcframework_import_test_suite(name):
       name: the base name to be used in things created by this macro
     """
 
+    # Verify the dependent app target successfully builds
+    archive_contents_test(
+        name = "{}_swift_multi_level_static_xcframework".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_swift_multi_level_static_xcframework",
+        contains = ["$ARCHIVE_ROOT/Payload"],
+        build_type = "simulator",
+        tags = [name],
+    )
+
     # Verify ios_application with XCFramework with static library dependency contains symbols and
     # does not bundle anything under Frameworks/
     archive_contents_test(

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1264,3 +1264,17 @@ apple_static_xcframework_import(
     visibility = ["//visibility:public"],
     xcframework_imports = ["//test/testdata/xcframeworks:generated_swift_static_xcframework_without_swiftmodule"],
 )
+
+apple_static_xcframework_import(
+    name = "ios_imported_static_xcframework_base",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    xcframework_imports = ["//test/testdata/xcframeworks:generated_static_xcframework_base"],
+)
+
+apple_static_xcframework_import(
+    name = "ios_imported_static_xcframework_depends_on_base",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    visibility = ["//visibility:public"],
+    xcframework_imports = ["//test/testdata/xcframeworks:generated_static_xcframework_depends_on_base"],
+    deps = [":ios_imported_static_xcframework_base"],
+)

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2023,6 +2023,34 @@ EOF
 """,
 )
 
+swift_library(
+    name = "swift_multi_level_static_xcframework",
+    srcs = [":swift_multi_level_static_xcframework_src"],
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/targets_under_test/apple:ios_imported_static_xcframework_depends_on_base",
+    ],
+)
+
+genrule(
+    name = "swift_multi_level_static_xcframework_src",
+    outs = ["SwiftMultiLevelStaticXCFramework.swift"],
+    cmd = "echo 'import generated_static_xcframework_depends_on_base' > $(OUTS)",
+)
+
+ios_application(
+    name = "app_with_swift_multi_level_static_xcframework",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = "11.0",
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":swift_multi_level_static_xcframework",
+        "//test/starlark_tests/resources:swift_main_lib",
+    ],
+)
+
 # ---------------------------------------------------------------------------------------
 
 ios_imessage_application(

--- a/test/testdata/xcframeworks/BUILD
+++ b/test/testdata/xcframeworks/BUILD
@@ -3,6 +3,7 @@ load("//test/starlark_tests:common.bzl", "FIXTURE_TAGS")
 load(
     "//test/testdata/xcframeworks:generate_xcframework.bzl",
     "generate_dynamic_xcframework",
+    "generate_static_framework_xcframework",
     "generate_static_xcframework",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
@@ -120,6 +121,30 @@ generate_static_xcframework(
     include_module_interface_files = False,
     platforms = {"ios_simulator": ["x86_64"]},
     swift_library = ":swift_lib_for_static_xcframework",
+    tags = FIXTURE_TAGS,
+)
+
+generate_static_framework_xcframework(
+    name = "generated_static_xcframework_base",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {"ios_simulator": "11.0"},
+    platforms = {"ios_simulator": ["x86_64"]},
+    tags = FIXTURE_TAGS,
+)
+
+genrule(
+    name = "generated_static_xcframework_depends_on_base_header",
+    outs = ["generated_static_xcframework_depends_on_base_header.h"],
+    cmd = "echo '@import generated_static_xcframework_base;' > $(OUTS)",
+)
+
+generate_static_framework_xcframework(
+    name = "generated_static_xcframework_depends_on_base",
+    srcs = ["@bazel_tools//tools/objc:objc_dummy.mm"],
+    hdrs = ["generated_static_xcframework_depends_on_base_header"],
+    minimum_os_versions = {"ios_simulator": "11.0"},
+    platforms = {"ios_simulator": ["x86_64"]},
     tags = FIXTURE_TAGS,
 )
 


### PR DESCRIPTION
This is the same fix as
https://github.com/bazelbuild/rules_apple/pull/1175 for nested static
xcframework imports.