### PR TITLE
Add dylib extension to dynamic libraries

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -200,7 +200,11 @@ def _register_binary_linking_action(
         stamp = stamp,
     )
 
-    fat_binary = ctx.actions.declare_file("{}_lipobin".format(ctx.label.name))
+    file_ending = "_lipobin"
+    if "-dynamiclib" in extra_linkopts:
+        file_ending += ".dylib"
+
+    fat_binary = ctx.actions.declare_file("{}{}".format(ctx.label.name, file_ending))
 
     _lipo_or_symlink_inputs(
         actions = ctx.actions,

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -586,6 +586,46 @@ function test_prebuilt_static_apple_static_framework_import_resources() {
       "Payload/app.app/fmwk.bundle/Some.plist"
 }
 
+# Tests that a dynamic framework with a "." in the name builds
+function test_ios_framework_name_with_dot() {
+  create_common_files
+  cat >> app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_framework"
+)
+ios_framework(
+    name = "fmwk.dynamic_framework",
+    deps = [":lib"],
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+)
+EOF
+
+  do_build ios //app:fmwk.dynamic_framework || fail "Should build"
+}
+
+# Tests that a dynamic framework without a "." in the name builds
+function test_ios_framework_name_without_dot() {
+  create_common_files
+  cat >> app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_framework"
+)
+ios_framework(
+    name = "fmwk",
+    deps = [":lib"],
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+)
+EOF
+
+  do_build ios //app:fmwk || fail "Should build"
+}
+
 # Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
 # is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -134,7 +134,7 @@ EOF
 
   mkdir -p app/fmwk.framework
   if [[ $framework_type == dynamic ]]; then
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin) \
+    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
         app/fmwk.framework/fmwk
   else
     cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_staticlib_lipo.a) \

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -586,46 +586,6 @@ function test_prebuilt_static_apple_static_framework_import_resources() {
       "Payload/app.app/fmwk.bundle/Some.plist"
 }
 
-# Tests that a dynamic framework with a "." in the name builds
-function test_ios_framework_name_with_dot() {
-  create_common_files
-  cat >> app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:ios.bzl",
-    "ios_framework"
-)
-ios_framework(
-    name = "fmwk.dynamic_framework",
-    deps = [":lib"],
-    bundle_id = "my.bundle.id",
-    families = ["iphone"],
-    infoplists = ["Info.plist"],
-    minimum_os_version = "${MIN_OS_IOS}",
-)
-EOF
-
-  do_build ios //app:fmwk.dynamic_framework || fail "Should build"
-}
-
-# Tests that a dynamic framework without a "." in the name builds
-function test_ios_framework_name_without_dot() {
-  create_common_files
-  cat >> app/BUILD <<EOF
-load("@build_bazel_rules_apple//apple:ios.bzl",
-    "ios_framework"
-)
-ios_framework(
-    name = "fmwk",
-    deps = [":lib"],
-    bundle_id = "my.bundle.id",
-    families = ["iphone"],
-    infoplists = ["Info.plist"],
-    minimum_os_version = "${MIN_OS_IOS}",
-)
-EOF
-
-  do_build ios //app:fmwk || fail "Should build"
-}
-
 # Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
 # is bundled properly with the application.
 function test_prebuilt_dynamic_apple_framework_import_dependency() {

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -200,7 +200,7 @@ EOF
 
   mkdir -p app/fmwk.framework
   if [[ $framework_type == dynamic ]]; then
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin) \
+    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
         app/fmwk.framework/fmwk
   else
     cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_staticlib_lipo.a) \

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -33,6 +33,17 @@ def ios_framework_test_suite(name):
     Args:
       name: the base name to be used in things created by this macro
     """
+    archive_contents_test(
+        name = "{}_with_dot_in_name_builds_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:fmwk_with_dot.dynamic_framework",
+        binary_test_file = "$BUNDLE_ROOT/fmwk_with_dot.dynamic_framework",
+        contains = [
+            "$BUNDLE_ROOT/fmwk_with_dot.dynamic_framework",
+        ],
+        tags = [name],
+    )
+
     infoplist_contents_test(
         name = "{}_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:fmwk",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1610,6 +1610,25 @@ ios_framework(
     ],
 )
 
+ios_framework(
+    name = "fmwk_with_dot.dynamic_framework",
+    hdrs = ["//test/starlark_tests/resources:common.h"],
+    bundle_id = "com.google.example.framework",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:framework_resources_lib",
+        "//test/starlark_tests/resources:objc_shared_lib",
+    ],
+)
+
 # ---------------------------------------------------------------------------------------
 # Targets for Apple dynamic framework import tests.
 

--- a/test/tvos_framework_test.sh
+++ b/test/tvos_framework_test.sh
@@ -1144,7 +1144,7 @@ apple_dynamic_framework_import(
 EOF
 
   mkdir -p app/inner_framework.framework
-  cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_tvos_dylib_lipobin) \
+  cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_tvos_dylib_lipobin.dylib) \
       app/inner_framework.framework/inner_framework
 
   cat > app/inner_framework.framework/Info.plist <<EOF


### PR DESCRIPTION
Right now the rules append `_lipobin` during linking. This no longer works because: https://github.com/bazelbuild/bazel/blob/1fe702cfbaeb9e5a93f4b122359d416a18c5ee87/src/main/java/com/google/devtools/build/lib/rules/cpp/CcModule.java#L648-L657 is being used (due to toolchain migration?)

This fixes the following error that shows up when linking dynamic libraries by adding `.dylib` if `-dynamiclib` is in the `extra_linkopts`:
```
Error in create_library_to_link: 'MyFramework.dynamic_framework_lipobin' does not have any of the allowed extensions .so, .dylib, .dll or .pyd
```