### PR TITLE
Allow for deps with only CcInfo on framework imports

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -433,6 +433,7 @@ A list of targets that are dependencies of the target being built, which will be
 target.
 """,
                 providers = [
+                    [CcInfo],
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],
@@ -525,6 +526,7 @@ A list of targets that are dependencies of the target being built, which will pr
 linked into that target.
 """,
                 providers = [
+                    [CcInfo],
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],


### PR DESCRIPTION
I'm trying to add some [`swift_c_module` deps for a framework import](https://github.com/bazel-ios/rules_ios/pull/562), and they don't currently work since that only provides `CcInfo` and `SwiftInfo`.

It appears that all the uses for `apple_common.Objc` check to see if it exists, so that shouldn't be a hard requirement at this point. That said, we also would need to cherry-pick this onto 5.x, and the existence check would need to be added along with this change: https://github.com/bazelbuild/rules_apple/compare/bazel/5.x...dierksen:rules_apple:objc_provider_check?expand=1