### PR TITLE
Flip `--incompatible_objc_linking_info_migration` back for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -11,6 +11,10 @@ x_defaults:
     - "tools/..."
     - "test/..."
     - "examples/..."
+  common_last_green: &common_last_green
+    build_flags:
+      # https://github.com/bazelbuild/bazel/issues/16939
+      - --incompatible_objc_linking_info_migration=false
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
@@ -33,6 +37,7 @@ tasks:
     name: "Last Green Bazel"
     bazel: last_green
     <<: *common
+    <<: *common_last_green
 
   macos_last_green_head_deps:
     name: "Last Green Bazel with Head Deps"
@@ -42,6 +47,7 @@ tasks:
     # has landed on them breaking this project.
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
+    <<: *common_last_green
 
   doc_tests:
     name: "Doc tests"
@@ -49,5 +55,6 @@ tasks:
     platform: ubuntu2004
     test_targets:
     - "doc/..."
+    <<: *common_last_green
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,6 +15,8 @@ x_defaults:
     build_flags:
       # https://github.com/bazelbuild/bazel/issues/16939
       - --incompatible_objc_linking_info_migration=false
+    test_flags:
+      - --incompatible_objc_linking_info_migration=false
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,6 @@ common --incompatible_allow_tags_propagation
 
 # TODO: Fix cases that relied on the old behavior and remove these flags.
 common --incompatible_unambiguous_label_stringification=false
-# https://github.com/bazelbuild/bazel/issues/16939
-build --incompatible_objc_linking_info_migration=false
 
 # Add the PATH to the test environment so that common macOS tools can be found
 # during a test run.

--- a/.bazelrc
+++ b/.bazelrc
@@ -4,7 +4,7 @@
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 
-# TODO: Fix cases that relied on the old behavior and remove these flags.
+# TODO: Fix cases that relied on the old behavior and remove this flag.
 common --incompatible_unambiguous_label_stringification=false
 
 # Add the PATH to the test environment so that common macOS tools can be found

--- a/.bazelrc
+++ b/.bazelrc
@@ -4,8 +4,10 @@
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 
-# TODO: Fix cases that relied on the old behavior and remove this flag.
+# TODO: Fix cases that relied on the old behavior and remove these flags.
 common --incompatible_unambiguous_label_stringification=false
+# https://github.com/bazelbuild/bazel/issues/16939
+build --incompatible_objc_linking_info_migration=false
 
 # Add the PATH to the test environment so that common macOS tools can be found
 # during a test run.


### PR DESCRIPTION
Fixes our builds with `last_green` bazel.

https://github.com/bazelbuild/bazel/commit/7b4acfe5bf510a887c7efa021f57b8f7bf5a0713