### PR TITLE
Upgrade to Xcode 14.3

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos
-    xcode_version: "14.2"
+    xcode_version: "14.3"
     build_targets:
     - "tools/..."
     - "test/..."


### PR DESCRIPTION
Xcode 14.3 is [being installed on all macOS machines](https://github.com/bazelbuild/continuous-integration/issues/1431#issuecomment-1682088974) as we speak. Once it's completed, we can merge this PR and https://github.com/bazelbuild/rules_apple/pull/2057.