### PR TITLE
Bump bzlmod version to 2.0.0-rc1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "rules_apple",
     compatibility_level = 1,
     repo_name = "build_bazel_rules_apple",
-    version = "1.1.2",
+    version = "2.0.0-rc1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.1.1")


### PR DESCRIPTION
This is preparation for a pre-release that supports Bazel 6.