### PR TITLE
Fix false negative regex.

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -479,7 +479,8 @@ fi
 # a success. These 2 cases are Swift fatalErrors, and C++ exceptions. There
 # are likely other cases we can add to this in the future. FB7801959
 if grep -q \
-  -e "^(.*:[0-9]+:\s)?Fatal error:" \
+  -e "^Fatal error:" \
+  -e "^.*:[0-9]\+:\sFatal error:" \
   -e "^libc++abi.dylib: terminating with uncaught exception" \
   "$testlog"
 then


### PR DESCRIPTION
Forgot that `grep -e` on mac using BRE, so lookbehind isn't supported and `+` needs escaping.

Tested locally that it matches correctly now.