### PR TITLE
Include Apple Symbols for watchOS extensions

### DIFF
--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -765,6 +765,15 @@ def _watchos_application_impl(ctx):
             binary_artifact = binary_artifact,
             label_name = label.name,
         ),
+        partials.apple_symbols_file_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            dependency_targets = [ctx.attr.extension],
+            dsym_binaries = {},
+            label_name = label.name,
+            include_symbols_in_bundle = False,
+            platform_prerequisites = platform_prerequisites,
+        ),
     ]
 
     if platform_prerequisites.platform.is_device:

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -462,6 +462,20 @@ def ios_application_test_suite(name):
     )
 
     # Tests that the archive contains .symbols package files when `include_symbols_in_bundle`
+    # is enabled for both the iOS application and the watchOS extensions.
+    apple_symbols_file_test(
+        name = "{}_archive_contains_apple_symbols_files_watchos_test".format(name),
+        binary_paths = [
+            "Payload/companion.app/companion",
+            "Payload/companion.app/Watch/app.app/PlugIns/ext.appex/ext",
+            "Payload/companion.app/Watch/app.app/PlugIns/ext.appex/PlugIns/watchos_app_extension.appex/watchos_app_extension",
+        ],
+        build_type = "simulator",
+        tags = [name],
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ios_watchos_with_watchos_extension_and_symbols_in_bundle",
+    )
+
+    # Tests that the archive contains .symbols package files when `include_symbols_in_bundle`
     # is enabled.
     apple_symbols_file_test(
         name = "{}_archive_contains_apple_symbols_files_test".format(name),

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -451,6 +451,24 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "ios_watchos_with_watchos_extension_and_symbols_in_bundle",
+    bundle_id = "com.google",
+    bundle_name = "companion",
+    families = ["iphone"],
+    include_symbols_in_bundle = True,
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.arm_sim_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    watch_application = ":watchos_app_with_extension",
+    deps = [
+        ":swift_lib",
+    ],
+)
+
 watchos_extension(
     name = "watchos_app_extension",
     application_extension = True,


### PR DESCRIPTION
This PR depends on https://github.com/bazelbuild/rules_apple/pull/1941 since I'd like to fully verify the tests before merging this.

This fixes bundling Apple Symbols for watchOS extensions correctly when `include_symbols_in_bundle` is set to True in the companion iOS app. The problem seemed to be that `watchos_application` was missing a `partials.apple_symbols_file_partial` implementation to propagate the symbols to the parent iOS app. This caused all symbols for watchOS extensions to be correctly created, but not included in the final `Symbols/` directory.