### PR TITLE
Revert "Set --incompatible_strict_conflict_checks=false"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,6 @@ common --incompatible_allow_tags_propagation
 # TODO: Fix cases that relied on the old behavior and remove this flag.
 common --incompatible_unambiguous_label_stringification=false
 
-build --incompatible_strict_conflict_checks=false
-
 # Add the PATH to the test environment so that common macOS tools can be found
 # during a test run.
 build --test_env=PATH


### PR DESCRIPTION
Reverts bazelbuild/rules_apple#1771

This was reverted in bazel for now, so in case it's flipped again we want CI to catch it