### PR TITLE
Add doc for provisioning_profile for ios tests

### DIFF
--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -79,6 +79,8 @@ provided test runner when invoked with `bazel test`. When using Tulsi to run
 tests built with this target, `runner` will not be used since Xcode is the test
 runner in that case.
 
+The `provisioning_profile` attribute needs to be set to run the test on a real device.
+
 To run the same test on multiple simulators/devices see
 [ios_ui_test_suite](#ios_ui_test_suite).
 
@@ -114,6 +116,8 @@ the tests will run outside the context of an iOS application. Because of this,
 certain functionalities might not be present (e.g. UI layout, NSUserDefaults).
 You can find more information about app and library testing for Apple platforms
 [here](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/testing_with_xcode/chapters/03-testing_basics.html).
+
+The `provisioning_profile` attribute needs to be set to run the test on a real device.
 
 To run the same test on multiple simulators/devices see
 [ios_unit_test_suite](#ios_unit_test_suite).

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -509,6 +509,8 @@ provided test runner when invoked with `bazel test`. When using Tulsi to run
 tests built with this target, `runner` will not be used since Xcode is the test
 runner in that case.
 
+The `provisioning_profile` attribute needs to be set to run the test on a real device.
+
 To run the same test on multiple simulators/devices see
 [ios_ui_test_suite](#ios_ui_test_suite).
 
@@ -551,6 +553,8 @@ the tests will run outside the context of an iOS application. Because of this,
 certain functionalities might not be present (e.g. UI layout, NSUserDefaults).
 You can find more information about app and library testing for Apple platforms
 [here](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/testing_with_xcode/chapters/03-testing_basics.html).
+
+The `provisioning_profile` attribute needs to be set to run the test on a real device.
 
 To run the same test on multiple simulators/devices see
 [ios_unit_test_suite](#ios_unit_test_suite).


### PR DESCRIPTION
close #1617 

Rendered result [here](https://github.com/kkpattern/rules_apple/blob/doc_ios_unit_test_provisioning_profile/doc/rules-ios.md#ios_unit_test).

I also added documentation for `ios_ui_test`. I assume it also requires `provisioning_profile` to be set to run on a real device. However, we don't have UI tests, so I can't verify. If this is not the case, I will remove the `provisioning_profile` doc for `ios_ui_test`.