### PR TITLE
Include clang_rt independent of asan, tsan, ubsan features.

### DIFF
--- a/apple/internal/utils/clang_rt_dylibs.bzl
+++ b/apple/internal/utils/clang_rt_dylibs.bzl
@@ -25,6 +25,7 @@ def _should_package_clang_runtime(*, features):
         "asan": True,
         "tsan": True,
         "ubsan": True,
+        "include_clang_rt": True,
     }
 
     for feature in features:

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -106,6 +106,10 @@ Similar to what you can find in Xcode, the Address and Thread sanitizers are
 mutually exclusive, i.e. you can only specify one or the other for a particular
 build.
 
+In case you want to have different compiler and linker flags, you can use 
+`--features=include_clang_rt` and specify the required compiler and linker
+flags yourself.
+
 -->
 
 ### linkmap Generation {#objc_generate_linkmap}

--- a/test/ios_application_swift_test.sh
+++ b/test/ios_application_swift_test.sh
@@ -150,9 +150,9 @@ EOF
   assert_ipa_contains_swift_dylibs_for_device
 }
 
-# Tests that swift_library build with ASAN enabled and that the ASAN
+# Tests that swift_library builds with ASAN enabled and that the ASAN
 # library is packaged into the IPA when enabled.
-function disabled_test_swift_builds_with_asan() {  # Blocked on b/73547309
+function test_swift_builds_with_asan() {  # Blocked on b/73547309
   create_minimal_ios_application
 
   cat >> app/BUILD <<EOF
@@ -173,9 +173,9 @@ EOF
   fi
 }
 
-# Tests that swift_library build with TSAN enabled and that the TSAN
+# Tests that swift_library builds with TSAN enabled and that the TSAN
 # library is packaged into the IPA when enabled.
-function disabled_test_swift_builds_with_tsan() {  # Blocked on b/73547309
+function test_swift_builds_with_tsan() {  # Blocked on b/73547309
   # Skip the device version as tsan is not supported on devices.
   if ! is_device_build ios ; then
     create_minimal_ios_application
@@ -191,6 +191,29 @@ EOF
         || fail "Should build"
     assert_zip_contains "test-bin/app/app.ipa" \
         "Payload/app.app/Frameworks/libclang_rt.tsan_iossim_dynamic.dylib"
+  fi
+}
+
+# Tests that swift_library builds with UBSAN enabled and that the UBSAN
+# library is packaged into the IPA when enabled.
+function test_swift_builds_with_ubsan() {  # Blocked on b/73547309
+  create_minimal_ios_application
+
+  cat >> app/BUILD <<EOF
+swift_library(
+    name = "lib",
+    srcs = ["AppDelegate.swift"],
+)
+EOF
+
+  do_build ios //app:app --features=asan || fail "Should build"
+
+  if is_device_build ios ; then
+    assert_zip_contains "test-bin/app/app.ipa" \
+        "Payload/app.app/Frameworks/libclang_rt.asan_ios_dynamic.dylib"
+  else
+    assert_zip_contains "test-bin/app/app.ipa" \
+        "Payload/app.app/Frameworks/libclang_rt.asan_iossim_dynamic.dylib"
   fi
 }
 

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -156,6 +156,45 @@ function test_pkginfo_contents() {
       "app.app/Contents/PkgInfo")"
 }
 
+# Tests that app builds with ASAN enabled and that the ASAN
+# library is packaged into the app when enabled.
+function test_app_builds_with_asan() {  # Blocked on b/73547309
+  create_common_files
+  create_minimal_macos_application
+
+  do_build macos //app:app --features=asan \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.asan_osx_dynamic.dylib"
+}
+
+# Tests that app builds with TSAN enabled and that the TSAN
+# library is packaged into the app when enabled.
+function test_app_builds_with_tsan() {  # Blocked on b/73547309
+  create_common_files
+  create_minimal_macos_application
+
+  do_build macos //app:app --features=tsan \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.tsan_osx_dynamic.dylib"
+}
+
+# Tests that app builds with UBSAN enabled and that the UBSAN
+# library is packaged into the app when enabled.
+function test_app_builds_with_ubsan() {  # Blocked on b/73547309
+  create_common_files
+  create_minimal_macos_application
+
+  do_build macos //app:app --features=ubsan \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.ubsan_osx_dynamic.dylib"
+}
+
 # Tests that app builds with include_clang_rt and asan linker option
 # enabled and that the ASAN library is packaged into the app when enabled.
 function test_app_builds_with_include_clang_rt_asan() {

--- a/test/macos_application_test.sh
+++ b/test/macos_application_test.sh
@@ -156,4 +156,52 @@ function test_pkginfo_contents() {
       "app.app/Contents/PkgInfo")"
 }
 
+# Tests that app builds with include_clang_rt and asan linker option
+# enabled and that the ASAN library is packaged into the app when enabled.
+function test_app_builds_with_include_clang_rt_asan() {
+  create_common_files
+  create_minimal_macos_application
+
+  # The clang_rt resolution implemented in tools/clangrttool.py requires
+  # the presence of a clang_rt*.dylib rpath.
+
+  do_build macos //app:app --features=include_clang_rt --linkopt=-fsanitize=address \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.asan_osx_dynamic.dylib"
+}
+
+# Tests that app builds with include_clang_rt and tsan linker option
+# enabled and that the TSAN library is packaged into the app when enabled.
+function test_app_builds_with_include_clang_rt_tsan() {
+  create_common_files
+  create_minimal_macos_application
+
+  # The clang_rt resolution implemented in tools/clangrttool.py requires
+  # the presence of a clang_rt*.dylib rpath.
+
+  do_build macos //app:app --features=include_clang_rt --linkopt=-fsanitize=thread \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.tsan_osx_dynamic.dylib"
+}
+
+# Tests that app builds with include_clang_rt and ubsan linker option
+# enabled and that the UBSAN library is packaged into the app when enabled.
+function test_app_builds_with_include_clang_rt_ubsan() {
+  create_common_files
+  create_minimal_macos_application
+
+  # The clang_rt resolution implemented in tools/clangrttool.py requires
+  # the presence of a clang_rt*.dylib rpath.
+
+  do_build macos //app:app --features=include_clang_rt --linkopt=-fsanitize=undefined \
+        || fail "Should build"
+
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Frameworks/libclang_rt.ubsan_osx_dynamic.dylib"
+}
+
 run_suite "macos_application bundling tests"


### PR DESCRIPTION
### What has changed
- Add support for a new feature flag that includes the clang_rt dylib.

### Why this was changed
- This allows specifying sanitizer compiler flags independent of the defaults set by other rules, but uses rules_apple to include the required clang_rt dylibs.

# How to test
Run e.g. `bazelisk run @//examples/ios/HelloWorldSwift:HelloWorldSwift --features=include_clang_rt --linkopt=-fsanitize=address`. The app bundle should include `libclang_rt.asan_iossim_dynamic.dylib` in its frameworks directory.
