### PR TITLE
Fix Xcode 14.3 incompatibilities

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos
-    xcode_version: "14.2"
+    xcode_version: "14.3"
     build_targets:
     - "tools/..."
     - "test/..."

--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -34,7 +34,7 @@ ios_application(
     ],
     infoplists = [":Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/examples/ios/PrenotCalculator/BUILD
+++ b/examples/ios/PrenotCalculator/BUILD
@@ -27,7 +27,7 @@ ios_application(
     bundle_id = "com.example.prenot-calculator",
     families = ["iphone"],
     infoplists = ["PrenotCalculator-Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     deps = [":PrenotCalculator_library"],
 )
 
@@ -69,7 +69,7 @@ objc_library(
 
 ios_unit_test(
     name = "PrenotCalculatorTests",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     deps = [":PrenotCalculatorTestsLib"],
 )
 

--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -17,14 +17,14 @@ objc_library(
 ios_unit_test(
     name = "SquarerTests",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     deps = [":SquarerTestsLib"],
 )
 
 ios_unit_test(
     name = "SquarerTestsOrdered",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     deps = [":SquarerTestsLib"],
 )
@@ -32,7 +32,7 @@ ios_unit_test(
 ios_unit_test(
     name = "SquarerTestsRandom",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":SquarerTestsLib"],
 )

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -303,7 +303,7 @@ macos_application(
     name = "ButtonsMac",
     bundle_id = "com.google.ButtonsMac",
     infoplists = ["ButtonsMac/Info.plist"],
-    minimum_os_version = "10.10",
+    minimum_os_version = "12.0",
     deps = [
         ":ButtonsMacLib",
         ":ButtonsMacResources",

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -272,6 +272,7 @@ swift_library(
 
 swift_library(
     name = "ButtonsMacTestsLib",
+    testonly = True,
     srcs = [
         "ButtonsMacTests/ButtonsMacTests.swift",
     ],
@@ -314,14 +315,14 @@ macos_application(
 macos_unit_test(
     name = "ButtonsMacLogicTests",
     bundle_id = "com.google.logic",
-    minimum_os_version = "10.10",
+    minimum_os_version = "12.0",
     tags = ["manual"],  # https://github.com/bazelbuild/continuous-integration/issues/1273
     deps = [":ButtonsMacTestsLib"],
 )
 
 macos_unit_test(
     name = "ButtonsMacTests",
-    minimum_os_version = "10.10",
+    minimum_os_version = "12.0",
     tags = ["manual"],
     test_host = ":ButtonsMac",
     deps = [":ButtonsMacTestsLib"],

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -92,7 +92,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Buttons/Info.plist"],
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     watch_application = ":ButtonsWatch",
     deps = [
         ":ButtonsLib",
@@ -115,7 +115,7 @@ ios_extension(
 ios_static_framework(
     name = "ButtonsStaticFramework",
     bundle_name = "Buttons",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     deps = [":ButtonsLib"],
 )
 

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -33,6 +33,6 @@ experimental_mixed_language_library(
 
 ios_unit_test(
     name = "MixedTests",
-    minimum_os_version = "8.0",
+    minimum_os_version = "9.0",
     deps = [":MixedTestsLib"],
 )

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -303,7 +303,7 @@ EOF
 }
 
 function do_ios_test() {
-  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=8.0" "$@"
+  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=9.0" "$@"
 }
 
 function test_ios_ui_test_pass() {

--- a/test/ios_xctestrun_runner_ui_test.sh
+++ b/test/ios_xctestrun_runner_ui_test.sh
@@ -329,7 +329,7 @@ EOF
 }
 
 function do_ios_test() {
-  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=8.0" "$@"
+  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=9.0" "$@"
 }
 
 function test_ios_ui_test_pass() {

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -50,7 +50,7 @@ def _apple_verification_transition_impl(settings, attr):
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "x86_64",
             "//command_line_option:tvos_cpus": "x86_64",
-            "//command_line_option:watchos_cpus": "i386",
+            "//command_line_option:watchos_cpus": "x86_64",
         })
     else:
         output_dictionary.update({

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -352,7 +352,7 @@ apple_static_xcframework(
         "device": ["arm64"],
     },
     minimum_os_versions = {
-        "ios": "8.0",
+        "ios": "9.0",
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",
@@ -874,7 +874,7 @@ apple_static_xcframework(
         "device": ["arm64"],
     },
     minimum_os_versions = {
-        "ios": "8.0",
+        "ios": "9.0",
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",
@@ -939,7 +939,7 @@ apple_static_xcframework(
         "device": ["arm64"],
     },
     minimum_os_versions = {
-        "ios": "8.0",
+        "ios": "9.0",
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",
@@ -961,7 +961,7 @@ apple_static_xcframework(
         "device": ["arm64"],
     },
     minimum_os_versions = {
-        "ios": "8.0",
+        "ios": "9.0",
     },
     public_hdrs = [
         "//test/starlark_tests/resources:shared.h",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -397,7 +397,7 @@ apple_dynamic_framework_import(
 
 generate_import_framework(
     name = "generated_watchos_dynamic_fmwk",
-    archs = ["i386"],
+    archs = ["x86_64"],
     libtype = "dynamic",
     minimum_os_version = common.min_os_watchos.baseline,
     sdk = "watchsimulator",
@@ -419,7 +419,7 @@ apple_static_framework_import(
 
 generate_import_framework(
     name = "generated_watchos_static_fmwk",
-    archs = ["i386"],
+    archs = ["x86_64"],
     libtype = "static",
     minimum_os_version = common.min_os_watchos.baseline,
     sdk = "watchsimulator",

--- a/test/starlark_tests/watchos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/watchos_dynamic_framework_tests.bzl
@@ -43,8 +43,8 @@ def watchos_dynamic_framework_test_suite(name):
             "$BUNDLE_ROOT/Headers/BasicFramework.h",
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
-            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/i386.swiftdoc",
-            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/i386.swiftmodule",
+            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/BasicFramework.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
@@ -81,8 +81,8 @@ def watchos_dynamic_framework_test_suite(name):
             "$BUNDLE_ROOT/Headers/DirectDependencyTest.h",
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
-            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/i386.swiftdoc",
-            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/i386.swiftmodule",
+            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/DirectDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )
@@ -96,8 +96,8 @@ def watchos_dynamic_framework_test_suite(name):
             "$BUNDLE_ROOT/Headers/TransitiveDependencyTest.h",
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Modules/module.modulemap",
-            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/i386.swiftdoc",
-            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/i386.swiftmodule",
+            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/TransitiveDependencyTest.swiftmodule/x86_64.swiftmodule",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/watchos_framework_tests.bzl
+++ b/test/starlark_tests/watchos_framework_tests.bzl
@@ -60,7 +60,7 @@ def watchos_framework_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:fmwk_dead_stripped",
         binary_test_file = "$BUNDLE_ROOT/fmwk_dead_stripped",
         compilation_mode = "opt",
-        binary_test_architecture = "i386",
+        binary_test_architecture = "x86_64",
         binary_contains_symbols = ["_anotherFunctionShared"],
         binary_not_contains_symbols = ["_dontCallMeShared", "_anticipatedDeadCode"],
         tags = [name],


### PR DESCRIPTION
With Xcode 14.3 the XCTest bundled with Xcode doesn't support the watchOS simulator with i386 or older deployment targets on iOS or macOS
