### PR TITLE
Update regex to catch post-run exceptions.

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -479,7 +479,7 @@ fi
 # a success. These 2 cases are Swift fatalErrors, and C++ exceptions. There
 # are likely other cases we can add to this in the future. FB7801959
 if grep -q \
-  -e "^Fatal error:" \
+  -e "^(.*:[0-9]+:\s)?Fatal error:" \
   -e "^libc++abi.dylib: terminating with uncaught exception" \
   "$testlog"
 then


### PR DESCRIPTION
The assertion functions (`fatalError`, `assertionMessage` etc.) all seem to include file + line numbers in their messages according to the docs. This updates the regex to match this pattern and catch any exceptions thrown after the tests have reportedly completed.