### PR TITLE
Add support for swiftinterface files from (xc)frameworks file processing

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -327,7 +327,9 @@ def _apple_static_framework_import_impl(ctx):
     additional_cc_infos = []
     additional_objc_providers = []
     additional_objc_provider_fields = {}
-    if framework_imports_by_category.swift_module_imports or has_swift:
+    if framework_imports_by_category.swift_interface_imports or \
+       framework_imports_by_category.swift_module_imports or \
+       has_swift:
         toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(SwiftUsageInfo())
 

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -145,6 +145,7 @@ def _classify_file_imports(config_vars, import_files):
             - header_imports: Objective-C(++) header imports.
             - module_map_imports: Clang modulemap imports.
             - swift_module_imports: Swift module imports.
+            - swift_interface_imports: Swift module interface imports.
             - bundling_imports: Unclassified imports.
     """
     bundling_imports = []
@@ -152,6 +153,7 @@ def _classify_file_imports(config_vars, import_files):
     header_imports = []
     module_map_imports = []
     swift_module_imports = []
+    swift_interface_imports = []
     for file in import_files:
         # Extension matching
         file_extension = file.extension
@@ -175,15 +177,22 @@ def _classify_file_imports(config_vars, import_files):
                 header_imports.append(file)
             module_map_imports.append(file)
             continue
-        if file_extension in ["swiftmodule", "swiftinterface"]:
+        if file_extension == "swiftmodule":
             # Add Swift's module files to header_imports so
             # that they are correctly included in the build
             # by Bazel but they aren't processed in any way
             header_imports.append(file)
             swift_module_imports.append(file)
             continue
+        if file_extension == "swiftinterface":
+            # Add Swift's interface files to header_imports so
+            # that they are correctly included in the build
+            # by Bazel but they aren't processed in any way
+            header_imports.append(file)
+            swift_interface_imports.append(file)
+            continue
         if file_extension in ["swiftdoc", "swiftsourceinfo"]:
-            # Ignore swiftdoc files, they don't matter in the build, only for IDEs
+            # Ignore swiftdoc files, they don't matter in the build, only for IDEs.
             continue
         if file_extension == "a":
             binary_imports.append(file)
@@ -202,6 +211,7 @@ def _classify_file_imports(config_vars, import_files):
         binary_imports = binary_imports,
         header_imports = header_imports,
         module_map_imports = module_map_imports,
+        swift_interface_imports = swift_interface_imports,
         swift_module_imports = swift_module_imports,
         bundling_imports = bundling_imports,
     )
@@ -220,6 +230,7 @@ def _classify_framework_imports(config_vars, framework_imports):
             - header_imports: Apple framework header imports.
             - module_map_imports: Apple framework modulemap imports.
             - swift_module_imports: Apple framework swiftmodule imports.
+            - swift_interface_imports: Apple framework Swift module interface imports.
     """
     framework_imports_by_category = _classify_file_imports(config_vars, framework_imports)
 
@@ -250,6 +261,7 @@ def _classify_framework_imports(config_vars, framework_imports):
         bundling_imports = bundling_imports,
         header_imports = framework_imports_by_category.header_imports,
         module_map_imports = framework_imports_by_category.module_map_imports,
+        swift_interface_imports = framework_imports_by_category.swift_interface_imports,
         swift_module_imports = framework_imports_by_category.swift_module_imports,
     )
 

--- a/test/testdata/fmwk/generate_framework.bzl
+++ b/test/testdata/fmwk/generate_framework.bzl
@@ -98,14 +98,12 @@ def _generate_import_framework_impl(ctx):
             ),
         )
 
-        # Mock swiftmodule file. Imported `.swiftmodule` files are not supported due to Swift
-        # toolchain compatibility and Swift's ABI stability through `.swiftinterface` files.
-        # However, Apple framework import rules use Swift interface files to flag an imported
-        # framework contains Swift, and thus propagate Swift toolchain specific flags up the
-        # build graph.
+        # Apple framework and XCFrameworks import rules use Swift interface files to flag an
+        # imported framework contains Swift, and thus propagate Swift toolchain specific flags up
+        # the build graph.
         if include_module_interface_files:
-            module_interface = actions.declare_file(architectures[0] + ".swiftmodule")
-            actions.write(output = module_interface, content = "I'm a mock .swiftmodule file")
+            module_interface = actions.declare_file(architectures[0] + ".swiftinterface")
+            actions.write(output = module_interface, content = "I'm a mock .swiftinterface file")
             module_interfaces.append(module_interface)
 
     # Create framework bundle
@@ -163,7 +161,7 @@ Info.plist file to test resource propagation.
         ),
         "swift_library": attr.label(
             allow_files = True,
-            doc = "Label for a Swift library target to source archive and swiftmodule files from.",
+            doc = "Label for a Swift library target to source archive and module files from.",
             providers = [SwiftInfo],
         ),
         "libtype": attr.string(


### PR DESCRIPTION
Originally we chose not to take this upstream commit because we want to
maintain support for pre-compiling your own internal frameworks without
library evolution. Due to future commits on the upstream branch that we
do want this commit takes swiftinterface only support while still
maintaining swiftmodule support

(cherry picked from commit 6c85e96dda26495f72ad77c041c750b53400314f)
