### PR TITLE
Add xctestrun based iOS unit test runner

### DIFF
--- a/apple/ios.doc.bzl
+++ b/apple/ios.doc.bzl
@@ -18,11 +18,6 @@
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
-    _ios_ui_test = "ios_ui_test",
-    _ios_unit_test = "ios_unit_test",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
     _ios_app_clip = "ios_app_clip",
     _ios_application = "ios_application",
@@ -40,18 +35,33 @@ load(
     _ios_ui_test_suite = "ios_ui_test_suite",
     _ios_unit_test_suite = "ios_unit_test_suite",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
+    _ios_ui_test = "ios_ui_test",
+    _ios_unit_test = "ios_unit_test",
+)
+load(
+    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    _ios_test_runner = "ios_test_runner",
+)
+load(
+    "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    _ios_xctestrun_runner = "ios_xctestrun_runner",
+)
 
-ios_application = _ios_application
 ios_app_clip = _ios_app_clip
+ios_application = _ios_application
+ios_build_test = _ios_build_test
 ios_dynamic_framework = _ios_dynamic_framework
-ios_imessage_application = _ios_imessage_application
 ios_extension = _ios_extension
-ios_imessage_extension = _ios_imessage_extension
-ios_sticker_pack_extension = _ios_sticker_pack_extension
 ios_framework = _ios_framework
+ios_imessage_application = _ios_imessage_application
+ios_imessage_extension = _ios_imessage_extension
 ios_static_framework = _ios_static_framework
+ios_sticker_pack_extension = _ios_sticker_pack_extension
+ios_test_runner = _ios_test_runner
 ios_ui_test = _ios_ui_test
 ios_ui_test_suite = _ios_ui_test_suite
 ios_unit_test = _ios_unit_test
 ios_unit_test_suite = _ios_unit_test_suite
-ios_build_test = _ios_build_test
+ios_xctestrun_runner = _ios_xctestrun_runner

--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -3,6 +3,10 @@ load(
     "ios_test_runner",
 )
 load(
+    "//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    "ios_xctestrun_runner",
+)
+load(
     "//apple/testing/default_runner:macos_test_runner.bzl",
     "macos_test_runner",
 )
@@ -53,6 +57,8 @@ bzl_library(
 
 exports_files([
     "ios_test_runner.template.sh",
+    "ios_xctestrun_runner.template.sh",
+    "ios_xctestrun_runner.template.xctestrun",
     "macos_test_runner.template.sh",
     "macos_test_runner.template.xctestrun",
     "tvos_test_runner.template.sh",
@@ -75,6 +81,18 @@ ios_test_runner(
     # Used by the rule implementations, so it needs to be public; but
     # should be considered an implementation detail of the rules and
     # not used by other things.
+    visibility = ["//visibility:public"],
+)
+
+ios_xctestrun_runner(
+    name = "ios_xctestrun_random_runner",
+    random = True,
+    visibility = ["//visibility:public"],
+)
+
+ios_xctestrun_runner(
+    name = "ios_xctestrun_ordered_runner",
+    random = False,
     visibility = ["//visibility:public"],
 )
 

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -34,7 +34,7 @@ def _ios_xctestrun_runner_impl(ctx):
     os_version = str(ctx.attr.os_version or ctx.fragments.objc.ios_simulator_version or
                      ctx.attr._xcode_config[apple_common.XcodeProperties].default_ios_sdk_version)
 
-    # TODO: Ideally we would be smarter about picking a device, but we don't know what the versoin of Xcode supports
+    # TODO: Ideally we would be smarter about picking a device, but we don't know what the current version of Xcode supports
     device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or "iPhone 12"
 
     if not os_version:

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -1,5 +1,5 @@
 """
-A iOS test runner rule that uses xctestrun files to run unit test bundles on
+An iOS test runner rule that uses xctestrun files to run unit test bundles on
 simulators. This rule currently doesn't support UI tests or running on device.
 """
 

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -1,0 +1,163 @@
+"""
+A iOS test runner rule that uses xctestrun files to run unit test bundles on
+simulators. This rule currently doesn't support UI tests or running on device.
+"""
+
+load("@build_bazel_rules_apple//apple/testing:apple_test_rules.bzl", "AppleTestRunnerInfo")
+
+def _get_template_substitutions(
+        *,
+        device_type,
+        os_version,
+        simulator_creator,
+        random,
+        xctestrun_template):
+    substitutions = {
+        "device_type": device_type,
+        "os_version": os_version,
+        "simulator_creator.py": simulator_creator,
+        # "ordered" isn't a special string, but anything besides "random" for this field runs in order
+        "test_order": "random" if random else "ordered",
+        "xctestrun_template": xctestrun_template,
+    }
+
+    return {"%({})s".format(key): value for key, value in substitutions.items()}
+
+def _get_execution_environment(ctx):
+    xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
+    if not xcode_version:
+        fail("error: No xcode_version in _xcode_config")
+
+    return {"XCODE_VERSION_OVERRIDE": xcode_version}
+
+def _ios_xctestrun_runner_impl(ctx):
+    os_version = str(ctx.attr.os_version or ctx.fragments.objc.ios_simulator_version or
+                     ctx.attr._xcode_config[apple_common.XcodeProperties].default_ios_sdk_version)
+
+    # TODO: Ideally we would be smarter about picking a device, but we don't know what the versoin of Xcode supports
+    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or "iPhone 12"
+
+    if not os_version:
+        fail("error: os_version must be set on ios_xctestrun_runner, or passed with --ios_simulator_version")
+    if not device_type:
+        fail("error: device_type must be set on ios_xctestrun_runner, or passed with --ios_simulator_device")
+
+    ctx.actions.expand_template(
+        template = ctx.file._test_template,
+        output = ctx.outputs.test_runner_template,
+        substitutions = _get_template_substitutions(
+            device_type = device_type,
+            os_version = os_version,
+            simulator_creator = ctx.executable._simulator_creator.short_path,
+            random = ctx.attr.random,
+            xctestrun_template = ctx.file._xctestrun_template.short_path,
+        ),
+    )
+
+    return [
+        AppleTestRunnerInfo(
+            execution_environment = _get_execution_environment(ctx),
+            execution_requirements = {"requires-darwin": ""},
+            test_runner_template = ctx.outputs.test_runner_template,
+        ),
+        DefaultInfo(
+            runfiles = ctx.runfiles(
+                files = [ctx.file._xctestrun_template],
+            ).merge(ctx.attr._simulator_creator[DefaultInfo].default_runfiles),
+        ),
+    ]
+
+ios_xctestrun_runner = rule(
+    _ios_xctestrun_runner_impl,
+    attrs = {
+        "device_type": attr.string(
+            default = "",
+            doc = """
+The device type of the iOS simulator to run test. The supported types correspond
+to the output of `xcrun simctl list devicetypes`. E.g., iPhone X, iPad Air.
+By default, it reads from --ios_simulator_device or falls back to some device.
+""",
+        ),
+        "random": attr.bool(
+            default = False,
+            doc = """
+Whether to run the tests in random order to identify unintended state
+dependencies.
+""",
+        ),
+        "os_version": attr.string(
+            default = "",
+            doc = """
+The os version of the iOS simulator to run test. The supported os versions
+correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5.
+By default, it reads --ios_simulator_version and then falls back to the latest
+supported version.
+""",
+        ),
+        "_simulator_creator": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator",
+            ),
+            executable = True,
+            cfg = "exec",
+        ),
+        "_test_template": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.template.sh",
+            ),
+            allow_single_file = True,
+        ),
+        "_xcode_config": attr.label(
+            default = configuration_field(
+                name = "xcode_config_label",
+                fragment = "apple",
+            ),
+        ),
+        "_xctestrun_template": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.template.xctestrun",
+            ),
+            allow_single_file = True,
+        ),
+    },
+    outputs = {
+        "test_runner_template": "%{name}.sh",
+    },
+    fragments = ["apple", "objc"],
+    doc = """
+This rule creates a test runner for iOS tests that uses xctestrun files to run
+hosted tests, and uses xctest directly to run logic tests.
+
+You can use this rule directly if you need to override 'device_type' or
+'os_version', otherwise you can use the predefined runners:
+
+```
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+```
+
+or:
+
+```
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+```
+
+Depending on if you want random test ordering or not. Set these as the `runner`
+attribute on your `ios_unit_test` target:
+
+```bzl
+ios_unit_test(
+    name = "Tests",
+    minimum_os_version = "15.5",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    deps = [":TestsLib"],
+)
+```
+
+If you would like this test runner to generate xcresult bundles for your tests,
+pass `--test_env=CREATE_XCRESULT_BUNDLE=1`
+
+This rule automatically handles running x86_64 tests on arm64 hosts. The only
+exception is that if you want to generate xcresult bundles, the test must have
+a test host. This is because of a limitation in Xcode.
+""",
+)

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -157,7 +157,8 @@ If you would like this test runner to generate xcresult bundles for your tests,
 pass `--test_env=CREATE_XCRESULT_BUNDLE=1`
 
 This rule automatically handles running x86_64 tests on arm64 hosts. The only
-exception is that if you want to generate xcresult bundles, the test must have
-a test host. This is because of a limitation in Xcode.
+exception is that if you want to generate xcresult bundles or run tests in
+random order, the test must have a test host. This is because of a limitation
+in Xcode.
 """,
 )

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# This script replaces the variables in the templated xctestrun file with the
+# the specific paths to the test bundle, and the optionally test host
+
+set -euo pipefail
+
+if [[ -z "${DEVELOPER_DIR:-}" ]]; then
+  echo "error: Missing \$DEVELOPER_DIR" >&2
+  exit 1
+fi
+
+# Retrieve the basename of a file or folder with an extension.
+basename_without_extension() {
+  local filename
+  filename=$(basename "$1")
+  echo "${filename%.*}"
+}
+
+test_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/test_tmp_dir.XXXXXX")"
+if [[ -z "${NO_CLEAN:-}" ]]; then
+  trap 'rm -rf "${test_tmp_dir}"' EXIT
+else
+  test_tmp_dir="${TMPDIR:-/tmp}/test_tmp_dir"
+  rm -rf "$test_tmp_dir"
+  mkdir -p "$test_tmp_dir"
+  echo "note: keeping test dir around at: $test_tmp_dir"
+fi
+
+test_bundle_path="%(test_bundle_path)s"
+test_bundle_name=$(basename_without_extension "$test_bundle_path")
+
+if [[ "$test_bundle_path" == *.xctest ]]; then
+  cp -cRL "$test_bundle_path" "$test_tmp_dir"
+  # Need to modify permissions as Bazel will set all files to non-writable, and
+  # Xcode's test runner requires the files to be writable.
+  chmod -R 777 "$test_tmp_dir/$test_bundle_name.xctest"
+else
+  unzip -qq -d "${test_tmp_dir}" "${test_bundle_path}"
+fi
+
+# In case there is no test host, test_host_path will be empty
+test_host_path="%(test_host_path)s"
+if [[ -n "$test_host_path" ]]; then
+  test_host_name=$(basename_without_extension "$test_host_path")
+
+  if [[ "$test_host_path" == *.app ]]; then
+    cp -cRL "$test_host_path" "$test_tmp_dir"
+    # Need to modify permissions as Bazel will set all files to non-writable,
+    # and Xcode's test runner requires the files to be writable.
+    chmod -R 777 "$test_tmp_dir/$test_host_name.app"
+  else
+    unzip -qq -d "${test_tmp_dir}" "${test_host_path}"
+    mv "$test_tmp_dir"/Payload/*.app "$test_tmp_dir"
+  fi
+fi
+
+# Basic XML character escaping for environment variable substitution.
+function escape() {
+  local escaped=${1//&/&amp;}
+  escaped=${escaped//</&lt;}
+  escaped=${escaped//>/&gt;}
+  escaped=${escaped//'"'/&quot;}
+  echo "$escaped"
+}
+
+# Add the test environment variables into the xctestrun file to propagate them
+# to the test runner
+test_env="%(test_env)s"
+xctestrun_env=""
+for single_test_env in ${test_env//,/ }; do
+  IFS="=" read -r key value <<< "$single_test_env"
+  xctestrun_env+="<key>$(escape "$key")</key><string>$(escape "$value")</string>"
+done
+
+if [[ -n "$test_host_path" ]]; then
+  xctestrun_test_host_path="__TESTROOT__/$test_host_name.app"
+  xctestrun_test_host_based=true
+  # If this is set in the case there is no test host, some tests hang indefinitely
+  xctestrun_env+="<key>XCInjectBundleInto</key><string>$(escape "__TESTHOST__/$test_host_name.app/$test_host_name")</string>"
+else
+  xctestrun_test_host_path="__PLATFORMS__/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/xctest"
+  xctestrun_test_host_based=false
+fi
+
+profraw=$(mktemp)
+
+sanitizer_dyld_env=""
+readonly sanitizer_root="$test_tmp_dir/$test_bundle_name.xctest/Frameworks"
+for sanitizer in "$sanitizer_root"/libclang_rt.*.dylib; do
+  if [[ -n "$sanitizer_dyld_env" ]]; then
+    sanitizer_dyld_env="$sanitizer_dyld_env:"
+  fi
+  sanitizer_dyld_env="${sanitizer_dyld_env}${sanitizer}"
+done
+
+xctestrun_libraries="__PLATFORMS__/iPhoneSimulator.platform/Developer/usr/lib/libXCTestBundleInject.dylib"
+if [[ -n "$sanitizer_dyld_env" ]]; then
+  xctestrun_libraries="${xctestrun_libraries}:${sanitizer_dyld_env}"
+fi
+
+readonly xctestrun_file="$test_tmp_dir/tests.xctestrun"
+/usr/bin/sed \
+  -e "s@BAZEL_INSERT_LIBRARIES@$xctestrun_libraries@g" \
+  -e "s@BAZEL_TEST_BUNDLE_PATH@__TESTROOT__/$test_bundle_name.xctest@g" \
+  -e "s@BAZEL_TEST_ENVIRONMENT@$xctestrun_env@g" \
+  -e "s@BAZEL_TEST_HOST_BASED@$xctestrun_test_host_based@g" \
+  -e "s@BAZEL_TEST_HOST_PATH@$xctestrun_test_host_path@g" \
+  -e "s@BAZEL_TEST_ORDER_STRING@%(test_order)s@g" \
+  -e "s@BAZEL_COVERAGE_PROFRAW@$profraw@g" \
+  -e "s@BAZEL_COVERAGE_OUTPUT_DIR@$test_tmp_dir@g" \
+  "%(xctestrun_template)s" > "$xctestrun_file"
+
+id="$("./%(simulator_creator.py)s" "%(os_version)s" "%(device_type)s")"
+test_exit_code=0
+testlog=$(mktemp)
+
+
+test_file=$(file "$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name")
+intel_simulator_hack=false
+if [[ $(arch) == arm64 && "$test_file" != *arm64* ]]; then
+  intel_simulator_hack=true
+fi
+
+if [[ -n "$test_host_path" || -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+  if [[ -z "$test_host_path" && "$intel_simulator_hack" == true ]]; then
+    echo "error: running x86_64 tests on arm64 macs with CREATE_XCRESULT_BUNDLE requires a test host" >&2
+    exit 1
+  fi
+
+  args=(
+    -destination "id=$id" \
+    -destination-timeout 15 \
+    -xctestrun "$xctestrun_file" \
+  )
+
+  readonly result_bundle_path="$TEST_UNDECLARED_OUTPUTS_DIR/tests.xcresult"
+  # TEST_UNDECLARED_OUTPUTS_DIR isn't cleaned up with multiple retries of flaky tests
+  rm -rf "$result_bundle_path"
+  if [[ -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+    args+=(-resultBundlePath "$result_bundle_path")
+  fi
+
+  xcodebuild test-without-building "${args[@]}" \
+    2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
+    || test_exit_code=$?
+else
+  platform_developer_dir="$(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer"
+  xctest_binary="$platform_developer_dir/Library/Xcode/Agents/xctest"
+  test_file=$(file "$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name")
+  if [[ "$intel_simulator_hack" == true ]]; then
+    sliced_xctest_binary=/tmp/xctest_intel
+    if [[ ! -x "$sliced_xctest_binary" ]]; then
+      lipo -thin x86_64 -output "$sliced_xctest_binary" "$xctest_binary"
+    fi
+
+    xctest_binary=$sliced_xctest_binary
+  fi
+
+  SIMCTL_CHILD_DYLD_LIBRARY_PATH="$platform_developer_dir/usr/lib" \
+    SIMCTL_CHILD_DYLD_FALLBACK_FRAMEWORK_PATH="$platform_developer_dir/Library/Frameworks" \
+    SIMCTL_CHILD_DYLD_INSERT_LIBRARIES="$sanitizer_dyld_env" \
+    SIMCTL_CHILD_LLVM_PROFILE_FILE="$profraw" \
+    xcrun simctl \
+    spawn \
+    "$id" \
+    "$xctest_binary" \
+    -XCTest All \
+    "$test_tmp_dir/$test_bundle_name.xctest" \
+    2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
+    || test_exit_code=$?
+fi
+
+if [[ "$test_exit_code" -ne 0 ]]; then
+  echo "error: tests exited with '$test_exit_code'" >&2
+  exit "$test_exit_code"
+fi
+
+# When tests crash after they have reportedly completed, XCTest marks them as
+# a success. These 2 cases are Swift fatalErrors, and C++ exceptions. There
+# are likely other cases we can add to this in the future. FB7801959
+if grep -q \
+  -e "^Fatal error:" \
+  -e "^libc++abi.dylib: terminating with uncaught exception" \
+  -e "Executed 0 tests, with 0 failures" \
+  "$testlog"
+then
+  echo "error: log contained test false negative" >&2
+  exit 1
+fi
+if [[ "${COVERAGE:-}" -ne 1 ]]; then
+  # Normal tests run without coverage
+  exit 0
+fi
+
+readonly profdata="$TMP_DIR/coverage.profdata"
+xcrun llvm-profdata merge "$profraw" --output "$profdata"
+
+lcov_args=(
+  -instr-profile "$profdata"
+  -ignore-filename-regex='.*external/.+'
+  -path-equivalence="$ROOT,."
+)
+has_binary=false
+IFS=";"
+arch=$(uname -m)
+for binary in $TEST_BINARIES_FOR_LLVM_COV; do
+  if [[ "$has_binary" == false ]]; then
+    lcov_args+=("${binary}")
+    has_binary=true
+    if ! file "$binary" | grep -q "$arch"; then
+      arch=x86_64
+    fi
+  else
+    lcov_args+=(-object "${binary}")
+  fi
+
+  lcov_args+=("-arch=$arch")
+done
+
+readonly error_file="$TMP_DIR/llvm-cov-error.txt"
+llvm_cov_status=0
+xcrun llvm-cov \
+  export \
+  -format lcov \
+  "${lcov_args[@]}" \
+  @"$COVERAGE_MANIFEST" \
+  > "$COVERAGE_OUTPUT_FILE" \
+  2> "$error_file" \
+  || llvm_cov_status=$?
+
+# Error ourselves if lcov outputs warnings, such as if we misconfigure
+# something and the file path of one of the covered files doesn't exist
+if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
+  echo "error: while exporting coverage report" >&2
+  cat "$error_file" >&2
+  exit 1
+fi
+
+if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
+  llvm_cov_json_export_status=0
+  xcrun llvm-cov \
+    export \
+    -format text \
+    "${lcov_args[@]}" \
+    @"$COVERAGE_MANIFEST" \
+    > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json" \
+    2> "$error_file" \
+    || llvm_cov_json_export_status=$?
+  if [[ -s "$error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
+    cat "$error_file" >&2
+    exit 1
+  fi
+fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -119,9 +119,10 @@ if [[ $(arch) == arm64 && "$test_file" != *arm64* ]]; then
   intel_simulator_hack=true
 fi
 
-if [[ -n "$test_host_path" || -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+# shellcheck disable=SC2050
+if [[ -n "$test_host_path" || -n "${CREATE_XCRESULT_BUNDLE:-}" || "%(test_order)s" == random ]]; then
   if [[ -z "$test_host_path" && "$intel_simulator_hack" == true ]]; then
-    echo "error: running x86_64 tests on arm64 macs with CREATE_XCRESULT_BUNDLE requires a test host" >&2
+    echo "error: running x86_64 tests on arm64 macs with CREATE_XCRESULT_BUNDLE or random ordering requires a test host" >&2
     exit 1
   fi
 

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>BazelTests</key>
+  <dict>
+    <key>TestBundlePath</key>
+    <string>BAZEL_TEST_BUNDLE_PATH</string>
+    <key>TestExecutionOrdering</key>
+    <string>BAZEL_TEST_ORDER_STRING</string>
+    <key>IsAppHostedTestBundle</key>
+    <BAZEL_TEST_HOST_BASED/>
+    <key>TestHostPath</key>
+    <string>BAZEL_TEST_HOST_PATH</string>
+    <key>TestingEnvironmentVariables</key>
+    <dict>
+      <key>LLVM_PROFILE_FILE</key>
+      <string>BAZEL_COVERAGE_PROFRAW</string>
+      <key>DYLD_INSERT_LIBRARIES</key>
+      <string>BAZEL_INSERT_LIBRARIES</string>
+      <key>DYLD_LIBRARY_PATH</key>
+      <string>__PLATFORMS__/iPhoneSimulator.platform/Developer/usr/lib</string>
+      <key>__XCODE_BUILT_PRODUCTS_DIR_PATHS</key>
+      <string>/DUMMY_SRCROOT/</string>
+      BAZEL_TEST_ENVIRONMENT
+    </dict>
+    <key>UserAttachmentLifetime</key>
+    <string>keepNever</string>
+    <key>ClangProfileDataDirectoryPath</key>
+    <string>BAZEL_COVERAGE_OUTPUT_DIR</string>
+  </dict>
+</dict>
+</plist>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -494,6 +494,42 @@ Builds and bundles an iOS Sticker Pack Extension.
 | <a id="ios_sticker_pack_extension-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-versioning.md#apple_bundle_version).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 
+<a id="ios_test_runner"></a>
+
+## ios_test_runner
+
+<pre>
+ios_test_runner(<a href="#ios_test_runner-name">name</a>, <a href="#ios_test_runner-device_type">device_type</a>, <a href="#ios_test_runner-execution_requirements">execution_requirements</a>, <a href="#ios_test_runner-os_version">os_version</a>, <a href="#ios_test_runner-test_environment">test_environment</a>)
+</pre>
+
+
+Rule to identify an iOS runner that runs tests for iOS.
+
+The runner will create a new simulator according to the given arguments to run
+tests.
+
+Outputs:
+  AppleTestRunnerInfo:
+    test_runner_template: Template file that contains the specific mechanism
+        with which the tests will be performed.
+    execution_requirements: Dictionary that represents the specific hardware
+        requirements for this test.
+  Runfiles:
+    files: The files needed during runtime for the test to be performed.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="ios_test_runner-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ios_test_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of <code>xcrun simctl list devicetypes</code>. E.g., iPhone 6, iPad Air. By default, it is the latest supported iPhone type.'   | String | optional | "" |
+| <a id="ios_test_runner-execution_requirements"></a>execution_requirements |  Dictionary of strings to strings which specifies the execution requirements for the runner. In most common cases, this should not be used.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {"requires-darwin": ""} |
+| <a id="ios_test_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. ' 'E.g., 11.2, 9.3. By default, it is the latest supported version of the device type.'   | String | optional | "" |
+| <a id="ios_test_runner-test_environment"></a>test_environment |  Optional dictionary with the environment variables that are to be propagated into the XCTest invocation.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
+
+
 <a id="ios_ui_test"></a>
 
 ## ios_ui_test
@@ -577,6 +613,62 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="ios_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
+
+
+<a id="ios_xctestrun_runner"></a>
+
+## ios_xctestrun_runner
+
+<pre>
+ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>)
+</pre>
+
+
+This rule creates a test runner for iOS tests that uses xctestrun files to run
+hosted tests, and uses xctest directly to run logic tests.
+
+You can use this rule directly if you need to override 'device_type' or
+'os_version', otherwise you can use the predefined runners:
+
+```
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+```
+
+or:
+
+```
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+```
+
+Depending on if you want random test ordering or not. Set these as the `runner`
+attribute on your `ios_unit_test` target:
+
+```bzl
+ios_unit_test(
+    name = "Tests",
+    minimum_os_version = "15.5",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    deps = [":TestsLib"],
+)
+```
+
+If you would like this test runner to generate xcresult bundles for your tests,
+pass `--test_env=CREATE_XCRESULT_BUNDLE=1`
+
+This rule automatically handles running x86_64 tests on arm64 hosts. The only
+exception is that if you want to generate xcresult bundles, the test must have
+a test host. This is because of a limitation in Xcode.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="ios_xctestrun_runner-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ios_xctestrun_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of <code>xcrun simctl list devicetypes</code>. E.g., iPhone X, iPad Air. By default, it reads from --ios_simulator_device or falls back to some device.   | String | optional | "" |
+| <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional | "" |
+| <a id="ios_xctestrun_runner-random"></a>random |  Whether to run the tests in random order to identify unintended state dependencies.   | Boolean | optional | False |
 
 
 <a id="ios_ui_test_suite"></a>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -656,8 +656,9 @@ If you would like this test runner to generate xcresult bundles for your tests,
 pass `--test_env=CREATE_XCRESULT_BUNDLE=1`
 
 This rule automatically handles running x86_64 tests on arm64 hosts. The only
-exception is that if you want to generate xcresult bundles, the test must have
-a test host. This is because of a limitation in Xcode.
+exception is that if you want to generate xcresult bundles or run tests in
+random order, the test must have a test host. This is because of a limitation
+in Xcode.
 
 
 **ATTRIBUTES**

--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -19,3 +19,17 @@ ios_unit_test(
     minimum_os_version = "8.0",
     deps = [":SquarerTestsLib"],
 )
+
+ios_unit_test(
+    name = "SquarerTestsOrdered",
+    minimum_os_version = "8.0",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    deps = [":SquarerTestsLib"],
+)
+
+ios_unit_test(
+    name = "SquarerTestsRandom",
+    minimum_os_version = "8.0",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    deps = [":SquarerTestsLib"],
+)


### PR DESCRIPTION
This test runner is a drop in replacement for the default iOS test
runner that you can use by setting it on the `runner` attribute of an
`ios_unit_test`. It uses the `xctest` CLI directly for logic tests, and
uses `xcodebuild test-without-building` with a `xctestrun` file for
hosted tests. It supports running tests in random order, and generating
`xcresult` bundles from any type of test. It also supports running
x86_64 test bundles on arm64 hosts. Examples can be found in the docs.