### PR TITLE
Remove implicit_outputs from apple_binary

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -183,8 +183,4 @@ rule is being provided for the purpose of transitioning users from the built-in
 implementation of `apple_binary` in Bazel core so that it can be removed.
 """,
     implementation = _apple_binary_impl,
-    implicit_outputs = {
-        # Provided for compatibility with built-in `apple_binary` only.
-        "lipobin": "%{name}_lipobin",
-    },
 )

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -1156,7 +1156,6 @@ def _create_apple_binary_rule(
         doc,
         additional_attrs = {},
         cfg = transition_support.apple_rule_transition,
-        implicit_outputs = None,
         platform_type = None,
         product_type = None,
         require_linking_attrs = True):
@@ -1254,7 +1253,6 @@ binaries/libraries will be created combining all architectures specified by
         doc = doc,
         executable = is_executable,
         fragments = ["apple", "cpp", "objc"],
-        outputs = implicit_outputs,
         toolchains = use_cpp_toolchain(),
     )
 


### PR DESCRIPTION
This is never used by the rules or anything requesting it. I don't think
the compatibility mentioned here really matters anymore.
