### PR TITLE
Introduce experimental binary linking Starlark API.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -299,6 +299,8 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
+        ":cc_toolchain_info_support",
+        ":entitlements_support",
         ":rule_support",
         "@bazel_skylib//lib:collections",
         "@build_bazel_apple_support//lib:lipo",

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -19,6 +19,10 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
+    "cc_toolchain_info_support",
+)
 
 def _debug_outputs_by_architecture(link_outputs):
     """Returns debug outputs indexed by architecture from `register_binary_linking_action` output.
@@ -279,8 +283,142 @@ def _lipo_or_symlink_inputs(actions, inputs, output, apple_fragment, xcode_confi
         # Symlink if there was only a single architecture created; it's faster.
         actions.symlink(target_file = inputs[0], output = output)
 
+def _link_multi_arch_binary(
+        *,
+        actions,
+        additional_inputs = [],
+        cc_toolchains,
+        ctx,
+        deps,
+        disabled_features,
+        features,
+        grep_includes = None,
+        label,
+        stamp = -1,
+        user_link_flags = []):
+    """Experimental Starlark version of multiple architecture binary linking action.
+
+    This Stalark version is an experimental re-write of the apple_common.link_multi_arch_binary API
+    with minimal support for linking multiple architecture binaries from split dependencies.
+
+    Specifically, this lacks support for:
+        - Generating Apple DSYMs binaries.
+        - Generating Apple bitcode symbols.
+        - Generating Objective-C linkmaps.
+        - Avoid linking Objective-C(++) dependencies symbols (ie. avoid_deps).
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        additional_inputs: List of additional `File`s required for the C++ linking action (e.g.
+            linking scripts).
+        cc_toolchains: Dictionary of targets (`ctx.split_attr`) containing CcToolchainInfo
+            providers to use for C++ actions.
+        ctx: The Starlark context for a rule target being built.
+        deps: Dictionary of targets (`ctx.split_attr`) referencing dependencies for a given target
+            to retrieve transitive CcInfo providers for C++ linking action.
+        disabled_features: List of features to be disabled for C++ actions.
+        features: List of features to be enabled for C++ actions.
+        grep_includes: File reference to grep_includes binary required by cc_common APIs.
+        label: Label for the current target (`ctx.label`).
+        stamp: Boolean to indicate whether to include build information in the linked binary.
+            If 1, build information is always included.
+            If 0, the default build information is always excluded.
+            If -1, uses the default behavior, which may be overridden by the --[no]stamp flag.
+            This should be set to 0 when generating the executable output for test rules.
+        user_link_flags: List of `str` user link flags to add to the C++ linking action.
+    Returns:
+        A struct containing the following information:
+            - cc_info: Merged CcInfo providers from each linked binary CcInfo provider.
+            - output_groups: OutputGroupInfo provider with CcInfo validation artifacts.
+            - outputs: List of `struct`s containing the linking output information below.
+                - architecture: The target Apple architecture.
+                - binary: `File` referencing the linked binary.
+                - environment: The target Apple environment.
+                - platform: The target Apple platform/os.
+    """
+    if type(deps) != "dict" or type(cc_toolchains) != "dict":
+        fail(
+            "Expected deps and cc_toolchains to be split attributes (dictionaries).\n",
+            "deps: %s\n" % deps,
+            "cc_toolchains: %s" % cc_toolchains,
+        )
+
+    if deps.keys() != cc_toolchains.keys():
+        fail(
+            "Expected deps and cc_toolchains split attribute keys to match",
+            "deps: %s\n" % deps.keys(),
+            "cc_toolchains: %s\n" % cc_toolchains.keys(),
+        )
+
+    all_cc_infos = []
+    linking_outputs = []
+    validation_artifacts = []
+    for split_attr_key, cc_toolchain_target in cc_toolchains.items():
+        cc_toolchain = cc_toolchain_target[cc_common.CcToolchainInfo]
+        target_triple = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
+
+        feature_configuration = cc_common.configure_features(
+            cc_toolchain = cc_toolchain,
+            ctx = ctx,
+            language = "objc",
+            requested_features = features,
+            unsupported_features = disabled_features,
+        )
+
+        cc_infos = [
+            dep[CcInfo]
+            for dep in deps[split_attr_key]
+            if CcInfo in dep
+        ]
+        all_cc_infos.extend(cc_infos)
+
+        cc_linking_contexts = [cc_info.linking_context for cc_info in cc_infos]
+        output_name = "{label}_{os}_{architecture}_bin".format(
+            architecture = target_triple.architecture,
+            label = label.name,
+            os = target_triple.os,
+        )
+        linking_output = cc_common.link(
+            actions = actions,
+            additional_inputs = additional_inputs,
+            cc_toolchain = cc_toolchain,
+            feature_configuration = feature_configuration,
+            grep_includes = grep_includes,
+            linking_contexts = cc_linking_contexts,
+            name = output_name,
+            stamp = stamp,
+            user_link_flags = user_link_flags,
+        )
+
+        validation_artifacts.extend([
+            cc_info.compilation_context.validation_artifacts
+            for cc_info in cc_infos
+        ])
+
+        linking_outputs.append(
+            struct(
+                architecture = target_triple.architecture,
+                binary = linking_output.executable,
+                environment = target_triple.environment,
+                platform = target_triple.os,
+            ),
+        )
+
+    return struct(
+        cc_info = cc_common.merge_cc_infos(
+            cc_infos = all_cc_infos,
+        ),
+        output_groups = {
+            "_validation": depset(
+                transitive = validation_artifacts,
+            ),
+        },
+        outputs = linking_outputs,
+    )
+
 linking_support = struct(
     debug_outputs_by_architecture = _debug_outputs_by_architecture,
+    link_multi_arch_binary = _link_multi_arch_binary,
     lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     register_binary_linking_action = _register_binary_linking_action,
     register_static_library_linking_action = _register_static_library_linking_action,


### PR DESCRIPTION
This change introduces a new experimental private Starlark API for
Apple binary linking, as a building block to begin Starlarkification
of the native apple_common binary linking API.

The introduced Starlark API does not have feature parity with the native
linking API, and leverages the `cc_common.link(...)` API to invoke linking
actions for each C++ toolchain from the split configuration.

Specifically, this Starlark API lacks support for:
  - Generating Apple DSYMs binaries.
  - Generating Apple bitcode symbols.
  - Generating Objective-C link maps.
  - Avoid linking Objective-C(++) dependencies symbols (ie. avoid_deps).

Introducing a minimal binary linking API allows rules_apple to:

  - Iterate on Starlarkification of the native linking API.
  - Link a binary with minimal features for App Intents support.

PiperOrigin-RevId: 503243236
(cherry picked from commit addd549b97a2060f216e57e18e3cdab7b80d2719)
