### PR TITLE
Update the platform split transition to interpret the raw --cpu value for iOS, to maintain compatibility with the native split transition and its inputs.

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -484,7 +484,14 @@ def _apple_platform_split_transition_impl(settings, attr):
         platform_type = attr.platform_type
         cpus = settings[_platform_specific_cpu_setting_name(platform_type)]
         if not cpus:
-            cpus = [_platform_specific_default_cpu(platform_type)]
+            if platform_type == "ios":
+                # Legacy exception to interpret the --cpu as an iOS arch.
+                cpu_value = settings["//command_line_option:cpu"]
+                if cpu_value.startswith("ios_"):
+                    cpus = [cpu_value[4:]]
+            if not cpus:
+                # Set the default cpu for the given platform type.
+                cpus = [_platform_specific_default_cpu(platform_type)]
         for cpu in cpus:
             found_cpu = _cpu_string(
                 cpu = cpu,

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -40,6 +40,7 @@ def _apple_verification_transition_impl(settings, attr):
     """Implementation of the apple_verification_transition transition."""
 
     output_dictionary = {
+        "//command_line_option:cpu": getattr(attr, "apple_cpu", "darwin_x86_64"),
         "//command_line_option:ios_signing_cert_name": "-",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
@@ -79,6 +80,7 @@ apple_verification_transition = transition(
         "//command_line_option:features",
     ],
     outputs = [
+        "//command_line_option:cpu",
         "//command_line_option:ios_signing_cert_name",
         "//command_line_option:ios_multi_cpus",
         "//command_line_option:macos_cpus",
@@ -209,6 +211,11 @@ apple_verification_test = rule(
             doc = """
 The Bitcode mode to use for compilation steps. Possible values are `none`,
 `embedded_markers`, or `embedded`. Defaults to `none`.
+""",
+        ),
+        "apple_cpu": attr.string(
+            doc = """
+A string to indicate what should be the value of the Apple --cpu flag. Defaults to `darwin_x86_64`.
 """,
         ),
         "build_type": attr.string(


### PR DESCRIPTION
PiperOrigin-RevId: 462251391
(cherry picked from commit e030b7b18ab1c0c38c106d0ae1cc1cc853fe741c)