### PR TITLE
Fix lldb when using `experimental_mixed_language_library`

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -333,7 +333,7 @@ target only contains Objective-C files.""")
             # attribute to declare custom inputs.
             ":" + umbrella_module_map,
         ],
-        module_map = umbrella_module_map,
+        module_map = objc_module_map_name,
         srcs = objc_srcs,
         **kwargs
     )


### PR DESCRIPTION
This applies a similar fix that https://github.com/buildbuddy-io/rules_xcodeproj/commit/d40173d84764c1256b95a537b2871e010398f18c did, for the same reason.