### PR TITLE
[docs] Document Xcode version selection and invalidation strategy

### DIFF
--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -515,7 +515,7 @@ if [[ $OSTYPE == darwin* ]]; then
   bazelrc_lines+=("build --repo_env=DEVELOPER_DIR=$xcode_path")
 fi
 
-printf '%s\n' "${bazelrc_lines[@]}" >> xcode.bazelrc
+printf '%s\n' "${bazelrc_lines[@]}" > xcode.bazelrc
 
 exec "$bazel_real" "$@"
 ```

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -494,7 +494,7 @@ There are a few steps required to properly make Bazel use the right Xcode versio
     * Capture `xcode-select -p` or use the value of `DEVELOPER_DIR` if available and forward it to repository rules for invalidation when changed: `--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`.
     * If not using the new [Apple CC toolchain](https://github.com/bazelbuild/apple_support#toolchain-setup) available starting in apple_support 1.4.0, pass `--repo_env=USE_CLANG_CL=$xcode_version` where `xcode_version` should be the value of `xcodebuild -version | tail -1 | cut -d " " -f3` which is unique to each version.
     * If using the new Apple CC toolchain and [apple_support](https://github.com/bazelbuild/apple_support) 1.7.0 or higher, pass `--repo_env=XCODE_VERSION=$xcode_version` instead.
-    * To invalidate the repository rule when the Xcode version changes but its path doesn't, pass the `--host_jvm_args=-Xdock:name=$developer_dir` startup flag. This forwards an argument to the JVM which is ignored except for causing the server to restart when its value changes.
+    * To invalidate the repository rule when Xcode's path changes but the version doesn't, pass the `--host_jvm_args=-Xdock:name=$developer_dir` startup flag. This forwards an argument to the JVM which is ignored except for causing the server to restart when its value changes.
 
 The above flags can be passed either directly to each invocation or by generating a `bazelrc` which is imported from your main `.bazelrc`. This snippet shows the latter option:
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -494,7 +494,7 @@ There are a few steps required to properly make Bazel use the right Xcode versio
     * Capture `xcode-select -p` or use the value of `DEVELOPER_DIR` if available and forward it to repository rules for invalidation when changed: `--repo_env=DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`.
     * If not using the new [Apple CC toolchain](https://github.com/bazelbuild/apple_support#toolchain-setup) available starting in apple_support 1.4.0, pass `--repo_env=USE_CLANG_CL=$xcode_version` where `xcode_version` should be the value of `xcodebuild -version | tail -1 | cut -d " " -f3` which is unique to each version.
     * If using the new Apple CC toolchain and [apple_support](https://github.com/bazelbuild/apple_support) 1.7.0 or higher, pass `--repo_env=XCODE_VERSION=$xcode_version` instead.
-    * To invalidate the repository rule when the Xcode version changes but its path doesn't, pass the `--host_jvm_args=-Xdock:name=$developer_dir` startup flag.
+    * To invalidate the repository rule when the Xcode version changes but its path doesn't, pass the `--host_jvm_args=-Xdock:name=$developer_dir` startup flag. This forwards an argument to the JVM which is ignored except for causing the server to restart when its value changes.
 
 The above flags can be passed either directly to each invocation or by generating a `bazelrc` which is imported from your main `.bazelrc`. This snippet shows the latter option:
 

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -507,22 +507,17 @@ bazelrc_lines=()
 if [[ $OSTYPE == darwin* ]]; then
   xcode_path=$(xcode-select -p)
   xcode_version=$(xcodebuild -version | tail -1 | cut -d " " -f3)
-
-  bazelrc_lines+=("startup --host_jvm_args=-Xdock:name=$xcode_path")
-  if [[ "$xcode_path" != /Applications/* ]]; then
-    echo "error: Xcode must be installed in /Applications/, not '$xcode_path'" >&2
-    exit 1
-  fi
-
   xcode_build_number=$(/usr/bin/xcodebuild -version 2>/dev/null | tail -1 | cut -d " " -f3)
-  bazelrc_lines+=("common --xcode_version=$xcode_version")
-  bazelrc_lines+=("common --repo_env=XCODE_VERSION=$xcode_version")
-  bazelrc_lines+=("common --repo_env=DEVELOPER_DIR=$xcode_path")
+
+  bazelrc_lines+=("startup --host_jvm_args=-Xdock:name=$xcode_path")  
+  bazelrc_lines+=("build --xcode_version=$xcode_version")
+  bazelrc_lines+=("build --repo_env=XCODE_VERSION=$xcode_version")
+  bazelrc_lines+=("build --repo_env=DEVELOPER_DIR=$xcode_path")
 fi
 
 printf '%s\n' "${bazelrc_lines[@]}" >> xcode.bazelrc
 
-exec "$bazel_real"
+exec "$bazel_real" "$@"
 ```
 
 In your main `.bazelrc` add `import xcode.bazelrc` at the very bottom.


### PR DESCRIPTION
As discussed on Slack, this paragraph documents how to get Bazel and Xcode to play nicely when switching between different Xcode versions. As a bonus, we also give a simple example of a Bazel wrapper implementation to generate a `bazelrc` that can apply the recommended flags.