### PR TITLE
[rules_apple] Add linkopt and link_inputs info to CcInfo

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -88,7 +88,6 @@ def _sectcreate_objc_provider(segname, sectname, file):
                 additional_inputs = [file],
             ),
         ),
-        AppleBinaryInfoplistInfo(infoplist = merged_infoplist),
     ]
 
 def _parse_platform_key(key):

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -121,6 +121,7 @@ def _macos_binary_infoplist_impl(ctx):
     )
 
     return linking_support.sectcreate_objc_provider(
+        rule_label,
         "__TEXT",
         "__info_plist",
         merged_infoplist,
@@ -183,6 +184,7 @@ def _macos_command_line_launchdplist_impl(ctx):
     )
 
     return linking_support.sectcreate_objc_provider(
+        rule_label,
         "__TEXT",
         "__launchd_plist",
         merged_launchdplist,

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -52,6 +52,7 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfoplistInfo",
     "AppleBundleVersionInfo",
 )
 load(
@@ -123,7 +124,7 @@ def _macos_binary_infoplist_impl(ctx):
         "__TEXT",
         "__info_plist",
         merged_infoplist,
-    )
+    ) + [AppleBinaryInfoplistInfo(infoplist = merged_infoplist)]
 
 macos_binary_infoplist = rule(
     implementation = _macos_binary_infoplist_impl,

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -52,7 +52,6 @@ load(
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfoplistInfo",
     "AppleBundleVersionInfo",
 )
 load(
@@ -120,14 +119,11 @@ def _macos_binary_infoplist_impl(ctx):
         version = ctx.attr.version,
     )
 
-    return [
-        linking_support.sectcreate_objc_provider(
-            "__TEXT",
-            "__info_plist",
-            merged_infoplist,
-        ),
-        AppleBinaryInfoplistInfo(infoplist = merged_infoplist),
-    ]
+    return linking_support.sectcreate_objc_provider(
+        "__TEXT",
+        "__info_plist",
+        merged_infoplist,
+    )
 
 macos_binary_infoplist = rule(
     implementation = _macos_binary_infoplist_impl,
@@ -185,13 +181,11 @@ def _macos_command_line_launchdplist_impl(ctx):
         rule_label = rule_label,
     )
 
-    return [
-        linking_support.sectcreate_objc_provider(
-            "__TEXT",
-            "__launchd_plist",
-            merged_launchdplist,
-        ),
-    ]
+    return linking_support.sectcreate_objc_provider(
+        "__TEXT",
+        "__launchd_plist",
+        merged_launchdplist,
+    )
 
 macos_command_line_launchdplist = rule(
     implementation = _macos_command_line_launchdplist_impl,


### PR DESCRIPTION
We want to mirror any linking info in CcInfo, to aid migrating linking
info to it.

PiperOrigin-RevId: 480125145
(cherry picked from commit 254a4bba620054e633bc7a82c01b02a8661bf07d)
