### PR TITLE
Move Apple framework import test targets to targets starlark_tests

### DIFF
--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1,6 +1,8 @@
 load(
     "//apple:apple.bzl",
+    "apple_dynamic_framework_import",
     "apple_dynamic_xcframework_import",
+    "apple_static_framework_import",
     "apple_static_xcframework",
     "apple_static_xcframework_import",
     "apple_universal_binary",
@@ -1163,6 +1165,53 @@ apple_universal_binary(
     minimum_os_version = "11.0",
     platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple dynamic framework import tests.
+
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFramework",
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSDynamicFramework"],
+)
+
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithBitcode",
+    framework_imports = ["//test/testdata/fmwk:iOSDynamicFrameworkWithBitcode"],
+)
+
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithDebugInfo",
+    framework_imports = ["//test/testdata/fmwk:iOSDynamicFrameworkWithDebugInfo"],
+)
+
+apple_dynamic_framework_import(
+    name = "iOSImportedDynamicFrameworkWithDsym",
+    dsym_imports = ["//test/testdata/fmwk:iOSDynamicFrameworkDsym"],
+    framework_imports = ["//test/testdata/fmwk:iOSDynamicFramework"],
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple static framework import tests.
+
+apple_static_framework_import(
+    name = "iOSImportedStaticFramework",
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSStaticFramework"],
+)
+
+apple_static_framework_import(
+    name = "iOSImportedSwiftStaticFramework",
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSSwiftStaticFramework"],
+)
+
+apple_static_framework_import(
+    name = "iOSImportedSwiftStaticFrameworkWithoutModuleInterface",
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSSwiftStaticFramework"],
+    has_swift = True,
 )
 
 # ---------------------------------------------------------------------------------------

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -430,7 +430,7 @@ ios_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_lib_with_resources",
-        "//test/testdata/fmwk:iOSImportedDynamicFramework",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFramework",
     ],
 )
 
@@ -449,7 +449,7 @@ ios_application(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/testdata/fmwk:iOSImportedDynamicFrameworkWithBitcode",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFrameworkWithBitcode",
     ],
 )
 
@@ -469,8 +469,8 @@ ios_application(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/testdata/fmwk:iOSImportedDynamicFrameworkWithDebugInfo",
-        "//test/testdata/fmwk:iOSImportedDynamicFrameworkWithDsym",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFrameworkWithDebugInfo",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFrameworkWithDsym",
     ],
 )
 
@@ -534,7 +534,7 @@ ios_framework(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_lib_with_resources",
-        "//test/testdata/fmwk:iOSImportedStaticFramework",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFramework",
     ],
 )
 
@@ -981,7 +981,7 @@ ios_application(
     tags = FIXTURE_TAGS,
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/testdata/fmwk:iOSImportedDynamicFrameworkWithDebugInfo",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFrameworkWithDebugInfo",
     ],
 )
 
@@ -1518,7 +1518,7 @@ objc_library(
     name = "dynamic_fmwk_depending_lib",
     srcs = ["DynamicFmwkDependingLib.m"],
     tags = FIXTURE_TAGS,
-    deps = ["//test/testdata/fmwk:iOSImportedDynamicFramework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFramework"],
 )
 
 genrule(
@@ -1558,7 +1558,7 @@ ios_application(
 swift_library(
     name = "dynamic_fmwk_depending_swift_lib",
     srcs = ["DynamicFmwkDependingSwiftLib.swift"],
-    deps = ["//test/testdata/fmwk:iOSImportedDynamicFramework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFramework"],
 )
 
 genrule(
@@ -1600,7 +1600,7 @@ ios_application(
 objc_library(
     name = "static_fmwk_depending_lib",
     srcs = ["StaticFmwkDependingLib.m"],
-    deps = ["//test/testdata/fmwk:iOSImportedStaticFramework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFramework"],
 )
 
 genrule(
@@ -1641,7 +1641,7 @@ objc_library(
     name = "swift_static_fmwk_depending_lib",
     srcs = ["SwiftStaticFmwkDependingLib.m"],
     tags = FIXTURE_TAGS,
-    deps = ["//test/testdata/fmwk:iOSImportedSwiftStaticFramework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedSwiftStaticFramework"],
 )
 
 genrule(
@@ -1679,7 +1679,7 @@ objc_library(
     name = "swift_static_without_module_interfaces_fmwk_depending_lib",
     srcs = ["SwiftStaticFmwkWithoutInterfaceFilesDependingLib.m"],
     tags = FIXTURE_TAGS,
-    deps = ["//test/testdata/fmwk:iOSImportedSwiftStaticFrameworkWithoutModuleInterface"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedSwiftStaticFrameworkWithoutModuleInterface"],
 )
 
 genrule(
@@ -1887,7 +1887,7 @@ ios_application(
 swift_library(
     name = "static_fmwk_depending_swift_lib",
     srcs = ["StaticFmwkDependingSwiftLib.swift"],
-    deps = ["//test/testdata/fmwk:iOSImportedStaticFramework"],
+    deps = ["//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFramework"],
 )
 
 genrule(
@@ -2896,7 +2896,7 @@ swift_library(
     tags = FIXTURE_TAGS,
     visibility = ["//visibility:public"],
     deps = [
-        "//test/testdata/fmwk:iOSImportedDynamicFramework",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedDynamicFramework",
     ],
 )
 
@@ -2928,7 +2928,7 @@ swift_library(
     tags = FIXTURE_TAGS,
     visibility = ["//visibility:public"],
     deps = [
-        "//test/testdata/fmwk:iOSImportedStaticFramework",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFramework",
     ],
 )
 

--- a/test/testdata/fmwk/BUILD
+++ b/test/testdata/fmwk/BUILD
@@ -1,9 +1,4 @@
 load(
-    "//apple:apple.bzl",
-    "apple_dynamic_framework_import",
-    "apple_static_framework_import",
-)
-load(
     "//test/testdata/fmwk:generate_framework.bzl",
     "generate_import_framework",
 )
@@ -19,47 +14,6 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
-
-apple_dynamic_framework_import(
-    name = "iOSImportedDynamicFramework",
-    features = ["-swift.layering_check"],
-    framework_imports = [":iOSDynamicFramework"],
-)
-
-apple_dynamic_framework_import(
-    name = "iOSImportedDynamicFrameworkWithBitcode",
-    framework_imports = [":iOSDynamicFrameworkWithBitcode"],
-)
-
-apple_dynamic_framework_import(
-    name = "iOSImportedDynamicFrameworkWithDebugInfo",
-    framework_imports = [":iOSDynamicFrameworkWithDebugInfo"],
-)
-
-apple_dynamic_framework_import(
-    name = "iOSImportedDynamicFrameworkWithDsym",
-    dsym_imports = [":iOSDynamicFrameworkDsym"],
-    framework_imports = [":iOSDynamicFramework"],
-)
-
-apple_static_framework_import(
-    name = "iOSImportedStaticFramework",
-    features = ["-swift.layering_check"],
-    framework_imports = [":iOSStaticFramework"],
-)
-
-apple_static_framework_import(
-    name = "iOSImportedSwiftStaticFramework",
-    features = ["-swift.layering_check"],
-    framework_imports = [":iOSSwiftStaticFramework"],
-)
-
-apple_static_framework_import(
-    name = "iOSImportedSwiftStaticFrameworkWithoutModuleInterface",
-    features = ["-swift.layering_check"],
-    framework_imports = [":iOSSwiftStaticFramework"],
-    has_swift = True,
-)
 
 filegroup(
     name = "swift_source",


### PR DESCRIPTION
Currently `apple_(dynamic|static)_framework_import` test targets reside
on `test/testdata/fwmk`, for consistency, this change moves these targets
under test/starlark_tests/targets_under_test/apple instead.

PiperOrigin-RevId: 464613120
(cherry picked from commit 4a766f89be10d3e9b646318a6c60c08da33fed81)
