### PR TITLE
Add tests for tvOS XCFramework import rules.

### DIFF
--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -279,6 +279,48 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
 
+    # Verify tvos_application bundles XCFramework library for device and simulator architectures.
+    archive_contents_test(
+        name = "{}_bundles_imported_tvos_xcframework_to_application_device_build".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_dynamic_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        ],
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_bundles_imported_tvos_xcframework_to_application_simulator_arm64_build".format(name),
+        build_type = "simulator",
+        cpus = {"tvos_cpus": ["sim_arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_dynamic_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        ],
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_bundles_imported_tvos_xcframework_to_application_simulator_x86_64_build".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_dynamic_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        ],
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_tvos_xcframework.framework/generated_dynamic_tvos_xcframework",
+        binary_test_architecture = "x86_64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        tags = [name],
+    )
+
     # Verify importing XCFramework with dynamic libraries (i.e. not Apple frameworks) fails.
     analysis_failure_message_test(
         name = "{}_fails_importing_xcframework_with_libraries_test".format(name),

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -189,6 +189,48 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name, "manual"],  # TODO: Re-enable once CI is on Xcode 14.3+
     )
 
+    # Verify tvos_application links XCFramework library for device and simulator architectures.
+    archive_contents_test(
+        name = "{}_links_imported_tvos_xcframework_to_application_device_build".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_static_xcframework",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_imported_tvos_xcframework_to_application_simulator_arm64_build".format(name),
+        build_type = "simulator",
+        cpus = {"tvos_cpus": ["sim_arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_static_xcframework",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_links_imported_tvos_xcframework_to_application_simulator_x86_64_build".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_imported_static_xcframework",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        macho_load_commands_contain = ["cmd LC_VERSION_MIN_TVOS"],
+        tags = [name],
+    )
+
     # Verify ios_application bundles Framework files when using xcframework_processor_tool.
     archive_contents_test(
         name = "{}_ios_application_with_imported_static_xcframework_includes_symbols_with_xcframework_import_tool".format(name),

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -11,7 +11,9 @@ load(
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",
+    "apple_dynamic_xcframework_import",
     "apple_static_framework_import",
+    "apple_static_xcframework_import",
 )
 load(
     "//test/starlark_tests:common.bzl",
@@ -20,6 +22,11 @@ load(
 load(
     "//test/testdata/fmwk:generate_framework.bzl",
     "generate_import_framework",
+)
+load(
+    "//test/testdata/xcframeworks:generate_xcframework.bzl",
+    "generate_dynamic_xcframework",
+    "generate_static_xcframework",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
@@ -347,6 +354,7 @@ tvos_framework(
 )
 
 # ---------------------------------------------------------------------------------------
+# Targets for Apple dynamic framework import tests.
 
 objc_library(
     name = "dynamic_fmwk_depending_lib",
@@ -370,6 +378,7 @@ generate_import_framework(
 )
 
 # ---------------------------------------------------------------------------------------
+# Targets for Apple static framework import tests.
 
 objc_library(
     name = "static_fmwk_depending_lib",
@@ -387,6 +396,102 @@ generate_import_framework(
     libtype = "static",
     minimum_os_version = common.min_os_tvos.baseline,
     sdk = "appletvsimulator",
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple dynamic XCFramework import tests.
+
+tvos_application(
+    name = "app_with_imported_dynamic_xcframework",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = common.min_os_tvos.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [
+        ":tvos_imported_dynamic_xcframework",
+    ],
+)
+
+apple_dynamic_xcframework_import(
+    name = "tvos_imported_dynamic_xcframework",
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_dynamic_tvos_xcframework"],
+)
+
+generate_dynamic_xcframework(
+    name = "generated_dynamic_tvos_xcframework",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {
+        "tvos": common.min_os_tvos.baseline,
+        "tvos_simulator": common.min_os_tvos.arm_sim_support,
+    },
+    platforms = {
+        "tvos": [
+            "arm64",
+        ],
+        "tvos_simulator": [
+            "arm64",
+            "x86_64",
+        ],
+    },
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple static XCFramework import tests.
+
+tvos_application(
+    name = "app_with_imported_static_xcframework",
+    bundle_id = "com.google.example",
+    infoplists = ["//test/starlark_tests/resources:Info.plist"],
+    minimum_os_version = common.min_os_tvos.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":static_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "static_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [":tvos_imported_static_xcframework"],
+)
+
+apple_static_xcframework_import(
+    name = "tvos_imported_static_xcframework",
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_static_tvos_xcframework"],
+)
+
+generate_static_xcframework(
+    name = "generated_static_tvos_xcframework",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {
+        "tvos": common.min_os_tvos.baseline,
+        "tvos_simulator": common.min_os_tvos.arm_sim_support,
+    },
+    platforms = {
+        "tvos": [
+            "arm64",
+        ],
+        "tvos_simulator": [
+            "arm64",
+            "x86_64",
+        ],
+    },
 )
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
- Verify import rules correctly bundles framework for dynamic import.
- Verify tvos_application links XCFramework symbols for static import.

PiperOrigin-RevId: 473355649
(cherry picked from commit 422612e65fd8f66d149541d1e69d3488f5482d99)
