### PR TITLE
Remove obsolete `incompatible_use_toolchain_transition`

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -170,5 +170,4 @@ not in the top-level bundle.
     },
     fragments = ["objc", "apple", "cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/14127#issuecomment-1396053583