### PR TITLE
Raise the minimum_os_versions of the shell tests to versions supported by Xcode 14 RC and the arm64e architecture for iOS and tvOS.

### DIFF
--- a/test/apple_core_ml_library_test.sh
+++ b/test/apple_core_ml_library_test.sh
@@ -70,7 +70,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone", "ipad"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "12",
+    minimum_os_version = "12.0",
     deps = [":app_lib"],
 )
 EOF

--- a/test/ios_application_resources_test.sh
+++ b/test/ios_application_resources_test.sh
@@ -71,7 +71,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib", ":resources"],
 )
@@ -128,7 +128,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     settings_bundle = "@build_bazel_rules_apple//test/testdata/resources:settings_bundle_ios",
     deps = [":lib"],
@@ -166,7 +166,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
@@ -203,7 +203,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )

--- a/test/ios_application_swift_resources_test.sh
+++ b/test/ios_application_swift_resources_test.sh
@@ -45,7 +45,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )

--- a/test/ios_application_swift_test.sh
+++ b/test/ios_application_swift_test.sh
@@ -42,7 +42,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -81,7 +81,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
 EOF
 
   if [[ -n "$product_type" ]]; then
@@ -112,7 +112,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [
         ":frameworkDependingLib",
@@ -238,7 +238,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     ipa_post_processor = "post_processor.sh",
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -272,7 +272,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     linkopts = ["-alias", "_main", "_linkopts_test_main"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -300,7 +300,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     linkopts = ["-order_file", "$(location :linker_input)"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -345,7 +345,7 @@ ios_application(
     entitlements = "entitlements.plist",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "profile.mobileprovision",
     deps = [":lib"],
 )
@@ -449,7 +449,7 @@ ios_application(
     entitlements = "entitlements.plist",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -488,7 +488,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "bogus.mobileprovision",
     deps = [":lib"],
 )
@@ -516,7 +516,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [
         ":lib",
@@ -627,7 +627,7 @@ ios_application(
     bundle_id = "${bundle_id_to_test}",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -668,7 +668,7 @@ ios_application(
     bundle_id = "my#bundle",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -689,7 +689,7 @@ ios_application(
     bundle_name = "different",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -718,7 +718,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     version = ":app_version",
     deps = [":lib"],

--- a/test/ios_extension_swift_test.sh
+++ b/test/ios_extension_swift_test.sh
@@ -53,7 +53,7 @@ ios_application(
     extensions = [":ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":objclib"],
 )
@@ -63,7 +63,7 @@ ios_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":swiftlib"],
 )

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -104,12 +104,23 @@ function create_minimal_ios_application_extension() {
   product_type="${1:-}"
 
   cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = ["Info-App.plist"],
+    minimum_os_version = "12.0",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [":lib"],
+)
+
 ios_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
 EOF
 
   if [[ -n "$product_type" ]]; then
@@ -168,7 +179,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [
         ":frameworkDependingLib",
@@ -181,7 +192,7 @@ ios_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -338,7 +349,7 @@ ios_application(
     extensions = [":ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -348,7 +359,7 @@ ios_extension(
     bundle_id = "my.extension.bundle.id",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -408,7 +419,7 @@ ios_application(
     extensions = [":ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -418,7 +429,7 @@ ios_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -478,7 +489,7 @@ ios_application(
     extensions = [":ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -488,7 +499,7 @@ ios_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -632,7 +643,7 @@ ios_extension(
     bundle_id = "my.extension.bundle.id",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -674,7 +685,7 @@ ios_application(
     extensions = [":ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "13.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -684,7 +695,7 @@ ios_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )

--- a/test/ios_imessage_test.sh
+++ b/test/ios_imessage_test.sh
@@ -97,7 +97,7 @@ ios_application(
     extensions = [":stickerpack"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -107,7 +107,7 @@ ios_sticker_pack_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     # TODO(b/120618397): Reenable the stickers.
     # sticker_assets = ["@build_bazel_rules_apple//test/testdata/resources:sticker_pack_ios"],
@@ -130,7 +130,7 @@ ios_imessage_application(
     extension = ":stickerpack",
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -139,7 +139,7 @@ ios_sticker_pack_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     # TODO(b/120618397): Reenable the stickers.
     # sticker_assets = ["@build_bazel_rules_apple//test/testdata/resources:sticker_pack_ios"],
@@ -192,7 +192,7 @@ ios_application(
     extensions = [":stickerpack"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -202,7 +202,7 @@ ios_sticker_pack_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     sticker_assets = ["@build_bazel_rules_apple//test/testdata/resources:app_icons_ios"],
 )
@@ -227,7 +227,7 @@ ios_application(
     extensions = [":imessage_ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -238,7 +238,7 @@ ios_imessage_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -264,7 +264,7 @@ ios_application(
     extensions = [":imessage_ext"],
     families = ["iphone"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )
@@ -275,7 +275,7 @@ ios_imessage_extension(
     bundle_id = "my.bundle.id.extension",
     families = ["iphone"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":lib"],
 )

--- a/test/ios_static_framework_resources_test.sh
+++ b/test/ios_static_framework_resources_test.sh
@@ -35,7 +35,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 
 ios_static_framework(
     name = "sdk",
-    minimum_os_version = "7.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
     avoid_deps = [":framework_dependent_lib"],
 EOF
@@ -133,7 +133,7 @@ function test_sdk_contains_expected_files() {
 
   # Verify compiled NIBs.
   assert_zip_not_contains "test-bin/sdk/sdk.zip" \
-      "sdk.framework/view_ios~iphone.nib/"
+      "sdk.framework/view_ios.nib"
 }
 
 # Tests that the SDK's .framework bundle does not contain headers when not needed.
@@ -169,7 +169,7 @@ function test_sdk_does_not_contain_headers() {
 
   # Verify compiled NIBs.
   assert_zip_not_contains "test-bin/sdk/sdk.zip" \
-      "sdk.framework/view_ios~iphone.nib/"
+      "sdk.framework/view_ios.nib"
 }
 
 
@@ -214,7 +214,7 @@ function test_sdk_contains_expected_files_without_excluding_resources() {
 
   # Verify compiled NIBs.
   assert_zip_contains "test-bin/sdk/sdk.zip" \
-      "sdk.framework/view_ios~iphone.nib/"
+      "sdk.framework/view_ios.nib"
 }
 
 run_suite "ios_static_framework bundling resource tests"

--- a/test/ios_static_framework_test.sh
+++ b/test/ios_static_framework_test.sh
@@ -35,7 +35,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 
 ios_static_framework(
     name = "sdk",
-    minimum_os_version = "7.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -79,7 +79,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 ios_static_framework(
     name = "sdk",
     bundle_name = "different",
-    minimum_os_version = "7.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -125,7 +125,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 
 ios_static_framework(
     name = "sdk",
-    minimum_os_version = "7.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -84,7 +84,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "13.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
@@ -206,7 +206,7 @@ ios_ui_test(
     name = "PassingUiTest",
     infoplists = ["PassUiTest-Info.plist"],
     deps = [":pass_ui_test_lib"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )
@@ -221,7 +221,7 @@ ios_ui_test(
     name = "PassingUiSwiftTest",
     infoplists = ["PassUiSwiftTest-Info.plist"],
     deps = [":pass_ui_swift_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "13.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )
@@ -235,7 +235,7 @@ ios_ui_test(
     name = 'FailingUiTest',
     infoplists = ["FailUiTest-Info.plist"],
     deps = [":fail_ui_test_lib"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )
@@ -295,7 +295,7 @@ ios_ui_test(
     name = 'EnvUiTest',
     infoplists = ["EnvUiTest-Info.plist"],
     deps = [":env_ui_test_lib"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -85,7 +85,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
@@ -211,7 +211,7 @@ ios_unit_test(
     name = "PassingUnitTest",
     infoplists = ["PassUnitTest-Info.plist"],
     deps = [":pass_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     env = test_env,
     runner = ":ios_x86_64_sim_runner",
 )
@@ -220,7 +220,7 @@ ios_unit_test(
     name = "PassingWithHost",
     infoplists = ["PassUnitTest-Info.plist"],
     deps = [":pass_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     env = test_env,
     runner = ":ios_x86_64_sim_runner",
@@ -236,7 +236,7 @@ ios_unit_test(
     name = "PassingUnitSwiftTest",
     infoplists = ["PassUnitSwiftTest-Info.plist"],
     deps = [":pass_unit_swift_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )
@@ -250,7 +250,7 @@ ios_unit_test(
     name = 'FailingUnitTest',
     infoplists = ["FailUnitTest-Info.plist"],
     deps = [":fail_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     runner = ":ios_x86_64_sim_runner",
 )
 
@@ -258,7 +258,7 @@ ios_unit_test(
     name = 'FailingWithHost',
     infoplists = ["FailUnitTest-Info.plist"],
     deps = [":fail_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )
@@ -308,7 +308,7 @@ ios_unit_test(
     name = 'EnvUnitTest',
     infoplists = ["EnvUnitTest-Info.plist"],
     deps = [":env_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     runner = ":ios_x86_64_sim_runner",
 )
 
@@ -316,7 +316,7 @@ ios_unit_test(
     name = 'EnvWithHost',
     infoplists = ["EnvUnitTest-Info.plist"],
     deps = [":env_unit_test_lib"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
 )

--- a/test/macos_application_resources_test.sh
+++ b/test/macos_application_resources_test.sh
@@ -70,7 +70,7 @@ macos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":lib", ":resources"],
 )
 EOF
@@ -128,7 +128,7 @@ macos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":lib", ":resources"],
 )
 EOF

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -69,7 +69,7 @@ macos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.14",
     deps = [":lib"],
 )
 EOF
@@ -127,7 +127,7 @@ macos_application(
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
     ipa_post_processor = "post_processor.sh",
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":lib"],
 )
 EOF

--- a/test/macos_bundle_test.sh
+++ b/test/macos_bundle_test.sh
@@ -65,7 +65,7 @@ macos_bundle(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.14",
     deps = [":lib"],
 )
 EOF
@@ -123,7 +123,7 @@ macos_bundle(
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
     ipa_post_processor = "post_processor.sh",
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":lib"],
 )
 EOF

--- a/test/macos_quick_look_plugin_test.sh
+++ b/test/macos_quick_look_plugin_test.sh
@@ -65,7 +65,7 @@ macos_quick_look_plugin(
     name = "app",
     bundle_id = "my.bundle.id.qlgenerator",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.14",
     deps = [":lib"],
 )
 EOF
@@ -123,7 +123,7 @@ macos_quick_look_plugin(
     bundle_id = "my.bundle.id.qlgenerator",
     infoplists = ["Info.plist"],
     ipa_post_processor = "post_processor.sh",
-    minimum_os_version = "10.10",
+    minimum_os_version = "10.13",
     deps = [":lib"],
 )
 EOF

--- a/test/smart_resource_deduplication_test.sh
+++ b/test/smart_resource_deduplication_test.sh
@@ -122,7 +122,7 @@ ios_framework(
     bundle_id = "com.framework",
     families = ["iphone"],
     infoplists = ["FrameworkInfo.plist"],
-    minimum_os_version = "8",
+    minimum_os_version = "12.0",
     deps = [":shared_lib"],
 )
 
@@ -132,7 +132,7 @@ ios_application(
     families = ["iphone"],
     frameworks = [":framework"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9",
+    minimum_os_version = "13.0",
     strings = ["app.strings"],
     deps = [":app_lib"],
 )
@@ -199,7 +199,7 @@ ios_framework(
     bundle_id = "com.framework",
     families = ["iphone"],
     infoplists = ["FrameworkInfo.plist"],
-    minimum_os_version = "8",
+    minimum_os_version = "12.0",
     deps = [":shared_lib_with_no_direct_resources"],
 )
 
@@ -209,7 +209,7 @@ ios_application(
     families = ["iphone"],
     frameworks = [":framework"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "9",
+    minimum_os_version = "13.0",
     strings = ["app.strings"],
     deps = [":app_lib_with_no_direct_resources"],
 )
@@ -233,7 +233,7 @@ ios_framework(
     bundle_id = "com.framework",
     families = ["iphone"],
     infoplists = ["FrameworkInfo.plist"],
-    minimum_os_version = "8",
+    minimum_os_version = "12.0",
     deps = [":shared_lib"],
 )
 
@@ -248,7 +248,7 @@ ios_application(
     families = ["iphone"],
     frameworks = [":framework"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "8",
+    minimum_os_version = "12.0",
     deps = [":resource_only_lib", ":shared_lib", ":only_main_lib"],
 )
 EOF

--- a/test/tvos_application_swift_test.sh
+++ b/test/tvos_application_swift_test.sh
@@ -42,7 +42,7 @@ tvos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )

--- a/test/tvos_application_test.sh
+++ b/test/tvos_application_test.sh
@@ -65,7 +65,7 @@ tvos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -135,7 +135,7 @@ tvos_application(
     name = "app",
     bundle_id = "my.bundle.id",
     infoplists = ["Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "bogus.mobileprovision",
     deps = [":lib"],
 )

--- a/test/tvos_extension_swift_test.sh
+++ b/test/tvos_extension_swift_test.sh
@@ -52,7 +52,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":objclib"],
 )
@@ -61,7 +61,7 @@ tvos_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":swiftlib"],
 )

--- a/test/tvos_extension_test.sh
+++ b/test/tvos_extension_test.sh
@@ -45,7 +45,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -54,7 +54,7 @@ tvos_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -212,7 +212,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -221,7 +221,7 @@ tvos_extension(
     name = "ext",
     bundle_id = "my.extension.id",
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -288,7 +288,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -297,7 +297,7 @@ tvos_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -364,7 +364,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -373,7 +373,7 @@ tvos_extension(
     name = "ext",
     bundle_id = "my.bundle.id.extension",
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )

--- a/test/tvos_framework_test.sh
+++ b/test/tvos_framework_test.sh
@@ -65,7 +65,7 @@ tvos_application(
     extensions = [":ext"],
     frameworks = [":framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -75,7 +75,7 @@ tvos_extension(
     bundle_id = "my.bundle.id.extension",
     frameworks = [":framework"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -86,7 +86,7 @@ tvos_framework(
     bundle_id = "my.bundle.id.framework",
     extension_safe = 1,
     infoplists = ["Info-Framework.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -277,7 +277,7 @@ EOF
 
 # Creates the targets for a minimal tvOS dynamic framework.
 function create_minimal_tvos_framework() {
-  create_minimal_tvos_framework_with_params True "9.0"
+  create_minimal_tvos_framework_with_params True "12.0"
 }
 
 # Creates the targets for a minimal tvOS application and extension that both use
@@ -300,7 +300,7 @@ tvos_application(
     extensions = [":ext"],
     frameworks = ["//framework:framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -310,7 +310,7 @@ tvos_extension(
     bundle_id = "my.bundle.id.extension",
     frameworks = ["//framework:framework"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -497,7 +497,7 @@ tvos_framework(
   bundle_name = "FrameworkBundleName",
   infoplists = ["Info.plist"],
   extension_safe = True,
-  minimum_os_version = "9.0",
+  minimum_os_version = "12.0",
   deps = [":framework_lib"],
 )
 
@@ -602,7 +602,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     frameworks = [":framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -613,7 +613,7 @@ tvos_framework(
     bundle_id = "my.bundle.id.framework",
     infoplists = ["Info-Framework.plist"],
     linkopts = ["-application_extension"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -735,7 +735,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     extensions = [":ext"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -745,7 +745,7 @@ tvos_extension(
     bundle_id = "my.bundle.id.extension",
     frameworks = ["//framework:framework"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -846,7 +846,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     frameworks = ["//framework:framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -866,7 +866,7 @@ tvos_framework(
     bundle_id = "my.bundle.id.framework",
     infoplists = ["Info-Framework.plist"],
     linkopts = ["-application_extension"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -958,11 +958,11 @@ EOF
 
 
 function test_resource_bundle_is_in_framework_same_min_os() {
-  verify_resource_bundle_deduping "9.0" "9.0"
+  verify_resource_bundle_deduping "12.0" "12.0"
 }
 
 function test_resource_bundle_is_in_framework_different_min_os() {
-  verify_resource_bundle_deduping "9.0" "10.0"
+  verify_resource_bundle_deduping "12.0" "13.0"
 }
 
 # Tests that resource bundles that are dependencies of a framework are
@@ -987,7 +987,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     frameworks = [":framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -998,7 +998,7 @@ tvos_framework(
     bundle_id = "my.bundle.id.framework",
     infoplists = ["Info-Framework.plist"],
     linkopts = ["-application_extension"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -1110,7 +1110,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     frameworks = [":outer_framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -1120,7 +1120,7 @@ tvos_framework(
     hdrs = ["OuterFramework.h"],
     bundle_id = "my.bundle.id.framework",
     infoplists = ["Info-Framework.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [
         ":inner_framework",
         ":outer_framework_lib",
@@ -1264,7 +1264,7 @@ tvos_application(
     bundle_id = "my.bundle.id",
     frameworks = [":framework"],
     infoplists = ["Info-App.plist", "Info-Common.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -1275,7 +1275,7 @@ tvos_framework(
     bundle_id = "my.framework.id",
     frameworks = [":depframework"],
     infoplists = ["Framework-Info.plist", "Info-Common.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":framework_lib"],
 )
 
@@ -1284,7 +1284,7 @@ tvos_framework(
     hdrs = ["DepFramework.h"],
     bundle_id = "my.depframework.id",
     infoplists = ["Framework-Info.plist", "Info-Common.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     deps = [":dep_framework_lib"],
 )
 
@@ -1470,7 +1470,7 @@ EOF
 # Verifies that, when an extension depends on a framework with different
 # minimum_os, symbol subtraction still occurs.
 function test_differing_minimum_os() {
-  create_minimal_tvos_framework_with_params True "9.0"
+  create_minimal_tvos_framework_with_params True "12.0"
 
 cat > app/BUILD <<EOF
 load("@build_bazel_rules_apple//apple:tvos.bzl",
@@ -1490,7 +1490,7 @@ tvos_application(
     extensions = [":ext"],
     frameworks = ["//framework:framework"],
     infoplists = ["Info-App.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )
@@ -1500,7 +1500,7 @@ tvos_extension(
     bundle_id = "my.bundle.id.extension",
     frameworks = ["//framework:framework"],
     infoplists = ["Info-Ext.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "13.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_tvos.mobileprovision",
     deps = [":lib"],
 )

--- a/test/watchos_application_test.sh
+++ b/test/watchos_application_test.sh
@@ -52,7 +52,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info-PhoneApp.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "12.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     watch_application = ":watch_app",
     deps = [":lib"],
@@ -128,7 +128,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -137,7 +137,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -264,7 +264,7 @@ watchos_application(
     bundle_id = "my.bundle.id.watch-app",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "bogus.mobileprovision",
 )
 
@@ -272,7 +272,7 @@ watchos_extension(
     name = "watch_ext",
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -305,7 +305,7 @@ watchos_application(
     bundle_id = "my.bundle.id.watch-app",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -313,7 +313,7 @@ watchos_extension(
     name = "watch_ext",
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "bogus.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -341,7 +341,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -350,7 +350,7 @@ watchos_extension(
     bundle_id = "my.bundle2.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -389,7 +389,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -398,7 +398,7 @@ watchos_extension(
     bundle_id = "my.bundle2.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -420,7 +420,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -429,7 +429,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -480,7 +480,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -489,7 +489,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -527,7 +527,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -536,7 +536,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -587,7 +587,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -596,7 +596,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -634,7 +634,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -643,7 +643,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )
@@ -677,7 +677,7 @@ watchos_application(
     entitlements = "entitlements.entitlements",
     extension = ":watch_ext",
     infoplists = ["Info-WatchApp.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
 )
 
@@ -686,7 +686,7 @@ watchos_extension(
     bundle_id = "my.bundle.id.watch-app.watch-ext",
     entitlements = "entitlements.entitlements",
     infoplists = ["Info-WatchExt.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":watch_lib"],
 )


### PR DESCRIPTION
Since arm64e requires iOS 12 as a minimum, we use that as a guideline for raising the minimum_os_version of all ios_* tests.

For the remainder, we rely on supported deployment targets from https://developer.apple.com/support/xcode/.

PiperOrigin-RevId: 467315520
(cherry picked from commit 96a5fa31666e3d91118452717f135f615457dfc9)
