### PR TITLE
[CI] Use Xcode 14.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,6 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos
+    xcode_version: "14.2"
     build_targets:
     - "tools/..."
     - "test/..."


### PR DESCRIPTION
Looks like CI ~is~ was broken because the [CI fleet was upgraded to Xcode 14.2](https://github.com/bazelbuild/continuous-integration/issues/1431#issuecomment-1418841590) and some machines were missing the watchOS and tvOS SDKs. Now that the iMacs are properly set up, we should be able to simply use Xcode 14.2.

We can't use Xcode 13.0 anymore because it doesn't run on macOS Ventura (which all the x86_64 machines are on after the upgrade).

Future tasks might include adding support for arm64 in our tooling so that we can switch to run on Mac Studios instead of iMacs.