### PR TITLE
Remove apple_common.Objc provider linking

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -87,9 +87,6 @@ Expected Apple platform type of "{platform_type}", but that was not found in {to
         archive_result.output_groups,
     ]
 
-    if archive_result.objc:
-        providers.append(archive_result.objc)
-
     return providers
 
 apple_static_library = rule_factory.create_apple_rule(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -675,7 +675,6 @@ def _apple_static_xcframework_import_impl(ctx):
     providers.append(apple_framework_import_info)
 
     additional_cc_infos = []
-    additional_objc_providers = []
     if xcframework.files_by_category.swift_interface_imports or \
        xcframework.files_by_category.swift_module_imports or \
        has_swift:
@@ -688,13 +687,6 @@ def _apple_static_xcframework_import_impl(ctx):
         # no other Swift dependencies, make sure we pick those up so that it
         # links to the standard libraries correctly.
         additional_cc_infos.extend(swift_toolchains.swift.implicit_deps_providers.cc_infos)
-
-    # Create Objc provider
-    additional_objc_providers.extend([
-        dep[apple_common.Objc]
-        for dep in deps
-        if apple_common.Objc in dep
-    ])
 
     sdk_linkopts = []
     for dylib in ctx.attr.sdk_dylibs:

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -792,9 +792,7 @@ def _swift_interop_info_with_dependencies(deps, module_name, module_map_imports)
     and XCFrameworks remain visible to Swift.
     """
 
-    # Assume that there is only a single module map file (the legacy
-    # implementation that read from the Objc provider made the same
-    # assumption).
+    # Assume that there is only a single module map file.
     module_map = _primary_module_map(module_map_imports)
 
     return create_swift_interop_info(

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -97,16 +97,11 @@ def _archive_multi_arch_static_library(
                 deps = split_deps[split_transition_key],
             )
 
-        avoid_objc_providers = []
-        avoid_cc_providers = []
         avoid_cc_linking_contexts = []
 
         if len(split_avoid_deps.keys()):
             for dep in split_avoid_deps[split_transition_key]:
-                if apple_common.Objc in dep:
-                    avoid_objc_providers.append(dep[apple_common.Objc])
                 if CcInfo in dep:
-                    avoid_cc_providers.append(dep[CcInfo])
                     avoid_cc_linking_contexts.append(dep[CcInfo].linking_context)
 
         name = ctx.label.name + "-" + cc_toolchain.target_gnu_system_name + "-fl"

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -378,10 +378,10 @@ def _debug_outputs_by_architecture(link_outputs):
         linkmaps = linkmaps,
     )
 
-def _sectcreate_objc_provider(label, segname, sectname, file):
-    """Returns an objc provider that propagates a section in a linked binary.
+def _sectcreate_cc_info(label, segname, sectname, file):
+    """Returns a CcInfo that propagates a section in a linked binary.
 
-    This function creates a new objc provider that contains the necessary linkopts
+    This function creates a new CcInfo that contains the necessary linkopts
     to create a new section in the binary to which the provider is propagated; it
     is equivalent to the `ld` flag `-sectcreate segname sectname file`. This can
     be used, for example, to embed entitlements in a simulator executable (since
@@ -396,11 +396,9 @@ def _sectcreate_objc_provider(label, segname, sectname, file):
       file: The file whose contents will be used as the content of the section.
 
     Returns:
-      An objc provider that propagates the section linkopts.
+      A CcInfo that propagates the section linkopts.
     """
 
-    # linkopts get deduped, so use a single option to pass then through as a
-    # set.
     linkopts = ["-Wl,-sectcreate,%s,%s,%s" % (segname, sectname, file.path)]
     return [
         CcInfo(
@@ -444,10 +442,9 @@ def _register_binary_linking_action(
             This target must propagate the `AppleExecutableBinaryInfo` provider.
             This simplifies the process of passing the bundle loader to all the arguments
             that need it: the binary will automatically be added to the linker inputs, its
-            path will be added to linkopts via `-bundle_loader`, and the `apple_common.Objc`
-            provider of its dependencies (obtained from the `AppleExecutableBinaryInfo` provider)
-            will be passed as an additional `avoid_dep` to ensure that those dependencies are
-            subtracted when linking the bundle's binary.
+            path will be added to linkopts via `-bundle_loader`, and it will be passed as an
+            additional `avoid_dep` to ensure that those dependencies are subtracted when linking
+            the bundle's binary.
         cc_toolchains: Dictionary of CcToolchainInfo and ApplePlatformInfo providers under a split
             transition to relay target platform information for related deps.
         entitlements: An optional `File` that provides the processed entitlements for the
@@ -483,8 +480,6 @@ def _register_binary_linking_action(
             is a new universal (fat) binary obtained by invoking `lipo`.
         *   `cc_info`: The CcInfo provider containing information about the targets that were
             linked.
-        *   `objc`: The `apple_common.Objc` provider containing information about the targets
-            that were linked.
         *   `outputs`: A `list` of `struct`s containing the single-architecture binaries and
             debug outputs, with identifying information about the target platform, architecture,
             and environment that each was built for.
@@ -583,7 +578,6 @@ def _register_binary_linking_action(
         binary = fat_binary,
         cc_info = linking_outputs.cc_info,
         debug_outputs_provider = linking_outputs.debug_outputs_provider,
-        objc = getattr(linking_outputs, "objc", None),
         outputs = linking_outputs.outputs,
         output_groups = linking_outputs.output_groups,
     )
@@ -628,7 +622,6 @@ def _register_static_library_archive_action(
 
     return struct(
         library = fat_library,
-        objc = getattr(archive_outputs, "objc", None),
         outputs = archive_outputs.outputs,
         output_groups = archive_outputs.output_groups,
     )
@@ -662,5 +655,5 @@ linking_support = struct(
     lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     register_binary_linking_action = _register_binary_linking_action,
     register_static_library_archive_action = _register_static_library_archive_action,
-    sectcreate_objc_provider = _sectcreate_objc_provider,
+    sectcreate_cc_info = _sectcreate_cc_info,
 )

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -165,7 +165,7 @@ def _macos_binary_infoplist_impl(ctx):
         version = ctx.attr.version,
     )
 
-    return linking_support.sectcreate_objc_provider(
+    return linking_support.sectcreate_cc_info(
         rule_label,
         "__TEXT",
         "__info_plist",
@@ -260,7 +260,7 @@ def _macos_command_line_launchdplist_impl(ctx):
         rule_label = rule_label,
     )
 
-    return linking_support.sectcreate_objc_provider(
+    return linking_support.sectcreate_cc_info(
         rule_label,
         "__TEXT",
         "__launchd_plist",

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -120,9 +120,9 @@ def _macos_command_line_application_impl(name, visibility, **kwargs):
     additional_deps = []
 
     # If any of the Info.plist-affecting attributes is provided, create a merged
-    # Info.plist target. This target also propagates an objc provider that
-    # contains the linkopts necessary to add the Info.plist to the binary, so it
-    # must become a dependency of the binary as well.
+    # Info.plist target. This target also propagates CcInfo with the linkopts
+    # necessary to add the Info.plist to the binary, so it must become a
+    # dependency of the binary as well.
     base_bundle_id = kwargs.get("base_bundle_id")
     bundle_id = kwargs.get("bundle_id")
     infoplists = kwargs.get("infoplists")
@@ -182,9 +182,9 @@ def _macos_dylib_impl(name, visibility, **kwargs):
     additional_deps = []
 
     # If any of the Info.plist-affecting attributes is provided, create a merged
-    # Info.plist target. This target also propagates an objc provider that
-    # contains the linkopts necessary to add the Info.plist to the binary, so it
-    # must become a dependency of the binary as well.
+    # Info.plist target. This target also propagates CcInfo with the linkopts
+    # necessary to add the Info.plist to the binary, so it must become a
+    # dependency of the binary as well.
     base_bundle_id = kwargs.get("base_bundle_id")
     bundle_id = kwargs.get("bundle_id")
     infoplists = kwargs.get("infoplists")


### PR DESCRIPTION
Most of this is long done but there was some small cleanup left

(cherry picked from commit 1d7c1a1a8ff3f63642cfed569c0a86ea5aa14d3b)
