### PR TITLE
Add `reuse_simulator` attribute to `ios_xctestrun_runner`

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -24,7 +24,7 @@ def _get_template_substitutions(
         # "ordered" isn't a special string, but anything besides "random" for this field runs in order
         "test_order": "random" if random else "ordered",
         "xctestrun_template": xctestrun_template,
-        "reuse_simulator": reuse_simulator
+        "reuse_simulator": reuse_simulator,
     }
 
     return {"%({})s".format(key): value for key, value in substitutions.items()}

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -13,7 +13,8 @@ def _get_template_substitutions(
         simulator_creator,
         random,
         xcodebuild_args,
-        xctestrun_template):
+        xctestrun_template,
+        reuse_simulator):
     substitutions = {
         "device_type": device_type,
         "os_version": os_version,
@@ -23,6 +24,7 @@ def _get_template_substitutions(
         # "ordered" isn't a special string, but anything besides "random" for this field runs in order
         "test_order": "random" if random else "ordered",
         "xctestrun_template": xctestrun_template,
+        "reuse_simulator": reuse_simulator
     }
 
     return {"%({})s".format(key): value for key, value in substitutions.items()}
@@ -57,6 +59,7 @@ def _ios_xctestrun_runner_impl(ctx):
             random = ctx.attr.random,
             xcodebuild_args = " ".join(ctx.attr.xcodebuild_args) if ctx.attr.xcodebuild_args else "",
             xctestrun_template = ctx.file._xctestrun_template.short_path,
+            reuse_simulator = "true" if ctx.attr.reuse_simulator else "false",
         ),
     )
 
@@ -111,6 +114,12 @@ always use `xcodebuild test-without-building` to run the test bundle.
             doc = """
 Arguments to pass to `xcodebuild` when running the test bundle. This means it
 will always use `xcodebuild test-without-building` to run the test bundle.
+""",
+        ),
+        "reuse_simulator": attr.bool(
+            default = True,
+            doc = """
+Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.
 """,
         ),
         "_simulator_creator": attr.label(

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -227,10 +227,21 @@ fi
 
 readonly profraw="$test_tmp_dir/coverage.profraw"
 
-simulator_id="$("./%(simulator_creator.py)s" \
+simulator_creator_args=(
   "%(os_version)s" \
   "%(device_type)s" \
   --name "$simulator_name"
+)
+
+reuse_simulator=%(reuse_simulator)s
+if [[ "$reuse_simulator" == true ]]; then
+  simulator_creator_args+=(--reuse-simulator)
+else
+  simulator_creator_args+=(--no-reuse-simulator)
+fi
+
+simulator_id="$("./%(simulator_creator.py)s" \
+  "${simulator_creator_args[@]}"
 )"
 
 test_exit_code=0
@@ -332,6 +343,11 @@ else
     "$test_tmp_dir/$test_bundle_name.xctest" \
     2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
     || test_exit_code=$?
+fi
+
+if [[ "$reuse_simulator" == false ]]; then
+  xcrun simctl shutdown "$simulator_id"
+  xcrun simctl delete "$simulator_id"
 fi
 
 if [[ "$test_exit_code" -ne 0 ]]; then

--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -15,6 +15,8 @@
 
 import argparse
 import json
+import random
+import string
 import subprocess
 import sys
 import time
@@ -66,34 +68,49 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="The name to use for the device; default is 'BAZEL_TEST_[device_type]_[os_version]'",
     )
+    parser.add_argument(
+        "--reuse-simulator",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Toggle simulator reuse; default is True",
+    )
     return parser
 
 
-def _main(os_version: str, device_type: str, name: Optional[str]) -> None:
+def _main(os_version: str, device_type: str, name: Optional[str], reuse_simulator: bool) -> None:
     devices = json.loads(_simctl(["list", "devices", "-j"]))["devices"]
     device_name = name or _device_name(device_type, os_version)
     runtime_identifier = "com.apple.CoreSimulator.SimRuntime.iOS-{}".format(
         os_version.replace(".", "-")
     )
 
-    devices_for_os = devices.get(runtime_identifier) or []
-    existing_device = next(
-        (blob for blob in devices_for_os if blob["name"] == device_name), None
-    )
+    existing_device=None
+
+    if reuse_simulator:
+        devices_for_os = devices.get(runtime_identifier) or []
+        existing_device = next(
+            (blob for blob in devices_for_os if blob["name"] == device_name), None
+        )
 
     if existing_device:
         simulator_id = existing_device["udid"]
+        name = existing_device["name"]
         # If the device is already booted assume that it was created with this
         # script and bootstatus has already waited for it to be in a good state
         # once
         state = existing_device["state"].lower()
-        print(f"Simulator state is: {state}", file=sys.stderr)
+        print(f"Existing simulator '{name}' ({simulator_id}) state is: {state}", file=sys.stderr)
         if state != "booted":
             _boot_simulator(simulator_id)
     else:
+        # Simulator reuse is based on device name, therefore we must generate a unique name to
+        # prevent unintended reuse.
+        device_name_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+        device_name += f"_{device_name_suffix}"
         simulator_id = _simctl(
             ["create", device_name, device_type, runtime_identifier]
         ).strip()
+        print(f"Created new simulator '{device_name}' ({simulator_id})", file=sys.stderr)
         _boot_simulator(simulator_id)
 
     print(simulator_id.strip())
@@ -101,4 +118,4 @@ def _main(os_version: str, device_type: str, name: Optional[str]) -> None:
 
 if __name__ == "__main__":
     args = _build_parser().parse_args()
-    _main(args.os_version, args.device_type, args.name)
+    _main(args.os_version, args.device_type, args.name, args.reuse_simulator)

--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -103,10 +103,12 @@ def _main(os_version: str, device_type: str, name: Optional[str], reuse_simulato
         if state != "booted":
             _boot_simulator(simulator_id)
     else:
-        # Simulator reuse is based on device name, therefore we must generate a unique name to
-        # prevent unintended reuse.
-        device_name_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
-        device_name += f"_{device_name_suffix}"
+        if not reuse_simulator:
+            # Simulator reuse is based on device name, therefore we must generate a unique name to
+            # prevent unintended reuse.
+            device_name_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
+            device_name += f"_{device_name_suffix}"
+
         simulator_id = _simctl(
             ["create", device_name, device_type, runtime_identifier]
         ).strip()

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -624,8 +624,7 @@ of the attributes inherited by all test rules, please check the
 ## ios_xctestrun_runner
 
 <pre>
-ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>,
-                     <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
+ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
 </pre>
 
 
@@ -676,7 +675,6 @@ in Xcode.
 | <a id="ios_xctestrun_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of <code>xcrun simctl list devicetypes</code>. E.g., iPhone X, iPad Air. By default, it reads from --ios_simulator_device or falls back to some device.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-random"></a>random |  Whether to run the tests in random order to identify unintended state dependencies.   | Boolean | optional | <code>False</code> |
-| <a id="ios_xctestrun_runner-reuse_simulator"></a>reuse_simulator |  Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.   | Boolean | optional | <code>True</code> |
 | <a id="ios_xctestrun_runner-xcodebuild_args"></a>xcodebuild_args |  Arguments to pass to <code>xcodebuild</code> when running the test bundle. This means it will always use <code>xcodebuild test-without-building</code> to run the test bundle.   | List of strings | optional | <code>[]</code> |
 
 

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -624,7 +624,7 @@ of the attributes inherited by all test rules, please check the
 ## ios_xctestrun_runner
 
 <pre>
-ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
+ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>)
 </pre>
 
 
@@ -676,6 +676,7 @@ in Xcode.
 | <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-random"></a>random |  Whether to run the tests in random order to identify unintended state dependencies.   | Boolean | optional | <code>False</code> |
 | <a id="ios_xctestrun_runner-xcodebuild_args"></a>xcodebuild_args |  Arguments to pass to <code>xcodebuild</code> when running the test bundle. This means it will always use <code>xcodebuild test-without-building</code> to run the test bundle.   | List of strings | optional | <code>[]</code> |
+| <a id="ios_xctestrun_runner-reuse_simulator"></a>reuse_simulator |  Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.   | List of strings | optional | <code>True</code> |
 
 
 <a id="ios_ui_test_suite"></a>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -624,7 +624,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_xctestrun_runner
 
 <pre>
-ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>)
+ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>,
+                     <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
 </pre>
 
 
@@ -675,8 +676,8 @@ in Xcode.
 | <a id="ios_xctestrun_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of <code>xcrun simctl list devicetypes</code>. E.g., iPhone X, iPad Air. By default, it reads from --ios_simulator_device or falls back to some device.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-random"></a>random |  Whether to run the tests in random order to identify unintended state dependencies.   | Boolean | optional | <code>False</code> |
+| <a id="ios_xctestrun_runner-reuse_simulator"></a>reuse_simulator |  Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.   | Boolean | optional | <code>True</code> |
 | <a id="ios_xctestrun_runner-xcodebuild_args"></a>xcodebuild_args |  Arguments to pass to <code>xcodebuild</code> when running the test bundle. This means it will always use <code>xcodebuild test-without-building</code> to run the test bundle.   | List of strings | optional | <code>[]</code> |
-| <a id="ios_xctestrun_runner-reuse_simulator"></a>reuse_simulator |  Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.   | List of strings | optional | <code>True</code> |
 
 
 <a id="ios_ui_test_suite"></a>

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -44,6 +44,12 @@ ios_xctestrun_runner(
     device_type = "iPhone 8",
 )
 
+ios_xctestrun_runner(
+    name = "ios_x86_64_sim_reuse_disabled_runner",
+    device_type = "iPhone 8",
+    reuse_simulator = False,
+)
+
 EOF
 }
 
@@ -228,6 +234,16 @@ ios_unit_test(
     test_host = ":app",
     env = test_env,
     runner = ":ios_x86_64_sim_runner",
+)
+
+ios_unit_test(
+    name = "PassingWithHostSimReuseDisabled",
+    infoplists = ["PassUnitTest-Info.plist"],
+    deps = [":pass_unit_test_lib"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    test_host = ":app",
+    env = test_env,
+    runner = ":ios_x86_64_sim_ruse_disabled_runner",
 )
 
 swift_library(
@@ -463,6 +479,17 @@ function test_ios_unit_test_with_host_pass() {
 
   expect_log "Test Suite 'PassingUnitTest' passed"
   expect_log "Test Suite 'PassingWithHost.xctest' passed"
+  expect_log "Executed 4 tests, with 0 failures"
+}
+
+function test_ios_unit_test_with_host_sim_reuse_disabled_pass() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  do_ios_test //ios:PassingWithHostSimReuseDisabled || fail "should pass"
+
+  expect_log "Test Suite 'PassingUnitTest' passed"
+  expect_log "Test Suite 'PassingWithHostSimReuseDisabled.xctest' passed"
   expect_log "Executed 4 tests, with 0 failures"
 }
 


### PR DESCRIPTION
Simulator reuse is not compatible with test suites that use a test host and where `local_test_jobs` > 1. The concurrent app installations cause tests to exit prematurely or exit with obscure errors.

This change adds the `reuse_simulator` attribute that allows us to toggle reuse on the runner.