### PR TITLE
Fix black screen when using `disable_signing_resource_rules` and launch storyboard

### DIFF
--- a/tools/codesigningtool/disable_signing_resource_rules.plist
+++ b/tools/codesigningtool/disable_signing_resource_rules.plist
@@ -6,6 +6,8 @@
 	<dict>
 		<key>.*</key>
 		<false/>
+		<key>.*storyboard</key>
+		<true/>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Hello maintainers,

I'm submitting this pull request to address an issue that occurs when my storyboard is set as the startup screen and I utilize signed acceleration. In this scenario, if I cold launch the application on the simulator a black screen issue arises. To mitigate this problem, I suggest extending the signing process to include the storyboard as well.

## Steps to Reproduce:
Set the storyboard as the startup screen.
Utilize signed acceleration for the startup process.
Launch the application on the simulator.

## Expected Behavior:
The application should launch properly without any black screen issues.

## Actual Behavior
A black screen appears during the startup process on the simulator.

## Proposed Solution:
To address this issue, I recommend extending the code signing process to include the storyboard. By signing both the main application and the storyboard, we can ensure consistent behavior during the startup process, preventing the occurrence of the black screen problem.

Best regards,
caowenbo