### PR TITLE
Remove repo name from module import

### DIFF
--- a/tools/bitcode_strip/bitcode_strip.py
+++ b/tools/bitcode_strip/bitcode_strip.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 
 def invoke(input_path, output_path):

--- a/tools/bundletool/bundletool_unittest.py
+++ b/tools/bundletool/bundletool_unittest.py
@@ -24,7 +24,7 @@ import tempfile
 import unittest
 import zipfile
 
-from build_bazel_rules_apple.tools.bundletool import bundletool
+from tools.bundletool import bundletool
 
 
 def _run_bundler(control):

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -21,7 +21,7 @@ import re
 import subprocess
 import sys
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 
 # Regex with benign codesign messages that can be safely ignored.

--- a/tools/dossier_codesigningtool/dossier_codesigningtool.py
+++ b/tools/dossier_codesigningtool/dossier_codesigningtool.py
@@ -29,7 +29,7 @@ import sys
 import tempfile
 import uuid
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 
 class DossierDirectory(object):

--- a/tools/dossier_codesigningtool/dossier_codesigningtool_test.py
+++ b/tools/dossier_codesigningtool/dossier_codesigningtool_test.py
@@ -19,7 +19,7 @@ import unittest
 
 from unittest import mock
 
-from build_bazel_rules_apple.tools.dossier_codesigningtool import dossier_codesigningtool
+from tools.dossier_codesigningtool import dossier_codesigningtool
 
 _FAKE_MANIFEST = {
     'codesign_identity': '-',

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -18,9 +18,9 @@ import shutil
 import sys
 import time
 
-from build_bazel_rules_apple.tools.bitcode_strip import bitcode_strip
-from build_bazel_rules_apple.tools.codesigningtool import codesigningtool
-from build_bazel_rules_apple.tools.wrapper_common import lipo
+from tools.bitcode_strip import bitcode_strip
+from tools.codesigningtool import codesigningtool
+from tools.wrapper_common import lipo
 
 
 def _zip_framework(framework_temp_path, output_zip_path):

--- a/tools/plisttool/plisttool_unittest.py
+++ b/tools/plisttool/plisttool_unittest.py
@@ -23,7 +23,7 @@ import re
 import tempfile
 import unittest
 
-from build_bazel_rules_apple.tools.plisttool import plisttool
+from tools.plisttool import plisttool
 
 # Used as the target name for all tests.
 _testing_target = '//plisttool:tests'

--- a/tools/swift_stdlib_tool/swift_stdlib_tool.py
+++ b/tools/swift_stdlib_tool/swift_stdlib_tool.py
@@ -21,9 +21,9 @@ import shutil
 import sys
 import tempfile
 
-from build_bazel_rules_apple.tools.bitcode_strip import bitcode_strip
-from build_bazel_rules_apple.tools.wrapper_common import execute
-from build_bazel_rules_apple.tools.wrapper_common import lipo
+from tools.bitcode_strip import bitcode_strip
+from tools.wrapper_common import execute
+from tools.wrapper_common import lipo
 
 _OTOOL_MINIMUM_OS_VERSION_RE = re.compile(
     r"""

--- a/tools/versiontool/versiontool_unittest.py
+++ b/tools/versiontool/versiontool_unittest.py
@@ -19,7 +19,7 @@ import json
 import sys
 import unittest
 
-from build_bazel_rules_apple.tools.versiontool import versiontool
+from tools.versiontool import versiontool
 
 
 class VersionToolTest(unittest.TestCase):

--- a/tools/wrapper_common/execute_test.py
+++ b/tools/wrapper_common/execute_test.py
@@ -18,7 +18,7 @@ import io
 import signal
 import unittest
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 _INVALID_UTF8 = b'\xa0\xa1'
 

--- a/tools/wrapper_common/lipo.py
+++ b/tools/wrapper_common/lipo.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 
 def invoke_lipo(binary_path, binary_slices, output_path):

--- a/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from build_bazel_rules_apple.tools.xcframework_processor_tool import xcframework_processor_tool
+from tools.xcframework_processor_tool import xcframework_processor_tool
 
 
 _MOCK_XCFRAMEWORK_INFO_PLIST = {

--- a/tools/xctoolrunner/xctoolrunner.py
+++ b/tools/xctoolrunner/xctoolrunner.py
@@ -40,7 +40,7 @@ import re
 import shutil
 import sys
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
+from tools.wrapper_common import execute
 
 # This prefix is set for rules_apple rules in:
 # apple/internal/utils/xctoolrunner.bzl

--- a/tools/xctoolrunner/xctoolrunner_test.py
+++ b/tools/xctoolrunner/xctoolrunner_test.py
@@ -18,8 +18,8 @@ import unittest
 
 from unittest import mock
 
-from build_bazel_rules_apple.tools.wrapper_common import execute
-from build_bazel_rules_apple.tools.xctoolrunner import xctoolrunner
+from tools.wrapper_common import execute
+from tools.xctoolrunner import xctoolrunner
 
 
 _UNHANDLED_DESTINATION_METRICS_MSG = (


### PR DESCRIPTION
This is in preparation for adding support for bzlmod. This Python script loads another file via its runfiles. When bzlmod is enabled, the directory has the name of the actual dependency and its version and not the name of its defined `repo_name` (`rules_apple~1.1.2` instead of `build_bazel_rules_apple`). This causes issues and should be addressed in Bazel (which it is being thought about per [this Slack conversation](https://bazelbuild.slack.com/archives/C014RARENH0/p1664279459175029)), but this is a quick fix that should be backwards compatible.

If this passes CI and there are no objections, I'll remove all instances of this practice from the repo.