### PR TITLE
Fix unquoted WORK_DIR environment in bundletool

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -289,7 +289,7 @@ class Bundler(object):
       command_lines: A newline-separated list of command lines that should be
           executed in the bundle to sign it.
     """
-    exit_code = os.system('WORK_DIR=%s\n%s' % (bundle_root, command_lines))
+    exit_code = os.system('WORK_DIR="%s"\n%s' % (bundle_root, command_lines))
     if exit_code:
       raise CodeSignError(exit_code)
 


### PR DESCRIPTION
If using a `bundle_name` with a space (i.e. `bundle_name = "My Widget"`) during codesigning this fails with error:

```sh
ERROR: Code/Apps/MyAppWidgets/WidgetExtension/BUILD:11:19: Bundling, processing and signing WidgetExtension failed: (Exit 1): bundletool_experimental failed: error executing command (from target //Code/Apps/MyAppWidgets/WidgetExtension:WidgetExtension) 
  (cd /private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo && \
  exec env - \
    APPLE_SDK_PLATFORM=iPhoneSimulator \
    APPLE_SDK_VERSION_OVERRIDE=16.2 \
    XCODE_VERSION_OVERRIDE=14.2.0.14C18 \
  bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/bundletool/bundletool_experimental bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-19f4f7fe00fe/bin/Code/Apps/MyAppWidgets/WidgetExtension/WidgetExtension-intermediates/bundletool_control.json)
# Configuration: f4557a7e22b549f73b1cd10f00186e4db59437fa31c3915004b22bc393e5739e
# Execution platform: @local_config_platform//:host
sh: Extension.appex: command not found
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 417, in <module>
    sys.exit(main(generate_arg_parser().parse_args()))
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 412, in main
    _invoke_codesign(args.codesign, identity, args.entitlements, args.force,
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.py", line 79, in _invoke_codesign
    _, stdout, stderr = execute.execute_and_filter_output(cmd,
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/codesigningtool/codesigningtool.runfiles/build_bazel_rules_apple/tools/wrapper_common/execute.py", line 100, in execute_and_filter_output
    raise subprocess.CalledProcessError(proc.returncode, cmd_args)
subprocess.CalledProcessError: Command '['/usr/bin/codesign', '-v', '--sign', '-', '--generate-entitlement-der', '--entitlements', 'bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-19f4f7fe00fe/bin/Code/Apps/MyAppWidgets/WidgetExtension/WidgetExtension_entitlements.simulator.entitlements', '--force', '--timestamp=none', '/']' returned non-zero exit status 1.
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.runfiles/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.py", line 310, in <module>
    _main(sys.argv[1])
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.runfiles/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.py", line 302, in _main
    bundler.run()
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.runfiles/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.py", line 147, in run
    self._sign_bundle(output_path, code_signing_commands)
  File "/private/var/tmp/_bazel_USER/9ae9416857eb79bb978de35a53d54970/execroot/my-repo/bazel-out/darwin_arm64-opt-exec-2B5CBBC6-ST-a3028c819570/bin/external/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.runfiles/build_bazel_rules_apple/tools/bundletool/bundletool_experimental.py", line 294, in _sign_bundle
    raise CodeSignError(exit_code)
__main__.CodeSignError: Code signing failed with exit code 256
ERROR:

/: Is a directory
```

This is because `WORK_DIR` is unquoted when bundletool calls the codesigning tool via `os.system`.