### PR TITLE
Add --incompatible_strict_conflict_checks to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # NOTE: These are mainly just for the BazelCI setup so they don't have
 # to be repeated multiple times in .bazelci/presubmit.yml.
 
+# https://github.com/bazelbuild/bazel/issues/16729
+build --experimental_strict_conflict_checks
+
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 


### PR DESCRIPTION
To prevent backsliding. See https://github.com/bazelbuild/bazel/issues/16729 for context.