### PR TITLE
Fix `watchos_unit_test` incorrect handling of `test_host`

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -127,7 +127,7 @@ The type of binary that this target should build. Option are:
         "bundle_loader": attr.label(
             doc = """
 The target representing the executable that will be loading this bundle.
-Undefined symbols from the bundle are checked against this execuable during
+Undefined symbols from the bundle are checked against this executable during
 linking as if it were one of the dynamic libraries the bundle was linked with.
 """,
             providers = [apple_common.AppleExecutableBinary],

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -52,7 +52,6 @@ def watchos_unit_test(name, **kwargs):
         bundle_rule = _watchos_internal_unit_test_bundle,
         test_rule = _watchos_unit_test,
         runner = runner,
-        bundle_loader = kwargs.get("test_host"),
         **kwargs
     )
 


### PR DESCRIPTION
Before this change:
> ERROR: /Users/brentley/Developer/rules_xcodeproj/examples/integration/watchOSAppExtension/Test/UnitTests/BUILD:4:18: //watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests: no such attribute 'bundle_loader' in 'watchos_unit_test' rule