### PR TITLE
Add data attribute to apple_static_{framework,xcframework}_import rules

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -305,11 +305,9 @@ def _apple_static_framework_import_impl(ctx):
     # TODO(b/207475773): Remove grep-includes once it's no longer required for cc_common APIs.
     grep_includes = ctx.file._grep_includes
 
-    providers = []
-
-    # Create DefaultInfo provider
-    default_info_provider = DefaultInfo(runfiles = ctx.runfiles(files = ctx.files.data))
-    providers.append(default_info_provider)
+    providers = [
+        DefaultInfo(runfiles = ctx.runfiles(files = ctx.files.data)),
+    ]
 
     framework_imports_by_category = framework_import_support.classify_framework_imports(
         ctx.var,

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -23,10 +23,6 @@ load(
     "dicts",
 )
 load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
@@ -39,12 +35,12 @@ load(
     "AppleFrameworkImportInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
-    "cc_toolchain_info_support",
+    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
+    "AppleFrameworkImportBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
-    "resources",
+    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
+    "cc_toolchain_info_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
@@ -310,6 +306,11 @@ def _apple_static_framework_import_impl(ctx):
     grep_includes = ctx.file._grep_includes
 
     providers = []
+
+    # Create DefaultInfo provider
+    default_info_provider = DefaultInfo(runfiles = ctx.runfiles(files = ctx.files.data))
+    providers.append(default_info_provider)
+
     framework_imports_by_category = framework_import_support.classify_framework_imports(
         ctx.var,
         framework_imports,
@@ -395,20 +396,10 @@ def _apple_static_framework_import_impl(ctx):
     if swift_interop_info:
         providers.append(swift_interop_info)
 
-    # Create AppleResourceInfo provider.
+    # Create AppleFrameworkImportBundleInfo provider.
     bundle_files = [x for x in framework_imports if ".bundle/" in x.short_path]
     if bundle_files:
-        parent_dir_param = partial.make(
-            resources.bundle_relative_parent_dir,
-            extension = "bundle",
-        )
-        resource_provider = resources.bucketize_typed(
-            bundle_files,
-            owner = str(label),
-            bucket_type = "unprocessed",
-            parent_dir_param = parent_dir_param,
-        )
-        providers.append(resource_provider)
+        providers.append(AppleFrameworkImportBundleInfo(bundle_files = bundle_files))
 
     return providers
 
@@ -531,6 +522,16 @@ linked into that target.
                     [apple_common.Objc, CcInfo],
                     [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
                 ],
+            ),
+            "data": attr.label_list(
+                allow_files = True,
+                doc = """
+List of files needed by this target at runtime.
+
+Files and targets named in the `data` attribute will appear in the `*.runfiles`
+area of this target, if it has one. This may include data files needed by a
+binary or library, or other programs needed by it.
+""",
             ),
             "alwayslink": attr.bool(
                 default = False,

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -511,14 +511,12 @@ def _apple_static_xcframework_import_impl(ctx):
         xcode_config = xcode_config,
     )
 
-    providers = []
-
-    # Create DefaultInfo provider
-    default_info_provider = DefaultInfo(
-        files = depset(xcframework_imports),
-        runfiles = ctx.runfiles(files = ctx.files.data),
-    )
-    providers.append(default_info_provider)
+    providers = [
+        DefaultInfo(
+            files = depset(xcframework_imports),
+            runfiles = ctx.runfiles(files = ctx.files.data),
+        ),
+    ]
 
     fields = {}
     if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:

--- a/apple/internal/providers/framework_import_bundle_info.bzl
+++ b/apple/internal/providers/framework_import_bundle_info.bzl
@@ -1,0 +1,24 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AppleFrameworkImportBundleInfo provider implementation for framework .bundle/ propagation."""
+
+AppleFrameworkImportBundleInfo = provider(
+    doc = "Provider that propagates information about .bundle/ directories of framework import targets.",
+    fields = {
+        "bundle_files": """
+List of Files that represent .bundle/ directories inside the framework. 
+""",
+    },
+)

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -92,8 +92,8 @@ objc_library(
 ## apple_static_framework_import
 
 <pre>
-apple_static_framework_import(<a href="#apple_static_framework_import-name">name</a>, <a href="#apple_static_framework_import-alwayslink">alwayslink</a>, <a href="#apple_static_framework_import-deps">deps</a>, <a href="#apple_static_framework_import-framework_imports">framework_imports</a>, <a href="#apple_static_framework_import-has_swift">has_swift</a>, <a href="#apple_static_framework_import-sdk_dylibs">sdk_dylibs</a>,
-                              <a href="#apple_static_framework_import-sdk_frameworks">sdk_frameworks</a>, <a href="#apple_static_framework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>)
+apple_static_framework_import(<a href="#apple_static_framework_import-name">name</a>, <a href="#apple_static_framework_import-alwayslink">alwayslink</a>, <a href="#apple_static_framework_import-data">data</a>, <a href="#apple_static_framework_import-deps">deps</a>, <a href="#apple_static_framework_import-framework_imports">framework_imports</a>, <a href="#apple_static_framework_import-has_swift">has_swift</a>,
+                              <a href="#apple_static_framework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_framework_import-sdk_frameworks">sdk_frameworks</a>, <a href="#apple_static_framework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>)
 </pre>
 
 
@@ -125,6 +125,7 @@ objc_library(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="apple_static_framework_import-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="apple_static_framework_import-alwayslink"></a>alwayslink |  If true, any binary that depends (directly or indirectly) on this framework will link in all the object files for the framework file, even if some contain no symbols referenced by the binary. This is useful if your code isn't explicitly called by code in the binary; for example, if you rely on runtime checks for protocol conformances added in extensions in the library but do not directly reference any other symbols in the object file that adds that conformance.   | Boolean | optional | False |
+| <a id="apple_static_framework_import-data"></a>data |  List of files needed by this target at runtime.<br><br>Files and targets named in the <code>data</code> attribute will appear in the <code>*.runfiles</code> area of this target, if it has one. This may include data files needed by a binary or library, or other programs needed by it.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
 | <a id="apple_static_framework_import-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will provide headers and be linked into that target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
 | <a id="apple_static_framework_import-framework_imports"></a>framework_imports |  The list of files under a .framework directory which are provided to Apple based targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="apple_static_framework_import-has_swift"></a>has_swift |  A boolean indicating if the target has Swift source code. This helps flag frameworks that do not include Swift interface files but require linking the Swift libraries.   | Boolean | optional | False |
@@ -198,9 +199,9 @@ Generates an XCFramework with static libraries for third-party distribution.
 ## apple_static_xcframework_import
 
 <pre>
-apple_static_xcframework_import(<a href="#apple_static_xcframework_import-name">name</a>, <a href="#apple_static_xcframework_import-alwayslink">alwayslink</a>, <a href="#apple_static_xcframework_import-deps">deps</a>, <a href="#apple_static_xcframework_import-has_swift">has_swift</a>, <a href="#apple_static_xcframework_import-includes">includes</a>, <a href="#apple_static_xcframework_import-library_identifiers">library_identifiers</a>,
-                                <a href="#apple_static_xcframework_import-linkopts">linkopts</a>, <a href="#apple_static_xcframework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_xcframework_import-sdk_frameworks">sdk_frameworks</a>, <a href="#apple_static_xcframework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>,
-                                <a href="#apple_static_xcframework_import-xcframework_imports">xcframework_imports</a>)
+apple_static_xcframework_import(<a href="#apple_static_xcframework_import-name">name</a>, <a href="#apple_static_xcframework_import-alwayslink">alwayslink</a>, <a href="#apple_static_xcframework_import-data">data</a>, <a href="#apple_static_xcframework_import-deps">deps</a>, <a href="#apple_static_xcframework_import-has_swift">has_swift</a>, <a href="#apple_static_xcframework_import-includes">includes</a>,
+                                <a href="#apple_static_xcframework_import-library_identifiers">library_identifiers</a>, <a href="#apple_static_xcframework_import-linkopts">linkopts</a>, <a href="#apple_static_xcframework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_xcframework_import-sdk_frameworks">sdk_frameworks</a>,
+                                <a href="#apple_static_xcframework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#apple_static_xcframework_import-xcframework_imports">xcframework_imports</a>)
 </pre>
 
 
@@ -232,6 +233,7 @@ objc_library(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="apple_static_xcframework_import-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="apple_static_xcframework_import-alwayslink"></a>alwayslink |  If true, any binary that depends (directly or indirectly) on this XCFramework will link in all the object files for the XCFramework bundle, even if some contain no symbols referenced by the binary. This is useful if your code isn't explicitly called by code in the binary; for example, if you rely on runtime checks for protocol conformances added in extensions in the library but do not directly reference any other symbols in the object file that adds that conformance.   | Boolean | optional | False |
+| <a id="apple_static_xcframework_import-data"></a>data |  List of files needed by this target at runtime.<br><br>Files and targets named in the <code>data</code> attribute will appear in the <code>*.runfiles</code> area of this target, if it has one. This may include data files needed by a binary or library, or other programs needed by it.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
 | <a id="apple_static_xcframework_import-deps"></a>deps |  List of targets that are dependencies of the target being built, which will provide headers and be linked into that target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
 | <a id="apple_static_xcframework_import-has_swift"></a>has_swift |  A boolean indicating if the target has Swift source code. This helps flag XCFrameworks that do not include Swift interface files.   | Boolean | optional | False |
 | <a id="apple_static_xcframework_import-includes"></a>includes |  List of <code>#include/#import</code> search paths to add to this target and all depending targets.<br><br>The paths are interpreted relative to the single platform directory inside the XCFramework for the platform being built.<br><br>These flags are added for this rule and every rule that depends on it. (Note: not the rules it depends upon!) Be very careful, since this may have far-reaching effects.   | List of strings | optional | [] |

--- a/test/starlark_tests/apple_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_import_tests.bzl
@@ -118,6 +118,21 @@ def apple_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify ios_application with static XCFramework that has data attribute
+    # bundles the framework's data in the final binary.
+    archive_contents_test(
+        name = "{}_static_xcfw_with_bundle_resources_and_data".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcfmwk_bundling_resources_and_data",
+        contains = [
+            "$BUNDLE_ROOT/sample.png",
+            "$BUNDLE_ROOT/it.lproj/view_ios.nib",
+            "$BUNDLE_ROOT/fr.lproj/view_ios.nib",
+            "$BUNDLE_ROOT/resource_bundle.bundle/",
+        ],
+        tags = [name],
+    )
+
     analysis_target_outputs_test(
         name = "{}_static_xcfw_import_with_lib_ids_ipa_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_xcfmwk_with_lib_ids",

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -201,6 +201,21 @@ def ios_application_test_suite(name):
         tags = [name],
     )
 
+    # Verify ios_application with imported static framework that has data attribute
+    # bundles the framework's own .bundle/ and its data resources in the final binary.
+    archive_contents_test(
+        name = "{}_swift_with_imported_static_fmwk_with_bundle_and_data".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_with_imported_static_fmwk_with_data",
+        contains = [
+            "$BUNDLE_ROOT/sample.png",
+            "$BUNDLE_ROOT/it.lproj/view_ios.nib",
+            "$BUNDLE_ROOT/fr.lproj/view_ios.nib",
+            "$BUNDLE_ROOT/iOSStaticFramework.bundle/",
+        ],
+        tags = [name],
+    )
+
     apple_verification_test(
         name = "{}_fmwk_with_imported_fmwk_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1194,11 +1194,15 @@ apple_static_framework_import(
 )
 
 apple_static_framework_import(
+    name = "iOSImportedStaticFrameworkWithData",
+    data = ["//test/starlark_tests/resources:sample.png"],
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSSwiftStaticFramework"],
+)
+
+apple_static_framework_import(
     name = "iOSImportedStaticFrameworkWithDataAndBundle",
-    data = [
-        "//test/starlark_tests/resources:localized_xibs_ios",
-        "//test/starlark_tests/resources:sample.png",
-    ],
+    data = ["//test/starlark_tests/resources:localized_xibs_ios"],
     features = ["-swift.layering_check"],
     framework_imports = ["//test/testdata/fmwk:iOSStaticFramework"],
 )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -906,6 +906,16 @@ apple_static_xcframework_import(
     xcframework_imports = [":generated_ios_static_xcframework_with_resources"],
 )
 
+apple_static_xcframework_import(
+    name = "ios_static_xcframework_with_resources_and_data",
+    data = [
+        "//test/starlark_tests/resources:localized_xibs_ios",
+        "//test/starlark_tests/resources:sample.png",
+    ],
+    tags = ["manual"],
+    xcframework_imports = [":generated_ios_static_xcframework_with_resources"],
+)
+
 apple_static_xcframework(
     name = "ios_xcframework_bundling_static_fmwks",
     ios = {
@@ -1179,6 +1189,16 @@ apple_dynamic_framework_import(
 
 apple_static_framework_import(
     name = "iOSImportedStaticFramework",
+    features = ["-swift.layering_check"],
+    framework_imports = ["//test/testdata/fmwk:iOSStaticFramework"],
+)
+
+apple_static_framework_import(
+    name = "iOSImportedStaticFrameworkWithDataAndBundle",
+    data = [
+        "//test/starlark_tests/resources:localized_xibs_ios",
+        "//test/starlark_tests/resources:sample.png",
+    ],
     features = ["-swift.layering_check"],
     framework_imports = ["//test/testdata/fmwk:iOSStaticFramework"],
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2037,6 +2037,7 @@ ios_application(
     tags = common.fixture_tags,
     deps = [
         "//test/starlark_tests/resources:swift_main_lib",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFrameworkWithData",
         "//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFrameworkWithDataAndBundle",
     ],
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2022,6 +2022,25 @@ EOF
 """,
 )
 
+# Swift app with imported Swift static framework with data attribute
+ios_application(
+    name = "swift_app_with_imported_static_fmwk_with_data",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_main_lib",
+        "//test/starlark_tests/targets_under_test/apple:iOSImportedStaticFrameworkWithDataAndBundle",
+    ],
+)
+
 # ---------------------------------------------------------------------------------------
 # Targets for Apple static XCFramework import tests.
 
@@ -3441,6 +3460,25 @@ ios_application(
     deps = [
         "//test/starlark_tests/resources:objc_main_lib",
         "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_with_resources_import",
+    ],
+)
+
+ios_application(
+    name = "app_with_imported_xcfmwk_bundling_resources_and_data",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+        "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_with_resources_and_data",
     ],
 )
 


### PR DESCRIPTION
This diff adds the `data` attribute to `apple_static_framework_import` and `apple_static_xcframework_imports` rules. 

Follow up from https://github.com/bazelbuild/rules_apple/pull/869#issuecomment-1438473570.

The new attribute works very similarly to objc_library/swift_library's data: it's a list of resource targets that will be bundled together in the final binary.

### Example:

```python
apple_static_xcframework_import(
    name = "Appboy_iOS_SDK",
    xcframework_imports = glob(["Appboy-iOS-SDK/Frameworks/Appboy_iOS_SDK.xcframework/**"]),
    data = [
        ":AppboyResourceBundle",
        ":AppboyResourceFiles",
    ],
)

apple_bundle_import(
    name = "AppboyResourceBundle",
    bundle_imports = glob(["Appboy-iOS-SDK/AppboyKit/Appboy.bundle/**"]),
)

apple_resource_group(
    name = "AppboyResourceFiles",
    resources = glob([
        "Appboy-iOS-SDK/AppboyUI/**/*.strings",
        "Appboy-iOS-SDK/AppboyUI/**/*.storyboard",
    ]),
)
```

### Why?

The previous implementation of these rules only allowed for `.bundle/` resource files when mixed together with `framework_imports`. This behavior limits use cases because:

1 - Vendors can distribute resources without .bundle packages;
2 - Resources for static libraries don't need to be inside the .framework directory, since they will end up in the root of the binary target anyway.

### Implementation

At first, I had thought that only adding the names of the rules to `resource_aspect.bzl` would be enough, but both rules add `AppleResourceInfo` when `.bundle/` files are present inside `framework_imports`, which blocks the aspect from collecting the resources from `data`. It wouldn't be possible to use both `data` and .bundle/** logic of `framerwork_imports` at the same time.

In order to support both attributes, `AppleResourceInfo` was replaced with `AppleFrameworkImportBundleInfo`, which is a new internal provider that `resource_aspect.bzl` will use to collect .bundle/** files from `framework_imports`.

I'm new to Bazel so let me know if you have any suggestions. Thanks!