### PR TITLE
Add MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "rules_apple",
+    compatibility_level = 1,
+    repo_name = "build_bazel_rules_apple",
+    version = "1.1.2",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.1")
+bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,5 +6,5 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
-bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.1")
+bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
 bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")


### PR DESCRIPTION
This PR adds a basic `MODULE.bazel` to `rules_apple` in order to support bzlmod. I was able to compile our example app living in [bazelbuild/examples](https://github.com/bazelbuild/examples/tree/main/tutorial/ios-app). You can try it out for yourself here (it's a bit cumbersome until we add all the modules to the Bazel central registry): https://github.com/bazelbuild/examples/commit/eb7d65542f507bdb47585cd824d76253361d61aa