### PR TITLE
Revert "[rules_apple] Migrate static_framework_file to imported_library (#1697)"

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -305,7 +305,7 @@ def _objc_provider_with_dependencies(
         objc_provider_fields["dynamic_framework_file"] = depset(dynamic_framework_file)
 
     if static_framework_file:
-        objc_provider_fields["imported_library"] = depset(static_framework_file)
+        objc_provider_fields["static_framework_file"] = depset(static_framework_file)
 
         if alwayslink:
             objc_provider_fields["force_load_library"] = depset(static_framework_file)


### PR DESCRIPTION
This doesn't actually work, these libraries end up not being linked.

This reverts commit 8d841342c238457896cd7596cc29b2d06c9a75f0.
