### PR TITLE
Fix missing ownership

### DIFF
--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -266,6 +266,7 @@ def _resources_partial_impl(
                 infoplists.extend(result.infoplists)
 
     resources.deduplicate(
+        default_owner = str(rule_label),
         resources_provider = final_provider,
         avoid_providers = avoid_providers,
         field_handler = _deduplicated_field_handler,

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -880,12 +880,13 @@ def _deduplicate_field(
 
     return deduped_tuples
 
-def _deduplicate(*, resources_provider, avoid_providers, field_handler):
+def _deduplicate(*, resources_provider, avoid_providers, field_handler, default_owner = None):
     avoid_provider = None
     if avoid_providers:
         # Call merge_providers with validate_all_resources_owned set, to ensure that all the
         # resources from dependency bundles have an owner.
         avoid_provider = _merge_providers(
+            default_owner = default_owner,
             providers = avoid_providers,
             validate_all_resources_owned = True,
         )

--- a/doc/rules-resources.md
+++ b/doc/rules-resources.md
@@ -378,7 +378,7 @@ A list with all the collected resources for the target represented by attr.
 ## resources_common.deduplicate
 
 <pre>
-resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>)
+resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>, <a href="#resources_common.deduplicate-default_owner">default_owner</a>)
 </pre>
 
 
@@ -391,6 +391,7 @@ resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_pr
 | <a id="resources_common.deduplicate-resources_provider"></a>resources_provider |  <p align="center"> - </p>   |  none |
 | <a id="resources_common.deduplicate-avoid_providers"></a>avoid_providers |  <p align="center"> - </p>   |  none |
 | <a id="resources_common.deduplicate-field_handler"></a>field_handler |  <p align="center"> - </p>   |  none |
+| <a id="resources_common.deduplicate-default_owner"></a>default_owner |  <p align="center"> - </p>   |  <code>None</code> |
 
 
 <a id="resources_common.merge_providers"></a>


### PR DESCRIPTION
This is a port from this https://github.com/bazelbuild/rules_apple/pull/1745 to get into the 5.x branch so an apple_framework target (from rules_ios) that is built as dynamic which depends on an `apple_resource_group` or an `apple_resource_bundle` will have the right ownership and pass the validate_all_resources_owned check.

(cherry picked from commit https://github.com/bazelbuild/rules_apple/commit/893e8abf32e1692ff3cee083853f524fa678cc9b)