### PR TITLE
Add logic to lipo the stub binary to match the requested archs for the Apple build for watchOS extension-dependent applications (watchOS 2 apps).

### DIFF
--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -80,16 +80,13 @@ apple_static_library = rule(
     implementation = _apple_static_library_impl,
     attrs = dicts.add(
         rule_attrs.common_tool_attrs,
+        rule_attrs.cc_toolchain_forwarder_attrs(
+            deps_cfg = transition_support.apple_platform_split_transition,
+        ),
         rule_attrs.static_library_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
         ),
         {
-            "_cc_toolchain_forwarder": attr.label(
-                cfg = transition_support.apple_platform_split_transition,
-                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
-                default =
-                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
-            ),
             "additional_linker_inputs": attr.label_list(
                 # Flag required for compile_one_dependency
                 flags = ["DIRECT_COMPILE_TIME_INPUT"],

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -561,6 +561,7 @@ bzl_library(
     deps = [
         ":intermediates",
         "@build_bazel_apple_support//lib:apple_support",
+        "@build_bazel_apple_support//lib:lipo",
     ],
 )
 
@@ -660,6 +661,7 @@ bzl_library(
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
         "//apple/internal/utils:clang_rt_dylibs",
+        "@bazel_skylib//lib:sets",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",
         "@build_bazel_apple_support//lib:xcode_support",
     ],

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2631,6 +2631,8 @@ that this target depends on.
     ],
 )
 
+_STATIC_FRAMEWORK_DEPS_CFG = transition_support.apple_platform_split_transition
+
 ios_static_framework = rule_factory.create_apple_bundling_rule_with_attrs(
     implementation = _ios_static_framework_impl,
     doc = """Builds and bundles an iOS static framework for third-party distribution.
@@ -2673,7 +2675,7 @@ i.e. `--features=-swift.no_generated_header`).""",
     cfg = transition_support.apple_platforms_rule_base_transition,
     attrs = [
         rule_attrs.binary_linking_attrs(
-            deps_cfg = transition_support.apple_platform_split_transition,
+            deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
             extra_deps_aspects = [
                 apple_resource_aspect,
                 framework_provider_aspect,
@@ -2681,7 +2683,12 @@ i.e. `--features=-swift.no_generated_header`).""",
             is_test_supporting_rule = False,
             requires_legacy_cc_toolchain = True,
         ),
-        rule_attrs.common_bundle_attrs(deps_cfg = transition_support.apple_platform_split_transition),
+        rule_attrs.cc_toolchain_forwarder_attrs(
+            deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
+        ),
+        rule_attrs.common_bundle_attrs(
+            deps_cfg = transition_support.apple_platform_split_transition,
+        ),
         rule_attrs.common_tool_attrs,
         rule_attrs.device_family_attrs(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
@@ -2692,18 +2699,12 @@ i.e. `--features=-swift.no_generated_header`).""",
             add_environment_plist = True,
         ),
         {
-            "_cc_toolchain_forwarder": attr.label(
-                cfg = transition_support.apple_platform_split_transition,
-                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
-                default =
-                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
-            ),
             "_emitswiftinterface": attr.bool(
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
             ),
             "avoid_deps": attr.label_list(
-                cfg = transition_support.apple_platform_split_transition,
+                cfg = _STATIC_FRAMEWORK_DEPS_CFG,
                 doc = """
 A list of library targets on which this framework depends in order to compile, but the transitive
 closure of which will not be linked into the framework's binary.

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -3278,6 +3278,7 @@ i.e. `--features=-swift.no_generated_header`).""",
             is_test_supporting_rule = False,
             requires_legacy_cc_toolchain = True,
         ),
+        rule_attrs.cc_toolchain_forwarder_attrs(deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG),
         rule_attrs.common_bundle_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
         ),
@@ -3293,12 +3294,6 @@ i.e. `--features=-swift.no_generated_header`).""",
             "_emitswiftinterface": attr.bool(
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
-            ),
-            "_cc_toolchain_forwarder": attr.label(
-                cfg = _STATIC_FRAMEWORK_DEPS_CFG,
-                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
-                default =
-                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
             ),
             "avoid_deps": attr.label_list(
                 cfg = _STATIC_FRAMEWORK_DEPS_CFG,

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -73,6 +73,24 @@ _COMMON_TOOL_ATTRS = dicts.add(
     apple_toolchain_utils.shared_attrs(),
 )
 
+def _cc_toolchain_forwarder_attrs(*, deps_cfg):
+    """Returns dictionary with the cc_toolchain_forwarder attribute for toolchain and platform info.
+
+    Args:
+        deps_cfg: Bazel split transition to use on binary attrs, such as deps and split toolchains.
+            To satisfy native Bazel linking prerequisites, `deps` and this `deps_cfg` attribute must
+            use the same transition.
+    """
+
+    return {
+        "_cc_toolchain_forwarder": attr.label(
+            cfg = deps_cfg,
+            providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
+            default =
+                "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+        ),
+    }
+
 def _common_linking_api_attrs(*, deps_cfg):
     """Returns dictionary of required attributes for Bazel Apple linking APIs.
 
@@ -86,6 +104,8 @@ def _common_linking_api_attrs(*, deps_cfg):
             use the same transition.
     """
     return dicts.add(_COMMON_ATTRS, {
+        # TODO(b/251837356): Replace with the _cc_toolchain_forwarder attr when native code doesn't
+        # require that this attr be called `_child_configuration_dummy` in Bazel linking APIs.
         "_child_configuration_dummy": attr.label(
             cfg = deps_cfg,
             providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
@@ -579,6 +599,7 @@ _test_bundle_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBun
 rule_attrs = struct(
     common_attrs = _COMMON_ATTRS,
     common_tool_attrs = _COMMON_TOOL_ATTRS,
+    cc_toolchain_forwarder_attrs = _cc_toolchain_forwarder_attrs,
     static_library_linking_attrs = _static_library_linking_attrs,
     binary_linking_attrs = _binary_linking_attrs,
     platform_attrs = _platform_attrs,

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -19,6 +19,10 @@ load(
     "apple_support",
 )
 load(
+    "@build_bazel_apple_support//lib:lipo.bzl",
+    "lipo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -26,6 +30,7 @@ load(
 def _create_stub_binary(
         *,
         actions,
+        archs_for_lipo = [],
         output_discriminator = None,
         platform_prerequisites,
         rule_label,
@@ -34,6 +39,9 @@ def _create_stub_binary(
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        archs_for_lipo: A list of strings representing archs to lipo the stub binary against if
+            required of the target platform. If not specified, the stub binary will instead be
+            copied to its destination.
         output_discriminator: A string to differentiate between different target intermediate files
             or `None`.
         platform_prerequisites: Struct containing information on the platform being targeted.
@@ -51,19 +59,31 @@ def _create_stub_binary(
         file_name = "StubBinary",
     )
 
-    # TODO(b/79323243): Replace this with a symlink instead of a hard copy.
-    apple_support.run_shell(
-        actions = actions,
-        apple_fragment = platform_prerequisites.apple_fragment,
-        command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
-            output_path = binary_artifact.path,
-            xcode_stub_path = xcode_stub_path,
-        ),
-        mnemonic = "CopyStubExecutable",
-        outputs = [binary_artifact],
-        progress_message = "Copying stub executable for %s" % (rule_label),
-        xcode_config = platform_prerequisites.xcode_version_config,
-    )
+    if archs_for_lipo:
+        lipo.extract_or_thin(
+            actions = actions,
+            input_shell_expression = "\"$SDKROOT/{xcode_stub_path}\"".format(
+                xcode_stub_path = xcode_stub_path,
+            ),
+            archs = archs_for_lipo,
+            output = binary_artifact,
+            apple_fragment = platform_prerequisites.apple_fragment,
+            xcode_config = platform_prerequisites.xcode_version_config,
+        )
+    else:
+        # TODO(b/79323243): Replace this with a symlink instead of a hard copy.
+        apple_support.run_shell(
+            actions = actions,
+            apple_fragment = platform_prerequisites.apple_fragment,
+            command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
+                output_path = binary_artifact.path,
+                xcode_stub_path = xcode_stub_path,
+            ),
+            mnemonic = "CopyStubExecutable",
+            outputs = [binary_artifact],
+            progress_message = "Copying stub executable for %s" % (rule_label),
+            xcode_config = platform_prerequisites.xcode_version_config,
+        )
     return binary_artifact
 
 stub_support = struct(

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -1568,7 +1568,7 @@ i.e. `--features=-swift.no_generated_header`).
 """,
     attrs = [
         rule_attrs.binary_linking_attrs(
-            deps_cfg = transition_support.apple_platform_split_transition,
+            deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
             extra_deps_aspects = [
                 apple_resource_aspect,
                 framework_provider_aspect,
@@ -1576,8 +1576,11 @@ i.e. `--features=-swift.no_generated_header`).
             is_test_supporting_rule = False,
             requires_legacy_cc_toolchain = True,
         ),
+        rule_attrs.cc_toolchain_forwarder_attrs(
+            deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
+        ),
         rule_attrs.common_bundle_attrs(
-            deps_cfg = transition_support.apple_platform_split_transition,
+            deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
         ),
         rule_attrs.common_tool_attrs,
         rule_attrs.device_family_attrs(
@@ -1591,12 +1594,6 @@ i.e. `--features=-swift.no_generated_header`).
             "_emitswiftinterface": attr.bool(
                 default = True,
                 doc = "Private attribute to generate Swift interfaces for static frameworks.",
-            ),
-            "_cc_toolchain_forwarder": attr.label(
-                cfg = _STATIC_FRAMEWORK_DEPS_CFG,
-                providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
-                default =
-                    "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
             ),
             "avoid_deps": attr.label_list(
                 cfg = _STATIC_FRAMEWORK_DEPS_CFG,

--- a/test/configurations.bzl
+++ b/test/configurations.bzl
@@ -79,6 +79,7 @@ WATCHOS_SIMULATOR_OPTIONS = COMPILATION_MODE_OPTIONS + [
 ]
 
 WATCHOS_CONFIGURATIONS = {
-    "device": WATCHOS_DEVICE_OPTIONS,
+    # TODO(b/251910608): Re-enable when platform_mappings are exposed to the test runner.
+    #"device": WATCHOS_DEVICE_OPTIONS,
     "simulator": WATCHOS_SIMULATOR_OPTIONS,
 }

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -25,6 +25,7 @@ load(
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+    "binary_contents_test",
 )
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
@@ -108,6 +109,57 @@ def watchos_application_test_suite(name):
             "$ARCHIVE_ROOT/WatchKitSupport2/WK",
             "$BUNDLE_ROOT/Watch/app.app/_WatchKitStub/WK",
         ],
+        tags = [name],
+    )
+
+    # Test that the output multi-arch stub binary is identified as watchOS simulator via the Mach-O
+    # load command LC_BUILD_VERSION for the arm64 binary slice, and that 32-bit archs are
+    # eliminated.
+    binary_contents_test(
+        name = "{}_simulator_multiarch_platform_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_companion",
+        cpus = {
+            "watchos_cpus": ["x86_64", "arm64"],
+        },
+        binary_test_file = "$BUNDLE_ROOT/Watch/app.app/_WatchKitStub/WK",
+        binary_test_architecture = "arm64",
+        binary_not_contains_architectures = ["i386", "arm64e"],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
+        tags = [name],
+    )
+
+    # Test that the output multi-arch stub binary is identified as watchOS device via the Mach-O
+    # load command LC_VERSION_MIN_WATCHOS for the arm64_32 binary slice, and that 64-bit archs are
+    # eliminated.
+    binary_contents_test(
+        name = "{}_device_multiarch_arm32_platform_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_companion",
+        cpus = {
+            "watchos_cpus": ["armv7k", "arm64_32"],
+        },
+        binary_test_file = "$BUNDLE_ROOT/Watch/app.app/_WatchKitStub/WK",
+        binary_not_contains_architectures = ["arm64e", "arm64"],
+        binary_test_architecture = "arm64_32",
+        macho_load_commands_contain = ["cmd LC_VERSION_MIN_WATCHOS"],
+        tags = [name],
+    )
+
+    # Test that the output binary for a single arch build is identified as watchOS device via the
+    # Mach-O load command LC_VERSION_MIN_WATCHOS for the arm64_32 binary slice, and that the 64-bit
+    # archs and the armv7k arch are eliminated.
+    binary_contents_test(
+        name = "{}_device_arm64_32_platform_test".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_companion",
+        cpus = {
+            "watchos_cpus": ["arm64_32"],
+        },
+        binary_test_file = "$BUNDLE_ROOT/Watch/app.app/_WatchKitStub/WK",
+        binary_not_contains_architectures = ["armv7k", "arm64e", "arm64"],
+        binary_test_architecture = "arm64_32",
+        macho_load_commands_contain = ["cmd LC_VERSION_MIN_WATCHOS"],
         tags = [name],
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 480139567
(cherry picked from commit d6952f19de491ef4adc26e4b63d0035dbdc08841)
