### PR TITLE
Add experimental_mixed_language_library macro to support building mixed Objective-C and Swift modules

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -36,6 +36,7 @@ bzl_library(
     srcs = ["apple.bzl"],
     deps = [
         "//apple/internal:apple_framework_import",
+        "//apple/internal:apple_library",
         "//apple/internal:apple_universal_binary",
         "//apple/internal:apple_xcframework_import",
         "//apple/internal:local_provisioning_profiles",

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -36,9 +36,9 @@ bzl_library(
     srcs = ["apple.bzl"],
     deps = [
         "//apple/internal:apple_framework_import",
-        "//apple/internal:apple_library",
         "//apple/internal:apple_universal_binary",
         "//apple/internal:apple_xcframework_import",
+        "//apple/internal:experimental_mixed_language_library",
         "//apple/internal:local_provisioning_profiles",
         "//apple/internal:xcframework_rules",
     ],

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -24,10 +24,6 @@ load(
     _apple_static_framework_import = "apple_static_framework_import",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_library.bzl",
-    _apple_library = "apple_library",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
     _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
     _apple_static_xcframework_import = "apple_static_xcframework_import",
@@ -42,6 +38,10 @@ load(
     _apple_xcframework = "apple_xcframework",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:experimental_mixed_language_library.bzl",
+    _experimental_mixed_language_library = "experimental_mixed_language_library",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:local_provisioning_profiles.bzl",
     _local_provisioning_profile = "local_provisioning_profile",
     _provisioning_profile_repository = "provisioning_profile_repository",
@@ -50,13 +50,13 @@ load(
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
 apple_dynamic_xcframework_import = _apple_dynamic_xcframework_import
-apple_library = _apple_library
 apple_static_framework_import = _apple_static_framework_import
 apple_static_library = _apple_static_library
 apple_static_xcframework = _apple_static_xcframework
 apple_static_xcframework_import = _apple_static_xcframework_import
 apple_universal_binary = _apple_universal_binary
 apple_xcframework = _apple_xcframework
+experimental_mixed_language_library = _experimental_mixed_language_library
 local_provisioning_profile = _local_provisioning_profile
 provisioning_profile_repository = _provisioning_profile_repository
 provisioning_profile_repository_extension = _provisioning_profile_repository_extension

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -24,6 +24,10 @@ load(
     _apple_static_framework_import = "apple_static_framework_import",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_library.bzl",
+    _apple_library = "apple_library",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
     _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
     _apple_static_xcframework_import = "apple_static_xcframework_import",
@@ -46,6 +50,7 @@ load(
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import
 apple_dynamic_xcframework_import = _apple_dynamic_xcframework_import
+apple_library = _apple_library
 apple_static_framework_import = _apple_static_framework_import
 apple_static_library = _apple_static_library
 apple_static_xcframework = _apple_static_xcframework

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -69,8 +69,8 @@ bzl_library(
 )
 
 bzl_library(
-    name = "apple_library",
-    srcs = ["apple_library.bzl"],
+    name = "experimental_mixed_language_library",
+    srcs = ["experimental_mixed_language_library.bzl"],
     visibility = [
         "//apple:__subpackages__",
     ],

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -69,6 +69,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "apple_library",
+    srcs = ["apple_library.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
     name = "apple_universal_binary",
     srcs = ["apple_universal_binary.bzl"],
     visibility = [

--- a/apple/internal/apple_library.bzl
+++ b/apple/internal/apple_library.bzl
@@ -1,0 +1,309 @@
+"""apple_library macro implementation."""
+
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+    "swift_library",
+)
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+_CPP_FILE_TYPES = [".cc", ".cpp", ".mm", ".cxx", ".C"]
+
+_NON_CPP_FILE_TYPES = [".m", ".c"]
+
+_ASSEMBLY_FILE_TYPES = [".s", ".S", ".asm"]
+
+_OBJECT_FILE_FILE_TYPES = [".o"]
+
+_HEADERS_FILE_TYPES = [
+    ".h",
+    ".hh",
+    ".hpp",
+    ".ipp",
+    ".hxx",
+    ".h++",
+    ".inc",
+    ".inl",
+    ".tlh",
+    ".tli",
+    ".H",
+    ".hmap",
+]
+
+_OBJC_FILE_TYPES = _CPP_FILE_TYPES + \
+                   _NON_CPP_FILE_TYPES + \
+                   _ASSEMBLY_FILE_TYPES + \
+                   _OBJECT_FILE_FILE_TYPES + \
+                   _HEADERS_FILE_TYPES
+
+_SWIFT_FILE_TYPES = [".swift"]
+
+def _module_map_content(
+        module_name,
+        hdrs,
+        textual_hdrs,
+        swift_generated_header,
+        module_map_path):
+    # Up to the execution root
+    # bazel-out/<platform-config>/bin/<path/to/package>/<target-name>.modulemaps/<module-name>
+    slashes_count = module_map_path.count("/")
+    relative_path = "".join(["../"] * slashes_count)
+
+    content = "module " + module_name + " {\n"
+
+    for hdr in hdrs:
+        if hdr.extension == "h":
+            content += "  header \"%s%s\"\n" % (relative_path, hdr.path)
+    for hdr in textual_hdrs:
+        if hdr.extension == "h":
+            content += "  textual header \"%s%s\"\n" % (relative_path, hdr.path)
+
+    content += "\n"
+    content += "  export *\n"
+    content += "}\n"
+
+    # Add a Swift submodule if a Swift generated header exists
+    if swift_generated_header:
+        content += "\n"
+        content += "module " + module_name + ".Swift {\n"
+        content += "  header \"%s\"\n" % swift_generated_header.basename
+        content += "  requires objc\n"
+        content += "}\n"
+
+    return content
+
+def _umbrella_header_content(hdrs):
+    # If the platform is iOS, add an import call to `UIKit/UIKit.h` to the top
+    # of the umbrella header. This allows implicit import of UIKit from Swift.
+    content = """\
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
+#endif
+#endif
+
+"""
+    for hdr in hdrs:
+        if hdr.extension == "h":
+            content += "#import \"%s\"\n" % (hdr.path)
+
+    return content
+
+def _module_map_impl(ctx):
+    outputs = []
+
+    hdrs = ctx.files.hdrs
+    textual_hdrs = ctx.files.textual_hdrs
+    outputs.extend(hdrs)
+    outputs.extend(textual_hdrs)
+
+    # Find Swift generated header
+    swift_generated_header = None
+    for dep in ctx.attr.deps:
+        if CcInfo in dep:
+            objc_headers = dep[CcInfo].compilation_context.headers.to_list()
+        else:
+            objc_headers = []
+        for hdr in objc_headers:
+            if hdr.owner == dep.label:
+                swift_generated_header = hdr
+                outputs.append(swift_generated_header)
+
+    # Write the module map content
+    if swift_generated_header:
+        umbrella_header_path = ctx.attr.module_name + ".h"
+        umbrella_header = ctx.actions.declare_file(umbrella_header_path)
+        outputs.append(umbrella_header)
+        ctx.actions.write(
+            content = _umbrella_header_content(hdrs),
+            output = umbrella_header,
+        )
+        outputs.append(umbrella_header)
+
+    module_map = ctx.actions.declare_file(ctx.attr.name + "-module.modulemap")
+    outputs.append(module_map)
+
+    ctx.actions.write(
+        content = _module_map_content(
+            module_name = ctx.attr.module_name,
+            hdrs = hdrs,
+            textual_hdrs = textual_hdrs,
+            swift_generated_header = swift_generated_header,
+            module_map_path = module_map.path,
+        ),
+        output = module_map,
+    )
+
+    objc_provider = apple_common.new_objc_provider()
+
+    compilation_context = cc_common.create_compilation_context(
+        headers = depset(outputs),
+    )
+    cc_info = CcInfo(
+        compilation_context = compilation_context,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([module_map]),
+        ),
+        objc_provider,
+        cc_info,
+    ]
+
+_module_map = rule(
+    attrs = {
+        "module_name": attr.string(
+            mandatory = True,
+            doc = "The name of the module.",
+        ),
+        "hdrs": attr.label_list(
+            allow_files = _HEADERS_FILE_TYPES,
+            doc = """\
+The list of C, C++, Objective-C, and Objective-C++ header files used to
+construct the module map.
+""",
+        ),
+        "textual_hdrs": attr.label_list(
+            allow_files = _HEADERS_FILE_TYPES,
+            doc = """\
+The list of C, C++, Objective-C, and Objective-C++ header files used to
+construct the module map. Unlike hdrs, these will be declared as 'textual
+header' in the module map.
+""",
+        ),
+        "deps": attr.label_list(
+            providers = [SwiftInfo],
+            doc = """\
+The list of swift_library targets.  A `${module_name}.Swift` submodule will be
+generated if non-empty.
+""",
+        ),
+    },
+    doc = "Generates a module map given a list of header files.",
+    implementation = _module_map_impl,
+    provides = [
+        DefaultInfo,
+    ],
+)
+
+# TODO: Document the apple_library macro
+def apple_library(**kwargs):
+    """Compiles and links Objective-C and Swift code into a static library.
+
+    Args:
+      **kwargs: Other arguments are passed directly to `apple_library`.
+    """
+
+    hdrs = kwargs.pop("hdrs", [])
+    srcs = kwargs.pop("srcs", [])
+
+    if not srcs:
+        fail("'srcs' must be non-empty")
+
+    swift_srcs = []
+    objc_srcs = []
+    private_hdrs = []
+
+    for x in srcs:
+        _, extension = paths.split_extension(x)
+        if extension in _SWIFT_FILE_TYPES:
+            swift_srcs.append(x)
+        elif extension in _OBJC_FILE_TYPES:
+            objc_srcs.append(x)
+            if extension in _HEADERS_FILE_TYPES:
+                private_hdrs.append(x)
+    if not objc_srcs:
+        fail("""\
+'srcs' must contain Objective-C source files. Use 'swift_library' if this
+target only contains Swift files.""")
+    if not swift_srcs:
+        fail("""\
+'srcs' must contain Swift source files. Use 'objc_library' if this
+target only contains Objective-C files.""")
+
+    name = kwargs.get("name", None)
+    module_name = kwargs.pop("module_name", name)
+    swift_library_name = name + "_swift"
+
+    deps = kwargs.pop("deps", [])
+    objc_deps = []
+    swift_deps = [] + deps
+
+    swift_copts = kwargs.pop("swift_copts", [])
+    swift_copts = swift_copts + [
+        "-Xfrontend",
+        "-enable-objc-interop",
+        "-import-underlying-module",
+    ]
+
+    objc_deps = [":" + swift_library_name]
+
+    # Add Obj-C includes to Swift header search paths
+    repository_name = native.repository_name()
+    includes = kwargs.get("includes", [])
+    for x in includes:
+        include = x if repository_name == "@" else "external/" + repository_name.lstrip("@") + "/" + x
+        swift_copts += [
+            "-Xcc",
+            "-I{}".format(include),
+        ]
+
+    # Generate module map for the underlying Obj-C module
+    textual_hdrs = kwargs.get("textual_hdrs", [])
+    _module_map(
+        name = name + "_objc_module",
+        hdrs = hdrs,
+        module_name = module_name,
+        textual_hdrs = textual_hdrs,
+    )
+
+    objc_module_map = ":" + name + "_objc_module"
+    swiftc_inputs = kwargs.pop("swiftc_inputs", [])
+    swiftc_inputs = swiftc_inputs + hdrs + textual_hdrs + private_hdrs + [objc_module_map]
+
+    swift_copts += [
+        "-Xcc",
+        "-fmodule-map-file=$(execpath {})".format(objc_module_map),
+    ]
+
+    features = kwargs.pop("features", [])
+    swift_features = features + ["swift.no_generated_module_map"]
+
+    swift_library(
+        name = swift_library_name,
+        copts = swift_copts,
+        deps = swift_deps,
+        features = swift_features,
+        generated_header_name = module_name + "-Swift.h",
+        generates_header = True,
+        module_name = module_name,
+        srcs = swift_srcs,
+        swiftc_inputs = swiftc_inputs,
+    )
+
+    umbrella_module_map = name + "_umbrella_module"
+    _module_map(
+        name = umbrella_module_map,
+        deps = [":" + swift_library_name],
+        hdrs = hdrs,
+        module_name = module_name,
+    )
+    objc_deps.append(":" + umbrella_module_map)
+
+    objc_copts = kwargs.pop("objc_copts", [])
+
+    native.objc_library(
+        copts = objc_copts,
+        deps = objc_deps,
+        hdrs = hdrs + [
+            # These aren't headers but here is the only place to declare these
+            # files as the inputs because objc_library doesn't have an
+            # attribute to declare custom inputs.
+            ":" + umbrella_module_map,
+        ],
+        module_map = umbrella_module_map,
+        srcs = objc_srcs,
+        **kwargs
+    )

--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -200,6 +200,18 @@ def experimental_mixed_language_library(
         **kwargs):
     """Compiles and links Objective-C and Swift code into a static library.
 
+    This is an experimental macro that supports compiling mixed Objective-C and
+    Swift source files into a static library.
+
+    Due to the build performance reason, in general it's not recommended to
+    have mixed Objective-C and Swift modules, but it isn't uncommon to see
+    mixed language modules in some old codebases. This macro is meant to make
+    it easier to migrate codebases with mixed language modules to Bazel without
+    having to demix them first.
+
+    This macro only supports a very simple use case of mixed language
+    modules---it does not support for header maps or Clang modules.
+
     Args:
         name: A unique name for this target.
         deps: A list of targets that are dependencies of the target being

--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -1,4 +1,4 @@
-"""apple_library macro implementation."""
+"""experimental_mixed_language_library macro implementation."""
 
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
@@ -188,12 +188,12 @@ generated if non-empty.
     ],
 )
 
-# TODO: Document the apple_library macro
-def apple_library(**kwargs):
+# TODO: Document the experimental_mixed_language_library macro
+def experimental_mixed_language_library(**kwargs):
     """Compiles and links Objective-C and Swift code into a static library.
 
     Args:
-      **kwargs: Other arguments are passed directly to `apple_library`.
+      **kwargs: Other arguments are passed directly to `experimental_mixed_language_library`.
     """
 
     hdrs = kwargs.pop("hdrs", [])

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -434,12 +434,12 @@ ios_application(
 | <a id="provisioning_profile_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
 
 
-<a id="apple_library"></a>
+<a id="experimental_mixed_language_library"></a>
 
-## apple_library
+## experimental_mixed_language_library
 
 <pre>
-apple_library(<a href="#apple_library-kwargs">kwargs</a>)
+experimental_mixed_language_library(<a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
 </pre>
 
 Compiles and links Objective-C and Swift code into a static library.
@@ -449,6 +449,6 @@ Compiles and links Objective-C and Swift code into a static library.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="apple_library-kwargs"></a>kwargs |  Other arguments are passed directly to <code>apple_library</code>.   |  none |
+| <a id="experimental_mixed_language_library-kwargs"></a>kwargs |  Other arguments are passed directly to <code>experimental_mixed_language_library</code>.   |  none |
 
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -439,7 +439,8 @@ ios_application(
 ## experimental_mixed_language_library
 
 <pre>
-experimental_mixed_language_library(<a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
+experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>, <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>,
+                                    <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
 </pre>
 
 Compiles and links Objective-C and Swift code into a static library.
@@ -449,6 +450,13 @@ Compiles and links Objective-C and Swift code into a static library.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="experimental_mixed_language_library-kwargs"></a>kwargs |  Other arguments are passed directly to <code>experimental_mixed_language_library</code>.   |  none |
+| <a id="experimental_mixed_language_library-name"></a>name |  A unique name for this target.   |  none |
+| <a id="experimental_mixed_language_library-srcs"></a>srcs |  The list of Objective-C and Swift source files to compile.   |  none |
+| <a id="experimental_mixed_language_library-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will be linked into that target.   |  <code>[]</code> |
+| <a id="experimental_mixed_language_library-module_name"></a>module_name |  The name of the mixed language module being built. If left unspecified, the module name will be the name of the target.   |  <code>None</code> |
+| <a id="experimental_mixed_language_library-objc_copts"></a>objc_copts |  Additional compiler options that should be passed to <code>clang</code>.   |  <code>[]</code> |
+| <a id="experimental_mixed_language_library-swift_copts"></a>swift_copts |  Additional compiler options that should be passed to <code>swiftc</code>. These strings are subject to <code>$(location ...)</code> and "Make" variable expansion.   |  <code>[]</code> |
+| <a id="experimental_mixed_language_library-swiftc_inputs"></a>swiftc_inputs |  Additional files that are referenced using <code>$(location...)</code> in <code>swift_copts</code>.   |  <code>[]</code> |
+| <a id="experimental_mixed_language_library-kwargs"></a>kwargs |  Other arguments to pass through to the underlying <code>objc_library</code>.   |  none |
 
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -445,6 +445,19 @@ experimental_mixed_language_library(<a href="#experimental_mixed_language_librar
 
 Compiles and links Objective-C and Swift code into a static library.
 
+This is an experimental macro that supports compiling mixed Objective-C and
+Swift source files into a static library.
+
+Due to the build performance reason, in general it's not recommended to
+have mixed Objective-C and Swift modules, but it isn't uncommon to see
+mixed language modules in some old codebases. This macro is meant to make
+it easier to migrate codebases with mixed language modules to Bazel without
+having to demix them first.
+
+This macro only supports a very simple use case of mixed language
+modules---it does not support for header maps or Clang modules.
+
+
 **PARAMETERS**
 
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -434,3 +434,21 @@ ios_application(
 | <a id="provisioning_profile_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
 
 
+<a id="apple_library"></a>
+
+## apple_library
+
+<pre>
+apple_library(<a href="#apple_library-kwargs">kwargs</a>)
+</pre>
+
+Compiles and links Objective-C and Swift code into a static library.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="apple_library-kwargs"></a>kwargs |  Other arguments are passed directly to <code>apple_library</code>.   |  none |
+
+

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -1,10 +1,10 @@
-load("//apple:apple.bzl", "apple_library")
+load("//apple:apple.bzl", "experimental_mixed_language_library")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
 )
 
-apple_library(
+experimental_mixed_language_library(
     name = "MixedAnswer",
     srcs = [
         "MixedAnswer.m",

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -1,0 +1,22 @@
+load("//apple:apple.bzl", "apple_library")
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+apple_library(
+    name = "MixedAnswer",
+    srcs = [
+        "MixedAnswer.m",
+        "MixedAnswer.swift",
+    ],
+    hdrs = ["MixedAnswer.h"],
+)
+
+swift_library(
+    name = "SwiftLibDependingOnMixedLib",
+    srcs = [
+        "SwiftLibDependingOnMixedLib.swift",
+    ],
+    deps = [":MixedAnswer"],
+)

--- a/examples/multi_platform/MixedLib/MixedAnswer.h
+++ b/examples/multi_platform/MixedLib/MixedAnswer.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface MixedAnswerObjc : NSObject
+
++ (NSString *)mixedAnswerObjc;
+
+@end

--- a/examples/multi_platform/MixedLib/MixedAnswer.m
+++ b/examples/multi_platform/MixedLib/MixedAnswer.m
@@ -1,0 +1,10 @@
+#import "examples/multi_platform/MixedLib/MixedAnswer.h"
+#import "examples/multi_platform/MixedLib/MixedAnswer-Swift.h"
+
+@implementation MixedAnswerObjc
+
++ (NSString *)mixedAnswerObjc {
+    return [NSString stringWithFormat:@"%@_%@", @"mixedAnswerObjc", [MixedAnswerSwift swiftToObjcMixedAnswer]];
+}
+
+@end

--- a/examples/multi_platform/MixedLib/MixedAnswer.swift
+++ b/examples/multi_platform/MixedLib/MixedAnswer.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@objc
+public class MixedAnswerSwift: NSObject {
+
+    public
+    static func swiftMixedAnswer() -> String {
+        "\(MixedAnswerObjc.mixedAnswerObjc() ?? "invalid")_swiftMixedAnswer"
+    }
+
+    @objc
+    public
+    static func swiftToObjcMixedAnswer() -> String {
+        "swiftToObjcMixedAnswer"
+    }
+}

--- a/examples/multi_platform/MixedLib/SwiftLibDependingOnMixedLib.swift
+++ b/examples/multi_platform/MixedLib/SwiftLibDependingOnMixedLib.swift
@@ -1,0 +1,11 @@
+import MixedAnswer
+
+class SwiftLibDependingOnMixedLib {
+    static func callSwiftMixedAnswer() -> String {
+        MixedAnswerSwift.swiftMixedAnswer()
+    }
+
+    static func callObjcMixedAnswer() -> String? {
+        MixedAnswerObjc.mixedAnswerObjc()
+    }
+}


### PR DESCRIPTION
This is supposed to help with the migration and in general is discouraged to use. The implementation is a simplified version of a community rule but doesn't support header maps and Clang modules.

Closes https://github.com/bazelbuild/rules_apple/issues/1756