### PR TITLE
Add custom `xcodebuild` args to `ios_xctestrun_runner`

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -9,12 +9,17 @@ if [[ -z "${DEVELOPER_DIR:-}" ]]; then
   exit 1
 fi
 
+custom_xcodebuild_args=()
 simulator_name=""
 while [[ $# -gt 0 ]]; do
   arg="$1"
   case $arg in
     --simulator_name=*)
       simulator_name="${arg##*=}"
+      ;;
+    --xcodebuild_args=*)
+      xcodebuild_arg="${arg#--xcodebuild_args=}" # Strip "--xcodebuild_args=" prefix
+      custom_xcodebuild_args+=("$xcodebuild_arg")
       ;;
     *)
       echo "error: Unsupported argument '${arg}'" >&2
@@ -205,7 +210,7 @@ if [[ -n "$test_host_path" || -n "${CREATE_XCRESULT_BUNDLE:-}" || "%(test_order)
     args+=(-resultBundlePath "$result_bundle_path")
   fi
 
-  xcodebuild test-without-building "${args[@]}" \
+  xcodebuild test-without-building "${args[@]}" "${custom_xcodebuild_args[@]}" \
     2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
     || test_exit_code=$?
 else

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -210,7 +210,11 @@ if [[ -n "$test_host_path" || -n "${CREATE_XCRESULT_BUNDLE:-}" || "%(test_order)
     args+=(-resultBundlePath "$result_bundle_path")
   fi
 
-  xcodebuild test-without-building "${args[@]}" "${custom_xcodebuild_args[@]}" \
+  if (( ${#custom_xcodebuild_args[@]} )); then
+    args+=("${custom_xcodebuild_args[@]}")
+  fi
+
+  xcodebuild test-without-building "${args[@]}" \
     2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
     || test_exit_code=$?
 else


### PR DESCRIPTION
Forward custom `xcodebuild` args via `--test_arg=--xcodebuild_args=` like:
```
$ bazel coverage \
  --test_arg=--simulator_name="BazelPhone" \
  --test_arg=--xcodebuild_args=-retry-tests-on-failure \
  --test_arg=--xcodebuild_args=-test-iterations \
  --test_arg=--xcodebuild_args=3 \
  //FooTests
```

Closes https://github.com/bazelbuild/rules_apple/issues/1875.