### PR TITLE
Add test filter parameter to ios_unit_test

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -209,6 +209,12 @@ AppleTestRunnerInfo provider.
         ),
         cfg = "exec",
     ),
+    "test_filter": attr.string(
+        doc = """
+Test filter string that will be passed into the test runner to select which tests will run.
+""",
+        default = "",
+    ),
 }
 
 def _common_binary_linking_attrs(deps_cfg, product_type):

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -103,7 +103,7 @@ This aspect propagates a `CoverageFilesInfo` provider.
     implementation = _coverage_files_aspect_impl,
 )
 
-def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None):
+def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None, test_filter = None):
     """Dictionary with the substitutions to be applied to the template script."""
     subs = {}
 
@@ -114,6 +114,9 @@ def _get_template_substitutions(test_type, test_bundle, test_environment, test_h
     subs["test_bundle_path"] = test_bundle.short_path
     subs["test_type"] = test_type.upper()
     subs["test_env"] = ",".join([k + "=" + v for (k, v) in test_environment.items()])
+    if test_filter:
+        subs["test_filter"] = test_filter
+
 
     return {"%(" + k + ")s": subs[k] for k in subs}
 
@@ -134,6 +137,10 @@ def _apple_test_rule_impl(ctx, test_type):
     test_bundle_target = ctx.attr.deps[0]
 
     test_bundle = test_bundle_target[AppleTestInfo].test_bundle
+
+    test_filter = ctx.attr.test_filter
+    if len(test_filter) == 0:
+        test_filter = None
 
     # Environment variables to be set as the %(test_env)s substitution, which includes the
     # --test_env and env attribute values, but not the execution environment variables.
@@ -175,6 +182,7 @@ def _apple_test_rule_impl(ctx, test_type):
             test_bundle,
             test_environment,
             test_host = test_host_archive,
+            test_filter = test_filter,
         ),
         is_executable = True,
     )

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -114,8 +114,7 @@ def _get_template_substitutions(test_type, test_bundle, test_environment, test_h
     subs["test_bundle_path"] = test_bundle.short_path
     subs["test_type"] = test_type.upper()
     subs["test_env"] = ",".join([k + "=" + v for (k, v) in test_environment.items()])
-    if test_filter:
-        subs["test_filter"] = test_filter
+    subs["test_filter"] = test_filter or ""
 
     return {"%(" + k + ")s": subs[k] for k in subs}
 
@@ -136,8 +135,6 @@ def _apple_test_rule_impl(ctx, test_type):
     test_bundle_target = ctx.attr.deps[0]
 
     test_bundle = test_bundle_target[AppleTestInfo].test_bundle
-
-    test_filter = ctx.attr.test_filter
 
     # Environment variables to be set as the %(test_env)s substitution, which includes the
     # --test_env and env attribute values, but not the execution environment variables.
@@ -179,7 +176,7 @@ def _apple_test_rule_impl(ctx, test_type):
             test_bundle,
             test_environment,
             test_host = test_host_archive,
-            test_filter = test_filter,
+            test_filter = ctx.attr.test_filter,
         ),
         is_executable = True,
     )

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -117,7 +117,6 @@ def _get_template_substitutions(test_type, test_bundle, test_environment, test_h
     if test_filter:
         subs["test_filter"] = test_filter
 
-
     return {"%(" + k + ")s": subs[k] for k in subs}
 
 def _get_coverage_execution_environment(_ctx, covered_binaries):
@@ -139,8 +138,6 @@ def _apple_test_rule_impl(ctx, test_type):
     test_bundle = test_bundle_target[AppleTestInfo].test_bundle
 
     test_filter = ctx.attr.test_filter
-    if len(test_filter) == 0:
-        test_filter = None
 
     # Environment variables to be set as the %(test_env)s substitution, which includes the
     # --test_env and env attribute values, but not the execution environment variables.

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -19,7 +19,7 @@ load(
     "AppleTestRunnerInfo",
 )
 
-def _get_template_substitutions(*, device_type, os_version, simulator_creator, testrunner):
+def _get_template_substitutions(*, device_type, os_version, simulator_creator, testrunner, test_filter):
     """Returns the template substitutions for this runner."""
     subs = {
         "device_type": device_type,

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -19,7 +19,7 @@ load(
     "AppleTestRunnerInfo",
 )
 
-def _get_template_substitutions(*, device_type, os_version, simulator_creator, testrunner, test_filter):
+def _get_template_substitutions(*, device_type, os_version, simulator_creator, testrunner):
     """Returns the template substitutions for this runner."""
     subs = {
         "device_type": device_type,

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -152,7 +152,7 @@ TEST_FILTER="%(test_filter)s"
 # flag to set tests_to_run value in ios_test_runner's launch_options.
 # Any test prefixed with '-' will be passed to "skip_tests". Otherwise the tests
 # is passed to "tests_to_run"
-if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER"]]; then
+if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER" ]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
     LAUNCH_OPTIONS_JSON_STR+=","
   fi
@@ -160,12 +160,10 @@ if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER"]]; then
   IFS=","
   if [[ -n "$TESTBRIDGE_TEST_ONLY" && -n "$TEST_FILTER" ]]; then
     ALL_TESTS=("$TESTBRIDGE_TEST_ONLY,$TEST_FILTER")
+  elif [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
+    ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
   else
-    if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
-      ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
-    else
-      ALL_TESTS=("$TEST_FILTER")
-    fi
+    ALL_TESTS=("$TEST_FILTER")
   fi
   
   for TEST in $ALL_TESTS; do

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -158,7 +158,16 @@ if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER"]]; then
   fi
 
   IFS=","
-  ALL_TESTS=("$TESTBRIDGE_TEST_ONLY,$TEST_FILTER")
+  if [[ -n "$TESTBRIDGE_TEST_ONLY" && -n "$TEST_FILTER" ]]; then
+    ALL_TESTS=("$TESTBRIDGE_TEST_ONLY,$TEST_FILTER")
+  else
+    if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
+      ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
+    else
+      ALL_TESTS=("$TEST_FILTER")
+    fi
+  fi
+  
   for TEST in $ALL_TESTS; do
     if [[ $TEST == -* ]]; then
       if [[ -n "$SKIP_TESTS" ]]; then

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -146,17 +146,19 @@ if [[ -n "${command_line_args}" ]]; then
   LAUNCH_OPTIONS_JSON_STR+="\"args\":[\"$command_line_args\"]"
 fi
 
+TEST_FILTER="%(test_filter)s"
+
 # Use the TESTBRIDGE_TEST_ONLY environment variable set by Bazel's --test_filter
 # flag to set tests_to_run value in ios_test_runner's launch_options.
 # Any test prefixed with '-' will be passed to "skip_tests". Otherwise the tests
 # is passed to "tests_to_run"
-if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
+if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER"]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
     LAUNCH_OPTIONS_JSON_STR+=","
   fi
 
   IFS=","
-  ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
+  ALL_TESTS=("$TESTBRIDGE_TEST_ONLY,$TEST_FILTER")
   for TEST in $ALL_TESTS; do
     if [[ $TEST == -* ]]; then
       if [[ -n "$SKIP_TESTS" ]]; then

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -499,7 +499,7 @@ Builds and bundles an iOS Sticker Pack Extension.
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_host">test_host</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>)
 </pre>
 
 iOS UI Test rule.
@@ -528,6 +528,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_ui_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 
@@ -536,7 +537,7 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_host">test_host</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -570,6 +571,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_unit_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="ios_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -406,7 +406,7 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_host">test_host</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -427,6 +427,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="macos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 
@@ -435,7 +436,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_host">test_host</a>)
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -462,6 +463,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="macos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -306,7 +306,7 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
 </pre>
 
 
@@ -333,6 +333,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="tvos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 
@@ -341,7 +342,7 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
 </pre>
 
 
@@ -376,6 +377,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="tvos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -213,7 +213,7 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -229,6 +229,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="watchos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 
@@ -237,7 +238,7 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -253,6 +254,7 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="watchos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
 

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -420,13 +420,6 @@ EOF
 EOF
 
   cat >> ios/BUILD <<EOF
-test_env = {
-    "SomeVariable1": "Its My First Variable",
-    "SomeVariable2": "Its My Second Variable",
-    "REFERENCE_DIR": "/Project/My Tests/ReferenceImages",
-    "IMAGE_DIR": "/Project/My Tests/Images"
-}
-
 objc_library(
     name = "test_filter_unit_test_lib",
     srcs = ["test_filter_unit_test.m"],
@@ -438,7 +431,6 @@ ios_unit_test(
     deps = [":test_filter_unit_test_lib"],
     minimum_os_version = "9.0",
     test_host = ":app",
-    env = test_env,
     runner = ":ios_x86_64_sim_runner",
     test_filter = "$1",
 )
@@ -711,7 +703,7 @@ function test_ios_unit_test_multi_skip_test_filter_build_attribute() {
   expect_log "Executed 1 test, with 0 failures"
 }
 
-function test_ios_unit_test_with_skip_and_only_filters() {
+function test_ios_unit_test_with_skip_and_only_filters_build_attribute() {
   create_sim_runners
   create_test_host_app
   create_ios_unit_tests_test_filter TestFilterUnitTest,-TestFilterUnitTest/testPass2
@@ -719,6 +711,20 @@ function test_ios_unit_test_with_skip_and_only_filters() {
 
   expect_log "Test Case '-\[TestFilterUnitTest testPass\]' passed"
   expect_not_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_build_attribute_and_test_env_filters() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter TestFilterUnitTest/testPass2
+  do_ios_test --test_filter=TestFilterUnitTest/testPass3 //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
   expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
   expect_log "Test Suite 'TestFilterUnitTest' passed"
   expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"


### PR DESCRIPTION
This adds the ability to add your test_filter directly to the args passed into `ios_unit_test`, allowing you to specify a test filter on rule creation for your target.

This was talked about in [this](https://github.com/bazelbuild/rules_apple/discussions/1589) discussion and helps provide a way to shard targets.