### PR TITLE
[RFC][2] Add `ios_xctestrun_runner` rule override attribute

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -9,6 +9,11 @@ if [[ -z "${DEVELOPER_DIR:-}" ]]; then
   exit 1
 fi
 
+create_xcresult_bundle=%(create_xcresult_bundle)s
+if [[ -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+  create_xcresult_bundle=true
+fi
+
 custom_xcodebuild_args=()
 simulator_name=""
 while [[ $# -gt 0 ]]; do
@@ -245,7 +250,7 @@ if [[ "%(test_order)s" == random ]]; then
   echo "note: Using 'xcodebuild' because random test order was requested"
   should_use_xcodebuild=true
 fi
-if [[ -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+if [[ "$create_xcresult_bundle" == true ]]; then
   echo "note: Using 'xcodebuild' because XCResult bundle was requested"
   should_use_xcodebuild=true
 fi
@@ -290,7 +295,7 @@ if [[ "$should_use_xcodebuild" == true ]]; then
   readonly result_bundle_path="$TEST_UNDECLARED_OUTPUTS_DIR/tests.xcresult"
   # TEST_UNDECLARED_OUTPUTS_DIR isn't cleaned up with multiple retries of flaky tests
   rm -rf "$result_bundle_path"
-  if [[ -n "${CREATE_XCRESULT_BUNDLE:-}" ]]; then
+  if [[ "$create_xcresult_bundle" == true ]]; then
     args+=(-resultBundlePath "$result_bundle_path")
   fi
 


### PR DESCRIPTION
Comparing against https://github.com/bazelbuild/rules_apple/pull/1884.