### PR TITLE
Fix dependencies for Swift static framework import test

### DIFF
--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1192,7 +1192,7 @@ apple_static_framework_import(
 apple_static_framework_import(
     name = "iOSImportedSwiftStaticFrameworkWithoutModuleInterface",
     features = ["-swift.layering_check"],
-    framework_imports = ["//test/testdata/fmwk:iOSSwiftStaticFramework"],
+    framework_imports = ["//test/testdata/fmwk:iOSSwiftStaticFrameworkWithoutModuleInterfaces"],
     has_swift = True,
 )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1804,7 +1804,7 @@ genrule(
     name = "swift_static_without_module_interfaces_fmwk_depending_lib_src",
     outs = ["SwiftStaticFmwkWithoutInterfaceFilesDependingLib.m"],
     cmd = """cat > $@ <<EOF
-#import <iOSSwiftStaticFramework/iOSSwiftStaticFramework.h>
+#import <iOSSwiftStaticFrameworkWithoutModuleInterfaces/iOSSwiftStaticFrameworkWithoutModuleInterfaces.h>
 
 int main() {
   SharedClass *sharedClass = [[SharedClass alloc] init];


### PR DESCRIPTION
Currently the test fixture for a static framework import
with Swift but no module interface file has incorrect
dependencies.

PiperOrigin-RevId: 474631471
(cherry picked from commit 2b9e062fe1097c3e885229cfdac631a4337d7565)
