### PR TITLE
Migrate custom bundle loader tests to starlark

### DIFF
--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -226,48 +226,6 @@ This shouldn't get included
 EOF
 }
 
-# Test that the extension can be a bundle loader
-function test_bundle_loader() {
-  create_common_files
-  create_minimal_ios_application_extension
-
-  cat >> app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:ios.bzl",
-     "ios_unit_test",
-)
-
-objc_library(
-    name = "unit_test_lib",
-    hdrs = ["Foo.h"],
-    srcs = ["UnitTest.m"],
-)
-
-ios_unit_test(
-    name = "unit_tests",
-    deps = [":unit_test_lib"],
-    minimum_os_version = "${MIN_OS_IOS}",
-    test_host = ":ext",
-)
-EOF
-
-  cat > app/UnitTest.m <<EOF
-#import <XCTest/XCTest.h>
-#import "app/Foo.h"
-@interface UnitTest: XCTestCase
-@end
-
-@implementation UnitTest
-- (void)testAssertNil {
-  // Call something in test host to ensure bundle loading works.
-  [[[Foo alloc] init] doSomething];
-  XCTAssertNil(nil);
-}
-@end
-EOF
-
-  do_build ios //app:unit_tests || fail "Should build"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -200,6 +200,20 @@ def ios_unit_test_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_bundle_loader_reference_main".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_with_bundle_loader",
+        binary_test_file = "$BUNDLE_ROOT/unit_test_with_bundle_loader",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_OBJC_CLASS_$_CommonTests"],
+        cpus = {
+            "ios_multi_cpus": ["x86_64"],
+        },
+        binary_not_contains_symbols = ["_OBJC_CLASS_$_ObjectiveCCommonClass"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -39,6 +39,14 @@ objc_library(
 )
 
 objc_library(
+    name = "objc_common_test_lib",
+    srcs = [
+        "//test/starlark_tests/resources:common.h",
+        "//test/starlark_tests/resources:common_test.m",
+    ],
+)
+
+objc_library(
     name = "objc_shared_lib",
     srcs = ["shared.m"],
     hdrs = ["shared.h"],

--- a/test/starlark_tests/resources/common_test.m
+++ b/test/starlark_tests/resources/common_test.m
@@ -1,0 +1,15 @@
+#import <XCTest/XCTest.h>
+#import "test/starlark_tests/resources/common.h"
+
+@interface CommonTests: XCTestCase
+@end
+
+@implementation CommonTests
+
+- (void)testAnything {
+  // Call something in test host to ensure bundle loading works.
+  [[[ObjectiveCCommonClass alloc] init] doSomethingCommon];
+  XCTAssertNil(nil);
+}
+
+@end

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3273,3 +3273,35 @@ ios_application(
         "//test/starlark_tests/resources:swift_lib_importing_imported_static_xcfw",
     ],
 )
+
+# ---------------------------------------------------------------------------------------
+
+ios_extension(
+    name = "ext_for_bundle_loader",
+    bundle_id = "com.google.example.ext",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_common_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_unit_test(
+    name = "unit_test_with_bundle_loader",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    tags = common.fixture_tags,
+    test_host = ":ext_for_bundle_loader",
+    deps = [
+        "//test/starlark_tests/resources:objc_common_test_lib",
+    ],
+)

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -849,3 +849,34 @@ objc_library(
     srcs = ["//test/starlark_tests/resources:main.m"],
     runtime_deps = [":fmwk_with_provisioning"],
 )
+
+# ---------------------------------------------------------------------------------------
+
+tvos_extension(
+    name = "ext_for_bundle_loader",
+    bundle_id = "com.google.example.ext",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_tvos.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_common_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+tvos_unit_test(
+    name = "unit_test_with_bundle_loader",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_tvos.baseline,
+    tags = common.fixture_tags,
+    test_host = ":ext_for_bundle_loader",
+    deps = [
+        "//test/starlark_tests/resources:objc_common_test_lib",
+    ],
+)

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -184,6 +184,20 @@ def tvos_unit_test_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_bundle_loader_reference_main".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:unit_test_with_bundle_loader",
+        binary_test_file = "$BUNDLE_ROOT/unit_test_with_bundle_loader",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = ["_OBJC_CLASS_$_CommonTests"],
+        cpus = {
+            "tvos_cpus": ["x86_64"],
+        },
+        binary_not_contains_symbols = ["_OBJC_CLASS_$_ObjectiveCCommonClass"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/tvos_extension_test.sh
+++ b/test/tvos_extension_test.sh
@@ -106,47 +106,6 @@ EOF
 EOF
 }
 
-# Test that the extension can be a bundle loader
-function test_bundle_loader() {
-  create_minimal_tvos_application_with_extension
-
-  cat >> app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:tvos.bzl",
-     "tvos_unit_test",
-)
-
-objc_library(
-    name = "unit_test_lib",
-    hdrs = ["Foo.h"],
-    srcs = ["UnitTest.m"],
-)
-
-tvos_unit_test(
-    name = "unit_tests",
-    deps = [":unit_test_lib"],
-    minimum_os_version = "${MIN_OS_TVOS}",
-    test_host = ":ext",
-)
-EOF
-
-  cat > app/UnitTest.m <<EOF
-#import <XCTest/XCTest.h>
-#import "app/Foo.h"
-@interface UnitTest: XCTestCase
-@end
-
-@implementation UnitTest
-- (void)testAssertNil {
-  // Call something in test host to ensure bundle loading works.
-  [[[Foo alloc] init] doSomething];
-  XCTAssertNil(nil);
-}
-@end
-EOF
-
-  do_build tvos //app:unit_tests || fail "Should build"
-}
-
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_minimal_tvos_application_with_extension


### PR DESCRIPTION
The bash tests are being phased out, this one is not part of the
upstream changes.

These were added in d6f9a87d70781e92b95b9344c7d21d921ccc3ae2
