### PR TITLE
Fix missing frameworks attrs in test rules

### DIFF
--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -50,6 +50,7 @@ load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "MacosApplicationBundleInfo",
+    "MacosFrameworkBundleInfo",
     "MacosXcTestBundleInfo",
 )
 
@@ -138,6 +139,16 @@ desired Contents subdirectory.
 """,
             ),
         },
+        {
+            "frameworks": attr.label_list(
+                providers = [[AppleBundleInfo, MacosFrameworkBundleInfo]],
+                doc = """
+A list of framework targets (see
+[`macos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-macos.md#macos_framework))
+that this target depends on.
+""",
+            ),
+        },
     ],
 )
 
@@ -204,6 +215,16 @@ corresponding value is the name of the subdirectory of Contents where they shoul
 
 The relative directory structure of filegroup contents is preserved when they are copied into the
 desired Contents subdirectory.
+""",
+            ),
+        },
+        {
+            "frameworks": attr.label_list(
+                providers = [[AppleBundleInfo, MacosFrameworkBundleInfo]],
+                doc = """
+A list of framework targets (see
+[`macos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-macos.md#macos_framework))
+that this target depends on.
 """,
             ),
         },

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -50,6 +50,7 @@ load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "WatchosApplicationBundleInfo",
+    "WatchosFrameworkBundleInfo",
     "WatchosSingleTargetApplicationBundleInfo",
     "WatchosXcTestBundleInfo",
 )
@@ -127,6 +128,16 @@ _watchos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule_with_
             is_mandatory = True,
             providers = _WATCHOS_TEST_HOST_PROVIDERS,
         ),
+        {
+            "frameworks": attr.label_list(
+                providers = [[AppleBundleInfo, WatchosFrameworkBundleInfo]],
+                doc = """
+A list of framework targets (see
+[`watchos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-watchos.md#watchos_framework))
+that this target depends on.
+""",
+            ),
+        },
     ],
 )
 
@@ -176,6 +187,16 @@ _watchos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule_wit
             aspects = rule_attrs.aspects.test_host_aspects,
             providers = _WATCHOS_TEST_HOST_PROVIDERS,
         ),
+        {
+            "frameworks": attr.label_list(
+                providers = [[AppleBundleInfo, WatchosFrameworkBundleInfo]],
+                doc = """
+A list of framework targets (see
+[`watchos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-watchos.md#watchos_framework))
+that this target depends on.
+""",
+            ),
+        },
     ],
 )
 

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2448,6 +2448,7 @@ macos_ui_test(
         "//test/starlark_tests/resources:additional.txt": "Additional",
         "//test/starlark_tests/resources:all_nested": "Nested",
     },
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
@@ -2513,6 +2514,7 @@ macos_unit_test(
         "//test/starlark_tests/resources:additional.txt": "Additional",
         "//test/starlark_tests/resources:all_nested": "Nested",
     },
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -527,6 +527,7 @@ swift_library(
 
 tvos_ui_test(
     name = "ui_test",
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
@@ -584,6 +585,7 @@ tvos_ui_test(
 
 tvos_unit_test(
     name = "unit_test",
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -889,6 +889,7 @@ watchos_ui_test(
 
 watchos_ui_test(
     name = "single_target_ui_test",
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],
@@ -902,6 +903,7 @@ watchos_ui_test(
 
 watchos_unit_test(
     name = "unit_test",
+    frameworks = [":fmwk"],
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],


### PR DESCRIPTION
We didn't have any tests covering these so I silently dropped this attr
from ones that upstream doesn't support it for
