### PR TITLE
Fix incorrectly returned variable in clangrttool.py to resolve an issue when only LC_LOAD_DYLIB can be found in the objdump output.

### DIFF
--- a/tools/clangrttool/clangrttool.py
+++ b/tools/clangrttool/clangrttool.py
@@ -102,6 +102,8 @@ class ClangRuntimeTool(object):
         if not rpath.startswith("@") and "lib/clang" in rpath:
           found_rpath = rpath
       elif line.endswith(" LC_LOAD_DYLIB"):
+        # TODO(b/249129510): Make sure we have test coverage for this case when
+        # LC_RPATH is absent from the objdump output.
         library_line = objdump_output[index + 2].strip()
         library_segments = library_line.split(" ")
         if len(library_segments) != 4:
@@ -110,7 +112,7 @@ class ClangRuntimeTool(object):
         if library.startswith("@rpath/libclang_rt"):
           libs.add(library[len("@rpath/"):])
 
-    return rpath, libs
+    return found_rpath, libs
 
   def run(self):
     objdump_args = [


### PR DESCRIPTION
PiperOrigin-RevId: 476967206
(cherry picked from commit c9e31e9f62a01f392774fcce96fb9f92710b707d)
