### PR TITLE
Add `testonly` support to `experimental_mixed_language_library`

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -197,6 +197,7 @@ def experimental_mixed_language_library(
         objc_copts = [],
         swift_copts = [],
         swiftc_inputs = [],
+        testonly = False,
         **kwargs):
     """Compiles and links Objective-C and Swift code into a static library.
 
@@ -227,6 +228,8 @@ def experimental_mixed_language_library(
             variable expansion.
         swiftc_inputs: Additional files that are referenced using
             `$(location...)` in `swift_copts`.
+        testonly: If True, only testonly targets (such as tests) can depend on
+            this target. Default False.
         **kwargs: Other arguments to pass through to the underlying
             `objc_library`.
     """
@@ -290,6 +293,7 @@ target only contains Objective-C files.""")
         hdrs = hdrs,
         module_name = module_name,
         textual_hdrs = textual_hdrs,
+        testonly = testonly,
     )
 
     swiftc_inputs = swiftc_inputs + hdrs + textual_hdrs + private_hdrs + [":" + objc_module_map_name]
@@ -312,6 +316,7 @@ target only contains Objective-C files.""")
         module_name = module_name,
         srcs = swift_srcs,
         swiftc_inputs = swiftc_inputs,
+        testonly = testonly,
     )
 
     umbrella_module_map = name + ".internal.umbrella"
@@ -320,6 +325,7 @@ target only contains Objective-C files.""")
         deps = [":" + swift_library_name],
         hdrs = hdrs,
         module_name = module_name,
+        testonly = testonly,
     )
     objc_deps.append(":" + umbrella_module_map)
 
@@ -335,5 +341,6 @@ target only contains Objective-C files.""")
         ],
         module_map = umbrella_module_map,
         srcs = objc_srcs,
+        testonly = testonly,
         **kwargs
     )

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -442,7 +442,7 @@ ios_application(
 
 <pre>
 experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>, <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>,
-                                    <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
+                                    <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-testonly">testonly</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
 </pre>
 
 Compiles and links Objective-C and Swift code into a static library.
@@ -472,6 +472,7 @@ modules---it does not support for header maps or Clang modules.
 | <a id="experimental_mixed_language_library-objc_copts"></a>objc_copts |  Additional compiler options that should be passed to <code>clang</code>.   |  <code>[]</code> |
 | <a id="experimental_mixed_language_library-swift_copts"></a>swift_copts |  Additional compiler options that should be passed to <code>swiftc</code>. These strings are subject to <code>$(location ...)</code> and "Make" variable expansion.   |  <code>[]</code> |
 | <a id="experimental_mixed_language_library-swiftc_inputs"></a>swiftc_inputs |  Additional files that are referenced using <code>$(location...)</code> in <code>swift_copts</code>.   |  <code>[]</code> |
+| <a id="experimental_mixed_language_library-testonly"></a>testonly |  If True, only testonly targets (such as tests) can depend on this target. Default False.   |  <code>False</code> |
 | <a id="experimental_mixed_language_library-kwargs"></a>kwargs |  Other arguments to pass through to the underlying <code>objc_library</code>.   |  none |
 
 

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -23,12 +23,12 @@ swift_library(
 )
 
 experimental_mixed_language_library(
-  name = "MixedTestsLib",
-  srcs = [
-    "MixedTests.m",
-    "MixedTests.swift",
-  ],
-  testonly = True,
+    name = "MixedTestsLib",
+    testonly = True,
+    srcs = [
+        "MixedTests.m",
+        "MixedTests.swift",
+    ],
 )
 
 ios_unit_test(

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -1,4 +1,5 @@
 load("//apple:apple.bzl", "experimental_mixed_language_library")
+load("//apple:ios.bzl", "ios_unit_test")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
@@ -19,4 +20,19 @@ swift_library(
         "SwiftLibDependingOnMixedLib.swift",
     ],
     deps = [":MixedAnswer"],
+)
+
+experimental_mixed_language_library(
+  name = "MixedTestsLib",
+  srcs = [
+    "MixedTests.m",
+    "MixedTests.swift",
+  ],
+  testonly = True,
+)
+
+ios_unit_test(
+    name = "MixedTests",
+    minimum_os_version = "8.0",
+    deps = [":MixedTestsLib"],
 )

--- a/examples/multi_platform/MixedLib/MixedTests.m
+++ b/examples/multi_platform/MixedLib/MixedTests.m
@@ -1,0 +1,27 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface MixedTests : XCTestCase
+@end
+
+@implementation MixedTests
+
+- (void)testAlwaysPass {
+  XCTAssertTrue(YES);
+}
+
+@end

--- a/examples/multi_platform/MixedLib/MixedTests.swift
+++ b/examples/multi_platform/MixedLib/MixedTests.swift
@@ -1,0 +1,21 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+class MixedTests: XCTestCase {
+  func testAlwaysPass() {
+    XCTAssertTrue(true)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_apple/issues/1950.