### PR TITLE
Add an option to run unzip -t at the end of ProcessAndSign to verify its output.

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -649,6 +649,9 @@ def _post_process_and_sign_archive_action(
         default = (config_vars["COMPILATION_MODE"] == "opt"),
     )
 
+    # Verify the output file if the verify_zip_crc feature is enabled.
+    should_verify = "verify_zip_crc" in features
+
     # TODO(b/163217926): These are kept the same for the three different actions
     # that could be run to ensure anything keying off these values continues to
     # work. After some data is collected, the values likely can be revisited and
@@ -683,6 +686,7 @@ def _post_process_and_sign_archive_action(
             "%ipa_post_processor%": ipa_post_processor_path or "",
             "%output_path%": output_archive.path,
             "%should_compress%": "1" if should_compress else "",
+            "%should_verify%": "1" if should_verify else "",
             "%signing_command_lines%": signing_command_lines,
             "%unprocessed_archive_path%": input_archive.path,
             "%work_dir%": output_archive_root_path,

--- a/tools/bundletool/process_and_sign.sh.template
+++ b/tools/bundletool/process_and_sign.sh.template
@@ -15,6 +15,8 @@ readonly OUTPUT_PATH=%output_path%
 readonly POST_PROCESSOR=%ipa_post_processor%
 # Indicates whether the final archive should be compressed (1) or not (0).
 readonly SHOULD_COMPRESS=%should_compress%
+# Indicates whether the final archive should be verified by unzipping (1) or not (0).
+readonly SHOULD_VERIFY=%should_verify%
 # The path to archive with the unprocessed and unsigned bundle.
 readonly UNPROCESSED_ARCHIVE_PATH=%unprocessed_archive_path%
 # The absolute path to the directory where the unprocessed archive will be
@@ -69,3 +71,7 @@ TZ=UTC find . -depth -exec touch -h -t 198001010000 {} \+
   | zip -qX "-@" --compression-method "$COMPRESSION_METHOD" "$OUTPUT_BASENAME"
 popd >/dev/null
 mv "$WORK_DIR/$OUTPUT_BASENAME" "$OUTPUT_PATH"
+# Verify the CRC checksums in the zip file by running unzip -t
+if [[ "$SHOULD_VERIFY" == "1" ]]; then
+  unzip -t -qq "$OUTPUT_PATH"
+fi


### PR DESCRIPTION
The option is enabled with a "verify_zip_crc" feature.

PiperOrigin-RevId: 475625987
(cherry picked from commit 13c707dd92c445e78730dd40362d88a01724972a)
