### PR TITLE
Get rid of unnecessary dummy.c references

### DIFF
--- a/test/ios_application_resources_test.sh
+++ b/test/ios_application_resources_test.sh
@@ -61,7 +61,6 @@ function create_with_localized_unprocessed_resources() {
   cat >> app/BUILD <<EOF
 objc_library(
     name = "resources",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "@build_bazel_rules_apple//test/testdata/resources:localized_generic_resources"
     ],
@@ -151,7 +150,6 @@ function test_different_files_mapped_to_the_same_target_path_fails() {
   cat >> app/BUILD <<EOF
 objc_library(
     name = "shared_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
       "shared_res/foo.txt",
     ],

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -122,7 +122,6 @@ ios_application(
 
 objc_library(
     name = "frameworkDependingLib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     deps = [":fmwk"],
 )
 
@@ -527,7 +526,6 @@ ios_application(
 
 objc_library(
     name = "resLib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [":appResources"],
 )
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -188,7 +188,6 @@ ios_extension(
 
 objc_library(
     name = "frameworkDependingLib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     deps = [":fmwk"],
 )
 

--- a/test/macos_application_resources_test.sh
+++ b/test/macos_application_resources_test.sh
@@ -61,7 +61,6 @@ function create_with_localized_unprocessed_resources() {
   cat >> app/BUILD <<EOF
 objc_library(
     name = "resources",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "@build_bazel_rules_apple//test/testdata/resources:localized_generic_resources"
     ],
@@ -119,7 +118,6 @@ function test_bundle_localization_strip() {
   cat >> app/BUILD <<EOF
 objc_library(
     name = "resources",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "@build_bazel_rules_apple//test/testdata/resources:bundle_library_macos",
         "fr.lproj/localized.strings",

--- a/test/smart_resource_deduplication_test.sh
+++ b/test/smart_resource_deduplication_test.sh
@@ -78,7 +78,6 @@ objc_library(
 
 objc_library(
     name = "shared_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     deps = [":resource_only_lib"],
     data = [
         "@build_bazel_rules_apple//test/testdata/resources:assets_ios",
@@ -92,7 +91,6 @@ objc_library(
 
 objc_library(
     name = "shared_lib_with_no_direct_resources",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     deps = [":resource_only_lib"],
 )
 

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -397,7 +397,6 @@ filegroup(
 
 objc_library(
     name = "sticker_pack_ios_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         ":sticker_pack_ios",
     ],
@@ -412,7 +411,7 @@ apple_bundle_import(
 
 objc_library(
     name = "basic_bundle_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
+    srcs = ["@bazel_tools//tools/objc:objc_dummy.mm"],
     data = [
         ":basic_bundle",
     ],
@@ -427,7 +426,6 @@ apple_bundle_import(
 
 objc_library(
     name = "nested_bundle_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         ":nested_bundle",
     ],
@@ -491,7 +489,6 @@ objc_library(
 
 objc_library(
     name = "empty_strings_file_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "empty.strings",
     ],
@@ -532,7 +529,6 @@ apple_resource_bundle(
 
 objc_library(
     name = "bundle_library_ios_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         ":bundle_library_ios",
     ],
@@ -568,7 +564,6 @@ apple_resource_bundle(
 
 objc_library(
     name = "bundle_library_apple_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         ":bundle_library_apple",
     ],
@@ -607,7 +602,6 @@ filegroup(
 
 objc_library(
     name = "framework_resources_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "framework_resources/nonlocalized.plist",
     ],

--- a/test/starlark_tests/targets_under_test/apple/static_library/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/static_library/BUILD
@@ -16,7 +16,7 @@ package(
 
 objc_library(
     name = "main_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
+    srcs = ["@bazel_tools//tools/objc:objc_dummy.mm"],
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1741,7 +1741,6 @@ swift_library(
 
 objc_library(
     name = "objc_to_swift_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [":swift_lib"],
 )
@@ -2420,7 +2419,6 @@ ios_unit_test(
 
 objc_library(
     name = "shared_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:basic_bundle",
     ],
@@ -2429,7 +2427,6 @@ objc_library(
 
 objc_library(
     name = "app_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:empty.strings",
     ],
@@ -2439,7 +2436,6 @@ objc_library(
 
 objc_library(
     name = "test_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:nonlocalized.strings",
     ],
@@ -2449,7 +2445,6 @@ objc_library(
 
 objc_library(
     name = "main_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [
         ":app_lib",

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -215,7 +215,6 @@ macos_application(
 
 objc_library(
     name = "dynamic_fmwk_depending_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [":imported_macos_dynamic_fmwk"],
 )

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -294,7 +294,6 @@ tvos_framework(
 
 objc_library(
     name = "dynamic_fmwk_depending_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [":imported_tvos_dynamic_fmwk"],
 )
@@ -318,7 +317,6 @@ generate_import_framework(
 
 objc_library(
     name = "static_fmwk_depending_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     deps = [":imported_tvos_static_fmwk"],
 )
 
@@ -604,7 +602,6 @@ swift_library(
 
 objc_library(
     name = "objc_to_swift_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [":swift_lib"],
 )
@@ -614,7 +611,6 @@ objc_library(
 
 objc_library(
     name = "shared_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:basic_bundle",
     ],
@@ -623,7 +619,6 @@ objc_library(
 
 objc_library(
     name = "app_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:empty.strings",
     ],
@@ -633,7 +628,6 @@ objc_library(
 
 objc_library(
     name = "test_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     data = [
         "//test/starlark_tests/resources:nonlocalized.strings",
     ],
@@ -643,7 +637,6 @@ objc_library(
 
 objc_library(
     name = "main_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [
         ":app_lib",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -350,7 +350,6 @@ swift_library(
 
 objc_library(
     name = "dynamic_fmwk_depending_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
     tags = FIXTURE_TAGS,
     deps = [":imported_watchos_dynamic_fmwk"],
 )

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -38,5 +38,4 @@ apple_static_library(
 
 objc_library(
     name = "dummy_lib",
-    srcs = ["@bazel_tools//tools/objc:dummy.c"],
 )

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -38,4 +38,5 @@ apple_static_library(
 
 objc_library(
     name = "dummy_lib",
+    srcs = ["@bazel_tools//tools/objc:dummy.c"],
 )


### PR DESCRIPTION
PiperOrigin-RevId: 463128217
(cherry picked from commit 3bb3da5b1dc82214370b5f6f0acd92b17e616acc)

```
# Conflicts:
#	test/starlark_tests/targets_under_test/tvos/BUILD
```