### PR TITLE
Remove .bazelversion file

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,0 @@
-rolling


### PR DESCRIPTION
We added this to avoid 5.x breakages but since we still support 6.x we
can use that locally instead. CI still tests the newer versions.
