### PR TITLE
Allow test bundles to override `bundle_name`

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -222,6 +222,13 @@ A file that will be used in lcov export calls to limit the scope of files instru
 """,
         allow_single_file = True,
     ),
+    "bundle_name": attr.string(
+        mandatory = False,
+        doc = """
+The desired name of the bundle (without the extension). If this attribute is not set, then the name
+of the target will be used instead.
+""",
+    ),
 }
 
 def _common_binary_linking_attrs(deps_cfg, product_type):

--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -74,8 +74,6 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
     elif not runner and not runners:
         fail("Must specify one of runner or runners.")
 
-    test_bundle_name = name + ".__internal__.__test_bundle"
-
     test_attrs = {k: v for (k, v) in kwargs.items() if k not in _BUNDLE_ATTRS}
     bundle_attrs = {k: v for (k, v) in kwargs.items() if k in _BUNDLE_ATTRS}
 
@@ -84,15 +82,17 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
         if x in test_attrs:
             bundle_attrs[x] = test_attrs[x]
 
-    if "bundle_name" in kwargs:
-        fail("bundle_name is not supported in test rules.")
+    # `bundle_name` is either provided or the default is `name`.
+    bundle_name = bundle_attrs.pop("bundle_name", name)
+
+    test_bundle_name = bundle_name + ".__internal__.__test_bundle"
 
     # Ideally this target should be private, but the outputs should not be private, so we're
     # explicitly using the same visibility as the test (or None if none was set).
     bundle_rule(
         name = test_bundle_name,
-        bundle_name = name,
-        test_bundle_output = "{}.zip".format(name),
+        bundle_name = bundle_name,
+        test_bundle_output = "{}.zip".format(bundle_name),
         testonly = True,
         **bundle_attrs
     )

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -535,8 +535,8 @@ Outputs:
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>,
-            <a href="#ios_ui_test-test_host">test_host</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>,
+            <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>)
 </pre>
 
 iOS UI Test rule.
@@ -562,6 +562,7 @@ of the attributes inherited by all test rules, please check the
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="ios_ui_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ios_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="ios_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="ios_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
@@ -577,8 +578,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>,
-              <a href="#ios_unit_test-test_host">test_host</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>,
+              <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -609,6 +610,7 @@ of the attributes inherited by all test rules, please check the
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="ios_unit_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ios_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="ios_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="ios_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -406,8 +406,8 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>,
-              <a href="#macos_ui_test-test_host">test_host</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>,
+              <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -423,6 +423,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="macos_ui_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="macos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="macos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="macos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
@@ -438,8 +439,8 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>,
-                <a href="#macos_unit_test-test_host">test_host</a>)
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>,
+                <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -461,6 +462,7 @@ find more information about testing for Apple platforms
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="macos_unit_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="macos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="macos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="macos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -308,8 +308,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>,
-             <a href="#tvos_ui_test-test_host">test_host</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>,
+             <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>)
 </pre>
 
 
@@ -331,6 +331,7 @@ the attributes inherited by all test rules, please check the
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="tvos_ui_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="tvos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="tvos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="tvos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
@@ -346,8 +347,8 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>,
-               <a href="#tvos_unit_test-test_host">test_host</a>)
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>,
+               <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>)
 </pre>
 
 
@@ -377,6 +378,7 @@ of the attributes inherited by all test rules, please check the
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="tvos_unit_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="tvos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="tvos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="tvos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -266,8 +266,8 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>,
-                <a href="#watchos_ui_test-test_host">test_host</a>)
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>,
+                <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -278,6 +278,7 @@ watchOS UI Test rule.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="watchos_ui_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="watchos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="watchos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="watchos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
@@ -293,8 +294,8 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>,
-                  <a href="#watchos_unit_test-test_host">test_host</a>)
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>,
+                  <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -305,6 +306,7 @@ watchOS Unit Test rule.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="watchos_unit_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="watchos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional | <code>""</code> |
 | <a id="watchos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="watchos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -100,6 +100,15 @@ def ios_unit_test_test_suite(name):
         tags = [name],
     )
 
+    infoplist_contents_test(
+        name = "{}_test_bundle_name_override".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_custom_bundle_name",
+        expected_values = {
+            "CFBundleExecutable": "UnitTestCustomBundleName",
+        },
+        tags = [name],
+    )
+
     analysis_failure_message_test(
         name = "{}_test_bundle_id_same_as_test_host_error".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_invalid_bundle_id",
@@ -114,6 +123,17 @@ def ios_unit_test_test_suite(name):
             "AnotherKey": "AnotherValue",
             "CFBundleExecutable": "unit_test_multiple_infoplists",
         },
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_test_target_bundle_name_override".format(name),
+        build_type = "simulator",
+        contains = [
+            "$ARCHIVE_ROOT/UnitTestCustomBundleName.xctest",
+            "$BUNDLE_ROOT/UnitTestCustomBundleName",
+        ],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_custom_bundle_name",
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2468,6 +2468,24 @@ ios_unit_test(
 )
 
 ios_unit_test(
+    name = "unit_test_custom_bundle_name",
+    bundle_name = "UnitTestCustomBundleName",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    tags = common.fixture_tags,
+    test_host = ":app",
+    deps = [
+        "//test/starlark_tests/resources:objc_test_lib",
+    ],
+)
+
+ios_unit_test(
     name = "unit_test_invalid_bundle_id",
     bundle_id = "com.google.example",
     families = [


### PR DESCRIPTION
Tested this with both `ios_test_runner` & `ios_xctestrun_runner` on an unhosted unit test.