### PR TITLE
Embed frameworks in `ios_message_extension`

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2145,6 +2145,16 @@ def _ios_imessage_extension_impl(ctx):
             rule_label = label,
             targets_to_validate = ctx.attr.frameworks,
         ),
+        partials.framework_import_partial(
+            actions = actions,
+            apple_mac_toolchain_info = apple_mac_toolchain_info,
+            features = features,
+            label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
+            provisioning_profile = provisioning_profile,
+            rule_descriptor = rule_descriptor,
+            targets = ctx.attr.deps + ctx.attr.frameworks,
+        ),
         partials.resources_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,


### PR DESCRIPTION
I noticed that in BwX mode of rules_xcodeproj an iOS Message Extension would correctly embed frameworks. When running in BwB mode it crashed at runtime. This change fixes that.