### PR TITLE
Make testrunner attributes public

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -45,13 +45,13 @@ def _ios_test_runner_impl(ctx):
     device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or ""
 
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(
             device_type = device_type,
             os_version = os_version,
             simulator_creator = ctx.executable._simulator_creator.short_path,
-            testrunner = ctx.executable._testrunner.short_path,
+            testrunner = ctx.executable.testrunner.short_path,
         ),
     )
     return [
@@ -65,7 +65,7 @@ def _ios_test_runner_impl(ctx):
         ),
         DefaultInfo(
             runfiles = ctx.attr._simulator_creator[DefaultInfo].default_runfiles
-                .merge(ctx.attr._testrunner[DefaultInfo].default_runfiles),
+                .merge(ctx.attr.testrunner[DefaultInfo].default_runfiles),
         ),
     ]
 
@@ -102,13 +102,13 @@ Optional dictionary with the environment variables that are to be propagated
 into the XCTest invocation.
 """,
         ),
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label(
                 "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.template.sh",
             ),
             allow_single_file = True,
         ),
-        "_testrunner": attr.label(
+        "testrunner": attr.label(
             default = Label(
                 "@xctestrunner//:ios_test_runner",
             ),

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -85,7 +85,7 @@ def _macos_test_runner_impl(ctx):
     )
 
     ctx.actions.expand_template(
-        template = ctx.file._test_template,
+        template = ctx.file.test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(preprocessed_xctestrun_template),
     )
@@ -106,7 +106,7 @@ def _macos_test_runner_impl(ctx):
 macos_test_runner = rule(
     _macos_test_runner_impl,
     attrs = {
-        "_test_template": attr.label(
+        "test_template": attr.label(
             default = Label("@build_bazel_rules_apple//apple/testing/default_runner:macos_test_runner.template.sh"),
             allow_single_file = True,
         ),


### PR DESCRIPTION
In rules_ios we're building out Apple Silicon based ephemeral VM test
runners to improve running in remote execution and locally. Currently,
we use rules_apple xctestrunner to run the tests under Bazel directly.
You can find this PR here:
https://github.com/bazel-ios/rules_ios/pull/509

Today if you'd like to make a different test runner, you have to copy
the rule and making the attributes public would help hook into them
better. The archicture as it stands is quite nice. Ideally we could make
`sim_creator` an implementation detail of the testrunner / template
combo: or feed that in a different way but leaving as-is for now