### PR TITLE
Safer accessing of framework files xcframework

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -337,6 +337,7 @@ def _get_xcframework_library_with_xcframework_processor(
         includes = includes,
         clang_module_map = module_map_file,
         swiftmodule = [],
+        framework_files = [],
     )
 
 def _get_library_identifier(


### PR DESCRIPTION
Some imports can fail this conditional unless we
check for the existence of the attr on the
`xcframework_library`

Error log without this change

```terminal
ERROR: /private/var/tmp/_bazel_maxwellelliott/db37ab0e01ac1d9a8e5ea282dd04a720/external/Google-Mobile-Ads-SDK/BUILD.bazel:6:32: in apple_static_xcframework_import rule @Google-Mobile-Ads-SDK//:GoogleMobileAds: 
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_maxwellelliott/db37ab0e01ac1d9a8e5ea282dd04a720/external/build_bazel_rules_apple/apple/internal/apple_xcframework_import.bzl", line 594, column 51, in _apple_static_xcframework_import_impl
                bundle_files = [x for x in xcframework_library.framework_files if ".bundle/" in x.short_path]
Error: 'struct' value has no field or method 'framework_files'
Available attributes: binary, clang_module_map, framework_imports, framework_includes, headers, includes, swiftmodule
```