### PR TITLE
Lazy hash compute in bundletool.py

### DIFF
--- a/tools/bundletool/bundletool.py
+++ b/tools/bundletool/bundletool.py
@@ -92,7 +92,7 @@ class Bundler(object):
 
     # Keep track of hashes of each entry; this will be faster than pulling the
     # data back out of the archive as it's written.
-    self._entry_hashes = {}
+    self._entry_datas = {}
 
   def run(self):
     """Performs the operations requested by the control struct."""
@@ -193,14 +193,13 @@ class Bundler(object):
       BundleToolError: If two files with different content would be placed
           at the same location in the ZIP file.
     """
-    new_hash = hashlib.md5(data).digest()
-    existing_hash = self._entry_hashes.get(dest)
-    if existing_hash:
-      if existing_hash == new_hash:
+    existing_data = self._entry_datas.get(dest, None)
+    if existing_data is not None:
+      if hashlib.md5(existing_data).digest() == hashlib.md5(data).digest():
         return
       raise BundleToolError(BUNDLE_CONFLICT_MSG_TEMPLATE % dest)
 
-    self._entry_hashes[dest] = new_hash
+    self._entry_datas[dest] = data
 
     zipinfo = zipfile.ZipInfo(dest)
     if compress:

--- a/tools/bundletool/bundletool_unittest.py
+++ b/tools/bundletool/bundletool_unittest.py
@@ -287,6 +287,35 @@ class BundlerTest(unittest.TestCase):
           ]
       })
 
+  def test_duplicate_files_one_empty_raise_error(self):
+    foo_txt = self._scratch_file('foo.txt', '')
+    bar_txt = self._scratch_file('bar.txt', 'bar')
+    with self.assertRaisesRegex(
+        bundletool.BundleToolError,
+        re.escape(bundletool.BUNDLE_CONFLICT_MSG_TEMPLATE %
+            'Payload/foo.app/renamed')):
+      _run_bundler({
+          'bundle_path': 'Payload/foo.app',
+          'bundle_merge_files': [
+              {'src': foo_txt, 'dest': 'renamed'},
+              {'src': bar_txt, 'dest': 'renamed'},
+          ]
+      })
+
+    foo_txt = self._scratch_file('foo.txt', 'foo')
+    bar_txt = self._scratch_file('bar.txt', '')
+    with self.assertRaisesRegex(
+        bundletool.BundleToolError,
+        re.escape(bundletool.BUNDLE_CONFLICT_MSG_TEMPLATE %
+            'Payload/foo.app/renamed')):
+      _run_bundler({
+          'bundle_path': 'Payload/foo.app',
+          'bundle_merge_files': [
+              {'src': foo_txt, 'dest': 'renamed'},
+              {'src': bar_txt, 'dest': 'renamed'},
+          ]
+      })
+
   def test_zips_with_duplicate_files_but_same_content_are_allowed(self):
     one_zip = self._scratch_zip('one.zip', 'some.dylib:foo')
     two_zip = self._scratch_zip('two.zip', 'some.dylib:foo')


### PR DESCRIPTION
To prevent multiple files with different content be written into the same dest,
bundletool.py compare files by their hash value before writing. But in most
cases, there are no conflicting files, and the time used to calculate the hash
is wasted. This commit defers the calculation of the hash until there are
actually two files that need to be written to the same dest.

I also added a test case to check if empty files are correctly compared with other files.

close #1641 