### PR TITLE
Remove direct use of objc linking provider

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -49,15 +49,19 @@ def _apple_static_library_impl(ctx):
         collect_data = True,
     )
 
-    return [
+    providers = [
         DefaultInfo(files = depset(files_to_build), runfiles = runfiles),
         AppleBinaryInfo(
             binary = link_result.library,
             infoplist = None,
         ),
-        link_result.objc,
         link_result.output_groups,
     ]
+
+    if link_result.objc:
+        providers.append(link_result.objc)
+
+    return providers
 
 apple_static_library = rule(
     implementation = _apple_static_library_impl,

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -213,7 +213,7 @@ def _register_binary_linking_action(
         binary = fat_binary,
         cc_info = linking_outputs.cc_info,
         debug_outputs_provider = linking_outputs.debug_outputs_provider,
-        objc = linking_outputs.objc,
+        objc = getattr(linking_outputs, "objc", None),
         outputs = linking_outputs.outputs,
         output_groups = linking_outputs.output_groups,
     )
@@ -253,7 +253,7 @@ def _register_static_library_linking_action(ctx):
 
     return struct(
         library = fat_library,
-        objc = linking_outputs.objc,
+        objc = getattr(linking_outputs, "objc", None),
         outputs = linking_outputs.outputs,
         output_groups = linking_outputs.output_groups,
     )


### PR DESCRIPTION
This was removed on bazel @ HEAD but still required for supporting older
versions.

Fixes https://github.com/bazelbuild/rules_apple/issues/2020
