### PR TITLE
[5.x] Allow for deps with only CcInfo on framework imports

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -741,6 +741,7 @@ A list of targets that are dependencies of the target being built, which will be
 target.
 """,
                 providers = [
+                    [CcInfo],
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],
@@ -832,6 +833,7 @@ A list of targets that are dependencies of the target being built, which will pr
 linked into that target.
 """,
                 providers = [
+                    [CcInfo],
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],


### PR DESCRIPTION
cherry-pick from https://github.com/bazelbuild/rules_apple/pull/1751