### PR TITLE
Add override for startup_timeout_sec in tests

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -130,7 +130,7 @@ fi
 TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) "\":\"" substr($i, d+1); }}')
 TEST_ENV=${TEST_ENV//$'\n'/\",\"}
 TEST_ENV="{\"${TEST_ENV}\"}"
-LAUNCH_OPTIONS_JSON_STR="\"startup_timeout_sec\": ${STARTUP_TIMEOUT_SEC:150}, \"env_vars\":${TEST_ENV}"
+LAUNCH_OPTIONS_JSON_STR="\"startup_timeout_sec\": ${STARTUP_TIMEOUT_SEC:-150}, \"env_vars\":${TEST_ENV}"
 
 if [[ -n "${command_line_args}" ]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -99,11 +99,6 @@ if [[ -n "${TEST_TYPE}" ]]; then
   runner_flags+=("--test_type=${TEST_TYPE}")
 fi
 
-# Constructs the json string to configure the test env and tests to run.
-# It will be written into a temp json file which is passed to the test runner
-# flags --launch_options_json_path.
-LAUNCH_OPTIONS_JSON_STR=""
-
 TEST_ENV="%(test_env)s"
 if [[ -n "$TEST_ENV" ]]; then
   TEST_ENV="$TEST_ENV,TEST_SRCDIR=$TEST_SRCDIR"
@@ -135,7 +130,7 @@ fi
 TEST_ENV=$(echo "$TEST_ENV" | awk -F ',' '{for (i=1; i <=NF; i++) { d = index($i, "="); print substr($i, 1, d-1) "\":\"" substr($i, d+1); }}')
 TEST_ENV=${TEST_ENV//$'\n'/\",\"}
 TEST_ENV="{\"${TEST_ENV}\"}"
-LAUNCH_OPTIONS_JSON_STR="\"env_vars\":${TEST_ENV}"
+LAUNCH_OPTIONS_JSON_STR="\"startup_timeout_sec\": ${STARTUP_TIMEOUT_SEC:150}, \"env_vars\":${TEST_ENV}"
 
 if [[ -n "${command_line_args}" ]]; then
   if [[ -n "${LAUNCH_OPTIONS_JSON_STR}" ]]; then


### PR DESCRIPTION
This way you can pass `--test_env=STARTUP_TIMEOUT_SEC=N`. The default is
the same as if you don't pass anything to xctestrunner
