### PR TITLE
Improve documentation generation

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -2,7 +2,11 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
-_DOC_SRCS = [
+_PLAIN_DOC_SRCS = [
+    "providers",
+]
+
+_RULES_DOC_SRCS = [
     "apple",
     "dtrace",
     "ios.doc",
@@ -13,10 +17,12 @@ _DOC_SRCS = [
     "watchos.doc",
 ]
 
+_DOC_SRCS = _PLAIN_DOC_SRCS + _RULES_DOC_SRCS
+
 [
     stardoc(
         name = file + "_doc",
-        out = file + ".md",
+        out = file + ".gen.md",
         input = "//apple:%s.bzl" % file,
         tags = ["no-sandbox"],  # https://github.com/bazelbuild/stardoc/issues/112
         deps = ["//apple:" + file],
@@ -31,26 +37,21 @@ _failure_message = "\nPlease update the docs by running\n    bazel run //doc:upd
     diff_test(
         name = "check_" + file,
         failure_message = _failure_message,
-        file1 = file + ".md",
-        file2 = "rules-%s.md" % file.replace(".doc", ""),
+        file1 = file + ".gen.md",
+        file2 = "%s.md" % file.replace(".doc", ""),
     )
-    for file in _DOC_SRCS
+    for file in _PLAIN_DOC_SRCS
 ]
 
-# Special case since providers.md in the source folder doesn't follow the naming convention
-stardoc(
-    name = "providers_doc",
-    out = "providers.gen.md",
-    input = "//apple:providers.bzl",
-    deps = ["//apple:providers"],
-)
-
-diff_test(
-    name = "check_providers",
-    failure_message = _failure_message,
-    file1 = ":providers_doc",
-    file2 = "providers.md",
-)
+[
+    diff_test(
+        name = "check_" + file,
+        failure_message = _failure_message,
+        file1 = file + ".gen.md",
+        file2 = "rules-%s.md" % file.replace(".doc", ""),
+    )
+    for file in _RULES_DOC_SRCS
+]
 
 write_file(
     name = "gen_update",
@@ -58,19 +59,23 @@ write_file(
     content = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
-        "cd $BUILD_WORKSPACE_DIRECTORY",
-        "cp -fv bazel-bin/doc/providers.gen.md doc/providers.md",
     ] + [
-        "cp -fv bazel-bin/doc/{src}.md doc/rules-{dst}.md".format(
+        'cp -fv doc/{src}.gen.md "$BUILD_WORKSPACE_DIRECTORY/doc/{dst}.md"'.format(
             src = file,
             dst = file.replace(".doc", ""),
         )
-        for file in _DOC_SRCS
+        for file in _PLAIN_DOC_SRCS
+    ] + [
+        'cp -fv doc/{src}.gen.md "$BUILD_WORKSPACE_DIRECTORY/doc/rules-{dst}.md"'.format(
+            src = file,
+            dst = file.replace(".doc", ""),
+        )
+        for file in _RULES_DOC_SRCS
     ],
 )
 
 sh_binary(
     name = "update",
     srcs = ["update.sh"],
-    data = [file + ".md" for file in _DOC_SRCS] + ["providers.gen.md"],
+    data = [file + ".gen.md" for file in _DOC_SRCS],
 )


### PR DESCRIPTION
Before this change you would have to run `bazel build //doc:providers_doc` before `bazel run //doc:update` (to get`bazel-bin/` setup correctly). Also, this makes the repo work without convenience symlinks altogether.