### PR TITLE
Add support for simulator name input to `ios_xctestrun_runner`

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -155,14 +155,11 @@ readonly xctestrun_file="$test_tmp_dir/tests.xctestrun"
   -e "s@BAZEL_COVERAGE_OUTPUT_DIR@$test_tmp_dir@g" \
   "%(xctestrun_template)s" > "$xctestrun_file"
 
-simulator_creator_args=(
+simulator_id="$("./%(simulator_creator.py)s" \
   "%(os_version)s" \
   "%(device_type)s" \
-)
-if [[ -n "${BAZEL_IOS_SIMULATOR_NAME:-}" ]]; then
-  simulator_creator_args+=(--name "${BAZEL_IOS_SIMULATOR_NAME}")
-fi
-simulator_id="$("./%(simulator_creator.py)s" "${simulator_creator_args[@]}")"
+  --name "${BAZEL_IOS_SIMULATOR_NAME:-}"
+)"
 
 test_exit_code=0
 testlog=$(mktemp)

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -9,6 +9,21 @@ if [[ -z "${DEVELOPER_DIR:-}" ]]; then
   exit 1
 fi
 
+simulator_name=""
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+  case $arg in
+    --simulator_name=*)
+      simulator_name="${arg##*=}"
+      ;;
+    *)
+      echo "error: Unsupported argument '${arg}'" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 # Retrieve the basename of a file or folder with an extension.
 basename_without_extension() {
   local filename
@@ -158,7 +173,7 @@ readonly xctestrun_file="$test_tmp_dir/tests.xctestrun"
 simulator_id="$("./%(simulator_creator.py)s" \
   "%(os_version)s" \
   "%(device_type)s" \
-  --name "${BAZEL_IOS_SIMULATOR_NAME:-}"
+  --name "$simulator_name"
 )"
 
 test_exit_code=0


### PR DESCRIPTION
Pass in a specific simulator name using `bazel coverage --test_arg=--simulator_name=BazelPhone ...` to the test runner to avoid creating it/booting it in-situ in the test runner.

**No Args Provided:**
```
...
Monitoring boot status for BAZEL_TEST_iPhone 8 Plus_16.2 (702D84B5-AE74-422E-8C06-9A4A694D39D3).
Booting device...
...
```

**`--test_arg=--simulator_id=BazelPhone` Provided (Already Booted):**
```
...
Simulator state is: booted
...
```

**`--test_arg=--simulator_id=BazelPhone` Provided (Shutdown):**
```
...
Simulator state is: shutdown
Monitoring boot status for BazelPhone (47558DBF-629E-468E-AC45-CF5CA33EFA70).
Booting device...
...
```

Closes https://github.com/bazelbuild/rules_apple/issues/1873.