### PR TITLE
Remove 32 bit iOS defaults for integration test rules in anticipation of Xcode 14 RC.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -20,6 +20,7 @@ licenses(["notice"])
         "ios_x86_64",
         "ios_armv7",
         "ios_arm64",
+        "ios_arm64e",
         "ios_sim_arm64",
         "tvos_x86_64",
         "tvos_arm64",

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -357,14 +357,21 @@ function assert_frameworks_not_resigned_given_output() {
 }
 
 
-# Usage: current_archs <platform>
+# Usage: current_archs <platform> <keep_sim_string>
 #
 # Prints the architectures for the given platform that were specified in the
 # configuration used to run the current test. For multiple architectures, the
 # values will be printed on separate lines; the output here is typically meant
 # to be captured into an array.
+#
+# `platform` should be a label for an apple platform type we want to get the
+# list of available architectures from, such as "ios".
+#
+# `keep_sim_string` should be a boolean to indicate if we want to keep the
+# "sim_" substrings in the architecture results. This is false by default.
 function current_archs() {
   local platform="$1"
+  local keep_sim_string="${2:-false}"
   if [[ "$platform" == ios ]]; then
     # Fudge the ios platform name to match the expected command line option.
     platform=ios_multi
@@ -373,7 +380,12 @@ function current_archs() {
   for option in "${EXTRA_BUILD_OPTIONS[@]-}"; do
     case "$option" in
       --"${platform}"_cpus=*)
-        value="$(echo "$option" | cut -d= -f2)"
+        if [[ "$keep_sim_string" = true ]]; then
+          value="$(echo "$option" | cut -d= -f2)"
+        else
+          # Eliminate `sim_` prefixes from `cpu`s as it is not part of the arch.
+          value="$(echo "$option" | cut -d= -f2 | sed 's/sim_//g')"
+        fi
         echo "$value" | tr "," "\n"
         return
         ;;
@@ -507,10 +519,14 @@ function do_action() {
 # under multiple configurations.
 function is_device_build() {
   local platform="$1"
-  local archs="$(current_archs "$platform")"
+  local archs="$(current_archs "$platform" true)"
 
   # For simplicity, we just test the entire architecture list string and assume
   # users aren't writing tests with multiple incompatible architectures.
+  #
+  # This just happens to work given our current formatting for simulator archs
+  # which are `arm`, as when passed as arguments to Apple multi CPU flags, they
+  # will be of the form `sim_arm64` instead of `arm64`.
   [[ "$platform" == macos ]] || [[ "$archs" == arm* ]]
 }
 

--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -21,9 +21,9 @@ COMPILATION_MODE_OPTIONS = ["--compilation_mode opt"]
 # Configuration options used with `apple_shell_test` to run tests for
 # iOS simulator and device builds.
 #
-IOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=arm64,armv7"]
+IOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + ["--ios_multi_cpus=arm64,arm64e"]
 IOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [
-    "--ios_multi_cpus=i386,x86_64",
+    "--ios_multi_cpus=sim_arm64,x86_64",
 ]
 
 IOS_CONFIGURATIONS = {
@@ -70,7 +70,7 @@ TVOS_TEST_CONFIGURATIONS = {
 # with an iOS host app, we include that platform's configuration options as
 # well.
 WATCHOS_DEVICE_OPTIONS = COMPILATION_MODE_OPTIONS + [
-    "--ios_multi_cpus=arm64,armv7",
+    "--ios_multi_cpus=arm64,arm64e",
     "--watchos_cpus=armv7k",
 ]
 WATCHOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -445,7 +445,7 @@ apple_resource_bundle(
         "@build_bazel_rules_apple//apple:ios_x86_64": ["foo_sim.txt"],
         "@build_bazel_rules_apple//apple:ios_arm64": ["foo_device.txt"],
         "@build_bazel_rules_apple//apple:ios_arm64e": ["foo_device.txt"],
-        "@bazel_tools//tools/objc:ios_sim_arm64": ["foo_sim.txt"],
+        "@build_bazel_rules_apple//apple:ios_sim_arm64": ["foo_sim.txt"],
     }),
 )
 EOF

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -443,9 +443,9 @@ apple_resource_bundle(
     name = "appResources",
     resources = select({
         "@build_bazel_rules_apple//apple:ios_x86_64": ["foo_sim.txt"],
-        "@build_bazel_rules_apple//apple:ios_i386": ["foo_sim.txt"],
-        "@build_bazel_rules_apple//apple:ios_armv7": ["foo_device.txt"],
         "@build_bazel_rules_apple//apple:ios_arm64": ["foo_device.txt"],
+        "@build_bazel_rules_apple//apple:ios_arm64e": ["foo_device.txt"],
+        "@bazel_tools//tools/objc:ios_sim_arm64": ["foo_sim.txt"],
     }),
 )
 EOF

--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -255,8 +255,8 @@ def apple_static_xcframework_test_suite(name):
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_with_resources",
         contains = [
-            "$BUNDLE_ROOT/ios-arm64/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/Info.plist",
-            "$BUNDLE_ROOT/ios-arm64/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/custom_apple_resource_info.out",
+            "$BUNDLE_ROOT/ios-arm64_arm64e/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/Info.plist",
+            "$BUNDLE_ROOT/ios-arm64_arm64e/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/custom_apple_resource_info.out",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
+++ b/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
@@ -49,7 +49,7 @@ def _analysis_incoming_ios_platform_mismatch_test_impl(ctx):
     env = analysistest.begin(ctx)
     asserts.expect_failure(env, """
 ERROR: Unexpected resolved platform:
-Expected Apple platform type of \"{0}\", but that was not found in @build_bazel_apple_support//platforms:ios_i386.
+Expected Apple platform type of \"{0}\", but that was not found in @build_bazel_apple_support//platforms:ios_sim_arm64.
 """.format(ctx.attr.expected_platform_type))
     return analysistest.end(env)
 
@@ -64,6 +64,6 @@ analysis_incoming_ios_platform_mismatch_test = analysistest.make(
     },
     config_settings = {
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": True,
-        "//command_line_option:platforms": ["@build_bazel_apple_support//platforms:ios_i386"],
+        "//command_line_option:platforms": ["@build_bazel_apple_support//platforms:ios_sim_arm64"],
     },
 )

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -73,7 +73,7 @@ Internal Error: A verification test should only specify `apple_platforms` or `cp
         })
     else:
         output_dictionary.update({
-            "//command_line_option:ios_multi_cpus": "arm64",
+            "//command_line_option:ios_multi_cpus": "arm64,arm64e",
             "//command_line_option:tvos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
         })

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -513,7 +513,7 @@ genrule(
             "ios_xcframework_bundling_static_fmwks",
         ]
         for platform_id in [
-            "ios-arm64",
+            "ios-arm64_arm64e",
             "ios-arm64_x86_64-simulator",
         ]
     ] + ["ios_xcframework_bundling_static_fmwks.xcframework/Info.plist"],
@@ -905,10 +905,13 @@ apple_static_xcframework(
             "x86_64",
             "arm64",
         ],
-        "device": ["arm64"],
+        "device": [
+            "arm64",
+            "arm64e",
+        ],
     },
     minimum_os_versions = {
-        "ios": "9.0",
+        "ios": common.min_os_ios.baseline,
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",
@@ -937,7 +940,7 @@ genrule(
             "resource_bundle.bundle/Info.plist",
         ]
         for platform_id in [
-            "ios-arm64",
+            "ios-arm64_arm64e",
             "ios-arm64_x86_64-simulator",
         ]
     ] + ["ios_static_xcframework_with_resources.xcframework/Info.plist"],
@@ -970,10 +973,13 @@ apple_static_xcframework(
             "x86_64",
             "arm64",
         ],
-        "device": ["arm64"],
+        "device": [
+            "arm64",
+            "arm64e",
+        ],
     },
     minimum_os_versions = {
-        "ios": "9.0",
+        "ios": common.min_os_ios.baseline,
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",


### PR DESCRIPTION
Replacing them with usage of arm64e (device) or arm64 (simulator), to continue exercising "fat" binary workflows in tests.

PiperOrigin-RevId: 461910406
(cherry picked from commit 2181855ad2bf56a66bae07c292f1483a319b6a57)