### PR TITLE
Strip bitcode from stub binaries

### DIFF
--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -63,9 +63,9 @@ def _create_stub_binary(
                 output_path = binary_artifact.path,
                 xcode_stub_path = xcode_stub_path,
             ),
-            mnemonic = "CopyStubExecutable",
+            mnemonic = "BitcodeStripStub",
             outputs = [binary_artifact],
-            progress_message = "Copying stub executable for %s" % (rule_label),
+            progress_message = "Removing bitcode from stub executable for %s" % (rule_label),
             xcode_config = platform_prerequisites.xcode_version_config,
         )
     else:

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -56,15 +56,14 @@ def _create_stub_binary(
     )
 
     if bitcode_support.bitcode_mode_string(platform_prerequisites.apple_fragment) == "none":
-        apple_support.run_shell(
+        apple_support.run(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
-            command = "xcrun bitcode_strip -r \"$SDKROOT/{xcode_stub_path}\" -o {output_path}".format(
-                output_path = binary_artifact.path,
-                xcode_stub_path = xcode_stub_path,
-            ),
+            executable = "/usr/bin/xcrun",
+            arguments = ["bitcode_strip", "-r", "__BAZEL_XCODE_SDKROOT__/{}".format(xcode_stub_path), "-o", binary_artifact.path],
             mnemonic = "BitcodeStripStub",
             outputs = [binary_artifact],
+            xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
             progress_message = "Removing bitcode from stub executable for %s" % (rule_label),
             xcode_config = platform_prerequisites.xcode_version_config,
         )

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -19,6 +19,10 @@ load(
     "apple_verification_test",
 )
 load(
+    ":rules/common_verification_tests.bzl",
+    "archive_contents_test",
+)
+load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -60,6 +64,26 @@ def ios_sticker_pack_extension_test_suite(name):
             "NSExtension:NSExtensionPointIdentifier": "com.apple.message-payload-provider",
             "UIDeviceFamily:0": "1",
         },
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_bitcode_test".format(name),
+        apple_bitcode = "embedded",
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
+        binary_test_file = "$BUNDLE_ROOT/sticker_ext",
+        macho_load_commands_contain = ["segname __LLVM"],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_strip_bitcode_test".format(name),
+        build_type = "device",
+        apple_bitcode = "none",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
+        binary_test_file = "$BUNDLE_ROOT/sticker_ext",
+        macho_load_commands_not_contain = ["segname __LLVM"],
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2077,6 +2077,7 @@ ios_imessage_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "10.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = FIXTURE_TAGS,
 )
 
@@ -2091,6 +2092,7 @@ ios_sticker_pack_extension(
         "//test/starlark_tests/resources:StickerPackInfo.plist",
     ],
     minimum_os_version = "10.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     sticker_assets = [],
     tags = FIXTURE_TAGS,
 )


### PR DESCRIPTION
Xcode 14 doesn't allow uploading any binaries with bitcode, but the
stub binaries it provides for use with message extensions still contain
bitcode. This change strips that based on the bitcode mode.

Fixes https://github.com/bazelbuild/rules_apple/issues/1702
