### PR TITLE
Bump rules_swift to 1.5.0

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -121,9 +121,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
         http_archive,
         name = "build_bazel_rules_swift",
         urls = [
-            "https://github.com/bazelbuild/rules_swift/releases/download/1.4.0/rules_swift.1.4.0.tar.gz",
+            "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
         ],
-        sha256 = "c244e9f804a48c27fe490150c762d8b0c868b23ef93dc4e3f93d8117ca216d92",
+        sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_swift/releases/tag/1.5.0