### PR TITLE
Fix static frameworks with objc provider

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -360,7 +360,7 @@ def _apple_static_framework_import_impl(ctx):
             alwayslink = alwayslink,
             sdk_dylib = sdk_dylibs,
             sdk_framework = sdk_frameworks,
-            library = framework_imports_by_category.binary_imports,
+            static_framework_file = framework_imports_by_category.binary_imports,
             weak_sdk_framework = weak_sdk_frameworks,
         ),
     )

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -543,7 +543,7 @@ def _apple_static_xcframework_import_impl(ctx):
         sdk_dylib = ctx.attr.sdk_dylibs,
         sdk_framework = ctx.attr.sdk_frameworks,
         weak_sdk_framework = ctx.attr.weak_sdk_frameworks,
-        library = [xcframework_library.binary],
+        static_framework_file = [xcframework_library.binary],
     )
     providers.append(objc_provider)
 


### PR DESCRIPTION
In 3872a85c145710f183065fbc61edbad86d4d1ab0 I got confused about these
arguments being the real objc provider directly vs our wrapper which
actually moves static_framework_file into imported_library. Without this
rules_swift does not correctly remove autolink load commands that are
invalid.
