### PR TITLE
Fix various bzl_library references for stardoc integrations

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -38,6 +38,7 @@ bzl_library(
         "//apple/internal:apple_framework_import",
         "//apple/internal:apple_universal_binary",
         "//apple/internal:apple_xcframework_import",
+        "//apple/internal:local_provisioning_profiles",
         "//apple/internal:xcframework_rules",
     ],
 )
@@ -140,6 +141,7 @@ bzl_library(
         "//apple/internal/resource_rules:apple_bundle_import",
         "//apple/internal/resource_rules:apple_core_data_model",
         "//apple/internal/resource_rules:apple_core_ml_library",
+        "//apple/internal/resource_rules:apple_intent_library",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
     ],

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -356,6 +356,14 @@ bzl_library(
 )
 
 bzl_library(
+    name = "bitcode_support",
+    srcs = ["bitcode_support.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+)
+
+bzl_library(
     name = "partials",
     srcs = ["partials.bzl"],
     visibility = [
@@ -382,6 +390,7 @@ bzl_library(
         "//apple/internal/partials:resources",
         "//apple/internal/partials:settings_bundle",
         "//apple/internal/partials:swift_dylibs",
+        "//apple/internal/partials:swift_dynamic_framework",
         "//apple/internal/partials:swift_framework",
         "//apple/internal/partials:watchos_stub",
     ],
@@ -429,6 +438,7 @@ bzl_library(
         "//apple/internal/resource_actions:datamodel",
         "//apple/internal/resource_actions:ibtool",
         "//apple/internal/resource_actions:intent",
+        "//apple/internal/resource_actions:metals",
         "//apple/internal/resource_actions:mlmodel",
         "//apple/internal/resource_actions:plist",
         "//apple/internal/resource_actions:png",
@@ -466,6 +476,7 @@ bzl_library(
         "//apple:providers",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
+        "//apple/internal/aspects:swift_dynamic_framework_aspect",
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/testing:apple_test_bundle_support",
         "//apple/internal/testing:apple_test_rule_support",
@@ -631,6 +642,17 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
+    name = "local_provisioning_profiles",
+    srcs = ["local_provisioning_profiles.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "//apple:providers",
     ],
 )
 

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -40,6 +40,17 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_dynamic_framework_aspect",
+    srcs = ["swift_dynamic_framework_aspect.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
     name = "swift_usage_aspect",
     srcs = ["swift_usage_aspect.bzl"],
     visibility = [

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -178,6 +178,7 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
+        "//apple/internal:bitcode_support",
         "//apple/internal:codesigning_support",
         "//apple/internal:intermediates",
         "//apple/internal:processor",
@@ -301,6 +302,20 @@ bzl_library(
     deps = [
         "//apple/internal:processor",
         "//apple/internal:swift_info_support",
+        "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "swift_dynamic_framework",
+    srcs = ["swift_dynamic_framework.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "//apple/internal:intermediates",
+        "//apple/internal:processor",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
     ],

--- a/apple/internal/resource_actions/BUILD
+++ b/apple/internal/resource_actions/BUILD
@@ -62,6 +62,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "metals",
+    srcs = ["metals.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_apple_support//lib:apple_support",
+    ],
+)
+
+bzl_library(
     name = "mlmodel",
     srcs = ["mlmodel.bzl"],
     visibility = [


### PR DESCRIPTION
While working on setting up `rules_xcodeproj` with stardoc, I ran into some issues which I fixed in this PR. Mostly new `bzl` files without corresponding `bzl_library` or missing dependency declarations.