### PR TITLE
Revert handling ios_cpu in transition

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -233,19 +233,6 @@ def _command_line_options(
 
     output_dictionary["@build_bazel_rules_swift//swift:emit_swiftinterface"] = emit_swiftinterface
 
-    # Without handling this flag our transition differs from what we get
-    # from bazel when the dependency tree contains a rule inheriting bazel's
-    # built in transitions. This flag should not be used, we can remove this
-    # once https://github.com/bazelbuild/bazel/pull/13872 is merged
-    if platform_type == "ios":
-        output_dictionary["//command_line_option:ios_cpu"] = _cpu_string(
-            cpu = cpu,
-            platform_type = platform_type,
-            settings = settings,
-        )[len("ios_"):]
-    else:
-        output_dictionary["//command_line_option:ios_cpu"] = ""
-
     return output_dictionary
 
 def _xcframework_split_attr_key(*, cpu, environment, platform_type):
@@ -370,7 +357,6 @@ _apple_rule_base_transition_outputs = [
     "//command_line_option:apple_split_cpu",
     "//command_line_option:compiler",
     "//command_line_option:cpu",
-    "//command_line_option:ios_cpu",
     "//command_line_option:crosstool_top",
     "//command_line_option:fission",
     "//command_line_option:grte_top",


### PR DESCRIPTION
This should not be required after https://github.com/bazelbuild/bazel/commit/ecf9ac90f34c72562fc4a3fd4525c660082ef371

This partially reverts 366c561dd05b609efcb474a0b744775be50d4794.