### PR TITLE
Revert "exec macos app for better output when using bazel run"

### DIFF
--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -39,4 +39,4 @@ readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
 readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
 
 # Launch the app binary
-exec "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"
+"${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -39,4 +39,6 @@ readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
 readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
 
 # Launch the app binary
+# Do *not* use `exec` here becaues we need the clean up done by the trap to run after the 
+# executable has been run.
 "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"


### PR DESCRIPTION
Reverts bazelbuild/rules_apple#2019

I realized that we don't want the exec because of the use of trap earlier in the script to clean up the temp directory after run.