### PR TITLE
Add module extension to include non-bzlmod ready dependencies

### DIFF
--- a/.github/update-module-version.sh
+++ b/.github/update-module-version.sh
@@ -16,4 +16,16 @@ module(
 EOF
 
 grep bazel_dep MODULE.bazel >> MODULE.bazel.new
+
+cat >> MODULE.bazel.new <<EOF
+
+non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
+
+use_repo(
+    non_module_deps,
+    "subpar",
+    "xctestrunner",
+)
+EOF
+
 mv MODULE.bazel.new MODULE.bazel

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,4 +8,12 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
-bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.2.0")
+bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.5.0")
+
+non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
+
+use_repo(
+    non_module_deps,
+    "subpar",
+    "xctestrunner",
+)

--- a/apple/extensions.bzl
+++ b/apple/extensions.bzl
@@ -1,0 +1,22 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Definitions for bzlmod module extensions."""
+
+load("//apple:repositories.bzl", "apple_rules_dependencies")
+
+def _non_module_deps_impl(_):
+    apple_rules_dependencies(include_bzlmod_ready_dependencies = False)
+
+non_module_deps = module_extension(implementation = _non_module_deps_impl)

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -85,7 +85,7 @@ run into compatibility issues. To silence this warning, pass \
 
     repo_rule(name = name, **kwargs)
 
-def apple_rules_dependencies(ignore_version_differences = False):
+def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_ready_dependencies = True):
     """Fetches repositories that are dependencies of the `rules_apple` workspace.
 
     Users should call this macro in their `WORKSPACE` to ensure that all of the
@@ -95,37 +95,41 @@ def apple_rules_dependencies(ignore_version_differences = False):
     Args:
       ignore_version_differences: If `True`, warnings about potentially
           incompatible versions of depended-upon repositories will be silenced.
+      include_bzlmod_ready_dependencies: Whether or not bzlmod-ready
+             dependencies should be included.
     """
-    _maybe(
-        http_archive,
-        name = "bazel_skylib",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
-        ],
-        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
-        ignore_version_differences = ignore_version_differences,
-    )
 
-    _maybe(
-        http_archive,
-        name = "build_bazel_apple_support",
-        sha256 = "2e3dc4d0000e8c2f5782ea7bb53162f37c485b5d8dc62bb3d7d7fc7c276f0d00",
-        urls = [
-            "https://github.com/bazelbuild/apple_support/releases/download/1.3.2/apple_support.1.3.2.tar.gz",
-        ],
-        ignore_version_differences = ignore_version_differences,
-    )
+    if include_bzlmod_ready_dependencies:
+        _maybe(
+            http_archive,
+            name = "bazel_skylib",
+            urls = [
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            ],
+            sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+            ignore_version_differences = ignore_version_differences,
+        )
 
-    _maybe(
-        http_archive,
-        name = "build_bazel_rules_swift",
-        urls = [
-            "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
-        ],
-        sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
-        ignore_version_differences = ignore_version_differences,
-    )
+        _maybe(
+            http_archive,
+            name = "build_bazel_apple_support",
+            sha256 = "2e3dc4d0000e8c2f5782ea7bb53162f37c485b5d8dc62bb3d7d7fc7c276f0d00",
+            urls = [
+                "https://github.com/bazelbuild/apple_support/releases/download/1.3.2/apple_support.1.3.2.tar.gz",
+            ],
+            ignore_version_differences = ignore_version_differences,
+        )
+
+        _maybe(
+            http_archive,
+            name = "build_bazel_rules_swift",
+            urls = [
+                "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
+            ],
+            sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
+            ignore_version_differences = ignore_version_differences,
+        )
 
     _maybe(
         http_archive,


### PR DESCRIPTION
This will remove a patch that we have in the BCR that is required to expose non-bzlmod ready dependencies via a module extension. This is similar to what we do in [rules_swift](https://github.com/bazelbuild/rules_swift/pull/920/) already.