### PR TITLE
Improve Swift interface file filtering using target triplet.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -246,6 +246,7 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
+        "//apple:utils",
         "@bazel_skylib//lib:paths",
         "@build_bazel_rules_swift//swift",
     ],

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -278,9 +278,9 @@ def _apple_dynamic_framework_import_impl(ctx):
     if framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = swift_common.get_toolchain(ctx, "_swift_toolchain")
-        swiftinterface_files = framework_import_support.filter_swift_module_files_for_architecture(
-            architecture = target_triplet.architecture,
+        swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
             swift_module_files = framework.swift_interface_imports,
+            target_triplet = target_triplet,
         )
         providers.append(
             framework_import_support.swift_info_from_module_interface(
@@ -425,9 +425,9 @@ def _apple_static_framework_import_impl(ctx):
     if framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
-        swiftinterface_files = framework_import_support.filter_swift_module_files_for_architecture(
-            architecture = target_triplet.architecture,
+        swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
             swift_module_files = framework.swift_interface_imports,
+            target_triplet = target_triplet,
         )
         providers.append(
             framework_import_support.swift_info_from_module_interface(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -195,18 +195,18 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
     headers = filter_by_library_identifier(files_by_category.header_imports)
     module_maps = filter_by_library_identifier(files_by_category.module_map_imports)
 
-    swiftmodules = framework_import_support.filter_swift_module_files_for_architecture(
-        architecture = target_triplet.architecture,
+    swiftmodules = framework_import_support.get_swift_module_files_with_target_triplet(
         swift_module_files = filter_by_library_identifier(
             files_by_category.swift_module_imports,
         ),
+        target_triplet = target_triplet,
     )
 
-    swift_module_interfaces = framework_import_support.filter_swift_module_files_for_architecture(
-        architecture = target_triplet.architecture,
+    swift_module_interfaces = framework_import_support.get_swift_module_files_with_target_triplet(
         swift_module_files = filter_by_library_identifier(
             files_by_category.swift_interface_imports,
         ),
+        target_triplet = target_triplet,
     )
 
     framework_files = filter_by_library_identifier(xcframework.files)
@@ -332,9 +332,9 @@ def _get_xcframework_library_with_xcframework_processor(
             **intermediates_common
         )
         args.add_all(
-            framework_import_support.filter_swift_module_files_for_architecture(
-                architecture = target_triplet.architecture,
+            framework_import_support.get_swift_module_files_with_target_triplet(
                 swift_module_files = files_by_category.swift_interface_imports,
+                target_triplet = target_triplet,
             ),
             before_each = "--swiftinterface_file",
         )

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -17,6 +17,10 @@
 load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
 load("@build_bazel_rules_apple//apple/internal/utils:defines.bzl", "defines")
 load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
+)
+load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
     "swift_common",
@@ -320,26 +324,6 @@ def _libraries_to_link_for_static_framework(
 
     return libraries_to_link
 
-def _filter_swift_module_files_for_architecture(architecture, swift_module_files):
-    """Filters Swift module files for a given architecture.
-
-    Traverses a list of Swift module files (.swiftdoc, .swiftinterface, .swiftmodule) and selects
-    the effective files based on target architecture and file's basename without extension.
-
-    Args:
-        architecture: Effective target architecture (e.g. 'x86_64', 'arm64').
-        swift_module_files: List of Swift module files to filter using architecture.
-    Returns:
-        List of Swift module files for given architecture.
-    """
-    files = []
-    for file in swift_module_files:
-        filename, _ = paths.split_extension(file.basename)
-        if filename == architecture:
-            files.append(file)
-
-    return files
-
 def _framework_import_info_with_dependencies(
         *,
         build_archs,
@@ -374,6 +358,56 @@ def _framework_import_info_with_dependencies(
             transitive = transitive_framework_imports,
         ),
     )
+
+def _get_swift_module_files_with_target_triplet(target_triplet, swift_module_files):
+    """Filters Swift module files for a target triplet.
+
+    Traverses a list of Swift module files (.swiftdoc, .swiftinterface, .swiftmodule) and selects
+    the effective files based on target triplet. This method supports filtering for multiple
+    Swift module directories (e.g. XCFramework bundles).
+
+    Args:
+        target_triplet: Effective target triplet from CcToolchainInfo provider.
+        swift_module_files: List of Swift module files to filter using target triplet.
+    Returns:
+        List of Swift module files for given target_triplet.
+    """
+    files_by_module = group_files_by_directory(
+        files = swift_module_files,
+        extensions = ["swiftmodule"],
+        attr = "swift_module_files",
+    )
+
+    def _get_file_with_name(files, filename):
+        for file in files:
+            name, _ext = paths.split_extension(file.basename)
+            if name == filename:
+                return file
+        return None
+
+    filtered_files = []
+    for _module, module_files in files_by_module.items():
+        # Environment suffix is stripped for device interfaces.
+        environment = ""
+        if target_triplet.environment != "device":
+            environment = "-" + target_triplet.environment
+
+        target_triplet_file = _get_file_with_name(
+            files = module_files.to_list(),
+            filename = "{architecture}-{vendor}-{os}{environment}".format(
+                architecture = target_triplet.architecture,
+                environment = environment,
+                os = target_triplet.os,
+                vendor = target_triplet.vendor,
+            ),
+        )
+        architecture_file = _get_file_with_name(
+            files = module_files.to_list(),
+            filename = target_triplet.architecture,
+        )
+        filtered_files.append(target_triplet_file or architecture_file)
+
+    return filtered_files
 
 def _objc_provider_with_dependencies(
         *,
@@ -495,8 +529,8 @@ framework_import_support = struct(
     cc_info_with_dependencies = _cc_info_with_dependencies,
     classify_file_imports = _classify_file_imports,
     classify_framework_imports = _classify_framework_imports,
-    filter_swift_module_files_for_architecture = _filter_swift_module_files_for_architecture,
     framework_import_info_with_dependencies = _framework_import_info_with_dependencies,
+    get_swift_module_files_with_target_triplet = _get_swift_module_files_with_target_triplet,
     objc_provider_with_dependencies = _objc_provider_with_dependencies,
     swift_info_from_module_interface = _swift_info_from_module_interface,
     swift_interop_info_with_dependencies = _swift_interop_info_with_dependencies,


### PR DESCRIPTION
Currently, Swift module interface files from imported XCFrameworks/
frameworks are compiled and propagated throughout the build graph.
However, the effective Swift module interface file was inferred using
only the target architecture. This is an issue since Swift module
interface files can also use a target triplet instead. This change
modifies existing logic to filter module interface files.

PiperOrigin-RevId: 467723599
(cherry picked from commit d3977397f4ec700927f163ee209b6076e08a5796)
