### PR TITLE
Revert workaround for https://bugs.swift.org/browse/SR-16010

### DIFF
--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -127,16 +127,6 @@ def _swift_dylib_action(
         xcode_config = platform_prerequisites.xcode_version_config,
     )
 
-def _target_platform_is_arm_simulator(platform_prerequisites):
-    """Returns True if the target platform is a simulator with arm64 architecture, otherwise False.
-
-    Args:
-      platform_prerequisites: Struct containing information on the platform being targeted.
-    """
-
-    return (platform_prerequisites.apple_fragment.single_arch_cpu == "arm64" and
-            not platform_prerequisites.platform.is_device)
-
 def _swift_dylibs_partial_impl(
         *,
         actions,
@@ -175,13 +165,7 @@ def _swift_dylibs_partial_impl(
     swift_min_os = _MIN_OS_PLATFORM_SWIFT_PRESENCE[str(platform_prerequisites.platform_type)]
     swift_dylibs_path_prefix = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-"
     swift_dylibs_paths = [swift_dylibs_path_prefix + "5.5"]
-
-    # Workaround for https://bugs.swift.org/browse/SR-16010.
-    if (target_min_os < swift_min_os and
-        # There's no such a simulator on Apple silicon Macs with a minimum OS
-        # version before ABI stability, so it's unnecessary to bundle the
-        # original Swift runtime here.
-        not _target_platform_is_arm_simulator(platform_prerequisites)):
+    if target_min_os < swift_min_os:
         swift_dylibs_paths.append(swift_dylibs_path_prefix + "5.0")
 
     transitive_binaries = depset(

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -25,16 +25,15 @@ from build_bazel_rules_apple.tools.wrapper_common import execute
 from build_bazel_rules_apple.tools.wrapper_common import lipo
 
 
-def _copy_swift_stdlibs(binaries_to_scan, swift_dylibs_paths, sdk_platform,
-                        destination_path):
+def _copy_swift_stdlibs(binaries_to_scan, sdk_platform, destination_path):
   """Copies the Swift stdlibs required by the binaries to the destination."""
   # Rely on the swift-stdlib-tool to determine the subset of Swift stdlibs that
   # these binaries require.
   developer_dir = os.environ["DEVELOPER_DIR"]
-  swift_library_dirs = [
-    os.path.join(developer_dir, dylibs_path, sdk_platform)
-    for dylibs_path in swift_dylibs_paths
-  ]
+  swift_dylibs_root = "Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-*"
+  swift_library_dir_pattern = os.path.join(developer_dir, swift_dylibs_root,
+                                           sdk_platform)
+  swift_library_dirs = glob.glob(swift_library_dir_pattern)
 
   cmd = [
       "xcrun", "swift-stdlib-tool", "--copy", "--platform", sdk_platform,
@@ -95,11 +94,6 @@ def main():
       "'iphoneos'"
   )
   parser.add_argument(
-      "--swift_dylibs_path", action="append", type=str, required=True,
-      help="path relative from the developer directory to find the Swift "
-      "standard libraries, independent of platform"
-  )
-  parser.add_argument(
       "--strip_bitcode", action="store_true", default=False, help="strip "
       "bitcode from the Swift support libraries"
   )
@@ -113,8 +107,7 @@ def main():
   temp_path = tempfile.mkdtemp(prefix="swift_stdlib_tool.XXXXXX")
 
   # Use the binaries to copy only the Swift stdlibs we need for this app.
-  _copy_swift_stdlibs(args.binary, args.swift_dylibs_path, args.platform,
-                      temp_path)
+  _copy_swift_stdlibs(args.binary, args.platform, temp_path)
 
   # Determine the binary slices we need to strip with lipo.
   target_archs, _ = lipo.find_archs_for_binaries(args.binary)


### PR DESCRIPTION
Take the upstream change at https://github.com/bazelbuild/rules_apple/pull/1587 instead.