### PR TITLE
Mixed module umbrella module map rename to fix Xcode "print module interface" issues

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -66,7 +66,7 @@ def _module_map_content(
     if swift_generated_header:
         content += "\n"
         content += "module " + module_name + ".Swift {\n"
-        content += "  header \"%s\"\n" % swift_generated_header.basename
+        content += "  header \"../%s\"\n" % swift_generated_header.basename
         content += "  requires objc\n"
         content += "}\n"
 
@@ -120,8 +120,10 @@ def _module_map_impl(ctx):
             output = umbrella_header,
         )
         outputs.append(umbrella_header)
-
-    module_map = ctx.actions.declare_file(ctx.attr.name + ".modulemap")
+        module_map_path = "%s/%s" % (ctx.attr.name, "module.modulemap")
+    else:
+        module_map_path = ctx.attr.name + ".modulemap"
+    module_map = ctx.actions.declare_file(module_map_path)
     outputs.append(module_map)
 
     ctx.actions.write(


### PR DESCRIPTION
**Context:**
When attempting to open a mixed module interface (jump to definition on an import statement), Xcode either errors out or opens an empty interface in successive attempts. This can be reproduced even by using `swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=<MODULE NAME> -I <PATH> - target arm64-apple-ios16.4-simulator -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator16.4.sdk`

1. Looks like all this works as expected when the umbrella module map is named as: `module.modulemap` - the standard pattern. Hence this PR renames the umbrella module map and encloses it in a separate directory to avoid Bazel output conflicts if there are multiple rules declared within the same package.
2. `swift-ide-test` is successful too.
3. This PR only changes exposed module map naming/directory and not the internal one just to avoid conflicts as they both are a part of the same -I path. This works on testing(even when the internal one is named the same) but this is just to be safe incase.(lldb and indexing being selective few times given the above pattern)

**Post the fix:**
1. https://github.com/bazelbuild/rules_apple/assets/11925399/b6fec1bb-4bae-4875-a7a9-7724af2e1638
2. Index jobs are all successful.
<img width="1389" alt="Screenshot 2023-06-05 at 6 12 10 PM" src="https://github.com/bazelbuild/rules_apple/assets/11925399/e3af6f40-9c33-4703-b4c8-5bc0156a4ea5">

**Repro project:**
`bazel run :xcodeproj && xed App.xcodeproj`
[repro1.zip](https://github.com/bazelbuild/rules_apple/files/11657223/repro1.zip)
