### PR TITLE
Add logic to drop 32 bit archs for watchOS in the starlark transitions if the minimum OS version is 9 or greater.

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -150,13 +150,14 @@ def _is_cpu_supported_for_target_tuple(*, cpu, minimum_os_version, platform_type
 
     dotted_minimum_os_version = apple_common.dotted_version(minimum_os_version)
 
-    if platform_type == "ios":
-        # TODO(b/237317468): Return False for 32 bit iOS archs if Xcode 14+ is the selected Xcode.
-        if dotted_minimum_os_version >= apple_common.dotted_version("11.0"):
-            if cpu in _32_BIT_APPLE_CPUS:
-                return False
+    if cpu in _32_BIT_APPLE_CPUS:
+        if (platform_type == "ios" and
+            dotted_minimum_os_version >= apple_common.dotted_version("11.0")):
+            return False
+        if (platform_type == "watchos" and
+            dotted_minimum_os_version >= apple_common.dotted_version("9.0")):
+            return False
 
-    # TODO(b/237318193): Return False for 32 bit watchOS archs if the minimum OS is 9 or higher.
     return True
 
 def _command_line_options(

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -38,6 +38,7 @@ def archive_contents_test(
         binary_test_architecture = "",
         binary_contains_symbols = [],
         binary_contains_regex_symbols = [],
+        binary_not_contains_architectures = [],
         binary_not_contains_symbols = [],
         codesign_info_contains = [],
         codesign_info_not_contains = [],
@@ -87,6 +88,8 @@ def archive_contents_test(
         binary_contains_regex_symbols: Optional, a list of regular expressions to match symbols
             that should appear in the binary file specified in `binary_test_file`. Regular
             expressions must follow POSIX Basic Regular Expression (BRE) syntax.
+        binary_not_contains_architectures: Optional. A list of architectures to verify do not exist
+            within `binary_test_file`.
         binary_not_contains_symbols: Optional, A list of symbols that should not appear in the
             binary file specified in `binary_test_file`.
         codesign_info_contains: Optional, A list of codesign info that should appear in the binary
@@ -142,6 +145,8 @@ def archive_contents_test(
             fail("Need binary_test_file to check macho load commands")
         if any([codesign_info_contains, codesign_info_not_contains]):
             fail("Need binary_test_file to check codesign info")
+        if (binary_not_contains_architectures):
+            fail("Need binary_test_file to check for the absence of architectures")
 
     if not any([
         contains,
@@ -179,6 +184,7 @@ def archive_contents_test(
             "TEXT_TEST_VALUES": text_test_values,
             "BINARY_TEST_FILE": [binary_test_file],
             "BINARY_TEST_ARCHITECTURE": [binary_test_architecture],
+            "BINARY_NOT_CONTAINS_ARCHITECTURES": binary_not_contains_architectures,
             "BINARY_CONTAINS_SYMBOLS": binary_contains_symbols,
             "BINARY_NOT_CONTAINS_SYMBOLS": binary_not_contains_symbols,
             "BINARY_CONTAINS_REGEX_SYMBOLS": binary_contains_regex_symbols,

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -59,6 +59,19 @@ watchos_application(
     tags = FIXTURE_TAGS,
 )
 
+watchos_application(
+    name = "app_os9",
+    app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
+    bundle_id = "com.google.example",
+    extension = ":ext_os9",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosAppInfo.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = FIXTURE_TAGS,
+)
+
 watchos_extension(
     name = "ext",
     bundle_id = "com.google.example.ext",
@@ -190,6 +203,25 @@ watchos_extension(
     ],
     minimum_os_version = "4.0",
     tags = FIXTURE_TAGS,
+)
+
+watchos_extension(
+    name = "ext_os9",
+    bundle_id = "com.google.example.ext",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
+    ],
+    minimum_os_version = "9.0",
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    resources = [
+        "//test/starlark_tests/resources:example_filegroup",
+        "//test/starlark_tests/resources:localization",
+        "//test/starlark_tests/resources:resource_bundle",
+    ],
+    tags = FIXTURE_TAGS,
+    deps = [
+        "//test/starlark_tests/resources:watchkit_ext_main_lib",
+    ],
 )
 
 ios_application(

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -43,6 +43,8 @@ newline=$'\n'
 #  TEXT_TEST_VALUES: Array for regular expressions to test the contents of the
 #      text file with. Regular expressions must follow POSIX Basic Regular
 #      Expression (BRE) syntax.
+#  BINARY_NOT_CONTAINS_ARCHITECTURES: The architectures to verify are not in the
+#      assembled binary.
 #  BINARY_TEST_FILE: The file to test with `BINARY_TEST_SYMBOLS`
 #  BINARY_TEST_ARCHITECTURE: The architecture to use with `BINARY_TEST_SYMBOLS`.
 #  BINARY_CONTAINS_SYMBOLS: Array of symbols that should be present.
@@ -104,6 +106,27 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     fail "Archive did not contain binary at \"$path\"" \
       "contents were:$newline$(find $ARCHIVE_ROOT)"
   fi
+
+  if [[ -n "${BINARY_NOT_CONTAINS_ARCHITECTURES-}" ]]; then
+    IFS=' ' found_archs=($(lipo -archs "$path"))
+    for arch in "${BINARY_NOT_CONTAINS_ARCHITECTURES[@]}"
+    do
+      for found_arch in "${found_archs[@]}"
+      do
+        something_tested=true
+        arch_found=false
+        if [[ "$arch" == "$found_arch" ]]; then
+          arch_found=true
+          break
+        fi
+      done
+      if [[ "$arch_found" = true ]]; then
+        fail "Unexpectedly found architecture \"$arch\". The architectures " \
+          "in the binary were:$newline${found_archs[@]}"
+      fi
+    done
+  fi
+
   if [[ -n "${BINARY_TEST_ARCHITECTURE-}" ]]; then
     arch=$(eval echo "$BINARY_TEST_ARCHITECTURE")
     if [[ ! -n $arch ]]; then
@@ -280,6 +303,10 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     fi
   fi
 else
+  if [[ -n "${BINARY_NOT_CONTAINS_ARCHITECTURES-}" ]]; then
+    fail "Rule Misconfigured: Supposed to look for missing architectures," \
+      "but no binary was set to check: ${BINARY_NOT_CONTAINS_ARCHITECTURES[@]}"
+  fi
   if [[ -n "${BINARY_TEST_ARCHITECTURE-}" ]]; then
     fail "Rule Misconfigured: Binary arch was set," \
       "but no binary was set to check: ${BINARY_TEST_ARCHITECTURE}"

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -232,6 +232,34 @@ def watchos_extension_test_suite(name):
         name = "{}_product_type_app_extension".format(name),
         expected_product_type = apple_product_type.app_extension,
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:watchos_app_extension",
+    )
+
+    # Test that the output binary omits the 32 bit iOS slice when built for a minimum OS that does
+    # not support 32 bit architectures.
+    archive_contents_test(
+        name = "{}_ios_binary_contents_dropping_32_bit_device_archs_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext_os9",
+        cpus = {
+            "ios_multi_cpus": ["armv7k", "arm64_32"],
+        },
+        binary_test_file = "$BINARY",
+        binary_not_contains_architectures = ["armv7k"],
+        tags = [name],
+    )
+
+    # Test that the iOS output binary still contains the 64 bit Arm slice when built for
+    # a minimum OS that does not support 32 bit architectures.
+    archive_contents_test(
+        name = "{}_ios_binary_contents_retains_arm64_32_when_dropping_32_bit_device_archs_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext_os9",
+        cpus = {
+            "ios_multi_cpus": ["armv7k", "arm64_32"],
+        },
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64_32",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION"],
         tags = [name],
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 465095505
(cherry picked from commit 94526e6ff51ebf77d0e2d321a133207ed4e28eeb)
