### PR TITLE
Address test breakage for later versions of /usr/bin/file, probing into a fat binary for its architectures.

### DIFF
--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -113,8 +113,8 @@ def apple_dynamic_xcframework_import_test_suite(name):
         binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
         binary_contains_file_info = [
             "Mach-O universal binary with 2 architectures:",
-            "[x86_64:Mach-O 64-bit dynamically linked shared library x86_64",
-            "[arm64:Mach-O 64-bit dynamically linked shared library arm64",
+            "x86_64:Mach-O 64-bit dynamically linked shared library x86_64",
+            "arm64:Mach-O 64-bit dynamically linked shared library arm64",
         ],
         tags = [name],
     )


### PR DESCRIPTION
Taking advantage of the fuzzy matching capability to only look at the beginning of the file outputs, which passes the new output of the following form:

Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64 - Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64 - Mach-O 64-bit dynamically linked shared library arm64]

PiperOrigin-RevId: 464623807
(cherry picked from commit 136142634558f233e4ae4c8b35857119034ec14a)