### PR TITLE
Make emitswiftinterface parameter public

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -589,9 +589,9 @@ to manually dlopen the framework at runtime.
         })
     elif rule_descriptor.product_type == apple_product_type.static_framework:
         attrs.append({
-            "_emitswiftinterface": attr.bool(
+            "emitswiftinterface": attr.bool(
                 default = True,
-                doc = "Private attribute to generate Swift interfaces for static frameworks.",
+                doc = "Generate swift interfaces files (this triggers a config transition).",
             ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],
@@ -892,9 +892,9 @@ to manually dlopen the framework at runtime.
         })
     elif rule_descriptor.product_type == apple_product_type.static_framework:
         attrs.append({
-            "_emitswiftinterface": attr.bool(
+            "emitswiftinterface": attr.bool(
                 default = True,
-                doc = "Private attribute to generate Swift interfaces for static frameworks.",
+                doc = "Generate swift interfaces files (this triggers a config transition).",
             ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],
@@ -1029,9 +1029,9 @@ to manually dlopen the framework at runtime.
         })
     elif rule_descriptor.product_type == apple_product_type.static_framework:
         attrs.append({
-            "_emitswiftinterface": attr.bool(
+            "emitswiftinterface": attr.bool(
                 default = True,
-                doc = "Private attribute to generate Swift interfaces for static frameworks.",
+                doc = "Generate swift interfaces files (this triggers a config transition).",
             ),
             "hdrs": attr.label_list(
                 allow_files = [".h"],

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -327,7 +327,7 @@ def _command_line_options_for_xcframework_platform(
 def _apple_rule_base_transition_impl(settings, attr):
     """Rule transition for Apple rules."""
     return _command_line_options(
-        emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
+        emit_swiftinterface = getattr(attr, "emitswiftinterface", False),
         minimum_os_version = attr.minimum_os_version,
         platform_type = attr.platform_type,
         settings = settings,


### PR DESCRIPTION
On repositories where ios_static_framework() are built along side with other ios_*() targets, the emit-swiftinterface transition duplicates all the actions downstream of that transition.
This is by design, but it may not be desirable in all cases. For instance, if the swift code depends on a lot of cc_*() and objc_*() targets, it may be preferrable to not transition and add the swift.emit_swiftinterface feature to swift modules manually.

This changes makes the emitswiftinterface option to ios_static_framework() public so that the caller can opt-in to disable this transition and manage this feature manually.