### PR TITLE
Add -p to mkdir to prevent test runner error after UI Test device support

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -156,7 +156,7 @@ if [[ -n "$test_host_path" ]]; then
     plugins_path="$test_tmp_dir/$runner_app/PlugIns"
     mkdir -p "$plugins_path"
     mv "$test_tmp_dir/$test_bundle_name.xctest" "$plugins_path"
-    mkdir "$plugins_path/$test_bundle_name.xctest/Frameworks"
+    mkdir -p "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
     # No longer necessary starting in Xcode 15 - hence the `-f` file existence check


### PR DESCRIPTION
Followup fix for https://github.com/bazelbuild/rules_apple/pull/1968

Not entirely sure why this repros for us but not Matt/Maxwell, but saw this on our first run with 2.4.0

```
==================== Test output for //App:SlackEndToEndTests:
--
  | mkdir: /tmp/test_tmp_dir.HFIl8P/SlackEndToEndTests-Runner.app/PlugIns/SlackEndToEndTests.xctest/Frameworks: File exists
  | external/bazel_tools/tools/test/test-setup.sh: line 350: 97713 Killed: 9               sleep 10
  | ================================================================================
```