### PR TITLE
Add test filter parameter to ios_unit_test

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -202,6 +202,12 @@ AppleTestRunnerInfo provider.
     "test_host": attr.label(
         providers = [AppleBundleInfo],
     ),
+    "test_filter": attr.string(
+        doc = """
+Test filter string that will be passed into the test runner to select which tests will run.
+""",
+        default = "",
+    ),
     "_apple_coverage_support": attr.label(
         cfg = "exec",
         default = Label("@build_bazel_apple_support//tools:coverage_support"),

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -102,7 +102,7 @@ This aspect propagates a `CoverageFilesInfo` provider.
     implementation = _coverage_files_aspect_impl,
 )
 
-def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None):
+def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None, test_filter = None):
     """Dictionary with the substitutions to be applied to the template script."""
     subs = {}
 
@@ -113,6 +113,7 @@ def _get_template_substitutions(test_type, test_bundle, test_environment, test_h
     subs["test_bundle_path"] = test_bundle.short_path
     subs["test_type"] = test_type.upper()
     subs["test_env"] = ",".join([k + "=" + v for (k, v) in test_environment.items()])
+    subs["test_filter"] = test_filter or ""
 
     return {"%(" + k + ")s": subs[k] for k in subs}
 
@@ -174,6 +175,7 @@ def _apple_test_rule_impl(ctx, test_type):
             test_bundle,
             test_environment,
             test_host = test_host_archive,
+            test_filter = ctx.attr.test_filter,
         ),
         is_executable = True,
     )

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -127,17 +127,26 @@ if [[ -n "${command_line_args}" ]]; then
   LAUNCH_OPTIONS_JSON_STR+="\"args\":[\"$command_line_args\"]"
 fi
 
+TEST_FILTER="%(test_filter)s"
+
 # Use the TESTBRIDGE_TEST_ONLY environment variable set by Bazel's --test_filter
 # flag to set tests_to_run value in ios_test_runner's launch_options.
 # Any test prefixed with '-' will be passed to "skip_tests". Otherwise the tests
 # is passed to "tests_to_run"
-if [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
+if [[ -n "$TESTBRIDGE_TEST_ONLY" || -n "$TEST_FILTER" ]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then
     LAUNCH_OPTIONS_JSON_STR+=","
   fi
 
   IFS=","
-  ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
+  if [[ -n "$TESTBRIDGE_TEST_ONLY" && -n "$TEST_FILTER" ]]; then
+    ALL_TESTS=("$TESTBRIDGE_TEST_ONLY,$TEST_FILTER")
+  elif [[ -n "$TESTBRIDGE_TEST_ONLY" ]]; then
+    ALL_TESTS=("$TESTBRIDGE_TEST_ONLY")
+  else
+    ALL_TESTS=("$TEST_FILTER")
+  fi
+  
   for TEST in $ALL_TESTS; do
     if [[ $TEST == -* ]]; then
       if [[ -n "$SKIP_TESTS" ]]; then

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -500,7 +500,7 @@ Builds and bundles an iOS Sticker Pack Extension.
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_host">test_host</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>)
 </pre>
 
 iOS UI Test rule.
@@ -529,6 +529,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_ui_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
@@ -537,7 +538,7 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_host">test_host</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -571,6 +572,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_unit_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="ios_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -406,7 +406,7 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_host">test_host</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -427,6 +427,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="macos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
@@ -435,7 +436,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_host">test_host</a>)
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -462,6 +463,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="macos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -310,7 +310,7 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
 </pre>
 
 
@@ -337,6 +337,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="tvos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
@@ -345,7 +346,7 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
 </pre>
 
 
@@ -380,6 +381,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="tvos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -268,7 +268,7 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -284,6 +284,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="watchos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
@@ -292,7 +293,7 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -308,6 +309,7 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="watchos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -370,6 +370,57 @@ ios_unit_test(
 EOF
 }
 
+function create_ios_unit_tests_test_filter() {
+  if [[ ! -f ios/BUILD ]]; then
+    fail "create_sim_runners must be called first."
+  fi
+
+  cat > ios/test_filter_unit_test.m <<EOF
+#import <XCTest/XCTest.h>
+#import <XCTest/XCUIApplication.h>
+@interface TestFilterUnitTest : XCTestCase
+@end
+@implementation TestFilterUnitTest {
+  XCUIApplication *_app;
+}
+- (void)testPass {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+- (void)testPass2 {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+- (void)testPass3 {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+@end
+EOF
+
+  cat > ios/TestFilterUnitTest-Info.plist <<EOF
+<plist version="1.0">
+<dict>
+        <key>CFBundleExecutable</key>
+        <string>TestFilterUnitTest</string>
+</dict>
+</plist>
+EOF
+
+  cat >> ios/BUILD <<EOF
+objc_library(
+    name = "test_filter_unit_test_lib",
+    srcs = ["test_filter_unit_test.m"],
+)
+ios_unit_test(
+    name = "TestFilterUnitTest",
+    infoplists = ["TestFilterUnitTest-Info.plist"],
+    deps = [":test_filter_unit_test_lib"],
+    minimum_os_version = "9.0",
+    test_host = ":app",
+    runner = ":ios_x86_64_sim_runner",
+    test_filter = "$1",
+)
+EOF
+}
+
 function do_ios_test() {
   do_test ios "--test_output=all" "--spawn_strategy=local" "$@"
 }
@@ -571,6 +622,87 @@ function test_ios_unit_test_with_multi_equal_env() {
   do_ios_test --test_env=ENV_KEY1=ENV_VALUE2=ENV_VALUE3 //ios:EnvUnitTest || fail "should pass"
 
   expect_log "Test Suite 'EnvUnitTest' passed"
+}
+
+function test_with_test_filter_build_attribute() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter TestFilterUnitTest/testPass2
+  do_ios_test //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 1 test, with 0 failures"
+}
+
+function test_ios_unit_test_with_multi_test_filter_build_attribute() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter TestFilterUnitTest/testPass2,TestFilterUnitTest/testPass3 
+  do_ios_test //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_skip_test_filter_build_attribute() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter -TestFilterUnitTest/testPass
+  do_ios_test //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[TestFilterUnitTest testPass\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
+}
+
+function test_ios_unit_test_multi_skip_test_filter_build_attribute() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter -TestFilterUnitTest/testPass,-TestFilterUnitTest/testPass2 
+  do_ios_test //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[TestFilterUnitTest testPass\]' passed"
+  expect_not_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 1 test, with 0 failures"
+}
+
+function test_ios_unit_test_with_skip_and_only_filters_build_attribute() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter TestFilterUnitTest,-TestFilterUnitTest/testPass2
+  do_ios_test //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_log "Test Case '-\[TestFilterUnitTest testPass\]' passed"
+  expect_not_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_build_attribute_and_test_env_filters() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests_test_filter TestFilterUnitTest/testPass2
+  do_ios_test --test_filter=TestFilterUnitTest/testPass3 //ios:TestFilterUnitTest || fail "should pass"
+
+  expect_not_log "Test Case '-\[PassingUnitTest testPass\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass2\]' passed"
+  expect_log "Test Case '-\[TestFilterUnitTest testPass3\]' passed"
+  expect_log "Test Suite 'TestFilterUnitTest' passed"
+  expect_log "Test Suite 'TestFilterUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
 }
 
 run_suite "ios_unit_test with iOS test runner bundling tests"


### PR DESCRIPTION
This is a port from this [PR](https://github.com/bazelbuild/rules_apple/pull/1616) to get into the 5.x branch so we could use the ability to use the test filter parameter

(cherry picked from commit 3d5944d6011b37fb70a3f0da0a2e19b657069136)