### PR TITLE
Output platforms in transitions

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -26,11 +26,6 @@ tasks:
       - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
     <<: *common
 
-  macos_last_green:
-    name: "Last Green Bazel"
-    bazel: 6.0.0-pre.20220608.2
-    <<: *common
-
   macos_latest_head_deps:
     name: "Latest Bazel with Head Deps"
     bazel: latest
@@ -44,15 +39,6 @@ tasks:
     test_flags:
       - --build_tests_only
       - --test_tag_filters=-apple_static_xcframework,-apple_xcframework_import
-    <<: *common
-
-  macos_last_green_head_deps:
-    name: "Last Green Bazel with Head Deps"
-    bazel: 6.0.0-pre.20220608.2
-    shell_commands:
-    # Update the WORKSPACE to use head versions of some deps to ensure nothing
-    # has landed on them breaking this project.
-    - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
 
   doc_tests:

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -37,6 +37,7 @@ bzl_library(
     deps = [
         "//apple/internal:apple_framework_import",
         "//apple/internal:apple_universal_binary",
+        "//apple/internal:local_provisioning_profiles",
         "//apple/internal:xcframework_rules",
     ],
 )
@@ -127,6 +128,7 @@ bzl_library(
         "//apple/internal/resource_rules:apple_bundle_import",
         "//apple/internal/resource_rules:apple_core_data_model",
         "//apple/internal/resource_rules:apple_core_ml_library",
+        "//apple/internal/resource_rules:apple_intent_library",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
     ],

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -308,6 +308,14 @@ bzl_library(
 )
 
 bzl_library(
+    name = "bitcode_support",
+    srcs = ["bitcode_support.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+)
+
+bzl_library(
     name = "partials",
     srcs = ["partials.bzl"],
     visibility = [
@@ -334,6 +342,7 @@ bzl_library(
         "//apple/internal/partials:resources",
         "//apple/internal/partials:settings_bundle",
         "//apple/internal/partials:swift_dylibs",
+        "//apple/internal/partials:swift_dynamic_framework",
         "//apple/internal/partials:swift_framework",
         "//apple/internal/partials:swift_static_framework",
         "//apple/internal/partials:watchos_stub",
@@ -382,6 +391,7 @@ bzl_library(
         "//apple/internal/resource_actions:datamodel",
         "//apple/internal/resource_actions:ibtool",
         "//apple/internal/resource_actions:intent",
+        "//apple/internal/resource_actions:metals",
         "//apple/internal/resource_actions:mlmodel",
         "//apple/internal/resource_actions:plist",
         "//apple/internal/resource_actions:png",
@@ -420,6 +430,7 @@ bzl_library(
         "//apple:providers",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
+        "//apple/internal/aspects:swift_dynamic_framework_aspect",
         "//apple/internal/aspects:swift_static_framework_aspect",
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/testing:apple_test_bundle_support",
@@ -584,6 +595,17 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
+    name = "local_provisioning_profiles",
+    srcs = ["local_provisioning_profiles.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "//apple:providers",
     ],
 )
 

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -52,6 +52,17 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_dynamic_framework_aspect",
+    srcs = ["swift_dynamic_framework_aspect.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
     name = "swift_usage_aspect",
     srcs = ["swift_usage_aspect.bzl"],
     visibility = [

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -107,6 +107,7 @@ def _register_binary_linking_action(
         bundle_loader = None,
         entitlements = None,
         extra_linkopts = [],
+        extra_link_inputs = [],
         platform_prerequisites,
         stamp):
     """Registers linking actions using the Starlark Apple binary linking API.
@@ -130,6 +131,7 @@ def _register_binary_linking_action(
             binary or bundle being built. The entitlements will be embedded in a special section
             of the binary.
         extra_linkopts: Extra linkopts to add to the linking action.
+        extra_link_inputs: Extra link inputs to add to the linking action.
         platform_prerequisites: The platform prerequisites.
         stamp: Whether to include build information in the linked binary. If 1, build
             information is always included. If 0, the default build information is always
@@ -181,6 +183,7 @@ def _register_binary_linking_action(
         linkopts.extend(rule_descriptor.extra_linkopts)
 
     linkopts.extend(extra_linkopts)
+    link_inputs.extend(extra_link_inputs)
 
     all_avoid_deps = list(avoid_deps)
     if bundle_loader:

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -176,6 +176,7 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
+        "//apple/internal:bitcode_support",
         "//apple/internal:codesigning_support",
         "//apple/internal:intermediates",
         "//apple/internal:processor",
@@ -313,6 +314,20 @@ bzl_library(
     deps = [
         "//apple/internal:processor",
         "//apple/internal:swift_info_support",
+        "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "swift_dynamic_framework",
+    srcs = ["swift_dynamic_framework.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "//apple/internal:intermediates",
+        "//apple/internal:processor",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
     ],

--- a/apple/internal/resource_actions/BUILD
+++ b/apple/internal/resource_actions/BUILD
@@ -62,6 +62,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "metals",
+    srcs = ["metals.bzl"],
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_apple_support//lib:apple_support",
+    ],
+)
+
+bzl_library(
     name = "mlmodel",
     srcs = ["mlmodel.bzl"],
     visibility = [

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -680,6 +680,11 @@ Info.plist under the key `UILaunchStoryboardName`.
                 mandatory = test_host_mandatory,
                 providers = required_providers,
             ),
+            "_swizzle_absolute_xcttestsourcelocation": attr.label(
+                default = Label(
+                    "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation",
+                ),
+            ),
         })
 
     # TODO(kaipi): Once all platforms have framework rules, move this into
@@ -809,6 +814,11 @@ set, then the default extension is determined by the application's product_type.
                     [AppleBundleInfo, MacosExtensionBundleInfo],
                 ],
             ),
+            "_swizzle_absolute_xcttestsourcelocation": attr.label(
+                default = Label(
+                    "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation",
+                ),
+            ),
         })
 
     return attrs
@@ -893,6 +903,11 @@ fashion, such as a Cocoapod.
                     [AppleBundleInfo, TvosApplicationBundleInfo],
                     [AppleBundleInfo, TvosExtensionBundleInfo],
                 ],
+            ),
+            "_swizzle_absolute_xcttestsourcelocation": attr.label(
+                default = Label(
+                    "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation",
+                ),
             ),
         })
 
@@ -1020,6 +1035,11 @@ fashion, such as a Cocoapod.
                 aspects = [framework_provider_aspect],
                 mandatory = test_host_mandatory,
                 providers = [AppleBundleInfo, WatchosApplicationBundleInfo],
+            ),
+            "_swizzle_absolute_xcttestsourcelocation": attr.label(
+                default = Label(
+                    "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation",
+                ),
             ),
         })
 

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -272,7 +272,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -287,8 +289,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),
@@ -327,7 +331,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.messages_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -465,7 +471,10 @@ _RULE_TYPE_DESCRIPTORS = {
             rpaths = [
                 # Extension binaries live in
                 # Application.app/Contents/PlugIns/Extension.appex/Contents/MacOS/Extension
-                # Frameworks are packaged in Application.app/Contents/Frameworks
+                # Frameworks are packaged in
+                # Application.app/Contents/PlugIns/Extension.appex/Contents/Frameworks
+                # or Application.app/Contents/Frameworks
+                "@executable_path/../Frameworks",
                 "@executable_path/../../../../Frameworks",
             ],
         ),
@@ -640,7 +649,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -654,8 +665,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),
@@ -744,7 +757,9 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.watch2_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
-                # Frameworks are packaged in Application.app/Frameworks
+                # Frameworks are packaged in Application.app/PlugIns/Extension.appex/Frameworks
+                # or Application.app/Frameworks
+                "@executable_path/Frameworks",
                 "@executable_path/../../Frameworks",
             ],
         ),
@@ -758,8 +773,10 @@ _RULE_TYPE_DESCRIPTORS = {
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
-                # Application.app/Frameworks/Framework.framework/Framework
-                # Frameworks are packaged in Application.app/Frameworks
+                # Application.app/Frameworks/Framework.framework/Framework or
+                # Application.app/PlugIns/Extension.appex/Framework.framework/Framework
+                # Frameworks are packaged in Application.app/Frameworks or
+                # Application.app/PlugIns/Extension.appex/Frameworks
                 "@executable_path/Frameworks",
             ],
         ),

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -310,13 +310,33 @@ def _apple_test_bundle_impl(ctx):
     else:
         bundle_loader = None
 
+    extra_linkopts = ["-bundle"]
+    extra_link_inputs = []
+
+    if "apple.swizzle_absolute_xcttestsourcelocation" in features:
+        # `linking_support.register_binary_linking_action` uses
+        # `apple_common.link_multi_arch_binary`, which doesn't allow specifying
+        # dependencies (it reads them from `ctx.attr.deps`). So we have to
+        # manually link the `_swizzle_absolute_xcttestsourcelocation` library.
+        swizzle_lib = ctx.attr._swizzle_absolute_xcttestsourcelocation
+        for linker_input in swizzle_lib[CcInfo].linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                static_library = library.static_library
+                extra_link_inputs.append(static_library)
+                extra_linkopts.append(
+                    "-Wl,-force_load,{}".format(static_library.path),
+                )
+            extra_link_inputs.extend(linker_input.additional_inputs)
+            extra_linkopts.extend(linker_input.user_link_flags)
+
     link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = getattr(ctx.attr, "frameworks", []),
         bundle_loader = bundle_loader,
         # Unit/UI tests do not use entitlements.
         entitlements = None,
-        extra_linkopts = ["-bundle"],
+        extra_linkopts = extra_linkopts,
+        extra_link_inputs = extra_link_inputs,
         platform_prerequisites = platform_prerequisites,
         stamp = ctx.attr.stamp,
     )

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -126,16 +126,23 @@ def _command_line_options(
         A dictionary of `"//command_line_option"`s defined for the current target.
     """
 
+    # Derive platform label defined in @build_bazel_apple_support//platforms.
+    #
+    # Doing this transition allows to set number of constrains defined in @build_bazel_apple_support
+    # used by other rules (e.g. rules_rust).
+    cpu_string = _cpu_string(
+        cpu = cpu,
+        platform_type = platform_type,
+        settings = settings,
+    )
+
     output_dictionary = {
         "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,
         "//command_line_option:apple_platform_type": platform_type,
         "//command_line_option:apple_split_cpu": cpu if cpu else "",
         "//command_line_option:compiler": settings["//command_line_option:apple_compiler"],
-        "//command_line_option:cpu": _cpu_string(
-            cpu = cpu,
-            platform_type = platform_type,
-            settings = settings,
-        ),
+        "//command_line_option:cpu": cpu_string,
+        "//command_line_option:platforms": "@build_bazel_apple_support//platforms:{}".format(cpu_string),
         "//command_line_option:crosstool_top": (
             settings["//command_line_option:apple_crosstool_top"]
         ),
@@ -285,6 +292,7 @@ _apple_rule_base_transition_outputs = [
     "//command_line_option:macos_minimum_os",
     "//command_line_option:tvos_minimum_os",
     "//command_line_option:watchos_minimum_os",
+    "//command_line_option:platforms",
 ]
 _apple_universal_binary_rule_transition_outputs = _apple_rule_base_transition_outputs + [
     "//command_line_option:ios_multi_cpus",

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -110,9 +110,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
     _maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "df317473b5894dd8eb432240d209271ebc83c76bb30c55481374b36ddf1e4fd1",
+        sha256 = "f4f377d0df696a9112e95d227e55ac8bb7eb44084f37d2d215b18cc8571e5ba8",
         urls = [
-            "https://github.com/bazelbuild/apple_support/releases/download/1.0.0/apple_support.1.0.0.tar.gz",
+            "https://github.com/bazelbuild/apple_support/releases/download/1.2.0/apple_support.1.2.0.tar.gz",
         ],
         ignore_version_differences = ignore_version_differences,
     )

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -110,9 +110,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
     _maybe(
         http_archive,
         name = "build_bazel_apple_support",
-        sha256 = "f4f377d0df696a9112e95d227e55ac8bb7eb44084f37d2d215b18cc8571e5ba8",
+        sha256 = "d94b7a0f49d735f196e1f36d2e6ef79c4e8e8b82132848dd8cd93cd82d9b12a8",
         urls = [
-            "https://github.com/bazelbuild/apple_support/releases/download/1.2.0/apple_support.1.2.0.tar.gz",
+            "https://github.com/bazelbuild/apple_support/releases/download/1.3.0/apple_support.1.3.0.tar.gz",
         ],
         ignore_version_differences = ignore_version_differences,
     )

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -121,9 +121,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
         http_archive,
         name = "build_bazel_rules_swift",
         urls = [
-            "https://github.com/bazelbuild/rules_swift/releases/download/1.0.0/rules_swift.1.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_swift/releases/download/1.1.0/rules_swift.1.1.0.tar.gz",
         ],
-        sha256 = "12057b7aa904467284eee640de5e33853e51d8e31aae50b3fb25d2823d51c6b8",
+        sha256 = "b672c212173ab3b3a9c4666028c08ff474915c3ed2a5c19eb5d9b8e84acc1373",
         ignore_version_differences = ignore_version_differences,
     )
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -465,3 +465,12 @@ work i.e. naming your tests something like `ModelsTests` residing at `src/Models
 runfiles will break. To fix this rename the test target to something like `ModelsUnitTests`
 
 This issue is tracked [here](https://github.com/bazelbuild/bazel/issues/12312)
+
+### Xcode's Issue navigator
+
+If integrating with Xcode, the relative paths in test binaries can prevent the
+Issue navigator from working for test failures. To work around this, you can
+have the paths made absolute via swizzling by enabling the
+`"apple.swizzle_absolute_xcttestsourcelocation"` feature. You'll also need to
+set the `BAZEL_WORKSPACE_DIRECTORY` environment variable in your scheme to the
+root of your workspace (i.e. `$(SRCROOT)`).

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -156,6 +156,18 @@ def ios_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
+        tags = [name],
+    )
+
     entry_point_test(
         name = "{}_entry_point_nsextensionmain_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -16,6 +16,7 @@
 
 load(
     ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
     "entry_point_test",
 )
 
@@ -29,6 +30,18 @@ def macos_extension_test_suite(name):
         name = "{}_entry_point_nsextensionmain_test".format(name),
         build_type = "simulator",
         entry_point = "_NSExtensionMain",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ext",
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/MacOS/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/../Frameworks (offset 12)",
+            "path @executable_path/../../../../Frameworks (offset 12)",
+        ],
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ext",
         tags = [name],
     )

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -100,6 +100,18 @@ def tvos_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -183,6 +183,18 @@ def watchos_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_correct_rpath_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/ext",
+        macho_load_commands_contain = [
+            "path @executable_path/Frameworks (offset 12)",
+            "path @executable_path/../../Frameworks (offset 12)",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -1,3 +1,5 @@
+load("@build_bazel_apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
+
 licenses(["notice"])
 
 py_binary(
@@ -19,6 +21,13 @@ py_library(
         "//tools:__subpackages__",
     ],
     deps = ["//tools/wrapper_common:execute"],
+)
+
+toolchain_substitution(
+    name = "disable_signing_resource_rules",
+    src = "disable_signing_resource_rules.plist",
+    var_name = "RESOURCE_RULES",
+    visibility = ["//visibility:public"],
 )
 
 # Consumed by bazel tests.

--- a/tools/codesigningtool/disable_signing_resource_rules.plist
+++ b/tools/codesigningtool/disable_signing_resource_rules.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>rules</key>
+	<dict>
+		<key>.*</key>
+		<false/>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This one of the patches required to solve #1650 

AFAIK, there aren't any side effects to this. Setting the `--platforms` flag to the matching one from `apple_support` is required to get a functioning build anyways.

Both ways of invoking bazel then work:

* using your own platform declarations like so `bazel build --platforms=//:myplatform` and if configured properly with the platform mappings, it'll be matched to the `--cpu` and `--apple_platform_type` flags and then transitioned into [apple_support platform`](https://github.com/bazelbuild/apple_support/blob/master/platforms/BUILD)
* use `bazel` without platforms and `--cpu` + `--apple_platform_type` and rules like `rules_rust` will then build the right binary, as they rely on platforms to work
