### PR TITLE
Fix `//test:ios_test_runner_unit_test` on Apple silicon

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -413,7 +413,7 @@ apple_shell_test(
     size = "large",
     src = "ios_test_runner_unit_test.sh",
     args = [
-        "--ios_multi_cpus=i386,x86_64",
+        "--ios_multi_cpus=i386,x86_64,sim_arm64",
     ],
     shard_count = 9,
 )


### PR DESCRIPTION
Fixes the following error:

```
The bundle “PassingUnitTest.xctest” couldn’t be loaded because it
doesn’t contain a version for the current architecture. Try installing a
universal version of the bundle.

xctest[55577:4381014] (dlopen_preflight(/var/folders/x3/f2fpjwq53bb8_pwhztk_w0500000gp/T/test_runner_work_dir.MKZ5U8/PassingUnitTest/PassingUnitTest.xctest/PassingUnitTest) => false, tried: '/var/folders/x3/f2fpjwq53bb8_pwhztk_w0500000gp/T/test_runner_work_dir.MKZ5U8/PassingUnitTest/PassingUnitTest.xctest/PassingUnitTest' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64')))
```
