### PR TITLE
exec macos app for better output when using bazel run

### DIFF
--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -39,4 +39,4 @@ readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
 readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
 
 # Launch the app binary
-"${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"
+exec "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"


### PR DESCRIPTION
Before exec:
`/private/var/tmp/_blaze_dmaclach/eb1775fa47a3309e6db0790ce22e7105/execroot/google3/blaze-out/applebin_macos-darwin_x86_64-fastbuild-ST-176e1fda8278/bin/experimental/users/dmaclach/simple_crash/simple_crash: line 62: 12515 Illegal instruction: 4  "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"`

After exec:
`Illegal instruction: 4`