### PR TITLE
Add bzlmod module_extension for provisioning_profile_repository

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,3 +18,6 @@ use_repo(
     "subpar",
     "xctestrunner",
 )
+
+provisioning_profile_repository = use_extension("//apple:apple.bzl", "provisioning_profile_repository_extension")
+use_repo(provisioning_profile_repository, "local_provisioning_profiles")

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -41,6 +41,7 @@ load(
     "@build_bazel_rules_apple//apple/internal:local_provisioning_profiles.bzl",
     _local_provisioning_profile = "local_provisioning_profile",
     _provisioning_profile_repository = "provisioning_profile_repository",
+    _provisioning_profile_repository_extension = "provisioning_profile_repository_extension",
 )
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
@@ -53,3 +54,4 @@ apple_universal_binary = _apple_universal_binary
 apple_xcframework = _apple_xcframework
 local_provisioning_profile = _local_provisioning_profile
 provisioning_profile_repository = _provisioning_profile_repository
+provisioning_profile_repository_extension = _provisioning_profile_repository_extension

--- a/doc/README.md
+++ b/doc/README.md
@@ -122,6 +122,7 @@ below.
         <code><a href="rules-apple.md#apple_xcframework">apple_xcframework</a></code><br/>
         <code><a href="rules-apple.md#local_provisioning_profile">local_provisioning_profile</a></code><br/>
         <code><a href="rules-apple.md#provisioning_profile_repository">provisioning_profile_repository</a></code><br/>
+        <code><a href="rules-apple.md#provisioning_profile_repository_extension">provisioning_profile_repository_extension</a></code><br/>
       </td>
     </tr>
     <tr>

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -382,6 +382,18 @@ not having to update it every time a new device or certificate is added.
 
 ## Example
 
+### In your `MODULE.bazel` file:
+
+You only need this in the case you want to setup fallback profiles, otherwise
+it can be ommitted when using bzlmod.
+
+```bzl
+provisioning_profile_repository = use_extension("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
+provisioning_profile_repository.setup(
+    fallback_profiles = "//path/to/some:filegroup", # Profiles to use if one isn't found locally
+)
+```
+
 ### In your `WORKSPACE` file:
 
 ```starlark


### PR DESCRIPTION
This is required to be able to use provisioning_profile_repository at
the same time as using rules_apple with bzlmod. The setup is a bit
different but the gist of it is that we run the extension by default
(meaning users don't have to run it at all unless they need to specify
fallback_profiles), and then if the user runs it as well we fetch the
data from their run instead.
