### PR TITLE
Remove unused AppleDynamicFrameworkInfo fields for XCFramework import rules.

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -200,6 +200,8 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
            f.basename.startswith(target_triplet.architecture)
     ]
 
+    framework_files = filter_by_library_identifier(xcframework.files)
+
     includes = []
     framework_includes = []
     if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:
@@ -209,6 +211,7 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
 
     return struct(
         binary = binaries[0],
+        framework_files = framework_files,
         framework_imports = framework_imports,
         framework_includes = framework_includes,
         headers = headers,

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -133,8 +133,6 @@ def _get_xcframework_library(
     Returns:
         A struct containing processed XCFramework files:
             binary: File referencing the XCFramework library binary.
-            framework_dirs: List of strings referencing framework (.framework) directories.
-            framework_files: List of File referencing all XCFramework framework files.
             framework_imports: List of File referencing XCFramework library files to be bundled
                 by a top-level target (ios_application) consuming the target being built.
             framework_includes: List of strings referencing parent directories for framework
@@ -202,20 +200,15 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
            f.basename.startswith(target_triplet.architecture)
     ]
 
-    framework_dirs = [f.dirname for f in binaries]
-    framework_files = filter_by_library_identifier(xcframework.files)
-
     includes = []
     framework_includes = []
     if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:
-        framework_includes = [paths.dirname(f) for f in framework_dirs]
+        framework_includes = [paths.dirname(f.dirname) for f in binaries]
     else:
         includes = [h.dirname for h in headers]
 
     return struct(
         binary = binaries[0],
-        framework_dirs = framework_dirs,
-        framework_files = framework_files,
         framework_imports = framework_imports,
         framework_includes = framework_includes,
         headers = headers,
@@ -258,7 +251,6 @@ def _get_xcframework_library_with_xcframework_processor(
     library_suffix = ".framework" if xcframework.bundle_type == _BUNDLE_TYPE.frameworks else ""
     library_path = xcframework.bundle_name + library_suffix
 
-    library_dir = intermediates.directory(dir_name = library_path, **intermediates_common)
     framework_imports_dir = intermediates.directory(
         dir_name = paths.join("framework_imports", library_path),
         **intermediates_common
@@ -296,7 +288,7 @@ def _get_xcframework_library_with_xcframework_processor(
     args.add_all(files_by_category.module_map_imports, before_each = "--modulemap_file")
 
     args.add("--binary", binary.path)
-    args.add("--library_dir", library_dir.path)
+    args.add("--library_dir", binary.dirname)
     args.add("--framework_imports_dir", framework_imports_dir.path)
 
     inputs = []
@@ -307,7 +299,6 @@ def _get_xcframework_library_with_xcframework_processor(
         binary,
         framework_imports_dir,
         headers_dir,
-        library_dir,
         module_map_file,
     ]
 
@@ -331,14 +322,12 @@ def _get_xcframework_library_with_xcframework_processor(
     includes = []
     framework_includes = []
     if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:
-        framework_includes = [library_dir.dirname]
+        framework_includes = [paths.dirname(binary.dirname)]
     else:
         includes = [headers_dir.path]
 
     return struct(
         binary = binary,
-        framework_dirs = [library_dir.path],
-        framework_files = [library_dir],
         framework_imports = [framework_imports_dir],
         framework_includes = framework_includes,
         headers = [headers_dir],
@@ -466,8 +455,6 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     apple_dynamic_framework_info = apple_common.new_dynamic_framework_provider(
         objc = objc_provider,
         cc_info = cc_info,
-        framework_dirs = depset(xcframework_library.framework_dirs),
-        framework_files = depset(xcframework_library.framework_files),
     )
     providers.append(apple_dynamic_framework_info)
 


### PR DESCRIPTION
Fields are unused since dynamic framework linking now relies on
Objc/CcInfo providers.

Additionally, this fixes an issue with nested artifacts when using
Bazel's incompatible_strict_conflict_checks.

PiperOrigin-RevId: 491696986
(cherry picked from commit 375cfa418f5411cc3f59063b1f4a546f804a87b0)
