### PR TITLE
Remove all instances where ctx is used to create a rule_descriptor.

### DIFF
--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -72,6 +72,7 @@ def _apple_binary_impl(ctx):
         bundle_loader = bundle_loader,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = None,
+        rule_descriptor = None,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -151,9 +151,6 @@ bzl_library(
     visibility = [
         "//apple:__subpackages__",
     ],
-    deps = [
-        ":rule_support",
-    ],
 )
 
 bzl_library(
@@ -359,6 +356,7 @@ bzl_library(
         ":rule_factory",
         ":rule_support",
         ":run_support",
+        ":swift_support",
         ":transition_support",
         "//apple:providers",
         "//apple/internal/utils:clang_rt_dylibs",
@@ -423,10 +421,6 @@ bzl_library(
     srcs = ["platform_support.bzl"],
     visibility = [
         "//apple:__subpackages__",
-    ],
-    deps = [
-        ":rule_support",
-        ":swift_support",
     ],
 )
 
@@ -632,6 +626,7 @@ bzl_library(
         ":rule_factory",
         ":rule_support",
         ":stub_support",
+        ":swift_support",
         "//apple:providers",
         "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",

--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -14,12 +14,12 @@
 
 """Low-level bundling name helpers."""
 
-load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
-    "rule_support",
-)
-
-def _bundle_full_name(*, custom_bundle_extension, custom_bundle_name, label_name, rule_descriptor):
+def _bundle_full_name(
+        *,
+        custom_bundle_extension = None,
+        custom_bundle_name = None,
+        label_name,
+        rule_descriptor):
     """Returns a tuple containing information on the bundle file name.
 
     Args:
@@ -46,15 +46,6 @@ def _bundle_full_name(*, custom_bundle_extension, custom_bundle_name, label_name
         bundle_extension = rule_descriptor.bundle_extension
 
     return (bundle_name, bundle_extension)
-
-def _bundle_full_name_from_rule_ctx(ctx):
-    """Returns a tuple containing information on the bundle file name based on the rule context."""
-    return _bundle_full_name(
-        custom_bundle_extension = getattr(ctx.attr, "bundle_extension", ""),
-        custom_bundle_name = getattr(ctx.attr, "bundle_name", None),
-        label_name = ctx.label.name,
-        rule_descriptor = rule_support.rule_descriptor(ctx),
-    )
 
 def _ensure_single_xcassets_type(attr, files, extension, message = None):
     """Helper for when an xcassets catalog should have a single sub type.
@@ -162,7 +153,6 @@ def _ensure_path_format(attr, files, path_fragments_list, message = None):
 # Define the loadable module that lists the exported symbols in this file.
 bundling_support = struct(
     bundle_full_name = _bundle_full_name,
-    bundle_full_name_from_rule_ctx = _bundle_full_name_from_rule_ctx,
     ensure_path_format = _ensure_path_format,
     ensure_single_xcassets_type = _ensure_single_xcassets_type,
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -123,11 +123,20 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _ios_application_impl(ctx):
     """Experimental implementation of ios_application."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     bundle_verification_targets = [struct(target = ext) for ext in ctx.attr.extensions]
     embeddable_targets = (
@@ -141,11 +150,22 @@ def _ios_application_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -186,6 +206,7 @@ def _ios_application_impl(ctx):
         entitlements = entitlements.linking,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -430,11 +451,20 @@ def _ios_application_impl(ctx):
 
 def _ios_app_clip_impl(ctx):
     """Experimental implementation of ios_app_clip."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     embeddable_targets = ctx.attr.frameworks
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
@@ -442,11 +472,22 @@ def _ios_app_clip_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -478,6 +519,7 @@ def _ios_app_clip_impl(ctx):
         avoid_deps = ctx.attr.frameworks,
         entitlements = entitlements.linking,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -682,12 +724,21 @@ def _ios_app_clip_impl(ctx):
 
 def _ios_framework_impl(ctx):
     """Experimental implementation of ios_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
@@ -702,11 +753,22 @@ def _ios_framework_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     signed_frameworks = []
     if provisioning_profile:
         signed_frameworks = [
@@ -738,6 +800,7 @@ def _ios_framework_impl(ctx):
         entitlements = None,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -907,22 +970,42 @@ def _ios_framework_impl(ctx):
 
 def _ios_extension_impl(ctx):
     """Experimental implementation of ios_extension."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -959,6 +1042,7 @@ def _ios_extension_impl(ctx):
         entitlements = entitlements.linking,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -1133,6 +1217,10 @@ def _ios_extension_impl(ctx):
 
 def _ios_dynamic_framework_impl(ctx):
     """Experimental implementation of ios_dynamic_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
 
     # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 1
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
@@ -1150,7 +1238,11 @@ def _ios_dynamic_framework_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
@@ -1165,11 +1257,22 @@ def _ios_dynamic_framework_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -1208,6 +1311,7 @@ def _ios_dynamic_framework_impl(ctx):
         entitlements = None,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -1398,6 +1502,10 @@ def _ios_dynamic_framework_impl(ctx):
 
 def _ios_static_framework_impl(ctx):
     """Implementation of ios_static_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
 
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
@@ -1408,15 +1516,30 @@ def _ios_static_framework_impl(ctx):
     label = ctx.label
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
 
     link_result = linking_support.register_static_library_linking_action(ctx = ctx)
     binary_artifact = link_result.library
@@ -1517,11 +1640,20 @@ def _ios_static_framework_impl(ctx):
 
 def _ios_imessage_application_impl(ctx):
     """Experimental implementation of ios_imessage_application."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
@@ -1530,11 +1662,22 @@ def _ios_imessage_application_impl(ctx):
     bundle_verification_targets = [struct(target = ctx.attr.extension)]
     embeddable_targets = [ctx.attr.extension]
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = False,  # No binary deps to check.
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -1693,22 +1836,42 @@ def _ios_imessage_application_impl(ctx):
 
 def _ios_imessage_extension_impl(ctx):
     """Experimental implementation of ios_imessage_extension."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -1739,6 +1902,7 @@ def _ios_imessage_extension_impl(ctx):
         avoid_deps = ctx.attr.frameworks,
         entitlements = entitlements.linking,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -1903,22 +2067,42 @@ def _ios_imessage_extension_impl(ctx):
 
 def _ios_sticker_pack_extension_impl(ctx):
     """Experimental implementation of ios_sticker_pack_extension."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = ctx.attr.families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = False,  # No binary deps to check.
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -269,7 +269,7 @@ def _debug_symbols_partial_impl(
         debug_discriminator = None,
         dsym_binaries = {},
         dsym_info_plist_template,
-        executable_name,
+        executable_name = None,
         label_name,
         linkmaps = {},
         platform_prerequisites):
@@ -302,7 +302,7 @@ def _debug_symbols_partial_impl(
 
     if platform_prerequisites.cpp_fragment:
         if platform_prerequisites.cpp_fragment.apple_generate_dsym:
-            dsym_output_filename = executable_name
+            dsym_output_filename = executable_name or bundle_name
             if debug_discriminator:
                 dsym_output_filename += "_" + debug_discriminator
             dsym_files, dsym_bundle_dir = _bundle_dsym_files(

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -14,19 +14,6 @@
 
 """Support functions for working with Apple platforms and device families."""
 
-load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
-    "features_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
-    "rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
-    "swift_support",
-)
-
 # Maps the strings passed in to the "families" attribute to the numerical
 # representation in the UIDeviceFamily plist entry.
 # @unsorted-dict-items
@@ -127,44 +114,8 @@ def _platform_prerequisites(
         xcode_version_config = xcode_version_config,
     )
 
-def _platform_prerequisites_from_rule_ctx(ctx):
-    """Returns a struct containing information on the platform being targeted from a rule context.
-
-    Args:
-      ctx: The Starlark context for a rule.
-
-    Returns:
-      A struct representing the default collected platform information for that rule context.
-    """
-    device_families = getattr(ctx.attr, "families", None)
-    if not device_families:
-        rule_descriptor = rule_support.rule_descriptor(ctx)
-        device_families = rule_descriptor.allowed_device_families
-
-    deps = getattr(ctx.attr, "deps", None)
-    uses_swift = swift_support.uses_swift(deps) if deps else False
-    features = features_support.compute_enabled_features(
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
-    )
-
-    return _platform_prerequisites(
-        apple_fragment = ctx.fragments.apple,
-        config_vars = ctx.var,
-        cpp_fragment = ctx.fragments.cpp,
-        device_families = device_families,
-        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
-        explicit_minimum_os = ctx.attr.minimum_os_version,
-        features = features,
-        objc_fragment = ctx.fragments.objc,
-        platform_type_string = ctx.attr.platform_type,
-        uses_swift = uses_swift,
-        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
-    )
-
 # Define the loadable module that lists the exported symbols in this file.
 platform_support = struct(
     platform_prerequisites = _platform_prerequisites,
-    platform_prerequisites_from_rule_ctx = _platform_prerequisites_from_rule_ctx,
     ui_device_family_plist_value = _ui_device_family_plist_value,
 )

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -1353,7 +1353,10 @@ binaries/libraries will be created combining all architectures specified by
         })
 
     if platform_type and product_type:
-        rule_descriptor = rule_support.rule_descriptor_no_ctx(platform_type, product_type)
+        rule_descriptor = rule_support.rule_descriptor(
+            platform_type = platform_type,
+            product_type = product_type,
+        )
         is_executable = rule_descriptor.is_executable
 
         if rule_descriptor.requires_deps:
@@ -1410,7 +1413,10 @@ def _create_apple_bundling_rule(
         },
     ]
 
-    rule_descriptor = rule_support.rule_descriptor_no_ctx(platform_type, product_type)
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = platform_type,
+        product_type = product_type,
+    )
 
     rule_attrs.extend(
         [

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -205,7 +205,7 @@ _DEFAULT_MACOS_BUNDLE_LOCATIONS = _describe_bundle_locations(
 )
 
 # Descriptors for all possible platform/product type combinations.
-# TODO(b/62481675): Migrate extra_linkopts to crosstool features instead.
+# TODO(b/248317958): Migrate extra_linkopts and rpaths to args on the linking_support methods.
 _RULE_TYPE_DESCRIPTORS = {
     "ios": {
         # ios_application
@@ -890,7 +890,7 @@ _RULE_TYPE_DESCRIPTORS = {
     },
 }
 
-def _rule_descriptor_no_ctx(platform_type, product_type):
+def _rule_descriptor(*, platform_type, product_type):
     """Returns the rule descriptor for the given platform and product types.
 
     This method fails if the platform and product combination is invalid.
@@ -912,17 +912,7 @@ def _rule_descriptor_no_ctx(platform_type, product_type):
         )
     return rule_descriptor
 
-def _rule_descriptor(ctx):
-    """Returns the rule descriptor for platform and product types derived from the rule context."""
-
-    # Check the attribute explicitly instead of using platform_support, since that creates a
-    # cyclical dependency on this file.
-    platform_type = getattr(apple_common.platform_type, ctx.attr.platform_type)
-    product_type = ctx.attr._product_type
-    return _rule_descriptor_no_ctx(str(platform_type), product_type)
-
 rule_support = struct(
     rule_descriptor = _rule_descriptor,
-    rule_descriptor_no_ctx = _rule_descriptor_no_ctx,
     codesigning_exceptions = _CODESIGNING_EXCEPTIONS,
 )

--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -35,6 +35,7 @@ bzl_library(
         "//apple/internal:processor",
         "//apple/internal:resources",
         "//apple/internal:rule_support",
+        "//apple/internal:swift_support",
         "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:types",
         "@build_bazel_rules_swift//swift",

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -68,6 +68,10 @@ load(
     "rule_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "swift_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -271,10 +275,19 @@ def _apple_test_bundle_impl(ctx):
              "same as the test host's bundle identifier. Please change one of " +
              "them.")
 
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     config_vars = ctx.var
     features = features_support.compute_enabled_features(
@@ -282,11 +295,24 @@ def _apple_test_bundle_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        # iOS test bundles set `families` as a mandatory attr, other Apple OS test bundles do not
+        # have a `families` rule attr.
+        device_families = getattr(ctx.attr, "families", rule_descriptor.allowed_device_families),
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -336,6 +362,7 @@ def _apple_test_bundle_impl(ctx):
         extra_linkopts = extra_linkopts,
         extra_link_inputs = extra_link_inputs,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -117,12 +117,21 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 def _watchos_framework_impl(ctx):
     """Experimental implementation of watchos_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
@@ -137,11 +146,22 @@ def _watchos_framework_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     signed_frameworks = []
     if provisioning_profile:
         signed_frameworks = [
@@ -173,6 +193,7 @@ def _watchos_framework_impl(ctx):
         entitlements = None,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -340,6 +361,10 @@ def _watchos_framework_impl(ctx):
 
 def _watchos_dynamic_framework_impl(ctx):
     """Experimental implementation of watchos_dynamic_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
 
     # This rule should only have one swift_library dependency. This means len(ctx.attr.deps) should be 1
     swiftdeps = [x for x in ctx.attr.deps if SwiftInfo in x]
@@ -357,7 +382,11 @@ def _watchos_dynamic_framework_impl(ctx):
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bin_root_path = ctx.bin_dir.path
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     cc_toolchain = find_cpp_toolchain(ctx)
     cc_features = cc_common.configure_features(
@@ -372,11 +401,22 @@ def _watchos_dynamic_framework_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -414,6 +454,7 @@ def _watchos_dynamic_framework_impl(ctx):
         entitlements = None,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -604,22 +645,45 @@ def _watchos_dynamic_framework_impl(ctx):
 
 def _watchos_application_impl(ctx):
     """Implementation of watchos_application."""
+
+    # TODO(b/241001744): Set the product type as apple_product_type.application if the attrs set
+    # on the rule match a criteria appropriate for watchOS single target applications.
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = apple_product_type.watch2_application,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = False,  # No binary deps to check.
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -796,11 +860,24 @@ def _watchos_application_impl(ctx):
 
 def _watchos_extension_impl(ctx):
     """Implementation of watchos_extension."""
+
+    # TODO(b/155313625): Set the product type as apple_product_type.extension if the attrs set on
+    # the rule match a criteria appropriate for watchOS extensions (i.e. SiriKit, Notification
+    # Center, WidgetKit).
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = apple_product_type.watch2_extension,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     embeddable_targets = (
         ctx.attr.extensions + ctx.attr.frameworks + ctx.attr.deps
     )
@@ -810,11 +887,22 @@ def _watchos_extension_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -871,6 +959,7 @@ def _watchos_extension_impl(ctx):
         entitlements = entitlements.linking,
         extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary
@@ -1053,6 +1142,10 @@ def _watchos_extension_impl(ctx):
 
 def _watchos_static_framework_impl(ctx):
     """Implementation of watchos_static_framework."""
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = ctx.attr._product_type,
+    )
 
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
@@ -1063,17 +1156,31 @@ def _watchos_static_framework_impl(ctx):
     label = ctx.label
     predeclared_outputs = ctx.outputs
     split_deps = ctx.split_attr.deps
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     features = features_support.compute_enabled_features(
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
-    rule_descriptor = rule_support.rule_descriptor(ctx)
-
     link_result = linking_support.register_static_library_linking_action(ctx = ctx)
     binary_artifact = link_result.library
 

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -1307,11 +1307,22 @@ Resolved Xcode is version {xcode_version}.
     if minimum_os < apple_common.dotted_version("7.0"):
         fail("Single-target watchOS applications require a minimum_os_version of 7.0 or greater.")
 
+    # TODO(b/241001744): Fold this implementation into the watchos_application rule, removing the
+    # need for separate rules.
+    rule_descriptor = rule_support.rule_descriptor(
+        platform_type = ctx.attr.platform_type,
+        product_type = apple_product_type.application,
+    )
+
     actions = ctx.actions
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]
     apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     bundle_id = ctx.attr.bundle_id
-    bundle_name, bundle_extension = bundling_support.bundle_full_name_from_rule_ctx(ctx)
+    bundle_name, bundle_extension = bundling_support.bundle_full_name(
+        custom_bundle_name = ctx.attr.bundle_name,
+        label_name = ctx.label.name,
+        rule_descriptor = rule_descriptor,
+    )
     executable_name = ctx.attr.executable_name
     embeddable_targets = ctx.attr.deps
     features = features_support.compute_enabled_features(
@@ -1319,11 +1330,22 @@ Resolved Xcode is version {xcode_version}.
         unsupported_features = ctx.disabled_features,
     )
     label = ctx.label
-    platform_prerequisites = platform_support.platform_prerequisites_from_rule_ctx(ctx)
+    platform_prerequisites = platform_support.platform_prerequisites(
+        apple_fragment = ctx.fragments.apple,
+        config_vars = ctx.var,
+        cpp_fragment = ctx.fragments.cpp,
+        device_families = rule_descriptor.allowed_device_families,
+        explicit_minimum_deployment_os = ctx.attr.minimum_deployment_os_version,
+        explicit_minimum_os = ctx.attr.minimum_os_version,
+        features = features,
+        objc_fragment = ctx.fragments.objc,
+        platform_type_string = ctx.attr.platform_type,
+        uses_swift = swift_support.uses_swift(ctx.attr.deps),
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
     predeclared_outputs = ctx.outputs
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
-    rule_descriptor = rule_support.rule_descriptor(ctx)
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -1356,6 +1378,7 @@ Resolved Xcode is version {xcode_version}.
         entitlements = entitlements.linking,
         extra_linkopts = [],
         platform_prerequisites = platform_prerequisites,
+        rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
     )
     binary_artifact = link_result.binary

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -489,6 +489,9 @@ def _apple_xcframework_impl(ctx):
             ),
         ],
         platform_prerequisites = None,
+        # All required knowledge for 3P facing frameworks is passed directly through the given
+        # `extra_linkopts`; no rule_descriptor is needed to share with this linking action.
+        rule_descriptor = None,
         stamp = ctx.attr.stamp,
     )
 
@@ -516,9 +519,9 @@ def _apple_xcframework_impl(ctx):
     for library_identifier, link_output in link_outputs_by_library_identifier.items():
         binary_artifact = link_output.binary
 
-        rule_descriptor = rule_support.rule_descriptor_no_ctx(
-            link_output.platform,
-            apple_product_type.framework,
+        rule_descriptor = rule_support.rule_descriptor(
+            platform_type = link_output.platform,
+            product_type = apple_product_type.framework,
         )
 
         platform_prerequisites = platform_support.platform_prerequisites(
@@ -1021,9 +1024,9 @@ def _apple_static_xcframework_impl(ctx):
         )
 
         # Bundle resources
-        rule_descriptor = rule_support.rule_descriptor_no_ctx(
-            link_output.platform,
-            apple_product_type.framework,
+        rule_descriptor = rule_support.rule_descriptor(
+            platform_type = link_output.platform,
+            product_type = apple_product_type.framework,
         )
         platform_prerequisites = platform_support.platform_prerequisites(
             apple_fragment = ctx.fragments.apple,


### PR DESCRIPTION
Prerequisite to move _product_type out of attrs, and as a variable that can be set directly in a rule's implementation.

PiperOrigin-RevId: 476407943
(cherry picked from commit 5e47af6c54deb153e3d24a8cbd24621dbeede0fd)
