### PR TITLE
Add test validating builds with opt + objc_enable_binary_stripping

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -146,7 +146,22 @@ def _link_multi_arch_binary_attrs(*, cfg = transition_support.apple_platform_spl
     Args:
         cfg: Bazel split transition to use on attrs.
     """
-    return _common_linking_api_attrs(cfg = cfg)
+    return dicts.add(
+        _common_linking_api_attrs(cfg = cfg),
+        {
+            # xcrunwrapper is no longer used by rules_apple, but the underlying implementation of
+            # apple_common.link_multi_arch_binary and j2objc_dead_code_pruner require this attribute.
+            # See CompilationSupport.java:
+            # - `registerJ2ObjcDeadCodeRemovalActions()`
+            # - `registerLinkActions()` --> `registerBinaryStripAction()`
+            # TODO(b/117932394): Remove this attribute once Bazel no longer uses xcrunwrapper.
+            "_xcrunwrapper": attr.label(
+                cfg = "exec",
+                executable = True,
+                default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
+            ),
+        },
+    )
 
 # Needed for the J2ObjC processing code that already exists in the implementation of
 # apple_common.link_multi_arch_binary.

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -61,6 +61,16 @@ def ios_application_test_suite(name):
         tags = [name],
     )
 
+    apple_verification_test(
+        name = "{}_ipa_opt_strip_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        verifier_script = "verifier_scripts/codesign_verifier.sh",
+        compilation_mode = "opt",
+        objc_enable_binary_stripping = True,
+        tags = [name],
+    )
+
     # Tests that an app with a mixed target framework compiles
     analysis_target_outputs_test(
         name = "{}_mixed_target_framework_test".format(name),

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -55,7 +55,7 @@ Internal Error: A verification test should only specify `apple_platforms` or `cp
         "//command_line_option:ios_signing_cert_name": "-",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
-        "//command_line_option:objc_enable_binary_stripping": attr.objc_enable_binary_stripping,
+        "//command_line_option:objc_enable_binary_stripping": getattr(attr, "objc_enable_binary_stripping") or False,
         "//command_line_option:apple_generate_dsym": attr.apple_generate_dsym,
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": has_apple_platforms,
     }

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -55,7 +55,7 @@ Internal Error: A verification test should only specify `apple_platforms` or `cp
         "//command_line_option:ios_signing_cert_name": "-",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
-        "//command_line_option:objc_enable_binary_stripping": getattr(attr, "objc_enable_binary_stripping") or False,
+        "//command_line_option:objc_enable_binary_stripping": getattr(attr, "objc_enable_binary_stripping") if hasattr(attr, "objc_enable_binary_stripping") else False,
         "//command_line_option:apple_generate_dsym": attr.apple_generate_dsym,
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": has_apple_platforms,
     }

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -55,6 +55,7 @@ Internal Error: A verification test should only specify `apple_platforms` or `cp
         "//command_line_option:ios_signing_cert_name": "-",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
+        "//command_line_option:objc_enable_binary_stripping": attr.objc_enable_binary_stripping,
         "//command_line_option:apple_generate_dsym": attr.apple_generate_dsym,
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": has_apple_platforms,
     }
@@ -95,17 +96,18 @@ apple_verification_transition = transition(
         "//command_line_option:features",
     ],
     outputs = [
-        "//command_line_option:cpu",
-        "//command_line_option:ios_signing_cert_name",
-        "//command_line_option:ios_multi_cpus",
-        "//command_line_option:macos_cpus",
-        "//command_line_option:tvos_cpus",
-        "//command_line_option:watchos_cpus",
-        "//command_line_option:compilation_mode",
-        "//command_line_option:features",
         "//command_line_option:apple_generate_dsym",
         "//command_line_option:apple_platforms",
+        "//command_line_option:compilation_mode",
+        "//command_line_option:cpu",
+        "//command_line_option:features",
         "//command_line_option:incompatible_enable_apple_toolchain_resolution",
+        "//command_line_option:ios_multi_cpus",
+        "//command_line_option:ios_signing_cert_name",
+        "//command_line_option:macos_cpus",
+        "//command_line_option:objc_enable_binary_stripping",
+        "//command_line_option:tvos_cpus",
+        "//command_line_option:watchos_cpus",
     ],
 )
 
@@ -260,6 +262,14 @@ Dictionary of command line options cpu flags (e.g. ios_multi_cpus, macos_cpus) a
 cpu's to use for test under target (e.g. {'ios_multi_cpus': ['arm64', 'x86_64']}) Currently it is
 considered to be an error if this is set with `apple_platforms` as both opt into different means of
 toolchain resolution.
+""",
+        ),
+        "objc_enable_binary_stripping": attr.bool(
+            default = False,
+            doc = """
+Whether to perform symbol and dead-code strippings on linked binaries. Binary
+strippings will be performed if both this flag and --compilation_mode=opt are
+specified.
 """,
         ),
         "sanitizer": attr.string(


### PR DESCRIPTION
This was previously not covered by our test suite and has some codepaths
in bazel that can break depending on our changes
