### PR TITLE
Upgrade rules_swift to 1.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", version = "1.4.1", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_swift", version = "1.5.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "1.6.0", repo_name = "build_bazel_rules_swift")
 
 non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
 use_repo(

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -125,9 +125,9 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
             http_archive,
             name = "build_bazel_rules_swift",
             urls = [
-                "https://github.com/bazelbuild/rules_swift/releases/download/1.5.0/rules_swift.1.5.0.tar.gz",
+                "https://github.com/bazelbuild/rules_swift/releases/download/1.6.0/rules_swift.1.6.0.tar.gz",
             ],
-            sha256 = "32f95dbe6a88eb298aaa790f05065434f32a662c65ec0a6aabdaf6881e4f169f",
+            sha256 = "d25a3f11829d321e0afb78b17a06902321c27b83376b31e3481f0869c28e1660",
             ignore_version_differences = ignore_version_differences,
         )
 


### PR DESCRIPTION
We want the newer version in `MODULE.bazel` because of the bug fix with index-import.