### PR TITLE
Add package_for_distribution flag to ios_dynamic_framework so it won't include files in archive

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1331,13 +1331,16 @@ def _ios_dynamic_framework_impl(ctx):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
-        partials.swift_dynamic_framework_partial(
-            actions = actions,
-            bundle_name = bundle_name,
-            label_name = label.name,
-            swift_dynamic_framework_info = binary_target[SwiftDynamicFrameworkInfo],
-        ),
     ]
+    if ctx.attr.package_for_distribution:
+        processor_partials.append(
+            partials.swift_dynamic_framework_partial(
+                actions = actions,
+                bundle_name = bundle_name,
+                label_name = label.name,
+                swift_dynamic_framework_info = binary_target[SwiftDynamicFrameworkInfo],
+            ),
+        )
 
     processor_result = processor.process(
         actions = actions,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -580,6 +580,13 @@ Avoid linking the dynamic framework, but still include it in the app. This is us
 to manually dlopen the framework at runtime.
 """,
             ),
+            "package_for_distribution": attr.bool(
+                default = True,
+                doc = """
+If true, generates the Modules and Headers folder for proper distribution of an
+ios_dynamic_framework for use in Xcode
+""",
+            ),
         })
     elif rule_descriptor.product_type == apple_product_type.static_framework:
         attrs.append({

--- a/test/starlark_tests/ios_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/ios_dynamic_framework_tests.bzl
@@ -166,7 +166,9 @@ def ios_dynamic_framework_test_suite(name):
         ],
         not_contains = [
             "$BUNDLE_ROOT/Frameworks/swift_transitive_lib.framework/Frameworks/",
+            "$BUNDLE_ROOT/Frameworks/swift_transitive_lib.framework/Modules",
             "$BUNDLE_ROOT/Frameworks/swift_transitive_lib.framework/nonlocalized.plist",
+            "$BUNDLE_ROOT/Frameworks/swift_shared_lib.framework/Modules",
             "$BUNDLE_ROOT/framework_resources/nonlocalized.plist",
         ],
         binary_contains_symbols = ["_$s20swift_transitive_lib21anotherFunctionSharedyyF"],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2914,6 +2914,25 @@ ios_dynamic_framework(
 )
 
 ios_dynamic_framework(
+    name = "swift_shared_lib_framework_without_distribution",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "swift_shared_lib",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    package_for_distribution = False,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_shared_lib",
+    ],
+)
+
+ios_dynamic_framework(
     name = "swift_transitive_lib_framework",
     bundle_id = "com.google.example.framework",
     bundle_name = "swift_transitive_lib",
@@ -2930,6 +2949,24 @@ ios_dynamic_framework(
     deps = ["//test/starlark_tests/resources:swift_transitive_lib"],
 )
 
+ios_dynamic_framework(
+    name = "swift_transitive_lib_framework_without_distribution",
+    bundle_id = "com.google.example.framework",
+    bundle_name = "swift_transitive_lib",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    frameworks = [":swift_shared_lib_framework_without_distribution"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    package_for_distribution = False,
+    tags = common.fixture_tags,
+    deps = ["//test/starlark_tests/resources:swift_transitive_lib"],
+)
+
 ios_application(
     name = "app_with_dynamic_framework_with_dynamic_framework",
     bundle_id = "com.google.example",
@@ -2937,7 +2974,7 @@ ios_application(
         "iphone",
         "ipad",
     ],
-    frameworks = [":swift_transitive_lib_framework"],
+    frameworks = [":swift_transitive_lib_framework_without_distribution"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],


### PR DESCRIPTION
Adding package_for_distribution flag to ios_dynamic_framework so that swiftmodule and other files have the option to not be packaged in. Adding a test from https://github.com/bazelbuild/rules_apple/pull/1786 to confirm the new behavior.