### PR TITLE
Exclude test target source files from generated coverage report

### DIFF
--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -69,9 +69,9 @@ def _coverage_files_aspect_impl(target, ctx):
     if AppleBundleInfo in target and target[AppleBundleInfo].binary:
         if "exclude_test_target_coverage" not in ctx.features:
             direct_binaries.append(target[AppleBundleInfo].binary)
-        else:
-            if AppleTestInfo not in target:
-                direct_binaries.append(target[AppleBundleInfo].binary)
+        elif AppleTestInfo not in target:
+            direct_binaries.append(target[AppleBundleInfo].binary)
+
     # Collect dependencies coverage files.
     for dep in getattr(ctx.rule.attr, "deps", []):
         coverage_files.append(dep[CoverageFilesInfo].coverage_files)

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -67,8 +67,11 @@ def _coverage_files_aspect_impl(target, ctx):
     direct_binaries = []
     transitive_binaries_sets = []
     if AppleBundleInfo in target and target[AppleBundleInfo].binary:
-        direct_binaries.append(target[AppleBundleInfo].binary)
-
+        if "exclude_test_target_coverage" not in ctx.features:
+            direct_binaries.append(target[AppleBundleInfo].binary)
+        else:
+            if AppleTestInfo not in target:
+                direct_binaries.append(target[AppleBundleInfo].binary)
     # Collect dependencies coverage files.
     for dep in getattr(ctx.rule.attr, "deps", []):
         coverage_files.append(dep[CoverageFilesInfo].coverage_files)
@@ -78,8 +81,9 @@ def _coverage_files_aspect_impl(target, ctx):
         transitive_binaries_sets.append(fmwk[CoverageFilesInfo].covered_binaries)
 
     if hasattr(ctx.rule.attr, "test_host") and ctx.rule.attr.test_host:
-        coverage_files.append(ctx.rule.attr.test_host[CoverageFilesInfo].coverage_files)
-        transitive_binaries_sets.append(ctx.rule.attr.test_host[CoverageFilesInfo].covered_binaries)
+        if "exclude_test_target_coverage" not in ctx.features:
+            coverage_files.append(ctx.rule.attr.test_host[CoverageFilesInfo].coverage_files)
+            transitive_binaries_sets.append(ctx.rule.attr.test_host[CoverageFilesInfo].covered_binaries)
 
     return [
         CoverageFilesInfo(


### PR DESCRIPTION
When the `bazel coverage` command is run on an `ios_unit_test` target, the source files for the test target are included in the coverage report by default. That is not the desired behavior if you only want the coverage for what is being tested. This PR adds a feature`exclude_test_target_coverage` that if passed, the files from the test target itself will be excluded from the generated coverage report. This also is applied to any files present in test_host.