### PR TITLE
Same bundle name in test_tree_artifacts_with_same_bundle_names_dont_c…

### DIFF
--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -748,6 +748,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    bundle_name = "app",
     minimum_os_version = "${MIN_OS_IOS}",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [
@@ -759,6 +760,7 @@ ios_application(
     bundle_id = "my.bundle.id",
     families = ["iphone"],
     infoplists = ["Info.plist"],
+    bundle_name = "app",
     minimum_os_version = "${MIN_OS_IOS}",
     provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [


### PR DESCRIPTION
I missed this before in PR: https://github.com/bazelbuild/rules_apple/pull/2033. 
This now completes the intent of the test case - test_tree_artifacts_with_same_bundle_names_dont_conflict.




