### PR TITLE
Fix duplicate symbols for static frameworks

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -360,7 +360,7 @@ def _apple_static_framework_import_impl(ctx):
             alwayslink = alwayslink,
             sdk_dylib = sdk_dylibs,
             sdk_framework = sdk_frameworks,
-            static_framework_file = framework_imports_by_category.binary_imports,
+            library = framework_imports_by_category.binary_imports,
             weak_sdk_framework = weak_sdk_frameworks,
         ),
     )

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -510,12 +510,6 @@ def _apple_static_xcframework_import_impl(ctx):
         ),
     ]
 
-    fields = {}
-    if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:
-        fields = {"static_framework_file": [xcframework_library.binary]}
-    else:
-        fields = {"library": [xcframework_library.binary]}
-
     # Create AppleFrameworkImportInfo provider
     apple_framework_import_info = framework_import_support.framework_import_info_with_dependencies(
         build_archs = [apple_fragment.single_arch_cpu],
@@ -549,7 +543,7 @@ def _apple_static_xcframework_import_impl(ctx):
         sdk_dylib = ctx.attr.sdk_dylibs,
         sdk_framework = ctx.attr.sdk_frameworks,
         weak_sdk_framework = ctx.attr.weak_sdk_frameworks,
-        **fields
+        library = [xcframework_library.binary],
     )
     providers.append(objc_provider)
 


### PR DESCRIPTION
As part of moving the linking info into CcInfo (as well as objc info
during the migration). Static frameworks started cause duplicate symbols
in some cases. This was because bazel seems to dedup `library` between
the 2 providers but not `static_framework_file` since
`static_framework_file` has been removed from google's use. Otherwise this
change seems to be a no-op, probably because we're bazel 6.x+
