### PR TITLE
Move feature configuration platform_prerequisites caller

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -24,6 +24,10 @@ load(
     "apple_toolchain_utils",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
 )
@@ -61,6 +65,10 @@ def _platform_prerequisites_for_aspect(target, aspect_ctx):
     """Return the set of platform prerequisites that can be determined from this aspect."""
     deps_and_target = getattr(aspect_ctx.rule.attr, "deps", []) + [target]
     uses_swift = swift_support.uses_swift(deps_and_target)
+    features = features_support.compute_enabled_features(
+        requested_features = aspect_ctx.features,
+        unsupported_features = aspect_ctx.disabled_features,
+    )
 
     # TODO(b/176548199): Support device_families when rule_descriptor can be accessed from an
     # aspect, or the list of allowed device families can be determined independently of the
@@ -69,10 +77,9 @@ def _platform_prerequisites_for_aspect(target, aspect_ctx):
         apple_fragment = aspect_ctx.fragments.apple,
         config_vars = aspect_ctx.var,
         device_families = None,
-        disabled_features = aspect_ctx.disabled_features,
         explicit_minimum_deployment_os = None,
         explicit_minimum_os = None,
-        features = aspect_ctx.features,
+        features = features,
         objc_fragment = None,
         platform_type_string = str(aspect_ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = uses_swift,

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -21,6 +21,10 @@ load(
     "rule_factory",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -40,14 +44,18 @@ load(
 def _environment_plist_impl(ctx):
     # Only need as much platform information as this rule is able to give, for environment plist
     # processing.
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     platform_prerequisites = platform_support.platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
         device_families = None,
-        disabled_features = ctx.disabled_features,
         explicit_minimum_deployment_os = None,
         explicit_minimum_os = None,
-        features = ctx.features,
+        features = features,
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = False,

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -23,6 +23,10 @@ load(
     "AppleMacToolsToolchainInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
@@ -52,15 +56,18 @@ def _apple_core_data_model_impl(ctx):
     actions = ctx.actions
     swift_version = getattr(ctx.attr, "swift_version")
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
 
     platform_prerequisites = platform_support.platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
         device_families = None,
-        disabled_features = ctx.disabled_features,
         explicit_minimum_deployment_os = None,
         explicit_minimum_os = None,
-        features = ctx.features,
+        features = features,
         objc_fragment = None,
         platform_type_string = str(
             ctx.fragments.apple.single_arch_platform.platform_type,

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -24,6 +24,10 @@ load(
     "apple_toolchain_utils",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
@@ -69,6 +73,11 @@ def _apple_core_ml_library_impl(ctx):
         objc_output_src = actions.declare_file("{}.m".format(basename))
         objc_output_hdr = actions.declare_file("{}.h".format(basename))
 
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     # TODO(b/168721966): Consider if an aspect could be used to generate mlmodel sources. This
     # would be similar to how we are planning to use the resource aspect with the
     # apple_resource_bundle and apple_resource_group resource rules. That might allow for more
@@ -77,10 +86,9 @@ def _apple_core_ml_library_impl(ctx):
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
         device_families = None,
-        disabled_features = ctx.disabled_features,
         explicit_minimum_deployment_os = None,
         explicit_minimum_os = None,
-        features = ctx.features,
+        features = features,
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = uses_swift,

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -20,6 +20,10 @@ load(
     "apple_toolchain_utils",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
@@ -56,14 +60,18 @@ def _apple_intent_library_impl(ctx):
         objc_output_hdrs = ctx.actions.declare_directory("{}.hdrs.h".format(ctx.attr.name))
         objc_public_header = ctx.actions.declare_file("{}.h".format(ctx.attr.header_name))
 
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     platform_prerequisites = platform_support.platform_prerequisites(
         apple_fragment = ctx.fragments.apple,
         config_vars = ctx.var,
         device_families = None,
-        disabled_features = ctx.disabled_features,
         explicit_minimum_deployment_os = None,
         explicit_minimum_os = None,
-        features = ctx.features,
+        features = features,
         objc_fragment = None,
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = False,

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -36,6 +36,10 @@ load(
     "is_experimental_tree_artifact_enabled",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -504,6 +508,11 @@ def _apple_xcframework_impl(ctx):
     framework_output_files = []
     framework_output_groups = []
 
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     for library_identifier, link_output in link_outputs_by_library_identifier.items():
         binary_artifact = link_output.binary
 
@@ -520,12 +529,11 @@ def _apple_xcframework_impl(ctx):
                 link_output.platform,
                 default = rule_descriptor.allowed_device_families,
             ),
-            disabled_features = ctx.disabled_features,
             explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_versions.get(
                 link_output.platform,
             ),
             explicit_minimum_os = ctx.attr.minimum_os_versions.get(link_output.platform),
-            features = ctx.features,
+            features = features,
             objc_fragment = ctx.fragments.objc,
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
@@ -922,6 +930,10 @@ def _apple_static_xcframework_impl(ctx):
     deps = ctx.split_attr.deps
     label = ctx.label
     executable_name = getattr(ctx.attr, "executable_name", bundle_name)
+    features = features_support.compute_enabled_features(
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
     outputs_archive = ctx.outputs.archive
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
@@ -1021,12 +1033,11 @@ def _apple_static_xcframework_impl(ctx):
                 link_output.platform,
                 default = rule_descriptor.allowed_device_families,
             ),
-            disabled_features = ctx.disabled_features,
             explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_versions.get(
                 link_output.platform,
             ),
             explicit_minimum_os = ctx.attr.minimum_os_versions.get(link_output.platform),
-            features = ctx.features,
+            features = features,
             objc_fragment = ctx.fragments.objc,
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,


### PR DESCRIPTION
As part of removing the ctx version of platform_prerequisites we now can
just pass the configured version of this along as well since the rules
already do this
