### PR TITLE
Add support for --command_line_args in ios_xctestrun_runner

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -13,6 +13,7 @@ def _get_template_substitutions(
         simulator_creator,
         random,
         xcodebuild_args,
+        command_line_args,
         xctestrun_template,
         reuse_simulator,
         xctrunner_entitlements_template):
@@ -21,6 +22,7 @@ def _get_template_substitutions(
         "os_version": os_version,
         "create_xcresult_bundle": create_xcresult_bundle,
         "xcodebuild_args": xcodebuild_args,
+        "command_line_args": command_line_args,
         "simulator_creator.py": simulator_creator,
         # "ordered" isn't a special string, but anything besides "random" for this field runs in order
         "test_order": "random" if random else "ordered",
@@ -60,6 +62,7 @@ def _ios_xctestrun_runner_impl(ctx):
             simulator_creator = ctx.executable._simulator_creator.short_path,
             random = ctx.attr.random,
             xcodebuild_args = " ".join(ctx.attr.xcodebuild_args) if ctx.attr.xcodebuild_args else "",
+            command_line_args = " ".join(ctx.attr.command_line_args) if ctx.attr.command_line_args else "",
             xctestrun_template = ctx.file._xctestrun_template.short_path,
             reuse_simulator = "true" if ctx.attr.reuse_simulator else "false",
             xctrunner_entitlements_template = ctx.file._xctrunner_entitlements_template.short_path,
@@ -119,6 +122,12 @@ always use `xcodebuild test-without-building` to run the test bundle.
         "xcodebuild_args": attr.string_list(
             doc = """
 Arguments to pass to `xcodebuild` when running the test bundle. This means it
+will always use `xcodebuild test-without-building` to run the test bundle.
+""",
+        ),
+        "command_line_args": attr.string_list(
+            doc = """
+CommandLineArguments to pass to xctestrun file when running the test bundle. This means it
 will always use `xcodebuild test-without-building` to run the test bundle.
 """,
         ),

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
@@ -46,6 +46,7 @@
     <string>keepNever</string>
     <key>ClangProfileDataDirectoryPath</key>
     <string>BAZEL_COVERAGE_OUTPUT_DIR</string>
+BAZEL_COMMAND_LINE_ARGS_SECTION
 BAZEL_SKIP_TEST_SECTION
 BAZEL_ONLY_TEST_SECTION
   </dict>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -626,8 +626,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_xctestrun_runner
 
 <pre>
-ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>,
-                     <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
+ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-command_line_args">command_line_args</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>,
+                     <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
 </pre>
 
 
@@ -675,6 +675,7 @@ in Xcode.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="ios_xctestrun_runner-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="ios_xctestrun_runner-command_line_args"></a>command_line_args |  CommandLineArguments to pass to xctestrun file when running the test bundle. This means it will always use <code>xcodebuild test-without-building</code> to run the test bundle.   | List of strings | optional | <code>[]</code> |
 | <a id="ios_xctestrun_runner-create_xcresult_bundle"></a>create_xcresult_bundle |  Force the test runner to always create an XCResult bundle. This means it will always use <code>xcodebuild test-without-building</code> to run the test bundle.   | Boolean | optional | <code>False</code> |
 | <a id="ios_xctestrun_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of <code>xcrun simctl list devicetypes</code>. E.g., iPhone X, iPad Air. By default, it reads from --ios_simulator_device or falls back to some device.   | String | optional | <code>""</code> |
 | <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of <code>xcrun simctl list runtimes</code>. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional | <code>""</code> |

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -706,30 +706,24 @@ function test_ios_unit_test_with_host_with_env() {
   expect_log "Test Suite 'EnvUnitTest' passed"
 }
 
-# TODO (https://github.com/bazelbuild/rules_apple/issues/1879): Enable once
-# `--command_line_args` is supported
-#
-# function test_ios_unit_test_dot_separated_command_line_args() {
-#   create_sim_runners
-#   create_ios_unit_argtest arg1 arg2 arg3
-#   do_ios_test //ios:ArgUnitTest \
-#     --test_arg="--command_line_args=arg1,arg2,arg3" || fail "should pass"
-#
-#   expect_log "Test Suite 'ArgUnitTest' passed"
-# }
+function test_ios_unit_test_dot_separated_command_line_args() {
+  create_sim_runners
+  create_ios_unit_argtest arg1 arg2 arg3
+  do_ios_test //ios:ArgUnitTest \
+    --test_arg="--command_line_args=arg1,arg2,arg3" || fail "should pass"
 
-# TODO (https://github.com/bazelbuild/rules_apple/issues/1879): Enable once
-# `--command_line_args` is supported
-#
-# function test_ios_unit_test_multiple_command_line_args() {
-#   create_sim_runners
-#   create_ios_unit_argtest arg1 arg2
-#   do_ios_test //ios:ArgUnitTest \
-#     --test_arg="--command_line_args=arg1" \
-#     --test_arg="--command_line_args=arg2" || fail "should pass"
-#
-#   expect_log "Test Suite 'ArgUnitTest' passed"
-# }
+  expect_log "Test Suite 'ArgUnitTest' passed"
+}
+
+function test_ios_unit_test_multiple_command_line_args() {
+  create_sim_runners
+  create_ios_unit_argtest arg1 arg2
+  do_ios_test //ios:ArgUnitTest \
+    --test_arg="--command_line_args=arg1" \
+    --test_arg="--command_line_args=arg2" || fail "should pass"
+
+  expect_log "Test Suite 'ArgUnitTest' passed"
+}
 
 function test_ios_unit_other_arg() {
   create_sim_runners


### PR DESCRIPTION
Fixes #1879 and #1996. The reasoning is similar to #1161.