### PR TITLE
Downgrade bazel last_green to avoid runtime_deps change

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,7 +15,7 @@ x_defaults:
     test_flags:
     - --test_tag_filters=-skipci
   common_last_green: &common_last_green
-    bazel: last_green
+    bazel: 67d9d755552ed9b4fb182ea1e86f3470c62048e4
     test_flags:
       - --test_tag_filters=-skipci
 


### PR DESCRIPTION
Revert once https://github.com/bazelbuild/rules_apple/issues/1901 is
fixed
