### PR TITLE
Add docs on codesigning perf improvement

### DIFF
--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -1,3 +1,5 @@
+load("@build_bazel_apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
+
 licenses(["notice"])
 
 py_binary(
@@ -19,6 +21,13 @@ py_library(
         "//tools:__subpackages__",
     ],
     deps = ["//tools/wrapper_common:execute"],
+)
+
+toolchain_substitution(
+    name = "disable_signing_resource_rules",
+    src = "disable_signing_resource_rules.plist",
+    var_name = "RESOURCE_RULES",
+    visibility = ["//visibility:public"],
 )
 
 # Consumed by bazel tests.

--- a/tools/codesigningtool/disable_signing_resource_rules.plist
+++ b/tools/codesigningtool/disable_signing_resource_rules.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>rules</key>
+	<dict>
+		<key>.*</key>
+		<false/>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
For our app this cuts BundleTreeApp time in half from ~16s to ~8s.

Depends on https://github.com/bazelbuild/apple_support/pull/125