### PR TITLE
Move macOS and apple binary rules to rule_attrs.bzl.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -50,7 +50,10 @@ bzl_library(
     srcs = ["apple_binary.bzl"],
     deps = [
         "//apple/internal:linking_support",
-        "//apple/internal:rule_factory",
+        "//apple/internal:rule_attrs",
+        "//apple/internal:transition_support",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
@@ -63,7 +66,7 @@ bzl_library(
         "//apple/internal:rule_attrs",
         "//apple/internal:transition_support",
         "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/cpp:toolchain_utils",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
@@ -80,7 +83,7 @@ bzl_library(
     srcs = ["cc_toolchain_forwarder.bzl"],
     deps = [
         ":providers",
-        "@bazel_tools//tools/cpp:toolchain_utils",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -120,7 +120,7 @@ apple_binary = rule(
     implementation = _apple_binary_impl,
     attrs = dicts.add(
         rule_attrs.binary_linking_attrs(
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             is_test_supporting_rule = False,
             requires_legacy_cc_toolchain = True,
         ),

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -89,9 +89,11 @@ bzl_library(
     ],
     deps = [
         ":linking_support",
-        ":rule_factory",
+        ":rule_attrs",
         ":transition_support",
         "//apple:providers",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
@@ -366,6 +368,8 @@ bzl_library(
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
         "//apple/internal/utils:clang_rt_dylibs",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -15,8 +15,8 @@
 """Implementation for apple universal binary rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
-    "rule_factory",
+    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "rule_attrs",
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
@@ -30,6 +30,11 @@ load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
 )
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 def _apple_universal_binary_impl(ctx):
     inputs = [
@@ -62,23 +67,25 @@ def _apple_universal_binary_impl(ctx):
         ),
     ]
 
-apple_universal_binary = rule_factory.create_apple_binary_rule(
-    doc = """
-This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
-The `lipo` tool is used to combine built binaries of multiple architectures.
-""",
+apple_universal_binary = rule(
     implementation = _apple_universal_binary_impl,
-    require_linking_attrs = False,
-    additional_attrs = {
-        "binary": attr.label(
-            mandatory = True,
-            cfg = transition_support.apple_platform_split_transition,
-            doc = "Target to generate a 'fat' binary from.",
-        ),
-        "forced_cpus": attr.string_list(
-            mandatory = False,
-            allow_empty = True,
-            doc = """
+    attrs = dicts.add(
+        rule_attrs.common_attrs,
+        rule_attrs.platform_attrs(),
+        {
+            # Required to use the Apple Starlark rule and split transitions.
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
+            "binary": attr.label(
+                mandatory = True,
+                cfg = transition_support.apple_platform_split_transition,
+                doc = "Target to generate a 'fat' binary from.",
+            ),
+            "forced_cpus": attr.string_list(
+                mandatory = False,
+                allow_empty = True,
+                doc = """
 An optional list of target CPUs for which the universal binary should be built.
 
 If this attribute is present, the value of the platform-specific CPU flag
@@ -90,7 +97,14 @@ This is primarily useful to force macOS tools to be built as universal binaries
 using `forced_cpus = ["x86_64", "arm64"]`, without requiring the user to pass
 additional flags when invoking Bazel.
 """,
-        ),
-    },
+            ),
+        },
+    ),
     cfg = transition_support.apple_universal_binary_rule_transition,
+    doc = """
+This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
+The `lipo` tool is used to combine built binaries of multiple architectures.
+""",
+    fragments = ["apple", "cpp", "objc"],
+    toolchains = use_cpp_toolchain(),
 )

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -2429,7 +2429,7 @@ Targets created with `macos_command_line_application` can be executed using
 `bazel run`.""",
     attrs = dicts.add(
         rule_attrs.binary_linking_attrs(
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_deps_aspects = [
                 apple_resource_aspect,
                 framework_provider_aspect,
@@ -2490,7 +2490,7 @@ macos_dylib = rule(
     implementation = _macos_dylib_impl,
     attrs = dicts.add(
         rule_attrs.binary_linking_attrs(
-            deps_cfg = apple_common.multi_arch_split,
+            deps_cfg = transition_support.apple_platform_split_transition,
             extra_deps_aspects = [
                 apple_resource_aspect,
                 framework_provider_aspect,

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -153,7 +153,6 @@ macos_command_line_application(<a href="#macos_command_line_application-name">na
 
 Builds a macOS Command Line Application binary.
 
-
 A command line application is a standalone binary file, rather than a `.app`
 bundle like those produced by [`macos_application`](#macos_application). Unlike
 a plain `apple_binary` target, however, this rule supports versioning and
@@ -170,7 +169,7 @@ Targets created with `macos_command_line_application` can be executed using
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="macos_command_line_application-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="macos_command_line_application-additional_linker_inputs"></a>additional_linker_inputs |  A list of input files to be passed to the linker.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="macos_command_line_application-bundle_id"></a>bundle_id |  The bundle ID (reverse-DNS path followed by app name) of the command line application. If present, this value will be embedded in an Info.plist in the application binary.   | String | optional | <code>""</code> |
+| <a id="macos_command_line_application-bundle_id"></a>bundle_id |  The bundle ID (reverse-DNS path followed by app name) for this target.   | String | optional | <code>""</code> |
 | <a id="macos_command_line_application-codesign_inputs"></a>codesign_inputs |  A list of dependencies targets that provide inputs that will be used by <code>codesign</code> (referenced with <code>codesignopts</code>).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="macos_command_line_application-codesignopts"></a>codesignopts |  A list of strings representing extra flags that should be passed to <code>codesign</code>.   | List of strings | optional | <code>[]</code> |
 | <a id="macos_command_line_application-deps"></a>deps |  A list of dependent targets that will be linked into this target's binary(s). Any resources, such as asset catalogs, that are referenced by those targets will also be transitively included in the final bundle(s).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
@@ -183,7 +182,7 @@ Targets created with `macos_command_line_application` can be executed using
 | <a id="macos_command_line_application-platform_type"></a>platform_type |  -   | String | optional | <code>"macos"</code> |
 | <a id="macos_command_line_application-provisioning_profile"></a>provisioning_profile |  The provisioning profile (<code>.provisionprofile</code> file) to use when creating the bundle. This value is optional for simulator builds as the simulator doesn't fully enforce entitlements, but is required for device builds.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="macos_command_line_application-stamp"></a>stamp |  Enable link stamping. Whether to encode build information into the binary. Possible values:<br><br>*   <code>stamp = 1</code>: Stamp the build information into the binary. Stamped binaries are only rebuilt     when their dependencies change. Use this if there are tests that depend on the build     information. *   <code>stamp = 0</code>: Always replace build information by constant values. This gives good build     result caching. *   <code>stamp = -1</code>: Embedding of build information is controlled by the <code>--[no]stamp</code> flag.   | Integer | optional | <code>-1</code> |
-| <a id="macos_command_line_application-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-versioning.md#apple_bundle_version).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="macos_command_line_application-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-general.md?cl=head#apple_bundle_version).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="macos_dylib"></a>
@@ -205,7 +204,7 @@ Builds a macOS Dylib binary.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="macos_dylib-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="macos_dylib-additional_linker_inputs"></a>additional_linker_inputs |  A list of input files to be passed to the linker.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="macos_dylib-bundle_id"></a>bundle_id |  The bundle ID (reverse-DNS path followed by app name) of the command line application. If present, this value will be embedded in an Info.plist in the application binary.   | String | optional | <code>""</code> |
+| <a id="macos_dylib-bundle_id"></a>bundle_id |  The bundle ID (reverse-DNS path followed by app name) for this target.   | String | optional | <code>""</code> |
 | <a id="macos_dylib-codesign_inputs"></a>codesign_inputs |  A list of dependencies targets that provide inputs that will be used by <code>codesign</code> (referenced with <code>codesignopts</code>).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="macos_dylib-codesignopts"></a>codesignopts |  A list of strings representing extra flags that should be passed to <code>codesign</code>.   | List of strings | optional | <code>[]</code> |
 | <a id="macos_dylib-deps"></a>deps |  A list of dependent targets that will be linked into this target's binary(s). Any resources, such as asset catalogs, that are referenced by those targets will also be transitively included in the final bundle(s).   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
@@ -215,9 +214,9 @@ Builds a macOS Dylib binary.
 | <a id="macos_dylib-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from <code>minimum_os_version</code>, which is effective at compile time. Ensure version specific APIs are guarded with <code>available</code> clauses.   | String | optional | <code>""</code> |
 | <a id="macos_dylib-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="macos_dylib-platform_type"></a>platform_type |  -   | String | optional | <code>"macos"</code> |
-| <a id="macos_dylib-provisioning_profile"></a>provisioning_profile |  The provisioning profile (<code>.mobileprovision</code> file) to use when creating the bundle. This value is optional for simulator builds as the simulator doesn't fully enforce entitlements, but is required for device builds.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="macos_dylib-provisioning_profile"></a>provisioning_profile |  The provisioning profile (<code>.provisionprofile</code> file) to use when creating the bundle. This value is optional for simulator builds as the simulator doesn't fully enforce entitlements, but is required for device builds.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="macos_dylib-stamp"></a>stamp |  Enable link stamping. Whether to encode build information into the binary. Possible values:<br><br>*   <code>stamp = 1</code>: Stamp the build information into the binary. Stamped binaries are only rebuilt     when their dependencies change. Use this if there are tests that depend on the build     information. *   <code>stamp = 0</code>: Always replace build information by constant values. This gives good build     result caching. *   <code>stamp = -1</code>: Embedding of build information is controlled by the <code>--[no]stamp</code> flag.   | Integer | optional | <code>-1</code> |
-| <a id="macos_dylib-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-versioning.md#apple_bundle_version).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="macos_dylib-version"></a>version |  An <code>apple_bundle_version</code> target that represents the version for this target. See [<code>apple_bundle_version</code>](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-general.md?cl=head#apple_bundle_version).   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="macos_dynamic_framework"></a>


### PR DESCRIPTION
With this set of changes, rule_descriptor no longer dictates what attributes get set for a given rule.

PiperOrigin-RevId: 479366278
(cherry picked from commit a7edc9d0afc16cbfefb7517205f445c2b97bb67b)
