### PR TITLE
Include transitive data dep runfiles.

### DIFF
--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -181,10 +181,16 @@ def _apple_test_rule_impl(ctx, test_type):
         is_executable = True,
     )
 
+    transitive_runfile_objects = [
+        ctx.attr.runner.default_runfiles,
+        ctx.attr.runner.data_runfiles,
+    ]
+
     # Add required data into the runfiles to make it available during test
     # execution.
     for data_dep in ctx.attr.data:
         transitive_runfiles.append(data_dep.files)
+        transitive_runfile_objects.append(data_dep.default_runfiles)
 
     return [
         # Repropagate the AppleBundleInfo and AppleTestInfo providers from the test bundle so that
@@ -208,9 +214,7 @@ def _apple_test_rule_impl(ctx, test_type):
             runfiles = ctx.runfiles(
                 files = direct_runfiles,
                 transitive_files = depset(transitive = transitive_runfiles),
-            )
-                .merge(ctx.attr.runner.default_runfiles)
-                .merge(ctx.attr.runner.data_runfiles),
+            ).merge_all(transitive_runfile_objects),
         ),
     ]
 

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -34,6 +34,10 @@ load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
+load(
+    ":rules/analysis_runfiles_test.bzl",
+    "analysis_runfiles_test",
+)
 
 def macos_unit_test_test_suite(name):
     """Test suite for macos_unit_test.
@@ -114,6 +118,16 @@ def macos_unit_test_test_suite(name):
         binary_test_architecture = "x86_64",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "minos 11.0", "platform MACOS"],
         tags = [name],
+    )
+
+    analysis_runfiles_test(
+        name = "{}_transitive_runfiles_included".format(name),
+        tags = [name],
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test_data_deps",
+        expected_runfiles = [
+            "test/starlark_tests/targets_under_test/macos/runfile1.txt",
+            "test/starlark_tests/targets_under_test/macos/runfile2.txt",
+        ],
     )
 
     native.test_suite(

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -681,3 +681,31 @@ macos_unit_test(
         "//test/starlark_tests/resources:objc_test_lib",
     ],
 )
+
+macos_unit_test(
+    name = "unit_test_data_deps",
+    data = [":runfiles1"],
+    minimum_os_version = "10.10",
+    tags = FIXTURE_TAGS,
+)
+
+filegroup(
+    name = "runfiles1",
+    # NOTE: we specify `data` instead of `srcs` because `data` puts the files
+    # into runfiles, while `srcs` puts them into the default outputs.
+    data = [
+        "runfile1.txt",
+        # Add a second-order dependency to check that the transitive runfiles
+        # are being added.
+        ":runfiles2",
+    ],
+    tags = FIXTURE_TAGS,
+)
+
+filegroup(
+    name = "runfiles2",
+    # NOTE: we specify `data` instead of `srcs` because `data` puts the files
+    # into runfiles, while `srcs` puts them into the default outputs.
+    data = ["runfile2.txt"],
+    tags = FIXTURE_TAGS,
+)


### PR DESCRIPTION
Otherwise, any targets put in `data` don't include their higher order
dependencies. For example, an `sh_binary` put in data only includes its
final executable instead of the transitive set of shell files needed.

PiperOrigin-RevId: 466067463
(cherry picked from commit 5456eeed0f4fd730a5c5f0cadaf06fd175d8ee99)
