### PR TITLE
Fix linking static frameworks with sdk requirements

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -547,6 +547,18 @@ def _apple_static_xcframework_import_impl(ctx):
     )
     providers.append(objc_provider)
 
+    sdk_linkopts = []
+    for dylib in ctx.attr.sdk_dylibs:
+        if dylib.startswith("lib"):
+            dylib = dylib[3:]
+        sdk_linkopts.append("-l%s" % dylib)
+    for sdk_framework in ctx.attr.sdk_frameworks:
+        sdk_linkopts.append("-framework")
+        sdk_linkopts.append(sdk_framework)
+    for sdk_framework in ctx.attr.weak_sdk_frameworks:
+        sdk_linkopts.append("-weak_framework")
+        sdk_linkopts.append(sdk_framework)
+
     # Create CcInfo provider
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
@@ -563,7 +575,7 @@ def _apple_static_xcframework_import_impl(ctx):
         label = label,
         libraries = [xcframework_library.binary],
         framework_includes = xcframework_library.framework_includes,
-        linkopts = linkopts,
+        linkopts = sdk_linkopts + linkopts,
         swiftmodule_imports = [],
         includes = xcframework_library.includes + ctx.attr.includes,
     )

--- a/test/starlark_tests/apple_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_import_tests.bzl
@@ -15,6 +15,10 @@
 """apple_dynamic_xcframework_import and apple_static_xcframework_import Starlark tests."""
 
 load(
+    ":rules/analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
+)
+load(
     ":rules/analysis_target_outputs_test.bzl",
     "analysis_target_outputs_test",
 )
@@ -163,6 +167,21 @@ def apple_xcframework_import_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_xcfmwk_with_module_map",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    analysis_target_actions_test(
+        name = "{}_imported_xcframework_with_sdk_requirements".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_xcfmwk",
+        target_mnemonic = "ObjcLink",
+        expected_argv = [
+            "-framework",
+            "AVFoundation",
+            "-weak_framework",
+            "SwiftUI",
+            "-lz",
+            "-lc++",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -542,7 +542,13 @@ apple_dynamic_xcframework_import(
 apple_static_xcframework_import(
     name = "ios_imported_static_xcframework_old",
     includes = ["Headers"],
+    sdk_dylibs = [
+        "z",
+        "libc++",
+    ],
+    sdk_frameworks = ["AVFoundation"],
     tags = ["manual"],
+    weak_sdk_frameworks = ["SwiftUI"],
     xcframework_imports = [":generated_ios_static_xcframework"],
 )
 


### PR DESCRIPTION
These were dropped when using CcInfo only for linking
