### PR TITLE
Add support for generating test macOS frameworks and XCFrameworks

### DIFF
--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -171,7 +171,7 @@ def macos_application_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_fmwk",
         contains = [
             "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/generated_macos_dynamic_fmwk",
-            "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Info.plist",
+            "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Resources/Info.plist",
         ],
         not_contains = [
             "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Headers/SharedClass.h",

--- a/test/testdata/fmwk/generate_framework.bzl
+++ b/test/testdata/fmwk/generate_framework.bzl
@@ -50,6 +50,8 @@ def _generate_import_framework_impl(ctx):
     include_module_interface_files = ctx.attr.include_module_interface_files
     include_resource_bundle = ctx.attr.include_resource_bundle
 
+    target_os = _SDK_TO_OS[sdk]
+
     if swift_library_files and len(architectures) > 1:
         fail("Internal error: Can only generate a Swift " +
              "framework with a single architecture at this time")
@@ -115,6 +117,7 @@ def _generate_import_framework_impl(ctx):
                 files = swift_library_files,
                 extension = "swiftinterface",
             )
+
             if swiftinterface:
                 module_interfaces.extend([
                     generation_support.copy_file(
@@ -129,7 +132,7 @@ def _generate_import_framework_impl(ctx):
                         label = label,
                         target_filename = "{arch}-apple-{os}{environment}.swiftinterface".format(
                             arch = architectures[0],
-                            os = _SDK_TO_OS[sdk],
+                            os = target_os,
                             environment = "-simulator" if sdk.endswith("simulator") else "",
                         ),
                     ),
@@ -157,6 +160,7 @@ def _generate_import_framework_impl(ctx):
         label = label,
         library = library,
         module_interfaces = module_interfaces,
+        target_os = target_os,
     )
 
     return [

--- a/test/testdata/fmwk/generation_support.bzl
+++ b/test/testdata/fmwk/generation_support.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Apple Frameworks and XCFramework generation support methods for testing."""
+"""Apple frameworks and XCFramework generation support methods for testing."""
 
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
@@ -259,24 +259,27 @@ def _create_framework(
         library,
         headers,
         include_resource_bundle = False,
-        module_interfaces = []):
+        module_interfaces = [],
+        target_os):
     """Creates an Apple platform framework bundle.
 
     Args:
         actions: The actions provider from `ctx.actions`.
         base_path: Base path for the generated archive file (optional).
-        bundle_name: Name of the Framework bundle.
+        bundle_name: Name of the framework bundle.
         label: Label of the target being built.
-        library: The library for the Framework bundle.
-        headers: List of header files for the Framework bundle.
+        library: The library for the framework bundle.
+        headers: List of header files for the framework bundle.
         include_resource_bundle: Boolean to indicate if a resource bundle should be added to
             the framework bundle (optional).
         module_interfaces: List of Swift module interface files for the framework bundle (optional).
+        target_os: The target Apple OS for the generated framework bundle.
     Returns:
         List of files for a .framework bundle.
     """
     framework_files = []
     framework_directory = paths.join(base_path, bundle_name + ".framework")
+    resources_directory = paths.join(framework_directory, "Resources")
 
     framework_binary = intermediates.file(
         actions = actions,
@@ -290,9 +293,10 @@ def _create_framework(
         target_file = library,
     )
 
+    infoplist_directory = resources_directory if target_os == "macos" else framework_directory
     framework_plist = intermediates.file(
         actions = actions,
-        file_name = paths.join(framework_directory, "Info.plist"),
+        file_name = paths.join(infoplist_directory, "Info.plist"),
         output_discriminator = None,
         target_name = label.name,
     )
@@ -349,7 +353,7 @@ def _create_framework(
         ])
 
     if include_resource_bundle:
-        resources_path = paths.join(framework_directory, "Resources", bundle_name + ".bundle")
+        resources_path = paths.join(resources_directory, bundle_name + ".bundle")
 
         resource_file = intermediates.file(
             actions = actions,
@@ -413,8 +417,8 @@ def _generate_umbrella_header(
 
     Args:
         actions: The actions provider from `ctx.actions`.
-        bundle_name: Name of the Framework/XCFramework bundle.
-        headers: List of header files for the Framework bundle.
+        bundle_name: Name of the framework/XCFramework bundle.
+        headers: List of header files for the framework bundle.
         headers_path: Base path for the generated umbrella header file.
         label: Label of the target being built.
         is_framework_umbrella_header: Boolean to indicate if the generated umbrella header is for an
@@ -454,7 +458,7 @@ def _generate_module_map(
 
     Args:
         actions: The actions provider from `ctx.actions`.
-        bundle_name: Name of the Framework/XCFramework bundle.
+        bundle_name: Name of the framework/XCFramework bundle.
         headers: List of header files to use for the generated modulemap file.
         label: Label of the target being built.
         is_framework_module: Boolean to indicate if the generated modulemap is for a framework.

--- a/test/testdata/xcframeworks/generate_xcframework.bzl
+++ b/test/testdata/xcframeworks/generate_xcframework.bzl
@@ -221,6 +221,7 @@ def _generate_dynamic_xcframework_impl(ctx):
             headers = hdrs,
             label = label,
             library = dynamic_library,
+            target_os = platform,
         )
 
         framework_path = paths.join(
@@ -467,6 +468,7 @@ def _generate_static_framework_xcframework_impl(ctx):
             headers = hdrs,
             label = label,
             library = static_library,
+            target_os = platform,
         )
 
         framework_path = paths.join(


### PR DESCRIPTION
This change modifies both `generate_dynamic_framework` and
`generate_dynamic_xcframework` test rules to be able to generate
macOS framework and XCFrameworks intented for Starlark tests
verifying framework/XCFramework import rules.

macOS frameworks are nearly identical to all other Apple platforms
frameworks, except for the following:

  - macOS frameworks are versioned and include a 'Versions' directory
    with each framework version, and symlink top-bundle framework
    binary, headers, and resources directory to the framework under
    'MyFramework.framework/Versions/Current'

  - The Info.plist file is bundled into the 'Resources' directory.

PiperOrigin-RevId: 473356057
(cherry picked from commit 648ea4ed6a287f9714c45605b697624c946abb8c)
