### PR TITLE
Make `test_host` required for `ios_ui_test`

### DIFF
--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -570,7 +570,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="ios_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional | <code>""</code> |
-| <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required | <code>None</code> |
 
 
 <a id="ios_unit_test"></a>


### PR DESCRIPTION
When I define a `ios_ui_test` without `test_host`, I get errors.

I think this attribute is required (which makes sense).