### PR TITLE
Extend coverage to allow filtering of sources

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -216,6 +216,12 @@ Test filter string that will be passed into the test runner to select which test
 """,
         default = "",
     ),
+    "test_coverage_manifest": attr.label(
+        doc = """
+A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.
+""",
+        allow_single_file = True,
+    ),
 }
 
 def _common_binary_linking_attrs(deps_cfg, product_type):

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -103,10 +103,12 @@ This aspect propagates a `CoverageFilesInfo` provider.
     implementation = _coverage_files_aspect_impl,
 )
 
-def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None, test_filter = None):
+def _get_template_substitutions(test_type, test_bundle, test_environment, test_host = None, test_filter = None, test_coverage_manifest = None):
     """Dictionary with the substitutions to be applied to the template script."""
     subs = {}
 
+    if test_coverage_manifest:
+        subs["test_coverage_manifest"] = test_coverage_manifest.short_path
     if test_host:
         subs["test_host_path"] = test_host.short_path
     else:
@@ -146,6 +148,9 @@ def _apple_test_rule_impl(ctx, test_type):
     direct_runfiles = []
     transitive_runfiles = []
 
+    if ctx.file.test_coverage_manifest:
+        direct_runfiles.append(ctx.file.test_coverage_manifest)
+
     test_host_archive = test_bundle_target[AppleTestInfo].test_host
     if test_host_archive:
         direct_runfiles.append(test_host_archive)
@@ -177,6 +182,7 @@ def _apple_test_rule_impl(ctx, test_type):
             test_environment,
             test_host = test_host_archive,
             test_filter = ctx.attr.test_filter,
+            test_coverage_manifest = ctx.file.test_coverage_manifest,
         ),
         is_executable = True,
     )

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -254,7 +254,7 @@ xcrun llvm-profdata merge "$profraw" --output "$profdata"
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence="$ROOT,."
+  -path-equivalence=".,$PWD"
 )
 has_binary=false
 IFS=";"

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -251,12 +251,8 @@ fi
 readonly profdata="$TMP_DIR/coverage.profdata"
 xcrun llvm-profdata merge "$profraw" --output "$profdata"
 
-cp "$profdata" /tmp/coverage_manifest.profraw
-
-echo "ROOT: $ROOT"
-echo "PWD: $PWD"
 lcov_args=(
-  -instr-profile="$profdata"
+  -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
   -path-equivalence="$ROOT,."
 )
@@ -266,7 +262,6 @@ arch=$(uname -m)
 for binary in $TEST_BINARIES_FOR_LLVM_COV; do
   if [[ "$has_binary" == false ]]; then
     lcov_args+=("${binary}")
-    cp "${binary}" /tmp/test_binary
     has_binary=true
     if ! file "$binary" | grep -q "$arch"; then
       arch=x86_64

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -251,10 +251,14 @@ fi
 readonly profdata="$TMP_DIR/coverage.profdata"
 xcrun llvm-profdata merge "$profraw" --output "$profdata"
 
+cp "$profdata" /tmp/coverage_manifest.profraw
+
+echo "ROOT: $ROOT"
+echo "PWD: $PWD"
 lcov_args=(
-  -instr-profile "$profdata"
+  -instr-profile="$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence=.,"$PWD"
+  -path-equivalence="$ROOT,."
 )
 has_binary=false
 IFS=";"
@@ -262,6 +266,7 @@ arch=$(uname -m)
 for binary in $TEST_BINARIES_FOR_LLVM_COV; do
   if [[ "$has_binary" == false ]]; then
     lcov_args+=("${binary}")
+    cp "${binary}" /tmp/test_binary
     has_binary=true
     if ! file "$binary" | grep -q "$arch"; then
       arch=x86_64

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -210,7 +210,7 @@ xcrun llvm-profdata merge "$profraw" --output "$profdata"
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence="$ROOT,."
+  -path-equivalence=".,$PWD"
 )
 has_binary=false
 IFS=";"

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -210,7 +210,7 @@ xcrun llvm-profdata merge "$profraw" --output "$profdata"
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence=".,$PWD"
+  -path-equivalence="$ROOT,."
 )
 has_binary=false
 IFS=";"

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -162,7 +162,7 @@ llvm_cov_export_status=0
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence=.,"$PWD"
+  -path-equivalence="$ROOT,."
 )
 xcrun llvm-cov \
   export \

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -162,7 +162,7 @@ llvm_cov_export_status=0
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence="$ROOT",.
+  -path-equivalence=".,$PWD"
 )
 xcrun llvm-cov \
   export \

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -162,7 +162,7 @@ llvm_cov_export_status=0
 lcov_args=(
   -instr-profile "$profdata"
   -ignore-filename-regex='.*external/.+'
-  -path-equivalence="$ROOT,."
+  -path-equivalence="$ROOT",.
 )
 xcrun llvm-cov \
   export \

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -535,7 +535,8 @@ Outputs:
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>,
+            <a href="#ios_ui_test-test_host">test_host</a>)
 </pre>
 
 iOS UI Test rule.
@@ -566,6 +567,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_ui_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="ios_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
@@ -575,7 +577,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>,
+              <a href="#ios_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -611,6 +614,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="ios_unit_test-platform_type"></a>platform_type |  -   | String | optional | "ios" |
 | <a id="ios_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="ios_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="ios_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="ios_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -406,7 +406,8 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>,
+              <a href="#macos_ui_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -427,6 +428,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="macos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="macos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
@@ -436,7 +438,8 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>)
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>,
+                <a href="#macos_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -463,6 +466,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="macos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "macos" |
 | <a id="macos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="macos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="macos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="macos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -308,7 +308,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>,
+             <a href="#tvos_ui_test-test_host">test_host</a>)
 </pre>
 
 
@@ -335,6 +336,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="tvos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="tvos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
@@ -344,7 +346,8 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>,
+               <a href="#tvos_unit_test-test_host">test_host</a>)
 </pre>
 
 
@@ -379,6 +382,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="tvos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "tvos" |
 | <a id="tvos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="tvos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="tvos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="tvos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -266,7 +266,8 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>,
+                <a href="#watchos_ui_test-test_host">test_host</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -282,6 +283,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_ui_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="watchos_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="watchos_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 
@@ -291,7 +293,8 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>,
+                  <a href="#watchos_unit_test-test_host">test_host</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -307,6 +310,7 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 | <a id="watchos_unit_test-platform_type"></a>platform_type |  -   | String | optional | "watchos" |
 | <a id="watchos_unit_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="watchos_unit_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="watchos_unit_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | "" |
 | <a id="watchos_unit_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 

--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//apple:ios.bzl", "ios_application")
+load("//apple:ios.bzl", "ios_application", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 licenses(["notice"])
@@ -12,6 +12,40 @@ swift_library(
     data = [
         "Resources/Main.storyboard",
     ],
+    module_name = "Sources",
+)
+
+swift_library(
+    name = "Tests",
+    testonly = True,
+    srcs = [
+        "Tests/Tests.swift",
+    ],
+    deps = [
+        ":Sources",
+    ],
+)
+
+ios_unit_test(
+    name = "UnitTests",
+    minimum_os_version = "8.0",
+    deps = [":Tests"],
+)
+
+genrule(
+    name = "CreateTestCoverageManifest",
+    srcs = ["Sources/AppDelegate.swift"],
+    outs = [
+        "CoverageManifest.instrumented_files",
+    ],
+    cmd = "echo $(SRCS) > $@",
+)
+
+ios_unit_test(
+    name = "UnitTestsWithCoverageManifest",
+    minimum_os_version = "15.0",
+    test_coverage_manifest = "CoverageManifest.instrumented_files",
+    deps = [":Tests"],
 )
 
 ios_application(

--- a/examples/ios/HelloWorldSwift/Tests/Tests.swift
+++ b/examples/ios/HelloWorldSwift/Tests/Tests.swift
@@ -1,0 +1,8 @@
+@testable import Sources
+import XCTest
+
+final class HelloWorldSwiftTests: XCTestCase {
+    func testInit() {
+        XCTAssertNotNil(AppDelegate())
+    }
+}

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -183,13 +183,12 @@ function test_standalone_unit_test_coverage_json() {
       grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
 }
 
-# ME: I am not sure why this does not work yet a very similar setup in examples/ios/HelloWorldSwift/BUILD does work
-# function test_standalone_unit_test_coverage_coverage_manifest() {
-#   create_common_files
-#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true //app:coverage_manifest_test || fail "Should build"
-#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
-#   assert_contains "SF:./app/StandaloneTest.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
-# }
+function test_standalone_unit_test_coverage_coverage_manifest() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true //app:coverage_manifest_test || fail "Should build"
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+  assert_contains "SF:./app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+}
 
 function test_hosted_unit_test_coverage() {
   create_common_files

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -170,42 +170,40 @@ ios_unit_test(
 EOF
 }
 
-# function test_standalone_unit_test_coverage() {
-#   create_common_files
-#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
-#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
-# }
+function test_standalone_unit_test_coverage() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
+}
 
-# function test_standalone_unit_test_coverage_json() {
-#   create_common_files
-#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
-#   unzip_single_file "test-testlogs/app/standalone_test/test.outputs/outputs.zip" coverage.json \
-#       grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
-# }
+function test_standalone_unit_test_coverage_json() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
+  unzip_single_file "test-testlogs/app/standalone_test/test.outputs/outputs.zip" coverage.json \
+      grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
+}
 
 function test_standalone_unit_test_coverage_coverage_manifest() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true --spawn_strategy=local --sandbox_debug //app:coverage_manifest_test || fail "Should build"
-  echo "test_standalone_unit_test_coverage_coverage_manifest"
-  cat "test-testlogs/app/coverage_manifest_test/test.log"
-  cat "test-testlogs/app/coverage_manifest_test/coverage.dat"
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+  assert_contains "SF:./app/StandaloneTest.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
 }
 
-# function test_hosted_unit_test_coverage() {
-#   create_common_files
-#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
+function test_hosted_unit_test_coverage() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
 
-#   # Validate normal coverage is included
-#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"
-#   # Validate coverage for the hosting binary is included
-#   assert_contains "FN:3,foo" "test-testlogs/app/hosted_test/coverage.dat"
+  # Validate normal coverage is included
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"
+  # Validate coverage for the hosting binary is included
+  assert_contains "FN:3,foo" "test-testlogs/app/hosted_test/coverage.dat"
 
-#   # Validate that the symbol called from the hosted binary exists and is undefined
-#   unzip_single_file \
-#     "test-bin/app/hosted_test.runfiles/build_bazel_rules_apple_integration_tests/app/hosted_test.zip" \
-#     "hosted_test.xctest/hosted_test" \
-#     nm -u - | grep foo || fail "Undefined 'foo' symbol not found"
-# }
+  # Validate that the symbol called from the hosted binary exists and is undefined
+  unzip_single_file \
+    "test-bin/app/hosted_test.runfiles/build_bazel_rules_apple_integration_tests/app/hosted_test.zip" \
+    "hosted_test.xctest/hosted_test" \
+    nm -u - | grep foo || fail "Undefined 'foo' symbol not found"
+}
 
 run_suite "ios coverage tests"

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -183,13 +183,13 @@ function test_standalone_unit_test_coverage_json() {
       grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
 }
 
-function test_standalone_unit_test_coverage_coverage_manifest() {
-  create_common_files
-  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true //app:coverage_manifest_test || fail "Should build"
-  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
-  # ME: I am not sure why this does not work yet a very similar setup in examples/ios/HelloWorldSwift/BUILD does work
-  assert_contains "SF:./app/StandaloneTest.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
-}
+# ME: I am not sure why this does not work yet a very similar setup in examples/ios/HelloWorldSwift/BUILD does work
+# function test_standalone_unit_test_coverage_coverage_manifest() {
+#   create_common_files
+#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true //app:coverage_manifest_test || fail "Should build"
+#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+#   assert_contains "SF:./app/StandaloneTest.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+# }
 
 function test_hosted_unit_test_coverage() {
   create_common_files

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -134,7 +134,7 @@ EOF
 EOF
 
   cat > app/coverage_manifest.txt <<EOF
-./app/SharedLogic.m
+app/SharedLogic.m
 EOF
 
   cat >> app/BUILD <<EOF

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -185,8 +185,9 @@ function test_standalone_unit_test_coverage_json() {
 
 function test_standalone_unit_test_coverage_coverage_manifest() {
   create_common_files
-  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true --spawn_strategy=local --sandbox_debug //app:coverage_manifest_test || fail "Should build"
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true //app:coverage_manifest_test || fail "Should build"
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+  # ME: I am not sure why this does not work yet a very similar setup in examples/ios/HelloWorldSwift/BUILD does work
   assert_contains "SF:./app/StandaloneTest.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
 }
 

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -133,6 +133,10 @@ EOF
 }
 EOF
 
+  cat > app/coverage_manifest.txt <<EOF
+./app/SharedLogic.m
+EOF
+
   cat >> app/BUILD <<EOF
 ios_application(
     name = "app",
@@ -156,37 +160,52 @@ ios_unit_test(
     deps = [":standalone_test_lib"],
     minimum_os_version = "${MIN_OS_IOS}",
 )
+
+ios_unit_test(
+    name = "coverage_manifest_test",
+    deps = [":standalone_test_lib"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    test_coverage_manifest = "coverage_manifest.txt"
+)
 EOF
 }
 
-function test_standalone_unit_test_coverage() {
-  create_common_files
-  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
+# function test_standalone_unit_test_coverage() {
+#   create_common_files
+#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:standalone_test || fail "Should build"
+#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
+# }
 
-  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/standalone_test/coverage.dat"
+# function test_standalone_unit_test_coverage_json() {
+#   create_common_files
+#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
+#   unzip_single_file "test-testlogs/app/standalone_test/test.outputs/outputs.zip" coverage.json \
+#       grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
+# }
+
+function test_standalone_unit_test_coverage_coverage_manifest() {
+  create_common_files
+  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true --spawn_strategy=local --sandbox_debug //app:coverage_manifest_test || fail "Should build"
+  echo "test_standalone_unit_test_coverage_coverage_manifest"
+  cat "test-testlogs/app/coverage_manifest_test/test.log"
+  cat "test-testlogs/app/coverage_manifest_test/coverage.dat"
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
 }
 
-function test_standalone_unit_test_coverage_json() {
-  create_common_files
-  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap --test_env=COVERAGE_PRODUCE_JSON=1 //app:standalone_test || fail "Should build"
-  unzip_single_file "test-testlogs/app/standalone_test/test.outputs/outputs.zip" coverage.json \
-      grep '"name":"SharedLogic.m:-\[SharedLogic doSomething\]"'
-}
+# function test_hosted_unit_test_coverage() {
+#   create_common_files
+#   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
 
-function test_hosted_unit_test_coverage() {
-  create_common_files
-  do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"
+#   # Validate normal coverage is included
+#   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"
+#   # Validate coverage for the hosting binary is included
+#   assert_contains "FN:3,foo" "test-testlogs/app/hosted_test/coverage.dat"
 
-  # Validate normal coverage is included
-  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/hosted_test/coverage.dat"
-  # Validate coverage for the hosting binary is included
-  assert_contains "FN:3,foo" "test-testlogs/app/hosted_test/coverage.dat"
-
-  # Validate that the symbol called from the hosted binary exists and is undefined
-  unzip_single_file \
-    "test-bin/app/hosted_test.runfiles/build_bazel_rules_apple_integration_tests/app/hosted_test.zip" \
-    "hosted_test.xctest/hosted_test" \
-    nm -u - | grep foo || fail "Undefined 'foo' symbol not found"
-}
+#   # Validate that the symbol called from the hosted binary exists and is undefined
+#   unzip_single_file \
+#     "test-bin/app/hosted_test.runfiles/build_bazel_rules_apple_integration_tests/app/hosted_test.zip" \
+#     "hosted_test.xctest/hosted_test" \
+#     nm -u - | grep foo || fail "Undefined 'foo' symbol not found"
+# }
 
 run_suite "ios coverage tests"


### PR DESCRIPTION
Allows users to provide a custom coverage manifest file to allow for
more precise filtering of sources in llvm coverage invocations.

Related #1759 