### PR TITLE
Add WKWatchKitApp key by default to legacy watchOS 2 application bundles hosting an extension.

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -733,6 +733,7 @@ _RULE_TYPE_DESCRIPTORS = {
     "watchos": {
         # watchos_application
         apple_product_type.watch2_application: _describe_rule_type(
+            additional_infoplist_values = {"WKWatchKitApp": True},
             allowed_device_families = ["watch"],
             allows_locale_trimming = True,
             app_icon_parent_extension = ".xcassets",

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -73,6 +73,7 @@ def watchos_application_test_suite(name):
             "DTXcodeBuild": "*",
             "MinimumOSVersion": "4.0",
             "UIDeviceFamily:0": "4",
+            "WKWatchKitApp": "true",
         },
         tags = [name],
     )


### PR DESCRIPTION
This key is used to disambiguate watchOS 2 app bundles from the new single target watchOS app format pioneered by Xcode 14, supporting watchOS 7 and later.

PiperOrigin-RevId: 473031666
(cherry picked from commit fdd377dedf5d83a594147dea3586ab14067ad8ec)