### PR TITLE
Update apple rules tests to use iOS >= 11, macOS >= 10.13, tvOS >= 11, watchOS >= 4.

### DIFF
--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -36,7 +36,7 @@ ios_application(
     ],
     infoplists = [":Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/examples/ios/PrenotCalculator/BUILD
+++ b/examples/ios/PrenotCalculator/BUILD
@@ -27,7 +27,7 @@ ios_application(
     bundle_id = "com.example.prenot-calculator",
     families = ["iphone"],
     infoplists = ["PrenotCalculator-Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     deps = [":PrenotCalculator_library"],
 )
 
@@ -71,7 +71,7 @@ objc_library(
 
 ios_unit_test(
     name = "PrenotCalculatorTests",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     deps = [":PrenotCalculatorTestsLib"],
 )
 

--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -17,14 +17,14 @@ objc_library(
 ios_unit_test(
     name = "SquarerTests",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     deps = [":SquarerTestsLib"],
 )
 
 ios_unit_test(
     name = "SquarerTestsOrdered",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     deps = [":SquarerTestsLib"],
 )
@@ -32,7 +32,7 @@ ios_unit_test(
 ios_unit_test(
     name = "SquarerTestsRandom",
     env = {"TEST_ENV_VAR": "test_value"},
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":SquarerTestsLib"],
 )

--- a/examples/ios/StickersApp/BUILD
+++ b/examples/ios/StickersApp/BUILD
@@ -24,7 +24,7 @@ ios_sticker_pack_extension(
         "ipad",
     ],
     infoplists = ["StickersExtension-Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     sticker_assets = glob(["Stickers.xcstickers/**"]),
     version = ":StickerAppVersion",
 )
@@ -39,7 +39,7 @@ ios_imessage_application(
         "ipad",
     ],
     infoplists = ["StickersApp-Info.plist"],
-    minimum_os_version = "10.0",
+    minimum_os_version = "11.0",
     version = ":StickerAppVersion",
 )
 

--- a/examples/macos/CommandLine/BUILD
+++ b/examples/macos/CommandLine/BUILD
@@ -24,7 +24,7 @@ macos_command_line_application(
     name = "CommandLine",
     bundle_id = "com.example.command-line",
     infoplists = [":Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":CommandLineVersion",
     deps = [":Sources"],
 )

--- a/examples/macos/CommandLineSwift/BUILD
+++ b/examples/macos/CommandLineSwift/BUILD
@@ -28,7 +28,7 @@ macos_command_line_application(
     name = "CommandLineSwift",
     bundle_id = "com.example.command-line-swift",
     infoplists = [":Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":CommandLineSwiftVersion",
     deps = [":Sources"],
 )

--- a/examples/macos/HelloToday/BUILD
+++ b/examples/macos/HelloToday/BUILD
@@ -52,7 +52,7 @@ macos_application(
         ":TodayExtension",
     ],
     infoplists = [":App-Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":HelloTodayVersion",
     deps = [":AppSources"],
 )
@@ -62,7 +62,7 @@ macos_extension(
     bundle_id = "com.example.hello-today.today-extension",
     entitlements = ":Ext-Entitlements.entitlements",
     infoplists = [":Ext-Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":HelloTodayVersion",
     deps = [":ExtSources"],
 )

--- a/examples/macos/HelloWorld/BUILD
+++ b/examples/macos/HelloWorld/BUILD
@@ -32,7 +32,7 @@ macos_application(
     app_icons = ["//examples/resources:MacAppIcon.xcassets"],
     bundle_id = "com.example.hello-world",
     infoplists = [":Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/examples/macos/HelloWorldSwift/BUILD
+++ b/examples/macos/HelloWorldSwift/BUILD
@@ -32,7 +32,7 @@ macos_application(
     app_icons = ["//examples/resources:MacAppIcon.xcassets"],
     bundle_id = "com.example.hello-world-swift",
     infoplists = [":Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":HelloWorldSwiftVersion",
     deps = [":Sources"],
 )

--- a/examples/macos/XPCServiceApp/BUILD
+++ b/examples/macos/XPCServiceApp/BUILD
@@ -42,7 +42,7 @@ macos_xpc_service(
     name = "XPCService",
     bundle_id = "com.example.xpc-service-app.xpc-service",
     infoplists = ["XPCServiceSources/Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":XPCServiceAppVersion",
     deps = [":XPCServiceLib"],
 )
@@ -52,7 +52,7 @@ macos_application(
     app_icons = ["//examples/resources:MacAppIcon.xcassets"],
     bundle_id = "com.example.xpc-service-app",
     infoplists = ["XPCServiceAppSources/Info.plist"],
-    minimum_os_version = "10.11",
+    minimum_os_version = "10.13",
     version = ":XPCServiceAppVersion",
     xpc_services = [":XPCService"],
     deps = [":XPCServiceAppLib"],

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -98,7 +98,7 @@ ios_application(
         "ipad",
     ],
     infoplists = ["Buttons/Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     watch_application = ":ButtonsWatch",
     deps = [
         ":ButtonsLib",
@@ -114,7 +114,7 @@ ios_extension(
         "ipad",
     ],
     infoplists = ["ButtonsExtension/Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     deps = [":ButtonsExtensionLib"],
 )
 
@@ -129,20 +129,20 @@ ios_static_framework(
 
 ios_unit_test(
     name = "ButtonsTests",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     test_host = ":Buttons",
     deps = [":ButtonsTestsLib"],
 )
 
 ios_unit_test(
     name = "ButtonsLogicTests",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     deps = [":ButtonsTestsLib"],
 )
 
 ios_ui_test(
     name = "ButtonsUITests",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     test_host = ":Buttons",
     deps = [":ButtonsUITestsLib"],
 )
@@ -179,7 +179,7 @@ watchos_application(
     bundle_id = "com.google.Buttons.watchkitapp",
     extension = ":ButtonsWatchExtension",
     infoplists = ["ButtonsWatch/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     resources = ["ButtonsWatch/Base.lproj/Interface.storyboard"],
 )
 
@@ -187,7 +187,7 @@ watchos_extension(
     name = "ButtonsWatchExtension",
     bundle_id = "com.google.Buttons.watchkitapp.watchkitextension",
     infoplists = ["ButtonsWatchExtension/Info.plist"],
-    minimum_os_version = "3.0",
+    minimum_os_version = "4.0",
     deps = [
         ":ButtonsWatchExtensionLib",
     ],
@@ -248,7 +248,7 @@ tvos_application(
     bundle_id = "com.google.ButtonsTV",
     extensions = [":ButtonsTVExtension"],
     infoplists = ["ButtonsTV/Info.plist"],
-    minimum_os_version = "10.2",
+    minimum_os_version = "11.0",
     deps = [
         ":ButtonsTVLib",
         ":ButtonsTVResources",
@@ -259,7 +259,7 @@ tvos_extension(
     name = "ButtonsTVExtension",
     bundle_id = "com.google.ButtonsTV.ButtonsTVExtension",
     infoplists = ["ButtonsTVExtension/Info.plist"],
-    minimum_os_version = "10.2",
+    minimum_os_version = "11.0",
     deps = [":ButtonsTVExtensionLib"],
 )
 
@@ -364,7 +364,7 @@ macos_unit_test(
 # Enable when macos_test_runner supports macOS UI Tests.
 # macos_ui_test(
 #     name = "ButtonsMacUITests",
-#     minimum_os_version = "10.11",
+#     minimum_os_version = "10.13",
 #     test_host = ":ButtonsMac",
 #     deps = [":ButtonsMacUITestsLib"],
 # )

--- a/examples/tvos/HelloWorld/BUILD
+++ b/examples/tvos/HelloWorld/BUILD
@@ -33,7 +33,7 @@ tvos_application(
     app_icons = ["//examples/resources:TVBrandAssets.xcassets"],
     bundle_id = "com.example.hello-world",
     infoplists = [":Info.plist"],
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     version = ":HelloWorldVersion",
     deps = [":Sources"],
 )

--- a/examples/watchos/HelloWorld/BUILD
+++ b/examples/watchos/HelloWorld/BUILD
@@ -63,7 +63,7 @@ ios_application(
     ],
     infoplists = [":Phone-Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     version = ":HelloWorldVersion",
     watch_application = ":HelloWorld-WatchApplication",
     deps = [":PhoneSources"],
@@ -75,7 +75,7 @@ watchos_application(
     bundle_id = "com.example.hello-world.watch",
     extension = ":HelloWorld-WatchExtension",
     infoplists = [":WatchApp-Info.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     storyboards = [
         "WatchResources/Interface.storyboard",
     ],
@@ -86,7 +86,7 @@ watchos_extension(
     name = "HelloWorld-WatchExtension",
     bundle_id = "com.example.hello-world.watch.extension",
     infoplists = [":WatchExt-Info.plist"],
-    minimum_os_version = "2.0",
+    minimum_os_version = "4.0",
     version = ":HelloWorldVersion",
     deps = [":WatchSources"],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -165,8 +165,6 @@ apple_multi_shell_test(
     src = "macos_application_test.sh",
     configurations = MACOS_CONFIGURATIONS,
     data = [
-        "//test/testdata/binaries:empty_dylib",
-        "//test/testdata/binaries:empty_staticlib",
     ],
 )
 
@@ -264,7 +262,7 @@ apple_shell_test(
     size = "large",
     src = "ios_test_runner_unit_test.sh",
     args = [
-        "--ios_multi_cpus=i386,x86_64,sim_arm64",
+        "--ios_multi_cpus=sim_arm64,x86_64",
     ],
     flaky = 1,
     tags = common.skip_ci_tags,
@@ -285,7 +283,7 @@ apple_shell_test(
     size = "large",
     src = "ios_test_runner_ui_test.sh",
     args = [
-        "--ios_multi_cpus=i386,x86_64",
+        "--ios_multi_cpus=sim_arm64,x86_64",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -112,10 +112,6 @@ apple_multi_shell_test(
     size = "large",
     src = "ios_application_test.sh",
     configurations = IOS_CONFIGURATIONS,
-    data = [
-        "//test/testdata/binaries:empty_dylib",
-        "//test/testdata/binaries:empty_staticlib",
-    ],
 )
 
 apple_multi_shell_test(
@@ -143,10 +139,6 @@ apple_multi_shell_test(
     size = "medium",
     src = "ios_extension_test.sh",
     configurations = IOS_CONFIGURATIONS,
-    data = [
-        "//test/testdata/binaries:empty_dylib",
-        "//test/testdata/binaries:empty_staticlib",
-    ],
 )
 
 apple_multi_shell_test(
@@ -164,8 +156,6 @@ apple_multi_shell_test(
     size = "medium",
     src = "macos_application_test.sh",
     configurations = MACOS_CONFIGURATIONS,
-    data = [
-    ],
 )
 
 apple_multi_shell_test(

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -137,7 +137,7 @@ EOF
     cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
         app/fmwk.framework/fmwk
   else
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_staticlib_lipo.a) \
+    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/libdummy_lib.a) \
         app/fmwk.framework/fmwk
   fi
 

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -226,6 +226,34 @@ This shouldn't get included
 EOF
 }
 
+# Usage: create_minimal_ios_application_with_extension [product type]
+#
+# Creates a minimal iOS application target. The optional product type is
+# the Starlark constant that should be set on the extension using the
+# `product_type` attribute.
+function create_minimal_ios_application_with_extension() {
+  if [[ ! -f app/BUILD ]]; then
+    fail "create_common_files must be called first."
+  fi
+
+  product_type="${1:-}"
+
+  create_minimal_ios_application_extension "$product_type"
+
+  cat >> app/BUILD <<EOF
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = ["Info-App.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [":lib"],
+)
+EOF
+}
+
 # Test missing the CFBundleVersion fails the build.
 function test_missing_version_fails() {
   create_common_files
@@ -484,73 +512,6 @@ EOF
 
   ! do_build ios //app:app || fail "Should not build"
   expect_log "While processing target \"//app:app\"; the CFBundleVersion of the child target \"//app:ext\" should be the same as its parent's version string \"1.0\", but found \"1.1\"."
-}
-
-# Tests that a prebuilt static framework (i.e., apple_static_framework_import)
-# is not bundled with the application or extension.
-function test_prebuilt_static_apple_framework_import_dependency() {
-  create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import static apple_static_framework_import
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that it's not bundled.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
-}
-
-# Tests that a prebuilt dynamic framework (i.e., apple_dynamic_framework_import)
-# is bundled properly with the application.
-function test_prebuilt_dynamic_apple_framework_import_dependency() {
-  create_common_files
-  create_minimal_ios_application_and_extension_with_framework_import dynamic apple_dynamic_framework_import
-
-  do_build ios //app:app || fail "Should build"
-
-  # Verify that the framework is bundled with the application and that the
-  # binary, plist, and resources are included.
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/fmwk"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/resource.txt"
-
-  # Verify that Headers and Modules directories are excluded.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Frameworks/fmwk.framework/Modules/module.modulemap"
-
-  # Verify that the framework is not bundled with the extension.
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/fmwk"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/Info.plist"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appex/Frameworks/fmwk.framework/resource.txt"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Headers/fmwk.h"
-  assert_zip_not_contains "test-bin/app/app.ipa" \
-      "Payload/app.app/Plugins/ext.appexFrameworks/fmwk.framework/Modules/module.modulemap"
 }
 
 # Tests that ios_extension cannot be a depenency of objc_library.

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -203,7 +203,7 @@ EOF
     cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
         app/fmwk.framework/fmwk
   else
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_staticlib_lipo.a) \
+    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/libdummy_lib.a) \
         app/fmwk.framework/fmwk
   fi
 

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -303,7 +303,7 @@ EOF
 }
 
 function do_ios_test() {
-  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=9.0" "$@"
+  do_test ios "--test_output=all" "--spawn_strategy=local" "--ios_minimum_os=11.0" "$@"
 }
 
 function test_ios_ui_test_pass() {

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -166,6 +166,7 @@ def ios_application_test_suite(name):
             "-[SharedClass doSomethingShared]",
             "_OBJC_CLASS_$_SharedClass",
         ],
+        is_not_binary_plist = ["$BUNDLE_ROOT/iOSStaticFramework.bundle/Info.plist"],
         contains = ["$BUNDLE_ROOT/iOSStaticFramework.bundle/Info.plist"],
         not_contains = ["$BUNDLE_ROOT/Frameworks/iOSStaticFramework.framework"],
         tags = [name],

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -190,6 +190,39 @@ def ios_extension_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_with_imported_static_fmwk_contains_symbols_and_bundles_resources".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_fmwk_and_ext",
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "x86_64",
+        binary_contains_symbols = [
+            "-[SharedClass doSomethingShared]",
+            "_OBJC_CLASS_$_SharedClass",
+        ],
+        is_not_binary_plist = ["$BUNDLE_ROOT/iOSStaticFramework.bundle/Info.plist"],
+        contains = ["$BUNDLE_ROOT/iOSStaticFramework.bundle/Info.plist"],
+        not_contains = ["$BUNDLE_ROOT/Frameworks/iOSStaticFramework.framework"],
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_with_imported_dynamic_fmwk_bundles_files".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_dynamic_fmwk_and_ext",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/iOSDynamicFramework",
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Resources/iOSDynamicFramework.bundle/Info.plist",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Headers/SharedClass.h",
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Headers/iOSDynamicFramework.h",
+            "$BUNDLE_ROOT/Frameworks/iOSDynamicFramework.framework/Modules/module.modulemap",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -667,6 +667,23 @@ ios_framework(
     ],
 )
 
+ios_application(
+    name = "app_with_imported_static_fmwk_and_ext",
+    bundle_id = "com.google.example",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":iOSImportedStaticFramework",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 apple_static_framework_import(
     name = "iOSImportedStaticFramework",
     features = ["-swift.layering_check"],
@@ -1775,6 +1792,23 @@ func main() {
 }
 """],
     tags = common.fixture_tags,
+)
+
+ios_application(
+    name = "app_with_imported_dynamic_fmwk_and_ext",
+    bundle_id = "com.google.example",
+    extensions = [":ext"],
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":iOSImportedDynamicFramework",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
 )
 
 apple_dynamic_framework_import(

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -10,25 +10,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 apple_binary(
-    name = "empty_dylib",
-    binary_type = "dylib",
-    minimum_os_version = "11.0",
-    platform_type = "ios",
-    deps = [":dummy_lib"],
-)
-
-apple_binary(
     name = "empty_tvos_dylib",
     binary_type = "dylib",
     minimum_os_version = "11.0",
     platform_type = "tvos",
     deps = [":dummy_lib"],
-)
-
-filegroup(
-    name = "empty_staticlib",
-    srcs = ["dummy_lib"],
-    output_group = "archive",
 )
 
 cc_library(

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -2,10 +2,6 @@ load(
     "//apple:apple_binary.bzl",
     "apple_binary",
 )
-load(
-    "//apple:apple_static_library.bzl",
-    "apple_static_library",
-)
 
 # Public only because these are used by the integration tests from generated
 # workspaces. Please no not depend on them as they can change at any time.
@@ -16,7 +12,7 @@ licenses(["notice"])
 apple_binary(
     name = "empty_dylib",
     binary_type = "dylib",
-    minimum_os_version = "9.0",
+    minimum_os_version = "11.0",
     platform_type = "ios",
     deps = [":dummy_lib"],
 )
@@ -24,19 +20,18 @@ apple_binary(
 apple_binary(
     name = "empty_tvos_dylib",
     binary_type = "dylib",
-    minimum_os_version = "10.2",
+    minimum_os_version = "11.0",
     platform_type = "tvos",
     deps = [":dummy_lib"],
 )
 
-apple_static_library(
+filegroup(
     name = "empty_staticlib",
-    minimum_os_version = "9.0",
-    platform_type = "ios",
-    deps = [":dummy_lib"],
+    srcs = ["dummy_lib"],
+    output_group = "archive",
 )
 
-objc_library(
+cc_library(
     name = "dummy_lib",
     srcs = ["@bazel_tools//tools/objc:dummy.c"],
 )


### PR DESCRIPTION
XCode 14 has officially dropped support for earlier versions (although it doesn't yet fail to build).

Where necessary, swap out ios i386 platform for sim_arm64, since i386 is not supported in iOS 11 or later.

PiperOrigin-RevId: 478777929
(cherry picked from commit 5f7edb87f1447e98bb3e71c4da46dbdcece356f7)
