### PR TITLE
Fix sdk_framework discovery with other argument format

### DIFF
--- a/apple/internal/cc_info_support.bzl
+++ b/apple/internal/cc_info_support.bzl
@@ -54,6 +54,8 @@ def _get_sdk_frameworks(*, deps, split_deps_keys = []):
             for index, user_link_flag in enumerate(linker_input.user_link_flags):
                 if user_link_flag == "-framework":
                     sdk_frameworks.append(linker_input.user_link_flags[index + 1])
+                elif user_link_flag.startswith("-Wl,-framework,"):
+                    sdk_frameworks.append(user_link_flag.split(",")[-1])
 
     return depset(sdk_frameworks)
 


### PR DESCRIPTION
This changed with https://github.com/bazelbuild/bazel/commit/977d7fb3837ceeabd17ecd639037f95a99ca4cb1 causing some modulemap tests to fail
