### PR TITLE
Revert "Strip bitcode from stub binaries (#1703) (#1705)"

### DIFF
--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -19,10 +19,6 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bitcode_support.bzl",
-    "bitcode_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -55,32 +51,19 @@ def _create_stub_binary(
         file_name = "StubBinary",
     )
 
-    if bitcode_support.bitcode_mode_string(platform_prerequisites.apple_fragment) == "none":
-        apple_support.run(
-            actions = actions,
-            apple_fragment = platform_prerequisites.apple_fragment,
-            executable = "/usr/bin/xcrun",
-            arguments = ["bitcode_strip", "-r", "__BAZEL_XCODE_SDKROOT__/{}".format(xcode_stub_path), "-o", binary_artifact.path],
-            mnemonic = "BitcodeStripStub",
-            outputs = [binary_artifact],
-            xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
-            progress_message = "Removing bitcode from stub executable for %s" % (rule_label),
-            xcode_config = platform_prerequisites.xcode_version_config,
-        )
-    else:
-        # TODO(b/79323243): Replace this with a symlink instead of a hard copy.
-        apple_support.run_shell(
-            actions = actions,
-            apple_fragment = platform_prerequisites.apple_fragment,
-            command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
-                output_path = binary_artifact.path,
-                xcode_stub_path = xcode_stub_path,
-            ),
-            mnemonic = "CopyStubExecutable",
-            outputs = [binary_artifact],
-            progress_message = "Copying stub executable for %s" % (rule_label),
-            xcode_config = platform_prerequisites.xcode_version_config,
-        )
+    # TODO(b/79323243): Replace this with a symlink instead of a hard copy.
+    apple_support.run_shell(
+        actions = actions,
+        apple_fragment = platform_prerequisites.apple_fragment,
+        command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
+            output_path = binary_artifact.path,
+            xcode_stub_path = xcode_stub_path,
+        ),
+        mnemonic = "CopyStubExecutable",
+        outputs = [binary_artifact],
+        progress_message = "Copying stub executable for %s" % (rule_label),
+        xcode_config = platform_prerequisites.xcode_version_config,
+    )
     return binary_artifact
 
 stub_support = struct(

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -19,10 +19,6 @@ load(
     "apple_verification_test",
 )
 load(
-    ":rules/common_verification_tests.bzl",
-    "archive_contents_test",
-)
-load(
     ":rules/infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -64,26 +60,6 @@ def ios_sticker_pack_extension_test_suite(name):
             "NSExtension:NSExtensionPointIdentifier": "com.apple.message-payload-provider",
             "UIDeviceFamily:0": "1",
         },
-        tags = [name],
-    )
-
-    archive_contents_test(
-        name = "{}_bitcode_test".format(name),
-        apple_bitcode = "embedded",
-        build_type = "device",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
-        binary_test_file = "$BUNDLE_ROOT/sticker_ext",
-        macho_load_commands_contain = ["segname __LLVM"],
-        tags = [name],
-    )
-
-    archive_contents_test(
-        name = "{}_strip_bitcode_test".format(name),
-        build_type = "device",
-        apple_bitcode = "none",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
-        binary_test_file = "$BUNDLE_ROOT/sticker_ext",
-        macho_load_commands_not_contain = ["segname __LLVM"],
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1534,7 +1534,6 @@ ios_imessage_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = "10.0",
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = FIXTURE_TAGS,
 )
 
@@ -1549,7 +1548,6 @@ ios_sticker_pack_extension(
         "//test/starlark_tests/resources:StickerPackInfo.plist",
     ],
     minimum_os_version = "10.0",
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     sticker_assets = [],
     tags = FIXTURE_TAGS,
 )


### PR DESCRIPTION
This reverts commit 201fcbe1dba6dbeb42e31f0011c31168de938a79 since it's now causing the following error in AppStore Connect:
>TMS-90616: Invalid Messages Application Extension Support. The file MessagesApplicationExtensionSupportStub doesn't have a signing ID. Sign the file, rebuild your app using the current public (GM) version of Xcode, and resubmit it.

Confirmed we get to `Ready to Submit` when this is removed now.