### PR TITLE
Fix test crash at launch on iOS 14

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,13 +12,14 @@ x_defaults:
     - "tools/..."
     - "test/..."
     - "examples/..."
+    test_flags:
+    - --test_tag_filters=-skipci
   common_last_green: &common_last_green
     build_flags:
       # https://github.com/bazelbuild/bazel/issues/16939
       - --incompatible_objc_linking_info_migration=false
     test_flags:
       - --incompatible_objc_linking_info_migration=false
-      - --test_tag_filters=-skipci
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,6 +18,7 @@ x_defaults:
       - --incompatible_objc_linking_info_migration=false
     test_flags:
       - --incompatible_objc_linking_info_migration=false
+      - --test_tag_filters=-skipci
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,6 +20,7 @@ x_defaults:
       - --incompatible_objc_linking_info_migration=false
     test_flags:
       - --incompatible_objc_linking_info_migration=false
+      - --test_tag_filters=-skipci
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -109,6 +109,8 @@ fi
 sanitizer_dyld_env=""
 readonly sanitizer_root="${TEST_BUNDLE_PATH}/Frameworks"
 for sanitizer in "$sanitizer_root"/libclang_rt.*.dylib; do
+  [[ -e "$sanitizer" ]] || continue
+
   if [[ -n "$sanitizer_dyld_env" ]]; then
     sanitizer_dyld_env="$sanitizer_dyld_env:"
   fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -85,6 +85,8 @@ fi
 sanitizer_dyld_env=""
 readonly sanitizer_root="$test_tmp_dir/$test_bundle_name.xctest/Frameworks"
 for sanitizer in "$sanitizer_root"/libclang_rt.*.dylib; do
+  [[ -e "$sanitizer" ]] || continue
+
   if [[ -n "$sanitizer_dyld_env" ]]; then
     sanitizer_dyld_env="$sanitizer_dyld_env:"
   fi

--- a/test/BUILD
+++ b/test/BUILD
@@ -7,6 +7,10 @@ load(
     "WATCHOS_CONFIGURATIONS",
 )
 load(
+    "//test/starlark_tests:common.bzl",
+    "common",
+)
+load(
     "//test:test_rules.bzl",
     "apple_multi_shell_test",
     "apple_shell_test",
@@ -242,6 +246,16 @@ apple_shell_test(
     args = [
         "--ios_multi_cpus=i386,x86_64,sim_arm64",
     ],
+)
+
+apple_shell_test(
+    name = "ios_test_runner_unit_test_14.x",
+    size = "large",
+    src = "ios_test_runner_unit_test_14.x.sh",
+    args = [
+        "--ios_multi_cpus=i386,x86_64,sim_arm64",
+    ],
+    tags = common.skip_ci_tags,
 )
 
 apple_shell_test(

--- a/test/ios_test_runner_unit_test_14.x.sh
+++ b/test/ios_test_runner_unit_test_14.x.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration tests for iOS test runner.
+
+function set_up() {
+  mkdir -p ios
+}
+
+function tear_down() {
+  rm -rf ios
+}
+
+function create_sim_runners() {
+  cat > ios/BUILD <<EOF
+load(
+    "@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_application",
+    "ios_unit_test"
+)
+load("@build_bazel_rules_swift//swift:swift.bzl",
+     "swift_library"
+)
+load(
+    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "ios_test_runner"
+)
+
+ios_test_runner(
+    name = "ios_x86_64_sim_runner_14",
+    device_type = "iPhone 8",
+    os_version = "14.5",
+)
+EOF
+}
+
+function create_ios_unit_tests() {
+  if [[ ! -f ios/BUILD ]]; then
+    fail "create_sim_runners must be called first."
+  fi
+
+  cat > ios/pass_unit_test.m <<EOF
+#import <XCTest/XCTest.h>
+#import <XCTest/XCUIApplication.h>
+
+@interface PassingUnitTest : XCTestCase
+
+@end
+
+@implementation PassingUnitTest {
+  XCUIApplication *_app;
+}
+
+- (void)testPass {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+
+- (void)testPass2 {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+
+- (void)testPass3 {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+
+- (void)testPassEnvVariable {
+  XCTAssertEqualObjects([NSProcessInfo processInfo].environment[@"SomeVariable1"], @"Its My First Variable", @"should pass");
+  XCTAssertEqualObjects([NSProcessInfo processInfo].environment[@"SomeVariable2"], @"Its My Second Variable", @"should pass");
+  XCTAssertEqualObjects([NSProcessInfo processInfo].environment[@"REFERENCE_DIR"], @"/Project/My Tests/ReferenceImages", @"should pass");
+  XCTAssertEqualObjects([NSProcessInfo processInfo].environment[@"IMAGE_DIR"], @"/Project/My Tests/Images", @"should pass");
+}
+
+- (void)uiTestSymbols {
+  // This function triggers https://github.com/google/xctestrunner/blob/7f8fc81b10c8d93f09f6fe38b2a3f37ba25336a6/test_runner/xctest_session.py#L382
+  _app = [[XCUIApplication alloc] init];
+}
+
+@end
+EOF
+
+  cat > ios/PassUnitTest-Info.plist <<EOF
+<plist version="1.0">
+<dict>
+        <key>CFBundleExecutable</key>
+        <string>PassingUnitTest</string>
+</dict>
+</plist>
+EOF
+
+  cat >> ios/BUILD <<EOF
+test_env = {
+    "SomeVariable1": "Its My First Variable",
+    "SomeVariable2": "Its My Second Variable",
+    "REFERENCE_DIR": "/Project/My Tests/ReferenceImages",
+    "IMAGE_DIR": "/Project/My Tests/Images"
+}
+
+objc_library(
+    name = "pass_unit_test_lib",
+    srcs = ["pass_unit_test.m"],
+)
+
+ios_unit_test(
+    name = "PassingUnitTest",
+    infoplists = ["PassUnitTest-Info.plist"],
+    deps = [":pass_unit_test_lib"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    env = test_env,
+    runner = ":ios_x86_64_sim_runner_14",
+)
+EOF
+}
+
+function do_ios_test() {
+  do_test ios "--test_output=all" "--spawn_strategy=local" "$@"
+}
+
+function test_ios_unit_test_pass() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test //ios:PassingUnitTest || fail "should pass"
+
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingUnitTest.xctest' passed"
+  expect_log "Executed 4 tests, with 0 failures"
+}
+
+run_suite "ios_unit_test with iOS 14.x test runner bundling tests"

--- a/test/starlark_tests/common.bzl
+++ b/test/starlark_tests/common.bzl
@@ -21,6 +21,12 @@ _fixture_tags = [
     "notap",
 ]
 
+# Tags that indicate this test is not supported in CI (e.g., required runtimes
+# are not available).
+_skip_ci_tags = [
+    "skipci",
+]
+
 # The current baseline for iOS is version 12.0, based on when the arm64e architecture was
 # introduced.
 _min_os_ios = struct(
@@ -60,4 +66,5 @@ common = struct(
     min_os_macos = _min_os_macos,
     min_os_tvos = _min_os_tvos,
     min_os_watchos = _min_os_watchos,
+    skip_ci_tags = _skip_ci_tags,
 )


### PR DESCRIPTION
Fixes an issue where the sanitizer dylib glob pattern is used in its raw form if no sanitizer dylibs are found during the test.  Using a bad path in `DYLD_INSERT_LIBRARIES` breaks iOS 14 simulators although newer versions appear to ignore it.

Without this fix, the added test attempts to load the glob string itself:

> dyld: could not load inserted library '<snip>/test_runner_work_dir.khFsCk/PassingUnitTestiOS14/PassingUnitTestiOS14.xctest/Frameworks/libclang_rt.*.dylib' because image not found

Bash globs will return the raw pattern if no matches are found, so I made sure the file exists before setting `DYLD_INSERT_LIBRARIES`.  I considered setting `shopt -s nullglob` but that could have side effects for other globs in the template.


------

Added `--test_tag_filters=-skipci` to presubmit so that this iOS 14 test can be skipped in CI.