### PR TITLE
Revert "Fix linkmap test on M1s (#1595)"

### DIFF
--- a/test/starlark_tests/rules/linkmap_test.bzl
+++ b/test/starlark_tests/rules/linkmap_test.bzl
@@ -15,10 +15,6 @@
 """Starlark test rules for linkmap generation."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-)
-load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
@@ -35,13 +31,7 @@ def _linkmap_test_impl(ctx):
     architectures = ctx.attr.architectures
 
     if not architectures:
-        platform_type = target_under_test[AppleBundleInfo].platform_type
-        if platform_type == "ios" or platform_type == "macos":
-            architectures = [ctx.fragments.apple.single_arch_cpu]
-        elif platform_type == "watchos":
-            architectures = ["i386"]
-        else:
-            architectures = ["x86_64"]
+        architecture = [ctx.fragments.apple.single_arch_cpu]
 
     outputs = {
         x.short_path: None


### PR DESCRIPTION
This is now fixed since the rules support these other various
architectures. Without this revert these tests were broken on M1 for the
opposite reason of the original issue

This reverts commit 9d5fe6e38e7c3302d5031a9303d9eba1467457e5.
