### PR TITLE
Use new toolchain in tests

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -465,6 +465,9 @@ function do_action() {
       "--incompatible_merge_genfiles_directory"
       # TODO: Fix the tests that fail with this flag and remove this.
       "--incompatible_unambiguous_label_stringification=false"
+      "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
+      "--crosstool_top=@local_config_apple_cc//:toolchain"
+      "--host_crosstool_top=@local_config_apple_cc//:toolchain"
   )
 
   local bazel_version="$(bazel --version)"

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -112,6 +112,13 @@ load(
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
 EOF
 }
 


### PR DESCRIPTION
I thought doing this in the root bazelrc was enough but it's not
