### PR TITLE
Only fail `ios_xctestrun_runner` when bundle executes nothing

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -361,7 +361,9 @@ if [[ "$test_exit_code" -ne 0 ]]; then
 fi
 
 if grep -q -e "Executed 0 tests, with 0 failures" "$testlog"; then
-  if [[ -n "${ALLOW_EMPTY_TEST_BUNDLE:-}" ]]; then
+  # This assumes that a test bundle with no executed tests is intentional
+  # if `--test_filter` is passed to the test target.
+  if [[ -n "${TEST_FILTER:-}" ]]; then
     echo "warning: no tests were executed, is the test bundle empty?" >&2
   else
     echo "error: no tests were executed, is the test bundle empty?" >&2

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -360,15 +360,12 @@ if [[ "$test_exit_code" -ne 0 ]]; then
   exit "$test_exit_code"
 fi
 
-if grep -q -e "Executed 0 tests, with 0 failures" "$testlog"; then
-  # This assumes that a test bundle with no executed tests is intentional
-  # if `--test_filter` is passed to the test target.
-  if [[ -n "${TEST_FILTER:-}" ]]; then
-    echo "warning: no tests were executed, is the test bundle empty?" >&2
-  else
-    echo "error: no tests were executed, is the test bundle empty?" >&2
-    exit 1
-  fi
+# Assume the final 'Executed N tests' or 'Executed 1 test' is the
+# total execution count for the test bundle.
+test_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} tests*," "$testlog" | tail -n1)
+if echo "$test_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
+  echo "error: no tests were executed, is the test bundle empty?" >&2
+  exit 1
 fi
 
 # When tests crash after they have reportedly completed, XCTest marks them as

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -361,8 +361,12 @@ if [[ "$test_exit_code" -ne 0 ]]; then
 fi
 
 if grep -q -e "Executed 0 tests, with 0 failures" "$testlog"; then
-  echo "error: no tests were executed, is the test bundle empty?" >&2
-  exit 1
+  if [[ -n "${ALLOW_EMPTY_TEST_BUNDLE:-}" ]]; then
+    echo "warning: no tests were executed, is the test bundle empty?" >&2
+  else
+    echo "error: no tests were executed, is the test bundle empty?" >&2
+    exit 1
+  fi
 fi
 
 # When tests crash after they have reportedly completed, XCTest marks them as

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -103,15 +103,33 @@ function create_ios_unit_tests() {
     fail "create_sim_runners must be called first."
   fi
 
-  cat > ios/empty_unit_test.m <<EOF
+  cat > ios/small_unit_test_1.m <<EOF
 #import <XCTest/XCTest.h>
 #import <XCTest/XCUIApplication.h>
 
-@interface EmptyUnitTest : XCTestCase
+@interface SmallUnitTest1 : XCTestCase
 
 @end
 
-@implementation EmptyUnitTest
+@implementation SmallUnitTest1
+- (void)testPass {
+  XCTAssertEqual(1, 1, @"should pass");
+}
+@end
+EOF
+
+  cat > ios/small_unit_test_2.m <<EOF
+#import <XCTest/XCTest.h>
+#import <XCTest/XCUIApplication.h>
+
+@interface SmallUnitTest2 : XCTestCase
+
+@end
+
+@implementation SmallUnitTest2
+- (void)testPass {
+  XCTAssertEqual(1, 1, @"should pass");
+}
 @end
 EOF
 
@@ -189,11 +207,11 @@ EOF
 @end
 EOF
 
-  cat > ios/EmptyUnitTest-Info.plist <<EOF
+  cat > ios/SmallUnitTest-Info.plist <<EOF
 <plist version="1.0">
 <dict>
         <key>CFBundleExecutable</key>
-        <string>EmptyUnitTest</string>
+        <string>SmallUnitTest</string>
 </dict>
 </plist>
 EOF
@@ -234,14 +252,14 @@ test_env = {
 }
 
 objc_library(
-    name = "empty_unit_test_lib",
-    srcs = ["empty_unit_test.m"],
+    name = "small_unit_test_lib",
+    srcs = ["small_unit_test_1.m", "small_unit_test_2.m"],
 )
 
 ios_unit_test(
-    name = "EmptyUnitTest",
-    infoplists = ["EmptyUnitTest-Info.plist"],
-    deps = [":empty_unit_test_lib"],
+    name = "SmallUnitTest",
+    infoplists = ["SmallUnitTest-Info.plist"],
+    deps = [":small_unit_test_lib"],
     minimum_os_version = "${MIN_OS_IOS}",
     env = test_env,
     runner = ":ios_x86_64_sim_runner",
@@ -496,24 +514,37 @@ function do_ios_test() {
   do_test ios "--test_output=all" "--spawn_strategy=local" "$@"
 }
 
-function test_ios_unit_test_empty_pass() {
+function test_ios_unit_test_small_pass() {
   create_sim_runners
   create_ios_unit_tests
-  do_ios_test --test_filter=EmptyUnitTest/testThatDoesNotExist //ios:EmptyUnitTest || fail "should pass"
+  do_ios_test //ios:SmallUnitTest || fail "should pass"
 
-  expect_log "Test Suite 'EmptyUnitTest' passed"
-  expect_log "Test Suite 'EmptyUnitTest.xctest' passed"
-  expect_log "Executed 0 tests, with 0 failures"
+  expect_log "Test Suite 'SmallUnitTest1' passed"
+  expect_log "Test Suite 'SmallUnitTest2' passed"
+  expect_log "Test Suite 'SmallUnitTest.xctest' passed"
+  expect_log "Executed 2 tests, with 0 failures"
 }
 
-function test_ios_unit_test_empty_fail() {
+# Test bundle has tests with one test class with all tests filtered.
+function test_ios_unit_test_small_empty_test_class_filter_pass() {
+  create_sim_runners
+  create_ios_unit_tests
+  do_ios_test --test_filter="-SmallUnitTest1/testPass" //ios:SmallUnitTest || fail "should pass"
+
+  expect_log "Test Suite 'SmallUnitTest1' passed"
+  expect_log "Test Suite 'SmallUnitTest2' passed"
+  expect_log "Test Suite 'SmallUnitTest.xctest' passed"
+  expect_log "Executed 1 test, with 0 failures"
+}
+
+# Test bundle has tests but filter excludes all of them.
+function test_ios_unit_test_small_empty_fail() {
   create_sim_runners
   create_ios_unit_tests
 
-  ! do_ios_test //ios:EmptyUnitTest || fail "should fail"
+  ! do_ios_test --test_filter="BadFilter" //ios:SmallUnitTest || fail "should fail"
 
-  expect_log "Test Suite 'EmptyUnitTest' passed"
-  expect_log "Test Suite 'EmptyUnitTest.xctest' passed"
+  expect_log "Test Suite 'SmallUnitTest.xctest' passed"
   expect_log "Executed 0 tests, with 0 failures"
 }
 

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -499,7 +499,7 @@ function do_ios_test() {
 function test_ios_unit_test_empty_pass() {
   create_sim_runners
   create_ios_unit_tests
-  do_ios_test --test_env=ALLOW_EMPTY_TEST_BUNDLE=1 //ios:EmptyUnitTest || fail "should pass"
+  do_ios_test --test_filter=EmptyUnitTest/testThatDoesNotExist //ios:EmptyUnitTest || fail "should pass"
 
   expect_log "Test Suite 'EmptyUnitTest' passed"
   expect_log "Test Suite 'EmptyUnitTest.xctest' passed"

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -496,7 +496,7 @@ function do_ios_test() {
   do_test ios "--test_output=all" "--spawn_strategy=local" "$@"
 }
 
-function test_ios_unit_test_empty_success() {
+function test_ios_unit_test_empty_pass() {
   create_sim_runners
   create_ios_unit_tests
   do_ios_test --test_env=ALLOW_EMPTY_TEST_BUNDLE=1 //ios:EmptyUnitTest || fail "should pass"


### PR DESCRIPTION
Only fail a test bundle/target when no tests are ran. This could be because it's actually empty, it has all tests excluded, or has a bad filter that doesn't match any.

Closes https://github.com/bazelbuild/rules_apple/issues/1880.

Testing:
```
** test_ios_unit_test_small_empty_fail *****************************************
$TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_matt.robinson/ab4f9bfe2d3686b5a5595f6753e75e45/sandbox/darwin-sandbox/4/execroot/build_bazel_rules_apple/_tmp/f8d0ebbcaf3f9f8ca779b90b08771aac' and max_idle_secs default is '15'.
PASSED: test_ios_unit_test_small_empty_fail

** test_ios_unit_test_small_empty_test_class_filter_pass ***********************
$TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_matt.robinson/ab4f9bfe2d3686b5a5595f6753e75e45/sandbox/darwin-sandbox/4/execroot/build_bazel_rules_apple/_tmp/f8d0ebbcaf3f9f8ca779b90b08771aac' and max_idle_secs default is '15'.
PASSED: test_ios_unit_test_small_empty_test_class_filter_pass

** test_ios_unit_test_small_pass ***********************************************
$TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_matt.robinson/ab4f9bfe2d3686b5a5595f6753e75e45/sandbox/darwin-sandbox/4/execroot/build_bazel_rules_apple/_tmp/f8d0ebbcaf3f9f8ca779b90b08771aac' and max_idle_secs default is '15'.
PASSED: test_ios_unit_test_small_pass
```