### PR TITLE
Fix execute's inputstr argument, which was removed when the timeout argument was introduced.

### DIFF
--- a/tools/wrapper_common/execute.py
+++ b/tools/wrapper_common/execute.py
@@ -67,10 +67,7 @@ def execute_and_filter_output(cmd_args,
       stderr=subprocess.PIPE,
       env=env)
   try:
-      stdout, stderr = proc.communicate(
-        input=inputstr,
-        timeout=timeout,
-      )
+    stdout, stderr = proc.communicate(input=inputstr, timeout=timeout)
   except subprocess.TimeoutExpired:
       proc.kill()
       stdout, stderr = proc.communicate()

--- a/tools/wrapper_common/execute_test.py
+++ b/tools/wrapper_common/execute_test.py
@@ -56,6 +56,13 @@ class ExecuteTest(unittest.TestCase):
         args, timeout=1, raise_on_failure=False)
     self.assertEqual(-signal.SIGKILL, result)
 
+  def test_execute_inputstr(self):
+    args = ['cat', '-']
+    result, stdout, stderr = execute.execute_and_filter_output(
+        args, inputstr=b'foo', raise_on_failure=False)
+    self.assertEqual(0, result)
+    self.assertEqual('foo', stdout)
+
   @contextlib.contextmanager
   def _mock_streams(self):
     orig_stdout = sys.stdout


### PR DESCRIPTION
PiperOrigin-RevId: 471827739
(cherry picked from commit 2c54e9520b545937791204559a39a80cf7fc352a)
