### PR TITLE
Use apple_platforms_split_transition for static_framework rules

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -512,6 +512,7 @@ bzl_library(
     deps = [
         ":apple_product_type",
         ":bundle_package_type",
+        ":transition_support",
     ],
 )
 

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -15,6 +15,10 @@
 """Implementation of iOS rules."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -88,10 +92,6 @@ load(
     "swift_support",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
 )
@@ -100,16 +100,13 @@ load(
     "SwiftDynamicFrameworkInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
-    "clang_rt_dylibs",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
+    "ApplePlatformInfo",
     "IosAppClipBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
@@ -119,6 +116,7 @@ load(
     "IosStaticFrameworkBundleInfo",
     "IosStickerPackExtensionBundleInfo",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
@@ -1392,6 +1390,7 @@ def _ios_static_framework_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     avoid_deps = ctx.attr.avoid_deps
+    cc_toolchain_forwarder = ctx.split_attr._cc_toolchain_forwarder
     deps = ctx.attr.deps
     label = ctx.label
     predeclared_outputs = ctx.outputs
@@ -1431,15 +1430,11 @@ def _ios_static_framework_impl(ctx):
 
     swift_infos = {}
     if swift_support.uses_swift(deps):
-        for link_output in link_result.outputs:
-            split_attr_key = transition_support.apple_common_multi_arch_split_key(
-                cpu = link_output.architecture,
-                environment = link_output.environment,
-                platform_type = link_output.platform,
-            )
+        for split_attr_key, cc_toolchain in cc_toolchain_forwarder.items():
+            apple_platform_info = cc_toolchain[ApplePlatformInfo]
             for dep in split_deps[split_attr_key]:
                 if SwiftInfo in dep:
-                    swift_infos[link_output.architecture] = dep[SwiftInfo]
+                    swift_infos[apple_platform_info.target_arch] = dep[SwiftInfo]
 
     # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
     # framework.
@@ -2147,6 +2142,7 @@ target. Finally, it also bundles a `module.modulemap` file pointing to the
 umbrella header for Objetive-C module compatibility. This umbrella header and
 modulemap can be skipped by disabling the `swift.no_generated_header` feature (
 i.e. `--features=-swift.no_generated_header`).""",
+    cfg = transition_support.apple_platforms_rule_base_transition,
 )
 
 ios_imessage_application = rule_factory.create_apple_bundling_rule(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -108,6 +108,7 @@ load(
     "AppleBinaryInfo",
     "AppleBinaryInfoplistInfo",
     "AppleFrameworkBundleInfo",
+    "ApplePlatformInfo",
     "MacosApplicationBundleInfo",
     "MacosBundleBundleInfo",
     "MacosExtensionBundleInfo",
@@ -2369,6 +2370,7 @@ def _macos_static_framework_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     avoid_deps = ctx.attr.avoid_deps
+    cc_toolchain_forwarder = ctx.split_attr._cc_toolchain_forwarder
     deps = ctx.attr.deps
     label = ctx.label
     predeclared_outputs = ctx.outputs
@@ -2408,15 +2410,11 @@ def _macos_static_framework_impl(ctx):
 
     swift_infos = {}
     if swift_support.uses_swift(deps):
-        for link_output in link_result.outputs:
-            split_attr_key = transition_support.apple_common_multi_arch_split_key(
-                cpu = link_output.architecture,
-                environment = link_output.environment,
-                platform_type = link_output.platform,
-            )
+        for split_attr_key, cc_toolchain in cc_toolchain_forwarder.items():
+            apple_platform_info = cc_toolchain[ApplePlatformInfo]
             for dep in split_deps[split_attr_key]:
                 if SwiftInfo in dep:
-                    swift_infos[link_output.architecture] = dep[SwiftInfo]
+                    swift_infos[apple_platform_info.target_arch] = dep[SwiftInfo]
 
     # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
     # framework.

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -2503,6 +2503,7 @@ macos_static_framework = rule_factory.create_apple_bundling_rule(
     implementation = _macos_static_framework_impl,
     platform_type = "macos",
     product_type = apple_product_type.static_framework,
+    cfg = transition_support.apple_platforms_rule_base_transition,
     doc = """Builds and bundles a macOS static framework for third-party distribution.
 
 A static framework is bundled like a dynamic framework except that the embedded

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -66,6 +66,7 @@ load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleBundleVersionInfo",
+    "ApplePlatformInfo",
     "AppleResourceBundleInfo",
     "AppleTestRunnerInfo",
     "IosAppClipBundleInfo",
@@ -125,7 +126,9 @@ def _common_linking_api_attrs(*, cfg = apple_common.multi_arch_split):
     return {
         "_child_configuration_dummy": attr.label(
             cfg = cfg,
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+            default =
+                "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
         ),
     }
 
@@ -162,12 +165,22 @@ def _link_multi_arch_binary_attrs(*, cfg = apple_common.multi_arch_split):
 
 # Needed for the J2ObjC processing code that already exists in the implementation of
 # apple_common.link_multi_arch_binary.
-_J2OBJC_BINARY_LINKING_ATTRS = {
-    "_dummy_lib": attr.label(
-        cfg = apple_common.multi_arch_split,
-        default = Label("@bazel_tools//tools/objc:dummy_lib"),
-    ),
-}
+def _j2objc_binary_linking_attrs(*, cfg):
+    return {
+        "_dummy_lib": attr.label(
+            cfg = cfg,
+            default = Label("@bazel_tools//tools/objc:dummy_lib"),
+        ),
+        "_j2objc_dead_code_pruner": attr.label(
+            executable = True,
+            # Setting `allow_single_file=True` would be more correct. Unfortunately,
+            # doing so prevents using py_binary as the underlying target because py_binary
+            # produces at least _two_ output files (the executable plus any files in srcs)
+            allow_files = True,
+            cfg = "exec",
+            default = Label("@bazel_tools//tools/objc:j2objc_dead_code_pruner_binary"),
+        ),
+    }
 
 _COMMON_TEST_ATTRS = {
     "data": attr.label_list(
@@ -251,8 +264,8 @@ def _common_binary_linking_attrs(deps_cfg, product_type):
 
     return dicts.add(
         _COMMON_ATTRS,
-        _J2OBJC_BINARY_LINKING_ATTRS,
-        _link_multi_arch_binary_attrs(),
+        _j2objc_binary_linking_attrs(cfg = deps_cfg),
+        _link_multi_arch_binary_attrs(cfg = deps_cfg),
         {
             # This attribute is required by the Clang runtime libraries processing partial.
             # See utils/clang_rt_dylibs.bzl and partials/clang_rt_dylibs.bzl
@@ -601,6 +614,12 @@ to manually dlopen the framework at runtime.
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
             ),
+            "_cc_toolchain_forwarder": attr.label(
+                cfg = transition_support.apple_platform_split_transition,
+                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+                default =
+                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+            ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],
                 doc = """
@@ -619,7 +638,7 @@ umbrella header will be generated under the same name as this target.
 """,
             ),
             "avoid_deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive
 closure of which will not be linked into the framework's binary.
@@ -981,6 +1000,12 @@ to manually dlopen the framework at runtime.
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
             ),
+            "_cc_toolchain_forwarder": attr.label(
+                cfg = transition_support.apple_platform_split_transition,
+                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+                default =
+                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+            ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],
                 doc = """
@@ -999,7 +1024,7 @@ umbrella header will be generated under the same name as this target.
 """,
             ),
             "avoid_deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive
 closure of which will not be linked into the framework's binary.

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -878,6 +878,12 @@ to manually dlopen the framework at runtime.
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
             ),
+            "_cc_toolchain_forwarder": attr.label(
+                cfg = transition_support.apple_platform_split_transition,
+                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+                default =
+                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+            ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],
                 doc = """
@@ -1142,6 +1148,12 @@ to manually dlopen the framework at runtime.
             "_emitswiftinterface": attr.bool(
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
+            ),
+            "_cc_toolchain_forwarder": attr.label(
+                cfg = transition_support.apple_platform_split_transition,
+                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+                default =
+                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
             ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -29,6 +29,10 @@ load(
     "@build_bazel_rules_apple//apple/internal:bundle_package_type.bzl",
     "bundle_package_type",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
 
 # Options to declare signing behavior and exceptions.
 #
@@ -352,7 +356,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["iphone", "ipad"],
             bundle_extension = ".framework",
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.skip_signing,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_infoplist = False,
             product_type = apple_product_type.static_framework,
             requires_bundle_id = False,
@@ -705,7 +709,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["tv"],
             bundle_extension = ".framework",
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.skip_signing,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_infoplist = False,
             product_type = apple_product_type.static_framework,
             requires_bundle_id = False,

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -325,7 +325,7 @@ def _command_line_options_for_xcframework_platform(
     return output_dictionary
 
 def _apple_rule_base_transition_impl(settings, attr):
-    """Rule transition for Apple rules."""
+    """Rule transition for Apple rules using Bazel cpus and apple_common split transition."""
     return _command_line_options(
         emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
         minimum_os_version = attr.minimum_os_version,
@@ -347,6 +347,9 @@ _apple_rule_base_transition_inputs = _apple_rule_common_transition_inputs + [
     "//command_line_option:macos_cpus",
     "//command_line_option:tvos_cpus",
     "//command_line_option:watchos_cpus",
+]
+_apple_platforms_rule_base_transition_inputs = _apple_rule_base_transition_inputs + [
+    "//command_line_option:apple_platforms",
 ]
 _apple_platform_transition_inputs = _apple_rule_base_transition_inputs + [
     "//command_line_option:apple_platforms",
@@ -380,6 +383,22 @@ _apple_universal_binary_rule_transition_outputs = _apple_rule_base_transition_ou
 _apple_rule_base_transition = transition(
     implementation = _apple_rule_base_transition_impl,
     inputs = _apple_rule_base_transition_inputs,
+    outputs = _apple_rule_base_transition_outputs,
+)
+
+def _apple_platforms_rule_base_transition_impl(settings, attr):
+    """Rule transition for Apple rules using Bazel platforms and Starlark split transition."""
+    return _command_line_options(
+        apple_platforms = settings["//command_line_option:apple_platforms"],
+        emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
+        minimum_os_version = attr.minimum_os_version,
+        platform_type = attr.platform_type,
+        settings = settings,
+    )
+
+_apple_platforms_rule_base_transition = transition(
+    implementation = _apple_platforms_rule_base_transition_impl,
+    inputs = _apple_platforms_rule_base_transition_inputs,
     outputs = _apple_rule_base_transition_outputs,
 )
 
@@ -442,8 +461,12 @@ _apple_universal_binary_rule_transition = transition(
 def _apple_platform_split_transition_impl(settings, attr):
     """Starlark 1:2+ transition for Apple platform-aware rules"""
     output_dictionary = {}
-
     invalid_requested_archs = []
+
+    # iOS and tvOS static frameworks require underlying swift_library targets generate a Swift
+    # interface file. These rules define a private attribute called `_emitswiftinterface` that
+    # let's this transition flip rules_swift config down the build graph.
+    emit_swiftinterface = hasattr(attr, "_emitswiftinterface")
 
     if settings["//command_line_option:incompatible_enable_apple_toolchain_resolution"]:
         platforms = (
@@ -465,6 +488,7 @@ def _apple_platform_split_transition_impl(settings, attr):
             if str(platform) not in output_dictionary:
                 output_dictionary[str(platform)] = _command_line_options(
                     apple_platforms = apple_platforms,
+                    emit_swiftinterface = emit_swiftinterface,
                     minimum_os_version = attr.minimum_os_version,
                     platform_type = attr.platform_type,
                     settings = settings,
@@ -523,6 +547,7 @@ def _apple_platform_split_transition_impl(settings, attr):
 
             output_dictionary[found_cpu] = _command_line_options(
                 cpu = cpu,
+                emit_swiftinterface = emit_swiftinterface,
                 minimum_os_version = minimum_os_version,
                 platform_type = platform_type,
                 settings = settings,
@@ -549,33 +574,6 @@ _apple_platform_split_transition = transition(
     inputs = _apple_platform_transition_inputs,
     outputs = _apple_rule_base_transition_outputs,
 )
-
-# TODO(b/230527536): Add support for Bazel platforms on ios/tvos_static_framework transition support method
-def _apple_common_multi_arch_split_key(*, cpu, environment, platform_type):
-    """Returns split key for the apple_common.multi_arch_split transition based on target triplet.
-
-    See ApplePlatform.cpuStringForTarget for reference on how apple_common.multi_arch_split
-    transition key is built.
-
-     Args:
-        cpu: The architecture of the target that was built. For example, `x86_64` or
-            `arm64`.
-        environment: The environment of the target that was built, which corresponds to the
-            toolchain's target triple values as reported by `apple_support.link_multi_arch_*`
-            for environment. Typically `device` or `simulator`.
-        platform_type: The platform of the target that was built, which corresponds to the
-            toolchain's target triple values as reported by `apple_common.link_multi_arch_*`
-            for platform. For example, `ios`, `macos`, `tvos` or `watchos`.
-    """
-    cpu = _resolved_cpu_for_cpu(
-        cpu = cpu,
-        environment = environment,
-        platform_type = platform_type,
-    )
-    return _cpu_string(
-        cpu = cpu,
-        platform_type = platform_type,
-    )
 
 def _xcframework_transition_impl(settings, attr):
     """Starlark 1:2+ transition for generation of multiple frameworks for the current target."""
@@ -606,10 +604,10 @@ _xcframework_transition = transition(
 
 transition_support = struct(
     apple_platform_split_transition = _apple_platform_split_transition,
-    apple_rule_transition = _apple_rule_base_transition,
+    apple_platforms_rule_base_transition = _apple_platforms_rule_base_transition,
     apple_rule_arm64_as_arm64e_transition = _apple_rule_arm64_as_arm64e_transition,
+    apple_rule_transition = _apple_rule_base_transition,
     apple_universal_binary_rule_transition = _apple_universal_binary_rule_transition,
-    apple_common_multi_arch_split_key = _apple_common_multi_arch_split_key,
     xcframework_split_attr_key = _xcframework_split_attr_key,
     xcframework_transition = _xcframework_transition,
 )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -19,6 +19,10 @@ load(
     "SwiftDynamicFrameworkInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -88,16 +92,8 @@ load(
     "swift_support",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
-    "clang_rt_dylibs",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
@@ -106,12 +102,17 @@ load(
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
+    "ApplePlatformInfo",
     "TvosApplicationBundleInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
     "TvosStaticFrameworkBundleInfo",
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 
 def _tvos_application_impl(ctx):
     """Experimental implementation of tvos_application."""
@@ -1063,6 +1064,7 @@ def _tvos_static_framework_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     avoid_deps = ctx.attr.avoid_deps
+    cc_toolchain_forwarder = ctx.split_attr._cc_toolchain_forwarder
     deps = ctx.attr.deps
     label = ctx.label
     predeclared_outputs = ctx.outputs
@@ -1102,15 +1104,11 @@ def _tvos_static_framework_impl(ctx):
 
     swift_infos = {}
     if swift_support.uses_swift(deps):
-        for link_output in link_result.outputs:
-            split_attr_key = transition_support.apple_common_multi_arch_split_key(
-                cpu = link_output.architecture,
-                environment = link_output.environment,
-                platform_type = link_output.platform,
-            )
+        for split_attr_key, cc_toolchain in cc_toolchain_forwarder.items():
+            apple_platform_info = cc_toolchain[ApplePlatformInfo]
             for dep in split_deps[split_attr_key]:
                 if SwiftInfo in dep:
-                    swift_infos[link_output.architecture] = dep[SwiftInfo]
+                    swift_infos[apple_platform_info.target_arch] = dep[SwiftInfo]
 
     # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
     # framework.
@@ -1253,4 +1251,5 @@ umbrella header for Objetive-C module compatibility. This umbrella header and
 modulemap can be skipped by disabling the `swift.no_generated_header` feature (
 i.e. `--features=-swift.no_generated_header`).
 """,
+    cfg = transition_support.apple_platforms_rule_base_transition,
 )

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -84,10 +84,6 @@ load(
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
-    "transition_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -98,6 +94,7 @@ load(
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
+    "ApplePlatformInfo",
     "WatchosApplicationBundleInfo",
     "WatchosExtensionBundleInfo",
     "WatchosFrameworkBundleInfo",
@@ -1059,6 +1056,7 @@ def _watchos_static_framework_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     avoid_deps = ctx.attr.avoid_deps
+    cc_toolchain_forwarder = ctx.split_attr._cc_toolchain_forwarder
     deps = ctx.attr.deps
     label = ctx.label
     predeclared_outputs = ctx.outputs
@@ -1099,15 +1097,11 @@ def _watchos_static_framework_impl(ctx):
 
     swift_infos = {}
     if swift_support.uses_swift(deps):
-        for link_output in link_result.outputs:
-            split_attr_key = transition_support.apple_common_multi_arch_split_key(
-                cpu = link_output.architecture,
-                environment = link_output.environment,
-                platform_type = link_output.platform,
-            )
+        for split_attr_key, cc_toolchain in cc_toolchain_forwarder.items():
+            apple_platform_info = cc_toolchain[ApplePlatformInfo]
             for dep in split_deps[split_attr_key]:
                 if SwiftInfo in dep:
-                    swift_infos[link_output.architecture] = dep[SwiftInfo]
+                    swift_infos[apple_platform_info.target_arch] = dep[SwiftInfo]
 
     # If there's any Swift dependencies on the static framework rule, treat it as a Swift static
     # framework.

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -84,6 +84,10 @@ load(
     "swift_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -1224,4 +1228,5 @@ watchos_static_framework = rule_factory.create_apple_bundling_rule(
     platform_type = "watchos",
     product_type = apple_product_type.static_framework,
     doc = "Builds and bundles a watchOS Static Framework.",
+    cfg = transition_support.apple_platforms_rule_base_transition,
 )

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -102,8 +102,8 @@ def ios_static_framework_test_suite(name):
         binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
         binary_test_architecture = "x86_64",
-        macho_load_commands_contain = ["cmd LC_VERSION_MIN_IPHONEOS"],
-        macho_load_commands_not_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
+        macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_IPHONEOS"],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -81,7 +81,7 @@ def ios_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_sim_arm64_builds_using_apple_platforms".format(name),
         apple_platforms = [
-            "@build_bazel_apple_support//platforms:ios_arm64",
+            "@build_bazel_apple_support//platforms:ios_sim_arm64",
             "@build_bazel_apple_support//platforms:ios_x86_64",
         ],
         build_type = "simulator",
@@ -95,7 +95,7 @@ def ios_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_x86_64_builds_using_apple_platforms".format(name),
         apple_platforms = [
-            "@build_bazel_apple_support//platforms:ios_arm64",
+            "@build_bazel_apple_support//platforms:ios_sim_arm64",
             "@build_bazel_apple_support//platforms:ios_x86_64",
         ],
         build_type = "simulator",

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -51,7 +51,6 @@ def ios_static_framework_test_suite(name):
     )
 
     archive_contents_test(
-        name = "{}_swift_sim_arm64_builds".format(name),
         name = "{}_swift_sim_arm64_builds_using_ios_multi_cpus".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
@@ -82,8 +81,8 @@ def ios_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_sim_arm64_builds_using_apple_platforms".format(name),
         apple_platforms = [
-            "//buildenv/platforms/apple/simulator:ios_arm64",
-            "//buildenv/platforms/apple/simulator:ios_x86_64",
+            "@build_bazel_apple_support//platforms:ios_arm64",
+            "@build_bazel_apple_support//platforms:ios_x86_64",
         ],
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
@@ -96,8 +95,8 @@ def ios_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_x86_64_builds_using_apple_platforms".format(name),
         apple_platforms = [
-            "//buildenv/platforms/apple/simulator:ios_arm64",
-            "//buildenv/platforms/apple/simulator:ios_x86_64",
+            "@build_bazel_apple_support//platforms:ios_arm64",
+            "@build_bazel_apple_support//platforms:ios_x86_64",
         ],
         build_type = "simulator",
         binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -51,6 +51,7 @@ def ios_static_framework_test_suite(name):
     )
 
     archive_contents_test(
+        name = "{}_swift_sim_arm64_builds".format(name),
         name = "{}_swift_sim_arm64_builds_using_ios_multi_cpus".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
@@ -64,7 +65,7 @@ def ios_static_framework_test_suite(name):
         tags = [name],
     )
     archive_contents_test(
-        name = "{}_swift_x86_64_builds".format(name),
+        name = "{}_swift_x86_64_builds_using_ios_multi_cpus".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
         cpus = {
@@ -74,6 +75,36 @@ def ios_static_framework_test_suite(name):
         binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "minos " + common.min_os_ios.baseline, "platform IOSSIMULATOR"],
         macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_IPHONEOS"],
+        tags = [name],
+    )
+
+    # Tests Swift ios_static_framework builds correctly for apple_platforms.
+    archive_contents_test(
+        name = "{}_swift_sim_arm64_builds_using_apple_platforms".format(name),
+        apple_platforms = [
+            "//buildenv/platforms/apple/simulator:ios_arm64",
+            "//buildenv/platforms/apple/simulator:ios_x86_64",
+        ],
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
+        binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
+        macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_IPHONEOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_swift_x86_64_builds_using_apple_platforms".format(name),
+        apple_platforms = [
+            "//buildenv/platforms/apple/simulator:ios_arm64",
+            "//buildenv/platforms/apple/simulator:ios_x86_64",
+        ],
+        build_type = "simulator",
+        binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
+        binary_test_architecture = "x86_64",
+        macho_load_commands_contain = ["cmd LC_VERSION_MIN_IPHONEOS"],
+        macho_load_commands_not_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -74,8 +74,8 @@ def tvos_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_sim_arm64_builds_using_platforms".format(name),
         apple_platforms = [
-            "//buildenv/platforms/apple/simulator:tvos_arm64",
-            "//buildenv/platforms/apple/simulator:tvos_x86_64",
+            "@build_bazel_apple_support//platforms:tvos_arm64",
+            "@build_bazel_apple_support//platforms:tvos_x86_64",
         ],
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
@@ -88,8 +88,8 @@ def tvos_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_x86_64_builds_using_platforms".format(name),
         apple_platforms = [
-            "//buildenv/platforms/apple/simulator:tvos_arm64",
-            "//buildenv/platforms/apple/simulator:tvos_x86_64",
+            "@build_bazel_apple_support//platforms:tvos_arm64",
+            "@build_bazel_apple_support//platforms:tvos_x86_64",
         ],
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -74,7 +74,7 @@ def tvos_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_sim_arm64_builds_using_platforms".format(name),
         apple_platforms = [
-            "@build_bazel_apple_support//platforms:tvos_arm64",
+            "@build_bazel_apple_support//platforms:tvos_sim_arm64",
             "@build_bazel_apple_support//platforms:tvos_x86_64",
         ],
         build_type = "simulator",
@@ -88,7 +88,7 @@ def tvos_static_framework_test_suite(name):
     archive_contents_test(
         name = "{}_swift_x86_64_builds_using_platforms".format(name),
         apple_platforms = [
-            "@build_bazel_apple_support//platforms:tvos_arm64",
+            "@build_bazel_apple_support//platforms:tvos_sim_arm64",
             "@build_bazel_apple_support//platforms:tvos_x86_64",
         ],
         build_type = "simulator",

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -44,7 +44,7 @@ def tvos_static_framework_test_suite(name):
 
     # Tests Swift tvos_static_framework builds correctly for sim_arm64, and x86_64 cpu's.
     archive_contents_test(
-        name = "{}_swift_sim_arm64_builds".format(name),
+        name = "{}_swift_sim_arm64_builds_using_tvos_cpus".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
         cpus = {
@@ -57,7 +57,7 @@ def tvos_static_framework_test_suite(name):
         tags = [name],
     )
     archive_contents_test(
-        name = "{}_swift_x86_64_builds".format(name),
+        name = "{}_swift_x86_64_builds_using_tvos_cpus".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
         cpus = {
@@ -67,6 +67,36 @@ def tvos_static_framework_test_suite(name):
         binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "minos " + common.min_os_tvos.baseline, "platform TVOSSIMULATOR"],
         macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_TVOS"],
+        tags = [name],
+    )
+
+    # Tests Swift tvos_static_framework builds correctly using apple_platforms.
+    archive_contents_test(
+        name = "{}_swift_sim_arm64_builds_using_platforms".format(name),
+        apple_platforms = [
+            "//buildenv/platforms/apple/simulator:tvos_arm64",
+            "//buildenv/platforms/apple/simulator:tvos_x86_64",
+        ],
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
+        binary_test_file = "$BUNDLE_ROOT/swift_static_fmwk",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_TVOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_swift_x86_64_builds_using_platforms".format(name),
+        apple_platforms = [
+            "//buildenv/platforms/apple/simulator:tvos_arm64",
+            "//buildenv/platforms/apple/simulator:tvos_x86_64",
+        ],
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
+        binary_test_file = "$BUNDLE_ROOT/swift_static_fmwk",
+        binary_test_architecture = "x86_64",
+        macho_load_commands_contain = ["cmd LC_VERSION_MIN_TVOS"],
+        macho_load_commands_not_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -95,8 +95,8 @@ def tvos_static_framework_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:swift_static_fmwk",
         binary_test_file = "$BUNDLE_ROOT/swift_static_fmwk",
         binary_test_architecture = "x86_64",
-        macho_load_commands_contain = ["cmd LC_VERSION_MIN_TVOS"],
-        macho_load_commands_not_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        macho_load_commands_not_contain = ["cmd LC_VERSION_MIN_TVOS"],
         tags = [name],
     )
 


### PR DESCRIPTION
This change addresses removal of workaround introduced on <unknown commit>
to map apple_common.multi_arch_split split attribute keys based on Bazel
Apple static library linking API for iOS and tvOS static framework rules.

- Removes `_apple_common_multi_arch_split_key` from transition_support lib.
- Use `cc_toolchain_forwarder` for `_child_configuration_dummy` attribute.
- Use rule descriptor `deps_cfg` for j2objc and Bazel's binary linking API attributes.
- Introduce a new rule base transition that propagates `apple_platforms`.

(cherry picked from commit 15a38a1ea07504beb40c50088db7fb81cec808c6)