### PR TITLE
Add publish-to-bcr app configuration

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_apple",
+    "maintainers": [
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "name": "Keith Smiley"
+        },
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "github@brentleyjones.com",
+            "github": "brentleyjones",
+            "name": "Jones Brentley"
+        },
+        {
+            "email": "t@thi.im",
+            "github": "thii",
+            "name": "Thi Doãn"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_apple"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: macos
+    test_targets:
+    - '@rules_apple//examples/...'
+    # TODO(balestrapatrick): Re-enable these tests as soon as xctestrunner is bzlmod-compatible.
+    - '-@rules_apple//examples/ios/Squarer:SquarerTests'
+    - '-@rules_apple//examples/ios/PrenotCalculator:PrenotCalculatorTests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsUITests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsTests'
+    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsLogicTests'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/bazelbuild/rules_apple/releases/download/{TAG}/rules_apple.{TAG}.tar.gz"
+}


### PR DESCRIPTION
These configuration files are needed to get https://github.com/bazel-contrib/publish-to-bcr to publish new releases to the [bazel-central-registry](https://github.com/bazel-contrib/publish-to-bcr) every time a new release is cut.

I also requested to install the GitHub app in this repo, which is required in order for the sync to work.