### PR TITLE
Fix library identifier matching for XCFrameworks import rules

### DIFF
--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -267,7 +267,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         binary_test_architecture = "arm64",
         cpus = {"watchos_cpus": ["arm64"]},
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
-        tags = [name],
+        tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
     archive_contents_test(
         name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
@@ -276,7 +276,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_xcframework.appex/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
         binary_test_architecture = "arm64_32",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
-        tags = [name],
+        tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
 
     # Verify importing XCFramework with dynamic libraries (i.e. not Apple frameworks) fails.

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -123,6 +123,15 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
     binary_contents_test(
+        name = "{}_xcframework_binary_file_info_test_arm64_device".format(name),
+        build_type = "device",
+        cpus = {"ios_multi_cpus": ["arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_contains_file_info = ["Mach-O 64-bit dynamically linked shared library arm64"],
+        tags = [name],
+    )
+    binary_contents_test(
         name = "{}_xcframework_binary_file_info_test_fat".format(name),
         build_type = "simulator",
         cpus = {
@@ -214,6 +223,59 @@ def apple_dynamic_xcframework_import_test_suite(name):
         name = "{}_imported_xcframework_framework_files_registers_action_with_xcframework_import_tool".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_imported_dynamic_xcframework",
         target_mnemonic = "ProcessXCFrameworkFiles",
+        tags = [name],
+    )
+
+    # Verify ios_application links correct XCFramework library for arm64* architectures.
+    archive_contents_test(
+        name = "{}_links_ios_arm64_macho_load_cmd_for_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_test_architecture = "arm64",
+        cpus = {"ios_multi_cpus": ["sim_arm64"]},
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_ios_arm64_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        cpus = {"ios_multi_cpus": ["arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_ios_arm64e_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        cpus = {"ios_multi_cpus": ["arm64e"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        binary_test_architecture = "arm64e",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOS"],
+        tags = [name],
+    )
+
+    # Verify watchos_application links correct XCFramework library for arm64* architectures.
+    archive_contents_test(
+        name = "{}_links_watchos_arm64_macho_load_cmd_for_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_xcframework.appex/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
+        binary_test_architecture = "arm64",
+        cpus = {"watchos_cpus": ["arm64"]},
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_xcframework.appex/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
+        binary_test_architecture = "arm64_32",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
         tags = [name],
     )
 

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -126,6 +126,69 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify ios_application links correct XCFramework library between simulator and device builds.
+    archive_contents_test(
+        name = "{}_links_ios_arm64_macho_load_cmd_for_simulator_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework_with_static_library",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        cpus = {"ios_multi_cpus": ["sim_arm64"]},
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_ios_arm64_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        cpus = {"ios_multi_cpus": ["arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework_with_static_library",
+        binary_test_architecture = "arm64",
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_ios_arm64e_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        cpus = {"ios_multi_cpus": ["arm64e"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_xcframework_with_static_library",
+        binary_test_architecture = "arm64e",
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform IOS"],
+        tags = [name],
+    )
+
+    # Verify watchos_application links correct XCFramework library for arm64* architectures.
+    archive_contents_test(
+        name = "{}_links_watchos_arm64_macho_load_cmd_for_simulator_test".format(name),
+        build_type = "simulator",
+        cpus = {"watchos_cpus": ["arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_static_xcframework",
+        not_contains = ["$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/Frameworks"],
+        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/ext_with_imported_static_xcframework",
+        binary_test_architecture = "arm64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_static_xcframework",
+        not_contains = ["$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/Frameworks"],
+        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/ext_with_imported_static_xcframework",
+        binary_test_architecture = "arm64_32",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        tags = [name],
+    )
+
     # Verify ios_application bundles Framework files when using xcframework_processor_tool.
     archive_contents_test(
         name = "{}_ios_application_with_imported_static_xcframework_includes_symbols_with_xcframework_import_tool".format(name),

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -172,7 +172,7 @@ def apple_static_xcframework_import_test_suite(name):
             "_OBJC_CLASS_$_SharedClass",
         ],
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
-        tags = [name],
+        tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
     archive_contents_test(
         name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
@@ -186,7 +186,7 @@ def apple_static_xcframework_import_test_suite(name):
             "-[SharedClass doSomethingShared]",
             "_OBJC_CLASS_$_SharedClass",
         ],
-        tags = [name],
+        tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
 
     # Verify ios_application bundles Framework files when using xcframework_processor_tool.

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1925,6 +1925,7 @@ ios_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [
         ":dynamic_xcframework_depending_lib",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -15,7 +15,9 @@ load(
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",
+    "apple_dynamic_xcframework_import",
     "apple_static_framework_import",
+    "apple_static_xcframework_import",
 )
 load(
     "//test/starlark_tests:common.bzl",
@@ -24,6 +26,11 @@ load(
 load(
     "//test/testdata/fmwk:generate_framework.bzl",
     "generate_import_framework",
+)
+load(
+    "//test/testdata/xcframeworks:generate_xcframework.bzl",
+    "generate_dynamic_xcframework",
+    "generate_static_xcframework",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
@@ -848,4 +855,138 @@ objc_library(
     name = "objc_lib_with_data_fmwk",
     srcs = ["//test/starlark_tests/resources:main.m"],
     data = [":fmwk_with_provisioning"],
+)
+
+# -----------------------------------------------------------------------------------------
+# Targets for Apple dynamic XCFramework import tests.
+
+watchos_application(
+    name = "app_with_imported_xcframework",
+    app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
+    bundle_id = "com.google.example",
+    extension = ":ext_with_imported_xcframework",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosAppInfo.plist",
+    ],
+    minimum_os_version = common.min_os_watchos.arm64_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+)
+
+watchos_extension(
+    name = "ext_with_imported_xcframework",
+    bundle_id = "com.google.example.ext",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_watchos.arm64_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_xcframework_depending_lib",
+        "//test/starlark_tests/resources:watchkit_ext_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [
+        ":watchos_imported_dynamic_xcframework",
+    ],
+)
+
+apple_dynamic_xcframework_import(
+    name = "watchos_imported_dynamic_xcframework",
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_dynamic_watchos_xcframework"],
+)
+
+generate_dynamic_xcframework(
+    name = "generated_dynamic_watchos_xcframework",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {
+        "watchos": common.min_os_watchos.arm64_support,
+        "watchos_simulator": common.min_os_watchos.arm_sim_support,
+    },
+    platforms = {
+        "watchos": [
+            "armv7k",
+            "arm64_32",
+        ],
+        "watchos_simulator": [
+            "x86_64",
+            "arm64",
+            "i386",
+        ],
+    },
+)
+
+# -----------------------------------------------------------------------------------------
+# Targets for Apple static XCFramework import tests.
+
+watchos_application(
+    name = "app_with_imported_static_xcframework",
+    app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
+    bundle_id = "com.google.example",
+    extension = ":ext_with_imported_static_xcframework",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosAppInfo.plist",
+    ],
+    minimum_os_version = common.min_os_watchos.arm64_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+)
+
+watchos_extension(
+    name = "ext_with_imported_static_xcframework",
+    bundle_id = "com.google.example.ext",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
+    ],
+    minimum_os_version = common.min_os_watchos.arm64_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":static_xcframework_depending_lib",
+        "//test/starlark_tests/resources:watchkit_ext_main_lib",
+    ],
+)
+
+objc_library(
+    name = "static_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [":watchos_imported_static_xcframework"],
+)
+
+apple_static_xcframework_import(
+    name = "watchos_imported_static_xcframework",
+    features = ["-swift.layering_check"],
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_static_watchos_xcframework"],
+)
+
+generate_static_xcframework(
+    name = "generated_static_watchos_xcframework",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {
+        "watchos": common.min_os_watchos.arm64_support,
+        "watchos_simulator": common.min_os_watchos.arm_sim_support,
+    },
+    platforms = {
+        "watchos": [
+            "armv7k",
+            "arm64_32",
+        ],
+        "watchos_simulator": [
+            "x86_64",
+            "arm64",
+            "i386",
+        ],
+    },
 )

--- a/test/testdata/xcframeworks/BUILD
+++ b/test/testdata/xcframeworks/BUILD
@@ -45,7 +45,10 @@ generate_dynamic_xcframework(
             "x86_64",
             "arm64",
         ],
-        "ios": ["arm64"],
+        "ios": [
+            "arm64",
+            "arm64e",
+        ],
     },
 )
 
@@ -78,7 +81,10 @@ generate_static_xcframework(
             "x86_64",
             "arm64",
         ],
-        "ios": ["arm64"],
+        "ios": [
+            "arm64",
+            "arm64e",
+        ],
     },
 )
 


### PR DESCRIPTION
Current logic for figuring out an XCFramework library identifier
from file paths fails to match correctly for arm64 device builds,
choosing a simulator library due to how an XCFramework library
identifier for a device build is a substring for a simulator build:

  - Device build: `ios-arm64`
  - Simulator build: `ios-arm64-simulator`

This change updates current logic to match a library identifier from
file paths using the effective target triplet, as well as matching
XCFramework files using that library identifier from file paths.

Additionally, it adds extra handling logic to avoid selecting an
`arm64e` or `arm64_32` library when targeting `arm64` due to
substring matching.

Based on PR #1579 by keith

PiperOrigin-RevId: 471303360
(cherry picked from commit 717d4b4a8de934a99b14ff0a7c7331b3c0e78ca4)
