### PR TITLE
Add test_host_is_bundle_loader configuration

### DIFF
--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -404,6 +404,13 @@ def _test_host_attrs(
             mandatory = is_mandatory,
             providers = providers,
         ),
+        "test_host_is_bundle_loader": attr.bool(
+            default = True,
+            doc = """
+Whether the 'test_host' should be used as the -bundle_loader to allow testing
+the symbols from the test host app
+""",
+        ),
     }
 
 def _bundle_id_attrs(*, is_mandatory):

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -44,6 +44,7 @@ _SHARED_TEST_BUNDLE_ATTRS = {
         "minimum_os_version",
         "tags",
         "test_host",
+        "test_host_is_bundle_loader",
         "visibility",
     ]
 }

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -328,7 +328,8 @@ def _apple_test_bundle_impl(*, ctx, product_type):
     # is never passed as the bundle loader, because the host application is loaded out-of-process.)
     if (
         rule_descriptor.product_type == apple_product_type.unit_test_bundle and
-        test_host and apple_common.AppleExecutableBinary in test_host
+        test_host and apple_common.AppleExecutableBinary in test_host and
+        getattr(ctx.attr, "test_host_is_bundle_loader", True)
     ):
         bundle_loader = test_host
     else:

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -329,7 +329,7 @@ def _apple_test_bundle_impl(*, ctx, product_type):
     if (
         rule_descriptor.product_type == apple_product_type.unit_test_bundle and
         test_host and apple_common.AppleExecutableBinary in test_host and
-        getattr(ctx.attr, "test_host_is_bundle_loader", True)
+        ctx.attr.test_host_is_bundle_loader
     ):
         bundle_loader = test_host
     else:

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -537,7 +537,8 @@ Outputs:
 
 <pre>
 ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>,
-            <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>)
+            <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>,
+            <a href="#ios_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 iOS UI Test rule.
@@ -574,6 +575,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="ios_ui_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="ios_unit_test"></a>
@@ -582,7 +584,8 @@ of the attributes inherited by all test rules, please check the
 
 <pre>
 ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>,
-              <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>)
+              <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>,
+              <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -624,6 +627,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="ios_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="ios_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="ios_unit_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="ios_xctestrun_runner"></a>

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -591,7 +591,8 @@ i.e. `--features=-swift.no_generated_header`).
 
 <pre>
 macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>,
-              <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>)
+              <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>,
+              <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -618,6 +619,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="macos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="macos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="macos_ui_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="macos_unit_test"></a>
@@ -627,7 +629,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 <pre>
 macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                 <a href="#macos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>,
-                <a href="#macos_unit_test-test_host">test_host</a>)
+                <a href="#macos_unit_test-test_host">test_host</a>, <a href="#macos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -660,6 +662,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="macos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="macos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="macos_unit_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="macos_xpc_service"></a>

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -317,7 +317,8 @@ i.e. `--features=-swift.no_generated_header`).
 
 <pre>
 tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>,
-             <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
+             <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>,
+             <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 
@@ -350,6 +351,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="tvos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="tvos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="tvos_ui_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="tvos_unit_test"></a>
@@ -359,7 +361,7 @@ the attributes inherited by all test rules, please check the
 <pre>
 tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                <a href="#tvos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>,
-               <a href="#tvos_unit_test-test_host">test_host</a>)
+               <a href="#tvos_unit_test-test_host">test_host</a>, <a href="#tvos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 
@@ -400,5 +402,6 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="tvos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="tvos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="tvos_unit_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -282,7 +282,7 @@ Builds and bundles a watchOS Static Framework.
 <pre>
 watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                 <a href="#watchos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>,
-                <a href="#watchos_ui_test-test_host">test_host</a>)
+                <a href="#watchos_ui_test-test_host">test_host</a>, <a href="#watchos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -304,6 +304,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="watchos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="watchos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="watchos_ui_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 
 <a id="watchos_unit_test"></a>
@@ -313,7 +314,7 @@ watchOS UI Test rule.
 <pre>
 watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                   <a href="#watchos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>,
-                  <a href="#watchos_unit_test-test_host">test_host</a>)
+                  <a href="#watchos_unit_test-test_host">test_host</a>, <a href="#watchos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -335,5 +336,6 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="watchos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
 | <a id="watchos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="watchos_unit_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional | <code>True</code> |
 
 

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -39,7 +39,7 @@ load(
     "infoplist_contents_test",
 )
 load(
-    ":rules/action_command_line_test.bzl",
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
     "action_command_line_test",
 )
 
@@ -229,7 +229,7 @@ def ios_unit_test_test_suite(name):
         expected_argv = [
             "-bundle_loader",
             "app_lipobin",
-            "-Wl,-framework,CoreMotion",
+            "-framework CoreMotion",
         ],
         mnemonic = "ObjcLink",
         tags = [name],
@@ -241,7 +241,7 @@ def ios_unit_test_test_suite(name):
         not_expected_argv = [
             "-bundle_loader",
             "app_lipobin",
-            "-Wl,-framework,CoreMotion",
+            "-framework CoreMotion",
         ],
         mnemonic = "ObjcLink",
         tags = [name],

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -38,6 +38,10 @@ load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
+load(
+    ":rules/action_command_line_test.bzl",
+    "action_command_line_test",
+)
 
 def ios_unit_test_test_suite(name):
     """Test suite for ios_unit_test.
@@ -217,6 +221,29 @@ def ios_unit_test_test_suite(name):
         binary_test_file = "$BINARY",
         binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "minos 14.0", "platform IOSSIMULATOR"],
+    )
+
+    action_command_line_test(
+        name = "{}_bundle_loader_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test.__internal__.__test_bundle",
+        expected_argv = [
+            "-bundle_loader",
+            "app_lipobin",
+            "-Wl,-framework,CoreMotion",
+        ],
+        mnemonic = "ObjcLink",
+        tags = [name],
+    )
+
+    action_command_line_test(
+        name = "{}_no_bundle_loader_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_no_bundle_loader.__internal__.__test_bundle",
+        not_expected_argv = [
+            "-bundle_loader",
+            "app_lipobin",
+            "-Wl,-framework,CoreMotion",
+        ],
+        mnemonic = "ObjcLink",
         tags = [name],
     )
 

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -588,6 +588,13 @@ objc_library(
 )
 
 objc_library(
+    name = "objc_linkopt_lib",
+    srcs = ["@bazel_tools//tools/objc:dummy.c"],
+    linkopts = ["-Wl,-framework,CoreMotion"],
+    tags = FIXTURE_TAGS,
+)
+
+objc_library(
     name = "ios_non_localized_assets_lib",
     data = [
         ":assets",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -591,7 +591,7 @@ objc_library(
     name = "objc_linkopt_lib",
     srcs = ["@bazel_tools//tools/objc:dummy.c"],
     linkopts = ["-Wl,-framework,CoreMotion"],
-    tags = FIXTURE_TAGS,
+    tags = common.fixture_tags,
 )
 
 objc_library(

--- a/test/starlark_tests/rules/action_command_line_test.bzl
+++ b/test/starlark_tests/rules/action_command_line_test.bzl
@@ -1,0 +1,145 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rules for testing the contents of action command lines."""
+
+load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "unittest")
+
+def _action_command_line_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    # Find the desired action and verify that there is exactly one.
+    actions = analysistest.target_actions(env)
+    mnemonic = ctx.attr.mnemonic
+    matching_actions = [
+        action
+        for action in actions
+        if action.mnemonic == mnemonic
+    ]
+    if not matching_actions:
+        actual_mnemonics = collections.uniq(
+            [action.mnemonic for action in actions],
+        )
+        unittest.fail(
+            env,
+            ("Target '{}' registered no actions with the mnemonic '{}' " +
+             "(it had {}).").format(
+                str(target_under_test.label),
+                mnemonic,
+                actual_mnemonics,
+            ),
+        )
+        return analysistest.end(env)
+    if len(matching_actions) != 1:
+        # This is a hack to avoid CppLink meaning binary linking and static
+        # library archiving https://github.com/bazelbuild/bazel/pull/15060
+        if mnemonic == "CppLink" and len(matching_actions) == 2:
+            matching_actions = [
+                action
+                for action in matching_actions
+                if action.argv[0] not in [
+                    "/usr/bin/ar",
+                    "external/local_config_cc/libtool",
+                ]
+            ]
+        if len(matching_actions) != 1:
+            unittest.fail(
+                env,
+                ("Expected exactly one action with the mnemonic '{}', " +
+                 "but found {}.").format(
+                    mnemonic,
+                    len(matching_actions),
+                ),
+            )
+            return analysistest.end(env)
+
+    action = matching_actions[0]
+    message_prefix = "In {} action for target '{}', ".format(
+        mnemonic,
+        str(target_under_test.label),
+    )
+
+    # Concatenate the arguments into a single string so that we can easily look
+    # for subsequences of arguments. Note that we append an extra space to the
+    # end and look for arguments followed by a trailing space so that having
+    # `-foo` in the expected list doesn't match `-foobar`, for example.
+    concatenated_args = " ".join(action.argv) + " "
+    for expected in ctx.attr.expected_argv:
+        if expected + " " not in concatenated_args and expected + "=" not in concatenated_args:
+            unittest.fail(
+                env,
+                "{}expected argv to contain '{}', but it did not: {}".format(
+                    message_prefix,
+                    expected,
+                    concatenated_args,
+                ),
+            )
+    for not_expected in ctx.attr.not_expected_argv:
+        if not_expected + " " in concatenated_args or not_expected + "=" in concatenated_args:
+            unittest.fail(
+                env,
+                "{}expected argv to not contain '{}', but it did: {}".format(
+                    message_prefix,
+                    not_expected,
+                    concatenated_args,
+                ),
+            )
+
+    return analysistest.end(env)
+
+def make_action_command_line_test_rule(config_settings = {}):
+    """Returns a new `action_command_line_test`-like rule with custom configs.
+
+    Args:
+        config_settings: A dictionary of configuration settings and their values
+            that should be applied during tests.
+
+    Returns:
+        A rule returned by `analysistest.make` that has the
+        `action_command_line_test` interface and the given config settings.
+    """
+    return analysistest.make(
+        _action_command_line_test_impl,
+        attrs = {
+            "expected_argv": attr.string_list(
+                mandatory = False,
+                doc = """\
+A list of strings representing substrings expected to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+            ),
+            "not_expected_argv": attr.string_list(
+                mandatory = False,
+                doc = """\
+A list of strings representing substrings expected not to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+            ),
+            "mnemonic": attr.string(
+                mandatory = True,
+                doc = """\
+The mnemonic of the action to be inspected on the target under test. It is
+expected that there will be exactly one of these.
+""",
+            ),
+        },
+        config_settings = config_settings,
+    )
+
+# A default instantiation of the rule when no custom config settings are needed.
+action_command_line_test = make_action_command_line_test_rule()

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -130,6 +130,7 @@ ios_application(
         "//test/starlark_tests/resources:ios_localized_assets_lib",
         "//test/starlark_tests/resources:ios_non_localized_assets_lib",
         "//test/starlark_tests/resources:nested_bundle_lib",
+        "//test/starlark_tests/resources:objc_linkopt_lib",
         "//test/starlark_tests/resources:objc_main_lib",
         "//test/starlark_tests/resources:sticker_pack_ios_lib",
     ],
@@ -2944,6 +2945,28 @@ ios_unit_test(
     ],
     tags = common.fixture_tags,
     test_host = ":app",
+    deps = [
+        "//test/starlark_tests/resources:objc_test_lib",
+    ],
+)
+
+ios_unit_test(
+    name = "unit_test_no_bundle_loader",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = "8.0",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
+    tags = FIXTURE_TAGS,
+    test_host = ":app",
+    test_host_is_bundle_loader = False,
     deps = [
         "//test/starlark_tests/resources:objc_test_lib",
     ],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2964,7 +2964,7 @@ ios_unit_test(
         "//test/starlark_tests/resources:example_filegroup",
         "//test/starlark_tests/resources:resource_bundle",
     ],
-    tags = FIXTURE_TAGS,
+    tags = common.fixture_tags,
     test_host = ":app",
     test_host_is_bundle_loader = False,
     deps = [

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2959,7 +2959,7 @@ ios_unit_test(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = "8.0",
+    minimum_os_version = common.min_os_ios.baseline,
     resources = [
         "//test/starlark_tests/resources:example_filegroup",
         "//test/starlark_tests/resources:resource_bundle",


### PR DESCRIPTION
The default behavior for a test that has a test_host is to use that test
host app as the `-bundle_loader` linker argument. This is required if
you want to test APIs from the host app, but in the case you want to use
a host for other reasons, like testing iOS features that require you to
run in an app, you might not want this. This also works around some
surprising behavior where linkopts from the app are applied to the test
bundle as well.
