### PR TITLE
Add tests for macOS XCFramework import rules.

### DIFF
--- a/platform_mappings
+++ b/platform_mappings
@@ -5,7 +5,7 @@ platforms:
   @build_bazel_apple_support//platforms:macos_arm64
     --cpu=darwin_arm64
 
-  @build_bazel_apple_support//platforms:macos_arm64e
+  @build_bazel_apple_support//platforms:darwin_arm64e
     --cpu=darwin_arm64e
 
   @build_bazel_apple_support//platforms:ios_i386
@@ -61,7 +61,7 @@ flags:
 
   --cpu=darwin_arm64e
   --apple_platform_type=macos
-    @build_bazel_apple_support//platforms:macos_arm64e
+    @build_bazel_apple_support//platforms:darwin_arm64e
 
   --cpu=ios_i386
   --apple_platform_type=ios

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -321,6 +321,41 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify macos_application links XCFramework library for device and simulator architectures.
+    archive_contents_test(
+        name = "{}_bundles_imported_macos_xcframework_to_application_x86_64_build".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_xcframework",
+        binary_test_file = "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_xcframework.framework/generated_dynamic_macos_xcframework",
+        binary_test_architecture = "x86_64",
+        contains = [
+            "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_xcframework.framework/Resources/Info.plist",
+            "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_xcframework.framework/generated_dynamic_macos_xcframework",
+        ],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform MACOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_bundles_imported_macos_xcframework_to_application_arm64_build".format(name),
+        build_type = "device",
+        cpus = {"macos_cpus": ["arm64"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_xcframework",
+        binary_test_file = "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_xcframework.framework/generated_dynamic_macos_xcframework",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform MACOS"],
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_bundles_imported_macos_xcframework_to_application_arm64e_build".format(name),
+        build_type = "simulator",
+        cpus = {"macos_cpus": ["arm64e"]},
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_xcframework",
+        binary_test_file = "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_xcframework.framework/generated_dynamic_macos_xcframework",
+        binary_test_architecture = "arm64e",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform MACOS"],
+        tags = [name],
+    )
+
     # Verify importing XCFramework with dynamic libraries (i.e. not Apple frameworks) fails.
     analysis_failure_message_test(
         name = "{}_fails_importing_xcframework_with_libraries_test".format(name),

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -20,6 +20,7 @@ load(
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",
+    "apple_dynamic_xcframework_import",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
@@ -34,6 +35,10 @@ load(
     "generate_import_framework",
 )
 load("//test/testdata/rules:substitution.bzl", "substitution")
+load(
+    "//test/testdata/xcframeworks:generate_xcframework.bzl",
+    "generate_dynamic_xcframework",
+)
 
 licenses(["notice"])
 
@@ -1208,6 +1213,9 @@ macos_application(
     ],
 )
 
+# ---------------------------------------------------------------------------------------
+# Targets for Apple dynamic framework import tests.
+
 macos_application(
     name = "app_with_imported_fmwk",
     bundle_id = "com.google.example",
@@ -2022,6 +2030,54 @@ generate_import_framework(
     minimum_os_version = common.min_os_macos.baseline,
     sdk = "macosx",
     tags = common.fixture_tags,
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for Apple dynamic XCFramework import tests.
+
+macos_application(
+    name = "app_with_imported_dynamic_xcframework",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [
+        ":macos_imported_dynamic_xcframework",
+    ],
+)
+
+apple_dynamic_xcframework_import(
+    name = "macos_imported_dynamic_xcframework",
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_dynamic_macos_xcframework"],
+)
+
+generate_dynamic_xcframework(
+    name = "generated_dynamic_macos_xcframework",
+    srcs = ["//test/testdata/fmwk:objc_source"],
+    hdrs = ["//test/testdata/fmwk:objc_headers"],
+    minimum_os_versions = {
+        "macos": common.min_os_macos.arm64_support,
+    },
+    platforms = {
+        "macos": [
+            "arm64",
+            "arm64e",
+            "x86_64",
+        ],
+    },
 )
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Verify import rules correctly bundles framework for currently supported
macOS architectures.

PiperOrigin-RevId: 473356936
(cherry picked from commit ead4f7a4f84c5f39d1bd01259a5f8da1a4102fbd)
