### PR TITLE
Remove `apple_common.Objc` provider usage related to linking now that the Apple linking logic in Bazel gets everything from `CcInfo`.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -336,7 +336,6 @@ def _apple_static_framework_import_impl(ctx):
         # rare case that a binary has a Swift framework import dependency but
         # no other Swift dependencies, make sure we pick those up so that it
         # links to the standard libraries correctly.
-        additional_objc_providers.extend(toolchain.implicit_deps_providers.objc_infos)
         additional_cc_infos.extend(toolchain.implicit_deps_providers.cc_infos)
 
         if _is_debugging(compilation_mode):

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -545,7 +545,6 @@ def _apple_static_xcframework_import_impl(ctx):
         # no other Swift dependencies, make sure we pick those up so that it
         # links to the standard libraries correctly.
         additional_cc_infos.extend(swift_toolchain.implicit_deps_providers.cc_infos)
-        additional_objc_providers.extend(swift_toolchain.implicit_deps_providers.objc_infos)
 
     # Create Objc provider
     additional_objc_providers.extend([


### PR DESCRIPTION
There are still a couple uses in `swift_clang_module_aspect` unrelated to linking that will be cleaned up separately.

PiperOrigin-RevId: 503167994
(cherry picked from commit 19e48b97a7bc224bc5aff4e04fe2b42aabb5da8d)
