### PR TITLE
Adding ownership for apple_resource_group and apple_resource_bundle

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -123,7 +123,6 @@ def _apple_resource_aspect_impl(target, ctx):
     elif ctx.rule.kind == "apple_resource_group":
         collect_args["res_attrs"] = ["resources"]
         collect_structured_args["res_attrs"] = ["structured_resources"]
-        owner = str(ctx.label)
 
     elif ctx.rule.kind == "apple_resource_bundle":
         collect_infoplists_args["res_attrs"] = ["infoplists"]
@@ -131,7 +130,6 @@ def _apple_resource_aspect_impl(target, ctx):
         collect_structured_args["res_attrs"] = ["structured_resources"]
         process_args["bundle_id"] = ctx.rule.attr.bundle_id or None
         bundle_name = "{}.bundle".format(ctx.rule.attr.bundle_name or ctx.label.name)
-        owner = str(ctx.label)
 
     # Collect all resource files related to this target.
     if collect_infoplists_args:

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -123,6 +123,7 @@ def _apple_resource_aspect_impl(target, ctx):
     elif ctx.rule.kind == "apple_resource_group":
         collect_args["res_attrs"] = ["resources"]
         collect_structured_args["res_attrs"] = ["structured_resources"]
+        owner = str(ctx.label)
 
     elif ctx.rule.kind == "apple_resource_bundle":
         collect_infoplists_args["res_attrs"] = ["infoplists"]
@@ -130,6 +131,7 @@ def _apple_resource_aspect_impl(target, ctx):
         collect_structured_args["res_attrs"] = ["structured_resources"]
         process_args["bundle_id"] = ctx.rule.attr.bundle_id or None
         bundle_name = "{}.bundle".format(ctx.rule.attr.bundle_name or ctx.label.name)
+        owner = str(ctx.label)
 
     # Collect all resource files related to this target.
     if collect_infoplists_args:

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -203,6 +203,7 @@ def _resources_partial_impl(
         for x in targets_to_avoid
         if AppleResourceInfo in x
     ]
+
     # Map of resource provider fields to a tuple that contains the method to use to process those
     # resources and a boolean indicating whether the Swift module is required for that processing.
     provider_field_to_action = {

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -203,7 +203,6 @@ def _resources_partial_impl(
         for x in targets_to_avoid
         if AppleResourceInfo in x
     ]
-
     # Map of resource provider fields to a tuple that contains the method to use to process those
     # resources and a boolean indicating whether the Swift module is required for that processing.
     provider_field_to_action = {
@@ -266,6 +265,7 @@ def _resources_partial_impl(
                 infoplists.extend(result.infoplists)
 
     resources.deduplicate(
+        default_owner = str(rule_label),
         resources_provider = final_provider,
         avoid_providers = avoid_providers,
         field_handler = _deduplicated_field_handler,

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -880,12 +880,13 @@ def _deduplicate_field(
 
     return deduped_tuples
 
-def _deduplicate(*, resources_provider, avoid_providers, field_handler):
+def _deduplicate(*, resources_provider, avoid_providers, field_handler, default_owner = None):
     avoid_provider = None
     if avoid_providers:
         # Call merge_providers with validate_all_resources_owned set, to ensure that all the
         # resources from dependency bundles have an owner.
         avoid_provider = _merge_providers(
+            default_owner = default_owner,
             providers = avoid_providers,
             validate_all_resources_owned = True,
         )

--- a/doc/rules-resources.md
+++ b/doc/rules-resources.md
@@ -378,7 +378,7 @@ A list with all the collected resources for the target represented by attr.
 ## resources_common.deduplicate
 
 <pre>
-resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>)
+resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>, <a href="#resources_common.deduplicate-default_owner">default_owner</a>)
 </pre>
 
 
@@ -391,6 +391,7 @@ resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_pr
 | <a id="resources_common.deduplicate-resources_provider"></a>resources_provider |  <p align="center"> - </p>   |  none |
 | <a id="resources_common.deduplicate-avoid_providers"></a>avoid_providers |  <p align="center"> - </p>   |  none |
 | <a id="resources_common.deduplicate-field_handler"></a>field_handler |  <p align="center"> - </p>   |  none |
+| <a id="resources_common.deduplicate-default_owner"></a>default_owner |  <p align="center"> - </p>   |  <code>None</code> |
 
 
 <a id="resources_common.merge_providers"></a>


### PR DESCRIPTION
This PR adds a default owner for when [`resources.dedeplicate`](https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/partials/resources.bzl#L268-L272) is called. When an apple_framework target (from rules_ios) is built as dynamic, the resources_partial in rules_apple is called. This leads to `resources.deduplicate` being called with avoid_providers populated with `AppleResourceInfo` providers from the `apple_resource_group` or `apple_resource_bundle` target. This calls [_merge_proiders with validate_all_resources_owned = True](https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/resources.bzl#L888-L891), which results in `Error in fail: The given providers have a resource that doesn't have an owner, and validate_all_resources_owned was set. This is most likely a bug in rules_apple, please file a bug with reproduction steps.`

This PR adds a default owner to that call so the the validate_all_resources_owned check will pass.