### PR TITLE
Always set values for `AppleBinaryInfo.infoplist`

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -53,6 +53,7 @@ def _apple_static_library_impl(ctx):
         DefaultInfo(files = depset(files_to_build), runfiles = runfiles),
         AppleBinaryInfo(
             binary = link_result.library,
+            infoplist = None,
         ),
         link_result.objc,
         link_result.output_groups,

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -54,6 +54,7 @@ def _apple_universal_binary_impl(ctx):
     return [
         AppleBinaryInfo(
             binary = fat_binary,
+            infoplist = None,
         ),
         DefaultInfo(
             executable = fat_binary,


### PR DESCRIPTION
This makes it easier to use the provider in downstream rules.