### PR TITLE
Support filtering absolute paths in coverage data

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -387,11 +387,15 @@ for binary in $TEST_BINARIES_FOR_LLVM_COV; do
   lcov_args+=("-arch=$arch")
 done
 
-llvm_coverage_manifest="$COVERAGE_MANIFEST"
+original_coverage_manifest="$COVERAGE_MANIFEST"
 readonly provided_coverage_manifest="%(test_coverage_manifest)s"
 if [[ -s "${provided_coverage_manifest:-}" ]]; then
-  llvm_coverage_manifest="$provided_coverage_manifest"
+  original_coverage_manifest="$provided_coverage_manifest"
 fi
+
+readonly processed_coverage_manifest=$test_tmp_dir/processed_coverage_manifest.txt
+sed "s=^=$ROOT/=g" "$original_coverage_manifest" > "$processed_coverage_manifest"
+cat "$original_coverage_manifest" >> "$processed_coverage_manifest"
 
 readonly error_file="$test_tmp_dir/llvm-cov-error.txt"
 llvm_cov_status=0
@@ -399,7 +403,7 @@ xcrun llvm-cov \
   export \
   -format lcov \
   "${lcov_args[@]}" \
-  @"$llvm_coverage_manifest" \
+  @"$processed_coverage_manifest" \
   > "$COVERAGE_OUTPUT_FILE" \
   2> "$error_file" \
   || llvm_cov_status=$?
@@ -418,7 +422,7 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     export \
     -format text \
     "${lcov_args[@]}" \
-    @"$llvm_coverage_manifest" \
+    @"$processed_coverage_manifest" \
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json" \
     2> "$error_file" \
     || llvm_cov_json_export_status=$?

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -222,6 +222,14 @@ function test_standalone_unit_test_coverage_coverage_manifest_new_runner() {
   (! grep "SF:" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat" | grep -v "SF:./app/SharedLogic.m") || fail "Should not contain other files"
 }
 
+function test_coverage_coverage_manifest_new_runner_absolute_paths() {
+  create_common_files
+  do_coverage ios --test_output=all --ios_minimum_os=9.0 --experimental_use_llvm_covmap --action_env=LCOV_MERGER=/usr/bin/true --features=-coverage_prefix_map --features=-swift.coverage_prefix_map --features=-swift.file_prefix_map //app:coverage_manifest_test_new_runner || fail "Should build"
+  assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat"
+  assert_contains "SF:.*/app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat"
+  (! grep "SF:" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat" | grep -v "app/SharedLogic.m") || fail "Should not contain other files"
+}
+
 function test_hosted_unit_test_coverage() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:hosted_test || fail "Should build"


### PR DESCRIPTION
llvm-covs path-equivalence flag is a bit strange. Everything is
absolutized, including the paths in the binary, and the flag isn't
consulted in the case the files exist. Because of this if you're not
using the coverage-prefix-map flags and end up with absolute paths in
your binaries, the previous filtering wasn't working. Using
coverage-prefix-map is the default now, but folks using older rules and
the pre-apple_support toolchain might still be doing this. When the
filtering fails it just fails silently, so enabling this is nice to do
at least for now.
