### PR TITLE
Fix linkmap test on M1s

### DIFF
--- a/test/starlark_tests/rules/linkmap_test.bzl
+++ b/test/starlark_tests/rules/linkmap_test.bzl
@@ -15,6 +15,10 @@
 """Starlark test rules for linkmap generation."""
 
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+)
+load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
@@ -31,7 +35,13 @@ def _linkmap_test_impl(ctx):
     architectures = ctx.attr.architectures
 
     if not architectures:
-        architecture = [ctx.fragments.apple.single_arch_cpu]
+        platform_type = target_under_test[AppleBundleInfo].platform_type
+        if platform_type == "ios" or platform_type == "macos":
+            architectures = [ctx.fragments.apple.single_arch_cpu]
+        elif platform_type == "watchos":
+            architectures = ["i386"]
+        else:
+            architectures = ["x86_64"]
 
     outputs = {
         x.short_path: None


### PR DESCRIPTION
Amended fix for https://github.com/bazelbuild/rules_apple/pull/1516.

Only the default CPU of iOS and macOS platforms are determined by the
host architecture, other platforms' default CPU is hardcoded in Bazel.
