### PR TITLE
Strip stub like Xcode

### DIFF
--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -60,11 +60,18 @@ def _create_stub_binary(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
             executable = "/usr/bin/xcrun",
-            arguments = ["bitcode_strip", "-r", "__BAZEL_XCODE_SDKROOT__/{}".format(xcode_stub_path), "-o", binary_artifact.path],
-            mnemonic = "BitcodeStripStub",
+            arguments = [
+                "lipo",
+                "__BAZEL_XCODE_SDKROOT__/{}".format(xcode_stub_path),
+                "-output",
+                binary_artifact.path,
+                "-extract",
+                platform_prerequisites.apple_fragment.single_arch_cpu,
+            ],
+            mnemonic = "LipoStub",
             outputs = [binary_artifact],
             xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
-            progress_message = "Removing bitcode from stub executable for %s" % (rule_label),
+            progress_message = "Removing unused architectures from stub executable for %s" % (rule_label),
             xcode_config = platform_prerequisites.xcode_version_config,
         )
     else:

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -82,12 +82,12 @@ def ios_sticker_pack_extension_test_suite(name):
     )
 
     archive_contents_test(
-        name = "{}_strip_bitcode_test".format(name),
+        name = "{}_bitcode_off_test".format(name),
         build_type = "device",
         apple_bitcode = "none",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
         binary_test_file = "$BUNDLE_ROOT/sticker_ext",
-        macho_load_commands_not_contain = ["segname __LLVM"],
+        macho_load_commands_contain = ["segname __LLVM"],
         tags = [name],
     )
 


### PR DESCRIPTION
Replicate the stub strip that occurs as part of an Xcode build:
```
/Applications/Xcode_14.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo /Applications/Xcode_14.2.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Application\ Support/MessagesApplicationExtensionStub/MessagesApplicationExtensionStub -output /Users/matt.robinson/Library/Developer/Xcode/DerivedData/App-asfdasdfasdf/Build/Intermediates.noindex/ArchiveIntermediates/App/BuildProductsPath/MessagesApplicationExtensionSupport/MessagesApplicationExtensionStub -extract arm64
```
This replaces https://github.com/bazelbuild/rules_apple/pull/1755 with an approach that matches Xcode instead.