### PR TITLE
Fix test not expanding all binary paths

### DIFF
--- a/test/starlark_tests/verifier_scripts/apple_symbols_file_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/apple_symbols_file_verifier.sh
@@ -49,4 +49,4 @@ function assert_unpacked_archive_contains_symbols_directory() {
 }
 
 assert_unpacked_archive_contains_symbols_directory "${ARCHIVE_ROOT}" \
-  "${BINARY_PATHS}"
+  "${BINARY_PATHS[@]}"


### PR DESCRIPTION
This fixes a bug in `apple_symbols_file_verifier.sh` that was causing only the first binary path to actually be checked for presence in the produced symbols. This could have caused a test to pass even though it should have failed.

For example, changing every entry but the first to an invalid one (such as [here](https://github.com/bazelbuild/rules_apple/blob/f27d7f2751a453d2b5ab90d244237cbc0249c3c0/test/starlark_tests/ios_application_tests.bzl#L458)), would still make the test pass before this change:

Before the patch:
```
bazelisk test //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test --verbose_failures --sandbox_debug --test_output=all
…
INFO: From Testing //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test:
==================== Test output for //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test:
================================================================================
Target //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test up-to-date:
  bazel-bin/test/starlark_tests/ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test_test_script
INFO: Elapsed time: 0.270s, Critical Path: 0.18s
INFO: 2 processes: 2 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
//test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test PASSED in 0.1s
```

After the patch:
```
INFO: From Testing //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test:
==================== Test output for //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test:
error: /var/folders/tq/vxkgqjw51g3_w47k_vjx6y4h0000gn/T//bundle_tmp_dir.x9xWb0/Payload/app_with_imported_dynamic_fmwk_with_dsym.app/Frameworks/iOSDynamicFramework.framework/non_existing_binary: No such file or directory
================================================================================
Target //test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test up-to-date:
  bazel-bin/test/starlark_tests/ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test_test_script
INFO: Elapsed time: 0.303s, Critical Path: 0.19s
INFO: 2 processes: 2 darwin-sandbox.
INFO: Build completed, 1 test FAILED, 2 total actions
//test/starlark_tests:ios_application_archive_contains_apple_symbols_files_from_external_fmwk_test FAILED in 0.2s
```