### PR TITLE
Remove subpar dependency

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,6 @@ filegroup(
         "//tools:for_bazel_tests",
         "@build_bazel_apple_support//:for_bazel_tests",
         "@build_bazel_rules_swift//:for_bazel_tests",
-        "@subpar//:subpar.bzl",
         "@xctestrunner//:for_bazel_tests",
     ],
     visibility = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,5 @@ bazel_dep(name = "rules_swift", version = "1.5.0", repo_name = "build_bazel_rule
 non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
-    "subpar",
     "xctestrunner",
 )

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -133,17 +133,6 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
 
     _maybe(
         http_archive,
-        name = "subpar",
-        urls = [
-            "https://github.com/google/subpar/archive/2.0.0.tar.gz",
-        ],
-        strip_prefix = "subpar-2.0.0",
-        sha256 = "b80297a1b8d38027a86836dbadc22f55dc3ecad56728175381aa6330705ac10f",
-        ignore_version_differences = ignore_version_differences,
-    )
-
-    _maybe(
-        http_archive,
         name = "xctestrunner",
         urls = [
             "https://github.com/google/xctestrunner/archive/c9eac2841ab74fa109ea3cf2786646e616994d45.tar.gz",

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -74,12 +74,6 @@ new_local_repository(
     path = '$PWD/../external/bazel_skylib',
 )
 
-new_local_repository(
-    name = "subpar",
-    build_file_content = '',
-    path = '$PWD/../external/subpar',
-)
-
 local_repository(
     name = 'build_bazel_rules_apple',
     path = '$(rlocation build_bazel_rules_apple)',


### PR DESCRIPTION
We haven't used this since we moved to using xctestrunner directly as
python files
