### PR TITLE
Always set grte_top in transitions to Apple toolchain defaults.

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -207,7 +207,7 @@ def _command_line_options(
             settings["//command_line_option:apple_crosstool_top"]
         ),
         "//command_line_option:fission": [],
-        "//command_line_option:grte_top": settings["//command_line_option:apple_grte_top"],
+        "//command_line_option:grte_top": None,
         "//command_line_option:platforms": [apple_platforms[0]] if apple_platforms else [],
         "//command_line_option:ios_minimum_os": _min_os_version_or_none(
             minimum_os_version = minimum_os_version,
@@ -350,7 +350,6 @@ def _apple_rule_base_transition_impl(settings, attr):
 _apple_rule_common_transition_inputs = [
     "//command_line_option:apple_compiler",
     "//command_line_option:apple_crosstool_top",
-    "//command_line_option:apple_grte_top",
 ]
 _apple_rule_base_transition_inputs = _apple_rule_common_transition_inputs + [
     "//command_line_option:cpu",


### PR DESCRIPTION
apple_grte_top has never been used for the Apple rules, unlike android_grte_top, as custom instances of libc are not applicable for Apple platforms. This simplifies the inputs for our transitions somewhat.

PiperOrigin-RevId: 465090766
(cherry picked from commit 271bea1be2a85d1c7a34a4b4d609e685740dc483)