### PR TITLE
Fix env vars with xctestrun runner

### DIFF
--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -16,12 +16,14 @@ objc_library(
 
 ios_unit_test(
     name = "SquarerTests",
+    env = {"TEST_ENV_VAR": "test_value"},
     minimum_os_version = "8.0",
     deps = [":SquarerTestsLib"],
 )
 
 ios_unit_test(
     name = "SquarerTestsOrdered",
+    env = {"TEST_ENV_VAR": "test_value"},
     minimum_os_version = "8.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     deps = [":SquarerTestsLib"],
@@ -29,6 +31,7 @@ ios_unit_test(
 
 ios_unit_test(
     name = "SquarerTestsRandom",
+    env = {"TEST_ENV_VAR": "test_value"},
     minimum_os_version = "8.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":SquarerTestsLib"],

--- a/examples/ios/Squarer/Tests/SquarerTests.m
+++ b/examples/ios/Squarer/Tests/SquarerTests.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 #import "examples/ios/Squarer/Sources/Squarer.h"
@@ -24,6 +25,16 @@
 - (void)testNumberIsSquared {
   Squarer *squarer = [[Squarer alloc] init];
   XCTAssertEqual(49, [squarer squareInteger:7], @"Number should be squared");
+}
+
+- (void)testEnvIsSet {
+  XCTAssertNotNil([[NSProcessInfo processInfo] environment][@"TEST_ENV_VAR"],
+                  @"TEST_ENV_VAR should be set");
+}
+
+- (void)testSrcdirEnv {
+  XCTAssertNotNil([[NSProcessInfo processInfo] environment][@"TEST_SRCDIR"],
+                  @"TEST_SRCDIR should be set");
 }
 
 @end


### PR DESCRIPTION
These were missing when not using xctestrun files. It was also missing
TEST_SRCDIR

Fixes https://github.com/bazelbuild/rules_apple/issues/1825
