### PR TITLE
Adds target name to bundle output paths

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -220,6 +220,7 @@ def _ios_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -259,6 +260,7 @@ def _ios_application_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -383,6 +385,8 @@ def _ios_application_impl(ctx):
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         runner_template = ctx.file._runner_template,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     archive = outputs.archive(
@@ -392,6 +396,8 @@ def _ios_application_impl(ctx):
         executable_name = executable_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     return [
@@ -503,6 +509,7 @@ def _ios_app_clip_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -543,6 +550,7 @@ def _ios_app_clip_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             app_clips = [archive_for_embedding],
@@ -632,6 +640,8 @@ def _ios_app_clip_impl(ctx):
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         runner_template = ctx.file._runner_template,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     archive = outputs.archive(
@@ -641,6 +651,8 @@ def _ios_app_clip_impl(ctx):
         executable_name = executable_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     return [
@@ -755,6 +767,7 @@ def _ios_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -797,6 +810,7 @@ def _ios_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -982,6 +996,7 @@ def _ios_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1023,6 +1038,7 @@ def _ios_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -1225,6 +1241,7 @@ def _ios_dynamic_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1265,6 +1282,7 @@ def _ios_dynamic_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -1419,6 +1437,7 @@ def _ios_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1576,6 +1595,7 @@ def _ios_imessage_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1767,6 +1787,7 @@ def _ios_imessage_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1808,6 +1829,7 @@ def _ios_imessage_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -1974,6 +1996,7 @@ def _ios_sticker_pack_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -258,9 +258,9 @@ def _ios_application_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -381,12 +381,12 @@ def _ios_application_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = ctx.file._runner_template,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(
@@ -394,10 +394,10 @@ def _ios_application_impl(ctx):
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         executable_name = executable_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     return [
@@ -548,9 +548,9 @@ def _ios_app_clip_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             app_clips = [archive_for_embedding],
@@ -636,12 +636,12 @@ def _ios_app_clip_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = ctx.file._runner_template,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(
@@ -649,10 +649,10 @@ def _ios_app_clip_impl(ctx):
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         executable_name = executable_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     return [
@@ -808,9 +808,9 @@ def _ios_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -1036,9 +1036,9 @@ def _ios_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -1280,9 +1280,9 @@ def _ios_dynamic_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -1827,9 +1827,9 @@ def _ios_imessage_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -200,6 +200,7 @@ def _macos_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -239,6 +240,7 @@ def _macos_application_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -341,6 +343,8 @@ def _macos_application_impl(ctx):
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         runner_template = ctx.file._runner_template,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     archive = outputs.archive(
@@ -350,6 +354,8 @@ def _macos_application_impl(ctx):
         executable_name = executable_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     return [
@@ -437,6 +443,8 @@ def _macos_bundle_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -451,6 +459,7 @@ def _macos_bundle_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -490,6 +499,7 @@ def _macos_bundle_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -631,6 +641,8 @@ def _macos_extension_impl(ctx):
         bundle_extension = bundle_extension,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -646,6 +658,7 @@ def _macos_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -686,6 +699,7 @@ def _macos_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -845,6 +859,8 @@ def _macos_quick_look_plugin_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -859,6 +875,7 @@ def _macos_quick_look_plugin_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -901,6 +918,7 @@ def _macos_quick_look_plugin_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -1042,6 +1060,8 @@ def _macos_kernel_extension_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -1056,6 +1076,7 @@ def _macos_kernel_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1096,6 +1117,7 @@ def _macos_kernel_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1236,6 +1258,8 @@ def _macos_spotlight_importer_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -1250,6 +1274,7 @@ def _macos_spotlight_importer_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1290,6 +1315,7 @@ def _macos_spotlight_importer_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1428,6 +1454,8 @@ def _macos_xpc_service_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -1442,6 +1470,7 @@ def _macos_xpc_service_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -1482,6 +1511,7 @@ def _macos_xpc_service_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1607,6 +1637,7 @@ def _macos_command_line_application_impl(ctx):
         executable_name = executable_name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
+        label_name = label.name,
     )
 
     processor_result = processor.process(
@@ -1721,6 +1752,7 @@ def _macos_dylib_impl(ctx):
         executable_name = executable_name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
+        label_name = label.name,
     )
 
     processor_result = processor.process(
@@ -1958,6 +1990,7 @@ def _macos_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -2000,6 +2033,7 @@ def _macos_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -2202,6 +2236,7 @@ def _macos_dynamic_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -2242,6 +2277,7 @@ def _macos_dynamic_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -2396,6 +2432,7 @@ def _macos_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -238,9 +238,9 @@ def _macos_application_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -339,12 +339,12 @@ def _macos_application_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = ctx.file._runner_template,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(
@@ -352,10 +352,10 @@ def _macos_application_impl(ctx):
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
         executable_name = executable_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     return [
@@ -441,10 +441,10 @@ def _macos_bundle_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -497,9 +497,9 @@ def _macos_bundle_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -639,10 +639,10 @@ def _macos_extension_impl(ctx):
         actions = actions,
         bundle_name = bundle_name,
         bundle_extension = bundle_extension,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -697,9 +697,9 @@ def _macos_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -857,10 +857,10 @@ def _macos_quick_look_plugin_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -916,9 +916,9 @@ def _macos_quick_look_plugin_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -1058,10 +1058,10 @@ def _macos_kernel_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -1115,9 +1115,9 @@ def _macos_kernel_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1256,10 +1256,10 @@ def _macos_spotlight_importer_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -1313,9 +1313,9 @@ def _macos_spotlight_importer_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1452,10 +1452,10 @@ def _macos_xpc_service_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -1509,9 +1509,9 @@ def _macos_xpc_service_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             platform_prerequisites = platform_prerequisites,
@@ -1635,9 +1635,9 @@ def _macos_command_line_application_impl(ctx):
         dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
         executable_name = executable_name,
+        label_name = label.name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
-        label_name = label.name,
     )
 
     processor_result = processor.process(
@@ -1750,9 +1750,9 @@ def _macos_dylib_impl(ctx):
         dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
         executable_name = executable_name,
+        label_name = label.name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
-        label_name = label.name,
     )
 
     processor_result = processor.process(
@@ -2031,9 +2031,9 @@ def _macos_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -2275,9 +2275,9 @@ def _macos_dynamic_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -40,7 +40,9 @@ def _archive(
         bundle_name,
         executable_name = None,
         platform_prerequisites,
-        predeclared_outputs):
+        predeclared_outputs,
+        rule_descriptor,
+        label_name):
     """Returns a file reference for this target's archive."""
     bundle_name_with_extension = bundle_name + bundle_extension
 
@@ -48,7 +50,11 @@ def _archive(
         config_vars = platform_prerequisites.config_vars,
     )
     if tree_artifact_enabled:
-        return actions.declare_directory(bundle_name_with_extension)
+        archive_relative_path = rule_descriptor.bundle_locations.archive_relative
+        root_path = label_name + "_archive-root"
+        return actions.declare_directory(
+            paths.join(root_path, archive_relative_path, bundle_name_with_extension),
+        )
     return predeclared_outputs.archive
 
 def _archive_for_embedding(
@@ -77,6 +83,8 @@ def _archive_for_embedding(
             executable_name = executable_name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            label_name = label_name,
         )
 
 def _binary(*, actions, bundle_name, executable_name, label_name, output_discriminator):

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -39,10 +39,10 @@ def _archive(
         bundle_extension,
         bundle_name,
         executable_name = None,
+        label_name,
         platform_prerequisites,
         predeclared_outputs,
-        rule_descriptor,
-        label_name):
+        rule_descriptor):
     """Returns a file reference for this target's archive."""
     bundle_name_with_extension = bundle_name + bundle_extension
 
@@ -81,10 +81,10 @@ def _archive_for_embedding(
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
             executable_name = executable_name,
+            label_name = label_name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
-            label_name = label_name,
         )
 
 def _binary(*, actions, bundle_name, executable_name, label_name, output_discriminator):

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -40,7 +40,8 @@ def _apple_bundle_info_partial_impl(
         output_discriminator,
         platform_prerequisites,
         predeclared_outputs,
-        product_type):
+        product_type,
+        rule_descriptor):
     """Implementation for the AppleBundleInfo processing partial."""
 
     archive = outputs.archive(
@@ -49,6 +50,8 @@ def _apple_bundle_info_partial_impl(
         bundle_extension = bundle_extension,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label_name,
     )
     archive_root = outputs.root_path_from_archive(archive = archive)
 
@@ -104,7 +107,8 @@ def apple_bundle_info_partial(
         output_discriminator = None,
         platform_prerequisites,
         predeclared_outputs,
-        product_type):
+        product_type,
+        rule_descriptor):
     """Constructor for the AppleBundleInfo processing partial.
 
     This partial propagates the AppleBundleInfo provider for this target.
@@ -125,6 +129,7 @@ def apple_bundle_info_partial(
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`.
       product_type: Product type identifier used to describe the current bundle type.
+      rule_descriptor: The rule descriptor for the given rule.
 
     Returns:
       A partial that returns the AppleBundleInfo provider.
@@ -143,4 +148,5 @@ def apple_bundle_info_partial(
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         product_type = product_type,
+        rule_descriptor = rule_descriptor,
     )

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -48,10 +48,10 @@ def _apple_bundle_info_partial_impl(
         actions = actions,
         bundle_name = bundle_name,
         bundle_extension = bundle_extension,
+        label_name = label_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label_name,
     )
     archive_root = outputs.root_path_from_archive(archive = archive)
 

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -171,8 +171,8 @@ def _bundle_dsym_files(
         dsym_binaries = {},
         dsym_info_plist_template,
         dsym_output_filename,
-        platform_prerequisites,
-        label_name):
+        label_name,
+        platform_prerequisites):
     """Recreates the .dSYM bundle from the AppleDebugOutputs provider and dSYM binaries.
 
     The generated bundle will have the same name as the bundle being built (including its
@@ -192,8 +192,8 @@ def _bundle_dsym_files(
         architecture.
       dsym_info_plist_template: File referencing a plist template for dSYM bundles.
       dsym_output_filename: The dSYM binary file name.
-      platform_prerequisites: Struct containing information on the platform being targeted.
       label_name: The name of the target.
+      platform_prerequisites: Struct containing information on the platform being targeted.
 
     Returns:
       A tuple where the first argument is a list of files that comprise the .dSYM bundle, which
@@ -270,9 +270,9 @@ def _debug_symbols_partial_impl(
         dsym_binaries = {},
         dsym_info_plist_template,
         executable_name,
+        label_name,
         linkmaps = {},
-        platform_prerequisites,
-        label_name):
+        platform_prerequisites):
     """Implementation for the debug symbols processing partial."""
     deps_dsym_bundle_providers = [
         x[AppleDsymBundleInfo]
@@ -312,8 +312,8 @@ def _debug_symbols_partial_impl(
                 dsym_binaries = dsym_binaries,
                 dsym_info_plist_template = dsym_info_plist_template,
                 dsym_output_filename = dsym_output_filename,
-                platform_prerequisites = platform_prerequisites,
                 label_name = label_name,
+                platform_prerequisites = platform_prerequisites,
             )
             if dsym_bundle_dir:
                 direct_dsym_bundles.append(dsym_bundle_dir)
@@ -386,9 +386,9 @@ def debug_symbols_partial(
         dsym_binaries = {},
         dsym_info_plist_template,
         executable_name,
+        label_name,
         linkmaps = {},
-        platform_prerequisites,
-        label_name):
+        platform_prerequisites):
     """Constructor for the debug symbols processing partial.
 
     This partial collects all of the transitive debug files information. The output of this partial
@@ -410,9 +410,9 @@ def debug_symbols_partial(
         architecture.
       dsym_info_plist_template: File referencing a plist template for dSYM bundles.
       executable_name: The name of the output DWARF executable.
+      label_name: The name of the target.
       linkmaps: A mapping of architectures to Files representing linkmaps for each architecture.
       platform_prerequisites: Struct containing information on the platform being targeted.
-      label_name: The name of the target.
 
     Returns:
       A partial that returns the debug output files, if any were requested.
@@ -427,7 +427,7 @@ def debug_symbols_partial(
         dsym_binaries = dsym_binaries,
         dsym_info_plist_template = dsym_info_plist_template,
         executable_name = executable_name,
+        label_name = label_name,
         linkmaps = linkmaps,
         platform_prerequisites = platform_prerequisites,
-        label_name = label_name,
     )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -747,10 +747,10 @@ def _process(
             actions = actions,
             bundle_extension = bundle_extension,
             bundle_name = bundle_name,
+            label_name = rule_label.name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
-            label_name = rule_label.name,
         )
         _bundle_post_process_and_sign(
             actions = actions,

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -749,6 +749,8 @@ def _process(
             bundle_name = bundle_name,
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            label_name = rule_label.name,
         )
         _bundle_post_process_and_sign(
             actions = actions,

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -24,24 +24,24 @@ def _register_simulator_executable(
         actions,
         bundle_extension,
         bundle_name,
+        label_name,
         output,
         platform_prerequisites,
         predeclared_outputs,
-        runner_template,
         rule_descriptor,
-        label_name):
+        runner_template):
     """Registers an action that runs the bundled app in the iOS simulator.
 
     Args:
       actions: The actions provider from ctx.actions.
       bundle_extension: Extension for the Apple bundle inside the archive.
       bundle_name: The name of the output bundle.
+      label_name: The name of the target.
       output: The `File` representing where the executable should be generated.
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`
-      runner_template: The simulator runner template as a `File`.
       rule_descriptor: The rule descriptor for the given rule.
-      label_name: The name of the target.
+      runner_template: The simulator runner template as a `File`.
     """
 
     sim_device = str(platform_prerequisites.objc_fragment.ios_simulator_device or "")
@@ -51,10 +51,10 @@ def _register_simulator_executable(
         actions = actions,
         bundle_name = bundle_name,
         bundle_extension = bundle_extension,
+        label_name = label_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label_name,
     )
 
     actions.expand_template(
@@ -75,34 +75,34 @@ def _register_macos_executable(
         actions,
         bundle_extension,
         bundle_name,
+        label_name,
         output,
         platform_prerequisites,
         predeclared_outputs,
-        runner_template,
         rule_descriptor,
-        label_name):
+        runner_template):
     """Registers an action that runs the bundled macOS app.
 
     Args:
       actions: The actions provider from ctx.actions.
       bundle_extension: Extension for the Apple bundle inside the archive.
       bundle_name: The name of the output bundle.
+      label_name: The name of the target.
       output: The `File` representing where the executable should be generated.
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`
       runner_template: The macos runner template as a `File`.
       rule_descriptor: The rule descriptor for the given rule.
-      label_name: The name of the target.
     """
 
     archive = outputs.archive(
         actions = actions,
         bundle_name = bundle_name,
         bundle_extension = bundle_extension,
+        label_name = label_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label_name,
     )
 
     actions.expand_template(

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -27,7 +27,9 @@ def _register_simulator_executable(
         output,
         platform_prerequisites,
         predeclared_outputs,
-        runner_template):
+        runner_template,
+        rule_descriptor,
+        label_name):
     """Registers an action that runs the bundled app in the iOS simulator.
 
     Args:
@@ -38,6 +40,8 @@ def _register_simulator_executable(
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`
       runner_template: The simulator runner template as a `File`.
+      rule_descriptor: The rule descriptor for the given rule.
+      label_name: The name of the target.
     """
 
     sim_device = str(platform_prerequisites.objc_fragment.ios_simulator_device or "")
@@ -49,6 +53,8 @@ def _register_simulator_executable(
         bundle_extension = bundle_extension,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label_name,
     )
 
     actions.expand_template(
@@ -72,7 +78,9 @@ def _register_macos_executable(
         output,
         platform_prerequisites,
         predeclared_outputs,
-        runner_template):
+        runner_template,
+        rule_descriptor,
+        label_name):
     """Registers an action that runs the bundled macOS app.
 
     Args:
@@ -83,6 +91,8 @@ def _register_macos_executable(
       platform_prerequisites: Struct containing information on the platform being targeted.
       predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`
       runner_template: The macos runner template as a `File`.
+      rule_descriptor: The rule descriptor for the given rule.
+      label_name: The name of the target.
     """
 
     archive = outputs.archive(
@@ -91,6 +101,8 @@ def _register_macos_executable(
         bundle_extension = bundle_extension,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label_name,
     )
 
     actions.expand_template(

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -395,9 +395,9 @@ def _apple_test_bundle_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -475,10 +475,10 @@ def _apple_test_bundle_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     # The processor outputs has all the extra outputs like dSYM files that we want to propagate, but

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -369,6 +369,7 @@ def _apple_test_bundle_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -396,6 +397,7 @@ def _apple_test_bundle_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -475,6 +477,8 @@ def _apple_test_bundle_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     # The processor outputs has all the extra outputs like dSYM files that we want to propagate, but

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -230,9 +230,9 @@ def _tvos_application_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -333,22 +333,22 @@ def _tvos_application_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         output = executable,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
-        runner_template = ctx.file._runner_template,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
+        runner_template = ctx.file._runner_template,
     )
 
     archive = outputs.archive(
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     return [
@@ -456,10 +456,10 @@ def _tvos_dynamic_framework_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -513,9 +513,9 @@ def _tvos_dynamic_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -699,10 +699,10 @@ def _tvos_framework_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -758,9 +758,9 @@ def _tvos_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -915,10 +915,10 @@ def _tvos_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -974,9 +974,9 @@ def _tvos_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -192,6 +192,7 @@ def _tvos_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -231,6 +232,7 @@ def _tvos_application_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -335,6 +337,8 @@ def _tvos_application_impl(ctx):
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         runner_template = ctx.file._runner_template,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     archive = outputs.archive(
@@ -343,6 +347,8 @@ def _tvos_application_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     return [
@@ -452,6 +458,8 @@ def _tvos_dynamic_framework_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -466,6 +474,7 @@ def _tvos_dynamic_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -506,6 +515,7 @@ def _tvos_dynamic_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -691,6 +701,8 @@ def _tvos_framework_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -705,6 +717,7 @@ def _tvos_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -747,6 +760,7 @@ def _tvos_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive],
@@ -903,6 +917,8 @@ def _tvos_extension_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -918,6 +934,7 @@ def _tvos_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -959,6 +976,7 @@ def _tvos_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             embeddable_targets = ctx.attr.frameworks,
@@ -1090,6 +1108,7 @@ def _tvos_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -199,6 +199,7 @@ def _watchos_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -239,6 +240,7 @@ def _watchos_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -440,6 +442,7 @@ def _watchos_dynamic_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -480,6 +483,7 @@ def _watchos_dynamic_framework_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -668,6 +672,8 @@ def _watchos_application_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     processor_partials = [
@@ -682,6 +688,7 @@ def _watchos_application_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -721,6 +728,7 @@ def _watchos_application_impl(ctx):
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -886,6 +894,8 @@ def _watchos_extension_impl(ctx):
         bundle_name = bundle_name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+        label_name = label.name,
     )
 
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
@@ -903,6 +913,7 @@ def _watchos_extension_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,
@@ -944,6 +955,7 @@ def _watchos_extension_impl(ctx):
             executable_name = executable_name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
+            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -1087,6 +1099,7 @@ def _watchos_static_framework_impl(ctx):
             platform_prerequisites = platform_prerequisites,
             predeclared_outputs = predeclared_outputs,
             product_type = rule_descriptor.product_type,
+            rule_descriptor = rule_descriptor,
         ),
         partials.binary_partial(
             actions = actions,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -238,9 +238,9 @@ def _watchos_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -481,9 +481,9 @@ def _watchos_dynamic_framework_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             frameworks = [archive_for_embedding],
@@ -670,10 +670,10 @@ def _watchos_application_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     processor_partials = [
@@ -727,8 +727,8 @@ def _watchos_application_impl(ctx):
             debug_dependencies = [ctx.attr.extension],
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
-            platform_prerequisites = platform_prerequisites,
             label_name = label.name,
+            platform_prerequisites = platform_prerequisites,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,
@@ -892,10 +892,10 @@ def _watchos_extension_impl(ctx):
         actions = actions,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
+        label_name = label.name,
         platform_prerequisites = platform_prerequisites,
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
-        label_name = label.name,
     )
 
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
@@ -953,9 +953,9 @@ def _watchos_extension_impl(ctx):
             dsym_binaries = debug_outputs.dsym_binaries,
             dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
             executable_name = executable_name,
+            label_name = label.name,
             linkmaps = debug_outputs.linkmaps,
             platform_prerequisites = platform_prerequisites,
-            label_name = label.name,
         ),
         partials.embedded_bundles_partial(
             bundle_embedded_bundles = True,

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -567,6 +567,7 @@ def _apple_xcframework_impl(ctx):
                 platform_prerequisites = platform_prerequisites,
                 predeclared_outputs = overridden_predeclared_outputs,
                 product_type = rule_descriptor.product_type,
+                rule_descriptor = rule_descriptor,
             ),
             partials.binary_partial(
                 actions = actions,
@@ -586,6 +587,7 @@ def _apple_xcframework_impl(ctx):
                 executable_name = executable_name,
                 linkmaps = link_output.linkmaps,
                 platform_prerequisites = platform_prerequisites,
+                label_name = label.name,
             ),
             partials.resources_partial(
                 actions = actions,

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -585,9 +585,9 @@ def _apple_xcframework_impl(ctx):
                 dsym_binaries = link_output.dsym_binaries,
                 dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
                 executable_name = executable_name,
+                label_name = label.name,
                 linkmaps = link_output.linkmaps,
                 platform_prerequisites = platform_prerequisites,
-                label_name = label.name,
             ),
             partials.resources_partial(
                 actions = actions,

--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -30,6 +30,7 @@ ios_application(
     name = "HelloWorld",
     app_icons = ["//examples/resources:PhoneAppIcon.xcassets"],
     bundle_id = "com.example.hello-world",
+    bundle_name = "HelloWorld",
     families = [
         "iphone",
         "ipad",
@@ -37,6 +38,22 @@ ios_application(
     infoplists = [":Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
     minimum_os_version = "9.0",
+    version = ":HelloWorldVersion",
+    deps = [":Sources"],
+)
+
+ios_application(
+    name = "HelloWorld_Beta",
+    app_icons = ["//examples/resources:PhoneAppIcon.xcassets"],
+    bundle_id = "com.example.hello-world",
+    bundle_name = "HelloWorld",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [":Info.plist"],
+    launch_storyboard = "//examples/resources:Launch.storyboard",
+    minimum_os_version = "8.0",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -30,7 +30,6 @@ ios_application(
     name = "HelloWorld",
     app_icons = ["//examples/resources:PhoneAppIcon.xcassets"],
     bundle_id = "com.example.hello-world",
-    bundle_name = "HelloWorld",
     families = [
         "iphone",
         "ipad",
@@ -38,22 +37,6 @@ ios_application(
     infoplists = [":Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
     minimum_os_version = "9.0",
-    version = ":HelloWorldVersion",
-    deps = [":Sources"],
-)
-
-ios_application(
-    name = "HelloWorld_Beta",
-    app_icons = ["//examples/resources:PhoneAppIcon.xcassets"],
-    bundle_id = "com.example.hello-world",
-    bundle_name = "HelloWorld",
-    families = [
-        "iphone",
-        "ipad",
-    ],
-    infoplists = [":Info.plist"],
-    launch_storyboard = "//examples/resources:Launch.storyboard",
-    minimum_os_version = "8.0",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -738,4 +738,37 @@ function test_tree_artifacts_and_disable_simulator_codesigning() {
       --features=apple.skip_codesign_simulator_bundles || fail "Should build"
 }
 
+# Tests tree artifacts of bundle targets(with same bundles names) don't conflict with each other.
+function test_tree_artifacts_with_same_bundle_names_dont_conflict() {
+  create_common_files
+  
+  cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [
+        ":lib",
+    ],
+)
+ios_application(
+    name = "app-beta",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [
+        ":lib",
+    ],
+)
+EOF
+
+  do_build ios //app:app //app:app-beta \
+      --define=apple.experimental.tree_artifact_outputs=1 || fail "Should build"
+}
+
 run_suite "ios_application bundling tests"

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -648,13 +648,13 @@ function test_all_dsyms_propagated() {
       --output_groups=+dsyms \
       //app:app || fail "Should build"
 
-  assert_exists "test-bin/app/app.app.dSYM/Contents/Info.plist"
-  assert_exists "test-bin/app/ext.appex.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/app/app_dsyms/app.app.dSYM/Contents/Info.plist"
+  assert_exists "test-bin/app/ext_dsyms/ext.appex.dSYM/Contents/Info.plist"
 
   assert_exists \
-      "test-bin/app/app.app.dSYM/Contents/Resources/DWARF/app"
+      "test-bin/app/app_dsyms/app.app.dSYM/Contents/Resources/DWARF/app"
   assert_exists \
-      "test-bin/app/ext.appex.dSYM/Contents/Resources/DWARF/ext"
+      "test-bin/app/ext_dsyms/ext.appex.dSYM/Contents/Resources/DWARF/ext"
 }
 
 run_suite "ios_extension bundling tests"

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -179,8 +179,8 @@ def apple_xcframework_test_suite(name):
     dsyms_test(
         name = "{}_device_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
-        expected_direct_dsyms = ["ios_dynamic_xcframework_ios_device.framework"],
-        expected_transitive_dsyms = ["ios_dynamic_xcframework_ios_device.framework"],
+        expected_direct_dsyms = ["ios_dynamic_xcframework_dsyms/ios_dynamic_xcframework_ios_device.framework"],
+        expected_transitive_dsyms = ["ios_dynamic_xcframework_dsyms/ios_dynamic_xcframework_ios_device.framework"],
         architectures = ["arm64"],
         check_public_provider = False,
         tags = [name],
@@ -189,8 +189,8 @@ def apple_xcframework_test_suite(name):
     dsyms_test(
         name = "{}_simulator_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
-        expected_direct_dsyms = ["ios_dynamic_xcframework_ios_simulator.framework"],
-        expected_transitive_dsyms = ["ios_dynamic_xcframework_ios_simulator.framework"],
+        expected_direct_dsyms = ["ios_dynamic_xcframework_dsyms/ios_dynamic_xcframework_ios_simulator.framework"],
+        expected_transitive_dsyms = ["ios_dynamic_xcframework_dsyms/ios_dynamic_xcframework_ios_simulator.framework"],
         architectures = ["x86_64"],
         check_public_provider = False,
         tags = [name],
@@ -199,8 +199,8 @@ def apple_xcframework_test_suite(name):
     dsyms_test(
         name = "{}_fat_device_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_xcframework",
-        expected_direct_dsyms = ["ios_dynamic_lipoed_xcframework_ios_device.framework"],
-        expected_transitive_dsyms = ["ios_dynamic_lipoed_xcframework_ios_device.framework"],
+        expected_direct_dsyms = ["ios_dynamic_lipoed_xcframework_dsyms/ios_dynamic_lipoed_xcframework_ios_device.framework"],
+        expected_transitive_dsyms = ["ios_dynamic_lipoed_xcframework_dsyms/ios_dynamic_lipoed_xcframework_ios_device.framework"],
         architectures = ["arm64", "arm64e"],
         check_public_provider = False,
         tags = [name],
@@ -209,8 +209,8 @@ def apple_xcframework_test_suite(name):
     dsyms_test(
         name = "{}_fat_simulator_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_xcframework",
-        expected_direct_dsyms = ["ios_dynamic_lipoed_xcframework_ios_simulator.framework"],
-        expected_transitive_dsyms = ["ios_dynamic_lipoed_xcframework_ios_simulator.framework"],
+        expected_direct_dsyms = ["ios_dynamic_lipoed_xcframework_dsyms/ios_dynamic_lipoed_xcframework_ios_simulator.framework"],
+        expected_transitive_dsyms = ["ios_dynamic_lipoed_xcframework_dsyms/ios_dynamic_lipoed_xcframework_ios_simulator.framework"],
         architectures = ["x86_64", "arm64"],
         check_public_provider = False,
         tags = [name],

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -372,26 +372,26 @@ def ios_application_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
-        expected_direct_dsyms = ["app.app"],
-        expected_transitive_dsyms = ["app.app"],
+        expected_direct_dsyms = ["app_dsyms/app.app"],
+        expected_transitive_dsyms = ["app_dsyms/app.app"],
         tags = [name],
     )
 
     dsyms_test(
         name = "{}_transitive_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_ext_and_fmwk_provisioned",
-        expected_direct_dsyms = ["app_with_ext_and_fmwk_provisioned.app"],
-        expected_transitive_dsyms = ["app_with_ext_and_fmwk_provisioned.app", "ext_with_fmwk_provisioned.appex", "fmwk_with_provisioning.framework"],
+        expected_direct_dsyms = ["app_with_ext_and_fmwk_provisioned_dsyms/app_with_ext_and_fmwk_provisioned.app"],
+        expected_transitive_dsyms = ["app_with_ext_and_fmwk_provisioned_dsyms/app_with_ext_and_fmwk_provisioned.app", "ext_with_fmwk_provisioned_dsyms/ext_with_fmwk_provisioned.appex", "fmwk_with_provisioning_dsyms/fmwk_with_provisioning.framework"],
         tags = [name],
     )
 
     dsyms_test(
         name = "{}_custom_executable_name_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_custom_executable_name",
-        expected_direct_dsyms = ["custom_bundle_name.app"],
-        expected_transitive_dsyms = ["custom_bundle_name.app"],
+        expected_direct_dsyms = ["app_with_custom_executable_name_dsyms/custom_bundle_name.app"],
+        expected_transitive_dsyms = ["app_with_custom_executable_name_dsyms/custom_bundle_name.app"],
         expected_binaries = [
-            "custom_bundle_name.app.dSYM/Contents/Resources/DWARF/app.exe",
+            "app_with_custom_executable_name_dsyms/custom_bundle_name.app.dSYM/Contents/Resources/DWARF/app.exe",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -90,8 +90,8 @@ def ios_extension_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
-        expected_direct_dsyms = ["ext.appex"],
-        expected_transitive_dsyms = ["ext.appex"],
+        expected_direct_dsyms = ["ext_dsyms/ext.appex"],
+        expected_transitive_dsyms = ["ext_dsyms/ext.appex"],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_ui_test_tests.bzl
+++ b/test/starlark_tests/ios_ui_test_tests.bzl
@@ -80,8 +80,8 @@ def ios_ui_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ui_test",
-        expected_direct_dsyms = ["ui_test.xctest"],
-        expected_transitive_dsyms = ["ui_test.xctest", "app.app"],
+        expected_direct_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest"],
+        expected_transitive_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -86,8 +86,8 @@ def ios_unit_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test",
-        expected_direct_dsyms = ["unit_test.xctest"],
-        expected_transitive_dsyms = ["unit_test.xctest", "app.app"],
+        expected_direct_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest"],
+        expected_transitive_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -183,8 +183,8 @@ def macos_application_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
-        expected_direct_dsyms = ["app.app"],
-        expected_transitive_dsyms = ["app.app"],
+        expected_direct_dsyms = ["app_dsyms/app.app"],
+        expected_transitive_dsyms = ["app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -148,8 +148,8 @@ def macos_bundle_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle",
-        expected_direct_dsyms = ["bundle.bundle"],
-        expected_transitive_dsyms = ["bundle.bundle"],
+        expected_direct_dsyms = ["bundle_dsyms/bundle.bundle"],
+        expected_transitive_dsyms = ["bundle_dsyms/bundle.bundle"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -147,8 +147,8 @@ def macos_command_line_application_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
-        expected_direct_dsyms = ["cmd_app_basic"],
-        expected_transitive_dsyms = ["cmd_app_basic"],
+        expected_direct_dsyms = ["cmd_app_basic_dsyms/cmd_app_basic"],
+        expected_transitive_dsyms = ["cmd_app_basic_dsyms/cmd_app_basic"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_dylib_tests.bzl
+++ b/test/starlark_tests/macos_dylib_tests.bzl
@@ -86,8 +86,8 @@ def macos_dylib_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
-        expected_direct_dsyms = ["dylib"],
-        expected_transitive_dsyms = ["dylib"],
+        expected_direct_dsyms = ["dylib_dsyms/dylib"],
+        expected_transitive_dsyms = ["dylib_dsyms/dylib"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_ui_test_tests.bzl
+++ b/test/starlark_tests/macos_ui_test_tests.bzl
@@ -86,8 +86,8 @@ def macos_ui_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ui_test",
-        expected_direct_dsyms = ["ui_test.xctest"],
-        expected_transitive_dsyms = ["ui_test.xctest", "app.app"],
+        expected_direct_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest"],
+        expected_transitive_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -90,8 +90,8 @@ def macos_unit_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:unit_test",
-        expected_direct_dsyms = ["unit_test.xctest"],
-        expected_transitive_dsyms = ["unit_test.xctest", "app.app"],
+        expected_direct_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest"],
+        expected_transitive_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/dsyms_test.bzl
+++ b/test/starlark_tests/rules/dsyms_test.bzl
@@ -56,6 +56,11 @@ Contents were:\n\n{2}\n\n""".format(
             ),
         )
 
+def _file_name_without_extension(file_path):
+    file_name_with_extension = file_path.split("/")[-1]
+    file_name = file_name_with_extension.split(".")[0]
+    return file_name
+
 def _dsyms_test_impl(ctx):
     """Implementation of the dsyms_test rule."""
     env = analysistest.begin(ctx)
@@ -84,7 +89,6 @@ def _dsyms_test_impl(ctx):
     package = target_under_test.label.package
 
     all_expected_dsyms = ctx.attr.expected_direct_dsyms + ctx.attr.expected_transitive_dsyms
-
     expected_infoplists = [
         "{0}/{1}.dSYM/Contents/Info.plist".format(package, x)
         for x in all_expected_dsyms
@@ -98,12 +102,13 @@ def _dsyms_test_impl(ctx):
             )
             for x in ctx.attr.expected_binaries
         ]
+
     else:
         expected_binaries = [
             "{0}/{1}.dSYM/Contents/Resources/DWARF/{2}".format(
                 package,
                 x,
-                paths.split_extension(x)[0],
+                _file_name_without_extension(x),
             )
             for x in all_expected_dsyms
         ]

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -172,16 +172,16 @@ def tvos_application_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
-        expected_direct_dsyms = ["app.app"],
-        expected_transitive_dsyms = ["app.app"],
+        expected_direct_dsyms = ["app_dsyms/app.app"],
+        expected_transitive_dsyms = ["app_dsyms/app.app"],
         tags = [name],
     )
 
     dsyms_test(
         name = "{}_transitive_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_fmwk_with_fmwk_provisioned",
-        expected_direct_dsyms = ["app_with_fmwk_with_fmwk_provisioned.app"],
-        expected_transitive_dsyms = ["app_with_fmwk_with_fmwk_provisioned.app", "fmwk_with_provisioning.framework"],
+        expected_direct_dsyms = ["app_with_fmwk_with_fmwk_provisioned_dsyms/app_with_fmwk_with_fmwk_provisioned.app"],
+        expected_transitive_dsyms = ["app_with_fmwk_with_fmwk_provisioned_dsyms/app_with_fmwk_with_fmwk_provisioned.app", "fmwk_with_provisioning_dsyms/fmwk_with_provisioning.framework"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -52,8 +52,8 @@ def tvos_extension_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
-        expected_direct_dsyms = ["ext.appex"],
-        expected_transitive_dsyms = ["ext.appex"],
+        expected_direct_dsyms = ["ext_dsyms/ext.appex"],
+        expected_transitive_dsyms = ["ext_dsyms/ext.appex"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_ui_test_tests.bzl
+++ b/test/starlark_tests/tvos_ui_test_tests.bzl
@@ -52,8 +52,8 @@ def tvos_ui_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:ui_test",
-        expected_direct_dsyms = ["ui_test.xctest"],
-        expected_transitive_dsyms = ["ui_test.xctest", "app.app"],
+        expected_direct_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest"],
+        expected_transitive_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -56,8 +56,8 @@ def tvos_unit_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:unit_test",
-        expected_direct_dsyms = ["unit_test.xctest"],
-        expected_transitive_dsyms = ["unit_test.xctest", "app.app"],
+        expected_direct_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest"],
+        expected_transitive_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest", "app_dsyms/app.app"],
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -123,8 +123,8 @@ def watchos_extension_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
-        expected_direct_dsyms = ["ext.appex"],
-        expected_transitive_dsyms = ["ext.appex"],
+        expected_direct_dsyms = ["ext_dsyms/ext.appex"],
+        expected_transitive_dsyms = ["ext_dsyms/ext.appex"],
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_ui_test_tests.bzl
+++ b/test/starlark_tests/watchos_ui_test_tests.bzl
@@ -48,8 +48,8 @@ def watchos_ui_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ui_test",
-        expected_direct_dsyms = ["ui_test.xctest"],
-        expected_transitive_dsyms = ["ui_test.xctest", "ext.appex"],
+        expected_direct_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest"],
+        expected_transitive_dsyms = ["ui_test.__internal__.__test_bundle_dsyms/ui_test.xctest", "ext_dsyms/ext.appex"],
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_unit_test_tests.bzl
+++ b/test/starlark_tests/watchos_unit_test_tests.bzl
@@ -48,8 +48,8 @@ def watchos_unit_test_test_suite(name):
     dsyms_test(
         name = "{}_dsyms_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:unit_test",
-        expected_direct_dsyms = ["unit_test.xctest"],
-        expected_transitive_dsyms = ["unit_test.xctest"],
+        expected_direct_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest"],
+        expected_transitive_dsyms = ["unit_test.__internal__.__test_bundle_dsyms/unit_test.xctest"],
         tags = [name],
     )
 


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_apple/issues/1933

Adds target name to output path to avoid output conflicts when bundle names are the same