### PR TITLE
Fix ios_xctestrun_runner for Xcode 15

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -159,8 +159,8 @@ if [[ -n "$test_host_path" ]]; then
     mkdir "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
+    # No longer necessary starting in Xcode 15 - hence the `-f` file existence check
     libswift_concurrency_path="$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib"
-    # This is no longer necessary in Xcode 15
     if [[ -f "$libswift_concurrency_path" ]]; then
       cp "$libswift_concurrency_path" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
     fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -159,7 +159,11 @@ if [[ -n "$test_host_path" ]]; then
     mkdir "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
-    cp "$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
+    libswift_concurrency_path="$(xcode-select -p)/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/libswift_Concurrency.dylib"
+    # This is no longer necessary in Xcode 15
+    if [[ -f "$libswift_concurrency_path" ]]; then
+      cp "$libswift_concurrency_path" "$plugins_path/$test_bundle_name.xctest/Frameworks/libswift_Concurrency.dylib"
+    fi
     xcrun_test_bundle_path="__TESTHOST__/PlugIns/$test_bundle_name.xctest"
 
     /usr/bin/sed \


### PR DESCRIPTION
Starting in Xcode 15 `libswift_Concurrency.dylib` no longer exists in the `iOS.simruntime` folder. I don't think we even need this manual step anymore, but we for sure don't want to fail trying to copy a file that doesn't exist.