### PR TITLE
Replace apple_common.multi_arch_split with new transition

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,7 +15,7 @@ x_defaults:
     test_flags:
     - --test_tag_filters=-skipci
   common_last_green: &common_last_green
-    bazel: d9939570353e21ba4d8b8e986b30b753a0f29c5d
+    bazel: last_green
     test_flags:
       - --test_tag_filters=-skipci
 

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -72,7 +72,7 @@ The `lipo` tool is used to combine built binaries of multiple architectures.
     additional_attrs = {
         "binary": attr.label(
             mandatory = True,
-            cfg = apple_common.multi_arch_split,
+            cfg = transition_support.apple_platform_split_transition,
             doc = "Target to generate a 'fat' binary from.",
         ),
         "forced_cpus": attr.string_list(

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -113,7 +113,7 @@ _COMMON_ATTRS = dicts.add(
     apple_support.action_required_attrs(),
 )
 
-def _common_linking_api_attrs(*, cfg = apple_common.multi_arch_split):
+def _common_linking_api_attrs(*, cfg = transition_support.apple_platform_split_transition):
     """Returns dictionary of required attributes for Bazel Apple linking API's.
 
     These rule attributes are required by both Bazel Apple linking API's under apple_common module:
@@ -132,7 +132,7 @@ def _common_linking_api_attrs(*, cfg = apple_common.multi_arch_split):
         ),
     }
 
-def _link_multi_arch_static_library_attrs(*, cfg = apple_common.multi_arch_split):
+def _link_multi_arch_static_library_attrs(*, cfg = transition_support.apple_platform_split_transition):
     """Returns dictionary of required attributes for apple_common.link_multi_arch_static_library.
 
     Args:
@@ -140,7 +140,7 @@ def _link_multi_arch_static_library_attrs(*, cfg = apple_common.multi_arch_split
     """
     return _common_linking_api_attrs(cfg = cfg)
 
-def _link_multi_arch_binary_attrs(*, cfg = apple_common.multi_arch_split):
+def _link_multi_arch_binary_attrs(*, cfg = transition_support.apple_platform_split_transition):
     """Returns dictionary of required attributes for apple_common.link_multi_arch_binary.
 
     Args:
@@ -887,7 +887,7 @@ umbrella header will be generated under the same name as this target.
 """,
             ),
             "avoid_deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive
 closure of which will not be linked into the framework's binary.
@@ -1158,7 +1158,7 @@ umbrella header will be generated under the same name as this target.
 """,
             ),
             "avoid_deps": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive
 closure of which will not be linked into the framework's binary.
@@ -1344,7 +1344,7 @@ binaries/libraries will be created combining all architectures specified by
         is_executable = False
         if require_linking_attrs:
             rule_attrs.append(_common_binary_linking_attrs(
-                deps_cfg = apple_common.multi_arch_split,
+                deps_cfg = transition_support.apple_platform_split_transition,
                 product_type = None,
             ))
         else:

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -126,7 +126,7 @@ def _describe_rule_type(
         default_test_runner: Default test runner to set in the runner attribute. Only used for
             tests.
         deps_cfg: The configuration for the deps attribute. This should be None for rules that use
-            the apple_binary intermediate target, and apple_common.multi_arch_split for the rules
+            the apple_binary intermediate target, and transition_support.apple_platform_split_transition for the rules
             that use the Starlark linking API.
         expose_non_archive_relative_output: Whether or not to expose an output archive that ignores
             the `archive_relative` bundle location, to permit embedding within another target. Has no
@@ -218,7 +218,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
             bundle_package_type = bundle_package_type.application,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_alternate_icons = True,
             has_launch_images = True,
             has_settings_bundle = True,
@@ -242,7 +242,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
             bundle_package_type = bundle_package_type.application,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             expose_non_archive_relative_output = True,
             is_executable = True,
             mandatory_families = True,
@@ -262,7 +262,7 @@ _RULE_TYPE_DESCRIPTORS = {
             app_icon_extension = ".appiconset",
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-fapplication-extension",
                 "-e",
@@ -284,7 +284,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".framework",
             bundle_package_type = bundle_package_type.framework,
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.sign_with_provisioning_profile,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             mandatory_families = True,
             product_type = apple_product_type.framework,
             rpaths = [
@@ -321,7 +321,7 @@ _RULE_TYPE_DESCRIPTORS = {
             app_icon_extension = ".stickersiconset",
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-fapplication-extension",
                 "-e",
@@ -369,7 +369,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -392,7 +392,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -419,7 +419,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.application,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             is_executable = True,
             product_type = apple_product_type.application,
             provisioning_profile_extension = ".provisionprofile",
@@ -435,7 +435,7 @@ _RULE_TYPE_DESCRIPTORS = {
         apple_product_type.tool: _describe_rule_type(
             allowed_device_families = ["mac"],
             bundle_extension = "",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             is_executable = True,
             product_type = apple_product_type.tool,
             provisioning_profile_extension = ".provisionprofile",
@@ -446,7 +446,7 @@ _RULE_TYPE_DESCRIPTORS = {
         apple_product_type.dylib: _describe_rule_type(
             allowed_device_families = ["mac"],
             bundle_extension = "",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.dylib,
             requires_signing_for_device = False,
         ),
@@ -459,7 +459,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".appex",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-fapplication-extension",
                 "-e",
@@ -484,7 +484,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".qlgenerator",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.quicklook_plugin,
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
@@ -498,7 +498,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".bundle",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.bundle,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.bundle,
             provisioning_profile_extension = ".provisionprofile",
             requires_signing_for_device = False,
@@ -516,7 +516,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".kext",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.kernel_extension,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             # This was added for b/122473338, and should be removed eventually once symbol
             # stripping is better-handled. It's redundant with an option added in the CROSSTOOL
             # for the "kernel_extension" feature, but for now it's necessary to detect kext
@@ -535,7 +535,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".mdimporter",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.spotlight_importer,
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
@@ -547,7 +547,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".xpc",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.xpc_service,
             provisioning_profile_extension = ".provisionprofile",
             requires_deps = True,
@@ -570,7 +570,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:macos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -594,7 +594,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:macos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -616,7 +616,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".framework",
             bundle_package_type = bundle_package_type.framework,
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.sign_with_provisioning_profile,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             mandatory_families = True,
             provisioning_profile_extension = ".provisionprofile",
             product_type = apple_product_type.framework,
@@ -634,7 +634,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["mac"],
             bundle_extension = ".framework",
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.skip_signing,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_infoplist = False,
             product_type = apple_product_type.static_framework,
             requires_bundle_id = False,
@@ -652,7 +652,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".app",
             bundle_locations = _describe_bundle_locations(archive_relative = "Payload"),
             bundle_package_type = bundle_package_type.application,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_launch_images = True,
             has_settings_bundle = True,
             is_executable = True,
@@ -670,7 +670,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-e",
                 "_TVExtensionMain",
@@ -693,7 +693,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".framework",
             bundle_package_type = bundle_package_type.framework,
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.sign_with_provisioning_profile,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
@@ -722,7 +722,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:tvos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -745,7 +745,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:tvos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -783,7 +783,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-fapplication-extension",
             ],
@@ -802,7 +802,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".framework",
             bundle_package_type = bundle_package_type.framework,
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.sign_with_provisioning_profile,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             product_type = apple_product_type.framework,
             rpaths = [
                 # Framework binaries live in
@@ -818,7 +818,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["watch"],
             bundle_extension = ".framework",
             codesigning_exceptions = _CODESIGNING_EXCEPTIONS.skip_signing,
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             has_infoplist = False,
             product_type = apple_product_type.static_framework,
             requires_bundle_id = False,
@@ -831,7 +831,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:watchos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",
@@ -854,7 +854,7 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_package_type = bundle_package_type.bundle,
             default_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist",
             default_test_runner = "@build_bazel_rules_apple//apple/testing/default_runner:watchos_default_runner",
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_linkopts = [
                 "-framework",
                 "XCTest",

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -78,7 +78,7 @@ number (for example, `"9.0"`).
 """,
             ),
             "targets": attr.label_list(
-                cfg = apple_common.multi_arch_split,
+                cfg = transition_support.apple_platform_split_transition,
                 doc = "The targets to check for successful build.",
                 # Since `CcInfo` is the currency provider for rules that
                 # propagate libraries for linking to Apple bundles, this is
@@ -89,7 +89,7 @@ number (for example, `"9.0"`).
                 providers = [[CcInfo]],
             ),
             # This is a public attribute due to an implementation detail of
-            # `apple_common.multi_arch_split`. The private attribute of the
+            # `transition_support.apple_platform_split_transition`. The private attribute of the
             # same name is used in the implementation function to verify that
             # the user has not modified it.
             "platform_type": attr.string(default = platform_type),


### PR DESCRIPTION
This was removed in bazel https://github.com/bazelbuild/bazel/commit/a76763c4125fbbea17f415a40d9efca846b0b6f0
