### PR TITLE
[rules_apple] Migrate static_framework_file to imported_library

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -305,7 +305,7 @@ def _objc_provider_with_dependencies(
         objc_provider_fields["dynamic_framework_file"] = depset(dynamic_framework_file)
 
     if static_framework_file:
-        objc_provider_fields["static_framework_file"] = depset(static_framework_file)
+        objc_provider_fields["imported_library"] = depset(static_framework_file)
 
         if alwayslink:
             objc_provider_fields["force_load_library"] = depset(static_framework_file)


### PR DESCRIPTION
STATIC_FRAMEWORK_FILE is a static archive, and we should be able to
migrate it to IMPORTED_LIBRARY. We will eventually migrate it to a
LibraryToLink in the CcLinkingContext.

If this migration breaks build, it is likely because there are two
~equivalent static frameworks in the dependency, that were
deduplicated when -F are used to find them. We should fix those builds
by eliminating the redundant dependency.

PiperOrigin-RevId: 472471843
(cherry picked from commit 08a6456e893d544e65e55695e5962baeafddb776)
