### PR TITLE
[rules_apple] Stop requiring that deps have ObjcProvider

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -445,8 +445,7 @@ target.
 """,
                 providers = [
                     [CcInfo],
-                    [apple_common.Objc, CcInfo],
-                    [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
+                    [CcInfo, AppleFrameworkImportInfo],
                 ],
             ),
             "dsym_imports": attr.label_list(
@@ -538,8 +537,7 @@ linked into that target.
 """,
                 providers = [
                     [CcInfo],
-                    [apple_common.Objc, CcInfo],
-                    [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
+                    [CcInfo, AppleFrameworkImportInfo],
                 ],
             ),
             "data": attr.label_list(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -643,8 +643,8 @@ List of targets that are dependencies of the target being built, which will prov
 linked into that target.
 """,
                 providers = [
-                    [apple_common.Objc, CcInfo],
-                    [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
+                    [CcInfo],
+                    [CcInfo, AppleFrameworkImportInfo],
                 ],
                 aspects = [swift_clang_module_aspect],
             ),
@@ -719,8 +719,8 @@ List of targets that are dependencies of the target being built, which will prov
 linked into that target.
 """,
                 providers = [
-                    [apple_common.Objc, CcInfo],
-                    [apple_common.Objc, CcInfo, AppleFrameworkImportInfo],
+                    [CcInfo],
+                    [CcInfo, AppleFrameworkImportInfo],
                 ],
                 aspects = [swift_clang_module_aspect],
             ),


### PR DESCRIPTION
Now that CcInfo migration is done, we will be deleting many ObjcProviders that
are not needed.

PiperOrigin-RevId: 504073478
(cherry picked from commit 4d52a136c486ae5f91defd3ababa5d5e4e276e6d)
