### PR TITLE
Remove WORKSPACE snippet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,47 +23,8 @@ repository.
 
 ## Quick setup
 
-Add the following to your `WORKSPACE` file to add the external repositories,
-replacing the version number in the `tag` attribute with the version of the
-rules you wish to depend on:
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "build_bazel_rules_apple",
-    sha256 = "90e3b5e8ff942be134e64a83499974203ea64797fd620eddeb71b3a8e1bff681",
-    url = "https://github.com/bazelbuild/rules_apple/releases/download/1.1.2/rules_apple.1.1.2.tar.gz",
-)
-
-load(
-    "@build_bazel_rules_apple//apple:repositories.bzl",
-    "apple_rules_dependencies",
-)
-
-apple_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:repositories.bzl",
-    "swift_rules_dependencies",
-)
-
-swift_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:extras.bzl",
-    "swift_rules_extra_dependencies",
-)
-
-swift_rules_extra_dependencies()
-
-load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
-)
-
-apple_support_dependencies()
-```
+Copy the `WORKSPACE` snippet from [the releases
+page](https://github.com/bazelbuild/rules_apple/releases).
 
 ## Examples
 


### PR DESCRIPTION
This is automatically updated on the releases page now. I backfilled the
5.x releases too
