### PR TITLE
Inline executable_name reading

### DIFF
--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -56,25 +56,6 @@ def _bundle_full_name_from_rule_ctx(ctx):
         rule_descriptor = rule_support.rule_descriptor(ctx),
     )
 
-def _executable_name(ctx):
-    """Returns the executable name of the bundle.
-
-    The executable of the bundle is the value of the `executable_name`
-    attribute if it was given; if not, then the name of the `bundle_name`
-    attribute if it was given; if not, then the name of the target will be used
-    instead.
-
-    Args:
-      ctx: The Starlark context.
-
-    Returns:
-      The executable name.
-    """
-    executable_name = getattr(ctx.attr, "executable_name", None)
-    if not executable_name:
-        (executable_name, _) = _bundle_full_name_from_rule_ctx(ctx)
-    return executable_name
-
 def _ensure_single_xcassets_type(attr, files, extension, message = None):
     """Helper for when an xcassets catalog should have a single sub type.
 
@@ -184,5 +165,4 @@ bundling_support = struct(
     bundle_full_name_from_rule_ctx = _bundle_full_name_from_rule_ctx,
     ensure_path_format = _ensure_path_format,
     ensure_single_xcassets_type = _ensure_single_xcassets_type,
-    executable_name = _executable_name,
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -127,7 +127,7 @@ def _ios_application_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = (
         ctx.attr.frameworks +
@@ -430,7 +430,7 @@ def _ios_app_clip_impl(ctx):
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     embeddable_targets = ctx.attr.frameworks
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -682,7 +682,7 @@ def _ios_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -906,7 +906,7 @@ def _ios_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1145,7 +1145,7 @@ def _ios_dynamic_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -1403,7 +1403,7 @@ def _ios_static_framework_impl(ctx):
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1516,7 +1516,7 @@ def _ios_imessage_application_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1692,7 +1692,7 @@ def _ios_imessage_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1902,7 +1902,7 @@ def _ios_sticker_pack_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -78,7 +78,6 @@ def _macos_binary_infoplist_impl(ctx):
     actions = ctx.actions
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
     bundle_id = ctx.attr.bundle_id
-    executable_name = bundling_support.executable_name(ctx)
     rule_descriptor = rule_support.rule_descriptor(ctx)
     rule_label = ctx.label
     platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
@@ -105,7 +104,6 @@ def _macos_binary_infoplist_impl(ctx):
         bundle_extension = bundle_extension,
         bundle_id = bundle_id,
         bundle_name = bundle_name,
-        executable_name = executable_name,
         environment_plist = ctx.file._environment_plist,
         include_executable_name = False,
         input_plists = infoplists,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -140,7 +140,7 @@ def _macos_application_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
 
     bundle_verification_targets = [struct(target = ext) for ext in verification_targets]
 
@@ -389,7 +389,7 @@ def _macos_bundle_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -586,7 +586,7 @@ def _macos_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -800,7 +800,7 @@ def _macos_quick_look_plugin_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1009,7 +1009,7 @@ def _macos_kernel_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1210,7 +1210,7 @@ def _macos_spotlight_importer_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1406,7 +1406,7 @@ def _macos_xpc_service_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1601,7 +1601,6 @@ def _macos_command_line_application_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1628,7 +1627,6 @@ def _macos_command_line_application_impl(ctx):
         bundle_name = bundle_name,
         dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
-        executable_name = executable_name,
         label_name = label.name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
@@ -1714,7 +1712,6 @@ def _macos_dylib_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1742,7 +1739,6 @@ def _macos_dylib_impl(ctx):
         bundle_name = bundle_name,
         dsym_binaries = debug_outputs.dsym_binaries,
         dsym_info_plist_template = apple_mac_toolchain_info.dsym_info_plist_template,
-        executable_name = executable_name,
         label_name = label.name,
         linkmaps = debug_outputs.linkmaps,
         platform_prerequisites = platform_prerequisites,
@@ -1904,7 +1900,7 @@ def _macos_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -2141,7 +2137,7 @@ def _macos_dynamic_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -2399,7 +2395,7 @@ def _macos_static_framework_impl(ctx):
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -140,7 +140,7 @@ def apple_bundle_info_partial(
         bundle_id = bundle_id,
         bundle_extension = bundle_extension,
         bundle_name = bundle_name,
-        executable_name = executable_name,
+        executable_name = executable_name or bundle_name,
         extension_safe = extension_safe,
         entitlements = entitlements,
         label_name = label_name,

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -82,7 +82,7 @@ def binary_partial(
         actions = actions,
         binary_artifact = binary_artifact,
         bundle_name = bundle_name,
-        executable_name = executable_name,
+        executable_name = executable_name or bundle_name,
         label_name = label_name,
         output_discriminator = output_discriminator,
     )

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -302,7 +302,7 @@ def _debug_symbols_partial_impl(
 
     if platform_prerequisites.cpp_fragment:
         if platform_prerequisites.cpp_fragment.apple_generate_dsym:
-            dsym_output_filename = executable_name or bundle_name
+            dsym_output_filename = executable_name
             if debug_discriminator:
                 dsym_output_filename += "_" + debug_discriminator
             dsym_files, dsym_bundle_dir = _bundle_dsym_files(
@@ -426,7 +426,7 @@ def debug_symbols_partial(
         debug_discriminator = debug_discriminator,
         dsym_binaries = dsym_binaries,
         dsym_info_plist_template = dsym_info_plist_template,
-        executable_name = executable_name,
+        executable_name = executable_name or bundle_name,
         label_name = label_name,
         linkmaps = linkmaps,
         platform_prerequisites = platform_prerequisites,

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -302,7 +302,7 @@ def _debug_symbols_partial_impl(
 
     if platform_prerequisites.cpp_fragment:
         if platform_prerequisites.cpp_fragment.apple_generate_dsym:
-            dsym_output_filename = executable_name
+            dsym_output_filename = executable_name or bundle_name
             if debug_discriminator:
                 dsym_output_filename += "_" + debug_discriminator
             dsym_files, dsym_bundle_dir = _bundle_dsym_files(
@@ -385,7 +385,7 @@ def debug_symbols_partial(
         debug_discriminator = None,
         dsym_binaries = {},
         dsym_info_plist_template,
-        executable_name,
+        executable_name = None,
         label_name,
         linkmaps = {},
         platform_prerequisites):

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -436,7 +436,7 @@ def resources_partial(
         bundle_extension = bundle_extension,
         bundle_id = bundle_id,
         bundle_name = bundle_name,
-        executable_name = executable_name,
+        executable_name = executable_name or bundle_name,
         bundle_verification_targets = bundle_verification_targets,
         environment_plist = environment_plist,
         launch_storyboard = launch_storyboard,

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -188,7 +188,7 @@ def merge_root_infoplists(
         bundle_name,
         bundle_id = None,
         bundle_extension,
-        executable_name,
+        executable_name = None,
         child_plists = [],
         child_required_values = [],
         environment_plist,
@@ -275,7 +275,8 @@ def merge_root_infoplists(
     # Info.plists out of the box coming from Xcode.
     substitutions["DEVELOPMENT_LANGUAGE"] = "en"
 
-    if include_executable_name and executable_name:
+    executable_name = executable_name or bundle_name
+    if include_executable_name:
         substitutions["EXECUTABLE_NAME"] = executable_name
         forced_plists.append(struct(CFBundleExecutable = executable_name))
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -275,7 +275,7 @@ def _apple_test_bundle_impl(ctx):
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     config_vars = ctx.var
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -121,7 +121,7 @@ def _tvos_application_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -395,7 +395,7 @@ def _tvos_dynamic_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -643,7 +643,7 @@ def _tvos_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -863,7 +863,7 @@ def _tvos_extension_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1084,7 +1084,7 @@ def _tvos_static_framework_impl(ctx):
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -122,7 +122,7 @@ def _watchos_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -357,7 +357,7 @@ def _watchos_dynamic_framework_impl(ctx):
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
         ctx = ctx,
@@ -608,7 +608,7 @@ def _watchos_application_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -812,7 +812,7 @@ def _watchos_extension_impl(ctx):
     embeddable_targets = (
         ctx.attr.extensions + ctx.attr.frameworks + ctx.attr.deps
     )
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -1072,7 +1072,7 @@ def _watchos_static_framework_impl(ctx):
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
     bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
-    executable_name = bundling_support.executable_name(ctx)
+    executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,


### PR DESCRIPTION
In a future cherry pick we will no longer be able to get the bundle_name
with just the ctx argument as we do for the executable_name fallback.
Instead of passing along all the new required arguments this change
inlines the executable_name attr reading and passes that along, and
makes the consumers of that arg do the behavior of
`executable_name or bundle_name` themselves.
