### PR TITLE
Ignore skip_codesign_simulator_bundles for frameworks when building for device

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -419,6 +419,7 @@ def _codesigning_command(
         rule_descriptor = rule_descriptor,
     )
     paths_to_sign = []
+    is_device = platform_prerequisites.platform.is_device
 
     # The command returned by this function is executed as part of a bundling shell script.
     # Each directory to be signed must be prefixed by $WORK_DIR, which is the variable in that
@@ -426,7 +427,7 @@ def _codesigning_command(
     should_sign_sim_frameworks = _should_sign_simulator_frameworks(
         features = platform_prerequisites.features,
     )
-    if frameworks_path and should_sign_sim_frameworks:
+    if (frameworks_path and should_sign_sim_frameworks) or is_device:
         framework_root = paths.join("$WORK_DIR", frameworks_path) + "/"
         full_signed_frameworks = []
 
@@ -446,7 +447,7 @@ def _codesigning_command(
         features = platform_prerequisites.features,
         rule_descriptor = rule_descriptor,
     )
-    if platform_prerequisites.platform.is_device or should_sign_sim_bundles:
+    if is_device or should_sign_sim_bundles:
         path_to_sign = paths.join("$WORK_DIR", bundle_path)
         paths_to_sign.append(
             _path_to_sign(path = path_to_sign),


### PR DESCRIPTION
Cherry-pick to `bazel/5.x` branch of [#1770](https://github.com/bazelbuild/rules_apple/pull/1770).