### PR TITLE
Correct `ios_x86_64_sim_reuse_disabled_runner` typo

### DIFF
--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -296,7 +296,7 @@ ios_unit_test(
     minimum_os_version = "${MIN_OS_IOS}",
     test_host = ":app",
     env = test_env,
-    runner = ":ios_x86_64_sim_ruse_disabled_runner",
+    runner = ":ios_x86_64_sim_reuse_disabled_runner",
 )
 
 swift_library(


### PR DESCRIPTION
https://github.com/bazelbuild/rules_apple/blob/3897774b0a4fc0b16aa879e60706e450cdc0cbfe/test/ios_xctestrun_runner_unit_test.sh#L47-L51