### PR TITLE
Add support for apple.locales_to_exclude

### DIFF
--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -127,12 +127,12 @@ def _locales_requested(*, config_vars):
     else:
         return None
 
-def _validate_processed_locales(*, label, locales_dropped, locales_included, locales_requested):
+def _validate_processed_locales(*, label, locales_dropped, locales_included, locales_requested, locales_to_exclude):
     """Prints a warning if locales were dropped and none of the requested ones were included."""
     if sets.length(locales_dropped):
         # Display a warning if a locale was dropped and there are unfulfilled locale requests; it
         # could mean that the user made a mistake in defining the locales they want to keep.
-        if not sets.is_equal(locales_requested, locales_included):
+        if locales_requested and not sets.is_equal(locales_requested, locales_included):
             unused_locales = sets.difference(locales_requested, locales_included)
 
             # There is no way to issue a warning, so print is the only way
@@ -141,6 +141,33 @@ def _validate_processed_locales(*, label, locales_dropped, locales_included, loc
             print("Warning: " + str(label) + " did not have resources that matched " +
                   sets.str(unused_locales) + " in locale filter. Please verify " +
                   "apple.locales_to_include is defined properly.")
+
+        if locales_requested and locales_to_exclude:
+            conflicting_locales = sets.intersection(locales_requested, locales_to_exclude)
+            if sets.length(conflicting_locales):
+                # There is no way to issue a warning, so print is the only way
+                # to message.
+                # buildifier: disable=print
+                print("Warning: " + str(label) + " dropping " +
+                      sets.str(conflicting_locales) + " as they are explicitly excluded but also explicitly included. Please verify " +
+                      "apple.locales_to_include and apple.locales_to_exclude are defined properly.")
+
+def _locales_to_exclude(*, config_vars):
+    """Determines which locales to exclude when resource actions.
+
+    If the user has specified "apple.locales_to_exclude" we use those.
+
+    Args:
+        config_vars: A dictionary (String to String) of config variables. Typically from `ctx.var`.
+
+    Returns:
+        A set of locales to exclude or None if no locale exclude is requested.
+    """
+    excluded_locales = config_vars.get("apple.locales_to_exclude")
+    if excluded_locales != None:
+        return sets.make([x.strip() for x in excluded_locales.split(",")])
+    else:
+        return None
 
 def _resources_partial_impl(
         *,
@@ -231,6 +258,7 @@ def _resources_partial_impl(
     infoplists = []
 
     locales_requested = _locales_requested(config_vars = platform_prerequisites.config_vars)
+    locales_to_exclude = _locales_to_exclude(config_vars = platform_prerequisites.config_vars)
     locales_included = sets.make(["Base"])
     locales_dropped = sets.make()
 
@@ -242,6 +270,11 @@ def _resources_partial_impl(
                 if sets.contains(locales_requested, locale):
                     sets.insert(locales_included, locale)
                 elif locale != None:
+                    sets.insert(locales_dropped, locale)
+                    continue
+            if locales_to_exclude:
+                locale = bundle_paths.locale_for_path(parent_dir)
+                if locale and sets.contains(locales_to_exclude, locale):
                     sets.insert(locales_dropped, locale)
                     continue
 
@@ -277,12 +310,13 @@ def _resources_partial_impl(
         field_handler = _deduplicated_field_handler,
     )
 
-    if locales_requested:
+    if locales_requested or locales_to_exclude:
         _validate_processed_locales(
             label = rule_label,
             locales_dropped = locales_dropped,
             locales_included = locales_included,
             locales_requested = locales_requested,
+            locales_to_exclude = locales_to_exclude,
         )
 
     if bundle_id:

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -279,6 +279,13 @@ the exact names of the locales to be included.
 This can be used to improve compile/debug/test cycles because most developers
 only work/test in one language.
 
+#### Explicitly Excluding Locales
+
+Use `--define "apple.locales_to_exclude=foo,bar,bam"` where `foo,bar,bam` are
+the exact names of the locales to be excluded.
+
+Note: this overrides the `--define "apple.locales_to_include=foo,bar,bam"` i.e. if `foo` is present in `locales_to_include` but also present in `locales_to_exclude`, it will be excluded from the output bundle.
+
 #### Automatically Trimming Locales
 
 Use `--define "apple.trim_lproj_locales=(yes|true|1)"` to strip any `.lproj`

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -284,8 +284,6 @@ only work/test in one language.
 Use `--define "apple.locales_to_exclude=foo,bar,bam"` where `foo,bar,bam` are
 the exact names of the locales to be excluded.
 
-Note: this overrides the `--define "apple.locales_to_include=foo,bar,bam"` i.e. if `foo` is present in `locales_to_include` but also present in `locales_to_exclude`, it will be excluded from the output bundle.
-
 #### Automatically Trimming Locales
 
 Use `--define "apple.trim_lproj_locales=(yes|true|1)"` to strip any `.lproj`

--- a/test/ios_application_resources_test.sh
+++ b/test/ios_application_resources_test.sh
@@ -442,12 +442,11 @@ ios_application(
 )
 EOF
 
-  do_build ios //app:app --define "apple.locales_to_exclude=fr" --define "apple.locales_to_include=fr,it" \
-      || fail "Should build"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/it.lproj/localized.strings"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/fr.lproj/localized.strings"
+  ! do_build ios //app:app --define "apple.locales_to_exclude=fr" --define "apple.locales_to_include=fr,it" \
+      || fail "Should fail build"
+  error_message="\/\/app:app dropping \[\"fr\"\] as they are explicitly excluded but also explicitly included. \
+Please verify apple.locales_to_include and apple.locales_to_exclude are defined properly."
+  expect_log "$error_message"
 }
 
 run_suite "ios_application bundling with resources tests"

--- a/test/macos_application_resources_test.sh
+++ b/test/macos_application_resources_test.sh
@@ -149,4 +149,83 @@ EOF
       "app.app/Contents/Resources/bundle_library_macos.bundle/fr.lproj/localized.strings"
 }
 
+# Tests that the localizations that are explictly excluded via 
+# --define "apple.locales_to_exclude=fr" are not included in the output bundle.
+function test_bundle_localization_excludes() {
+  create_common_files
+
+  mkdir -p app/fr.lproj
+  touch app/fr.lproj/localized.strings
+
+  mkdir -p app/it.lproj
+  touch app/it.lproj/localized.strings
+
+  cat >> app/BUILD <<EOF
+objc_library(
+    name = "resources",
+    data = [
+        "fr.lproj/localized.strings",
+        "it.lproj/localized.strings",
+    ],
+)
+
+macos_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_MACOS}",
+    deps = [":lib", ":resources"],
+)
+EOF
+
+  do_build macos //app:app --define "apple.locales_to_exclude=fr" \
+      || fail "Should build"
+
+  # Verify the app has a `it` localization and not an `fr` localization.
+  assert_zip_not_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Resources/fr.lproj/localized.strings"
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Resources/it.lproj/localized.strings"
+}
+
+# Tests that the localizations that are explictly excluded via 
+# --define "apple.locales_to_exclude=fr" overrides the ones explicitly included via "apple.locales_to_include" and are not included in the output bundle.
+function test_bundle_localization_excludes_includes_conflict() {
+  create_common_files
+
+  mkdir -p app/fr.lproj
+  touch app/fr.lproj/localized.strings
+
+  mkdir -p app/it.lproj
+  touch app/it.lproj/localized.strings
+
+  cat >> app/BUILD <<EOF
+objc_library(
+    name = "resources",
+    data = [
+        "fr.lproj/localized.strings",
+        "it.lproj/localized.strings",
+    ],
+)
+
+macos_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_MACOS}",
+    deps = [":lib", ":resources"],
+)
+EOF
+
+  do_build macos //app:app --define "apple.locales_to_exclude=fr" --define "apple.locales_to_include=fr,it" \
+      || fail "Should build"
+
+  # Verify the app has a `it` localization and not an `fr` localization.
+  assert_zip_not_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Resources/fr.lproj/localized.strings"
+  assert_zip_contains "test-bin/app/app.zip" \
+      "app.app/Contents/Resources/it.lproj/localized.strings"
+}
+
+
 run_suite "macos_application bundling with resources tests"

--- a/test/macos_application_resources_test.sh
+++ b/test/macos_application_resources_test.sh
@@ -189,7 +189,8 @@ EOF
 }
 
 # Tests that the localizations that are explictly excluded via 
-# --define "apple.locales_to_exclude=fr" overrides the ones explicitly included via "apple.locales_to_include" and are not included in the output bundle.
+# --define "apple.locales_to_exclude=fr" overrides the ones explicitly included
+# via "apple.locales_to_include" and are not included in the output bundle.
 function test_bundle_localization_excludes_includes_conflict() {
   create_common_files
 
@@ -217,14 +218,11 @@ macos_application(
 )
 EOF
 
-  do_build macos //app:app --define "apple.locales_to_exclude=fr" --define "apple.locales_to_include=fr,it" \
-      || fail "Should build"
-
-  # Verify the app has a `it` localization and not an `fr` localization.
-  assert_zip_not_contains "test-bin/app/app.zip" \
-      "app.app/Contents/Resources/fr.lproj/localized.strings"
-  assert_zip_contains "test-bin/app/app.zip" \
-      "app.app/Contents/Resources/it.lproj/localized.strings"
+  ! do_build macos //app:app --define "apple.locales_to_exclude=fr" --define "apple.locales_to_include=fr,it" \
+      || fail "Should fail build"
+  error_message="\/\/app:app dropping \[\"fr\"\] as they are explicitly excluded but also explicitly included. \
+Please verify apple.locales_to_include and apple.locales_to_exclude are defined properly."
+  expect_log "$error_message"
 }
 
 


### PR DESCRIPTION
**Context**
We have a use-case where certain locales are only for testing our localization pipeline and they are totally disjoint from the locales that are a part of production-facing bundles. `locales_to_include` does a great job for debugging environments but needs a long list of accepted locales if we are building for production. There can also be a trivial maintenance cost associated. Hence, this PR adds support for `locales_to_exclude` so that we can explicitly filter out the testing locales.