### PR TITLE
Migrate rules built on create_apple_bundling_rule_with_attrs(...) to a new create_apple_rule(...) method. Expand usage to rules_apple binary/library/XCFramework rules.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -51,9 +51,7 @@ bzl_library(
     deps = [
         "//apple/internal:linking_support",
         "//apple/internal:rule_attrs",
-        "//apple/internal:transition_support",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+        "//apple/internal:rule_factory",
     ],
 )
 
@@ -64,9 +62,8 @@ bzl_library(
         ":providers",
         "//apple/internal:linking_support",
         "//apple/internal:rule_attrs",
+        "//apple/internal:rule_factory",
         "//apple/internal:transition_support",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -23,14 +23,9 @@ load(
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
-    "transition_support",
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
 )
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 def _linker_flag_for_sdk_dylib(dylib):
     """Returns a linker flag suitable for linking the given `sdk_dylib` value.
@@ -116,9 +111,26 @@ def _apple_binary_impl(ctx):
 
     return providers
 
-apple_binary = rule(
+apple_binary = rule_factory.create_apple_rule(
+    doc = """
+This rule produces single- or multi-architecture ("fat") binaries targeting
+Apple platforms.
+
+The `lipo` tool is used to combine files of multiple architectures. One of
+several flags may control which architectures are included in the output,
+depending on the value of the `platform_type` attribute.
+
+NOTE: In most situations, users should prefer the platform- and
+product-type-specific rules, such as `macos_command_line_application`. This
+rule is being provided for the purpose of transitioning users from the built-in
+implementation of `apple_binary` in Bazel core so that it can be removed.
+""",
     implementation = _apple_binary_impl,
-    attrs = dicts.add(
+    predeclared_outputs = {
+        # Provided for compatibility with built-in `apple_binary` only.
+        "lipobin": "%{name}_lipobin",
+    },
+    attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
             is_test_supporting_rule = False,
@@ -126,10 +138,6 @@ apple_binary = rule(
         ),
         rule_attrs.platform_attrs(),
         {
-            # Required to use the Apple Starlark rule and split transitions.
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
             "binary_type": attr.string(
                 default = "executable",
                 doc = """
@@ -191,21 +199,5 @@ not in the top-level bundle.
 """,
             ),
         },
-    ),
-    cfg = transition_support.apple_rule_transition,
-    doc = """
-This rule produces single- or multi-architecture ("fat") binaries targeting
-Apple platforms.
-
-The `lipo` tool is used to combine files of multiple architectures. One of
-several flags may control which architectures are included in the output,
-depending on the value of the `platform_type` attribute.
-
-NOTE: In most situations, users should prefer the platform- and
-product-type-specific rules, such as `macos_command_line_application`. This
-rule is being provided for the purpose of transitioning users from the built-in
-implementation of `apple_binary` in Bazel core so that it can be removed.
-""",
-    fragments = ["apple", "cpp", "objc"],
-    toolchains = use_cpp_toolchain(),
+    ],
 )

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -26,6 +26,10 @@ load(
     "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
 
 def _linker_flag_for_sdk_dylib(dylib):
     """Returns a linker flag suitable for linking the given `sdk_dylib` value.

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -130,10 +130,6 @@ rule is being provided for the purpose of transitioning users from the built-in
 implementation of `apple_binary` in Bazel core so that it can be removed.
 """,
     implementation = _apple_binary_impl,
-    predeclared_outputs = {
-        # Provided for compatibility with built-in `apple_binary` only.
-        "lipobin": "%{name}_lipobin",
-    },
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,

--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -27,15 +27,14 @@ load(
     "rule_attrs",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBinaryInfo",
     "ApplePlatformInfo",
 )
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 def _apple_static_library_impl(ctx):
     # Most validation of the platform type and minimum version OS currently happens in
@@ -76,9 +75,26 @@ Expected Apple platform type of "{platform_type}", but that was not found in {to
 
     return providers
 
-apple_static_library = rule(
+apple_static_library = rule_factory.create_apple_rule(
+    cfg = None,
+    doc = """
+This rule produces single- or multi-architecture ("fat") static libraries targeting
+Apple platforms.
+
+The `lipo` tool is used to combine files of multiple architectures. One of
+several flags may control which architectures are included in the output,
+depending on the value of the `platform_type` attribute.
+
+NOTE: In most situations, users should prefer the platform- and
+product-type-specific rules, such as `apple_static_xcframework`. This
+rule is being provided for the purpose of transitioning users from the built-in
+implementation of `apple_static_library` in Bazel core so that it can be removed.
+""",
     implementation = _apple_static_library_impl,
-    attrs = dicts.add(
+    predeclared_outputs = {
+        "lipo_archive": "%{name}_lipo.a",
+    },
+    attrs = [
         rule_attrs.common_tool_attrs,
         rule_attrs.cc_toolchain_forwarder_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -180,14 +196,6 @@ framework dependencies in the library targets where that framework is used,
 not in the top-level bundle.
 """,
             ),
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
         },
-    ),
-    outputs = {
-        "lipo_archive": "%{name}_lipo.a",
-    },
-    fragments = ["objc", "apple", "cpp"],
-    toolchains = use_cpp_toolchain(),
+    ],
 )

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -90,10 +90,9 @@ bzl_library(
     deps = [
         ":linking_support",
         ":rule_attrs",
+        ":rule_factory",
         ":transition_support",
         "//apple:providers",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
@@ -368,8 +367,6 @@ bzl_library(
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
         "//apple/internal/utils:clang_rt_dylibs",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
@@ -689,6 +686,7 @@ bzl_library(
         ":processor",
         ":resources",
         ":rule_attrs",
+        ":rule_factory",
         ":rule_support",
         ":swift_support",
         ":transition_support",
@@ -696,7 +694,6 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect",
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/utils:files",
-        "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -19,6 +19,10 @@ load(
     "rule_attrs",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBinaryInfo",
 )
@@ -30,11 +34,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
 )
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 def _apple_universal_binary_impl(ctx):
     inputs = [
@@ -67,9 +66,14 @@ def _apple_universal_binary_impl(ctx):
         ),
     ]
 
-apple_universal_binary = rule(
+apple_universal_binary = rule_factory.create_apple_rule(
+    cfg = transition_support.apple_universal_binary_rule_transition,
+    doc = """
+This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
+The `lipo` tool is used to combine built binaries of multiple architectures.
+""",
     implementation = _apple_universal_binary_impl,
-    attrs = dicts.add(
+    attrs = [
         rule_attrs.common_attrs,
         rule_attrs.platform_attrs(),
         {
@@ -99,12 +103,5 @@ additional flags when invoking Bazel.
 """,
             ),
         },
-    ),
-    cfg = transition_support.apple_universal_binary_rule_transition,
-    doc = """
-This rule produces a multi-architecture ("fat") binary targeting Apple platforms.
-The `lipo` tool is used to combine built binaries of multiple architectures.
-""",
-    fragments = ["apple", "cpp", "objc"],
-    toolchains = use_cpp_toolchain(),
+    ],
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2264,11 +2264,11 @@ def _ios_sticker_pack_extension_impl(ctx):
         OutputGroupInfo(**processor_result.output_groups),
     ] + processor_result.providers
 
-ios_application = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_application_impl,
-    archive_extension = ".ipa",
+ios_application = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS Application.",
+    implementation = _ios_application_impl,
     is_executable = True,
+    predeclared_outputs = {"archive": "%{name}.ipa"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".appiconset",
@@ -2380,11 +2380,11 @@ that should be embedded in the application bundle.
     ],
 )
 
-ios_app_clip = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_app_clip_impl,
-    archive_extension = ".ipa",
+ios_app_clip = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS App Clip.",
+    implementation = _ios_app_clip_impl,
     is_executable = True,
+    predeclared_outputs = {"archive": "%{name}.ipa"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".appiconset",
@@ -2441,14 +2441,15 @@ Info.plist under the key `UILaunchStoryboardName`.
     ],
 )
 
-ios_extension = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_extension_impl,
+ios_extension = rule_factory.create_apple_rule(
     doc = """Builds and bundles an iOS Application Extension.
 
 Most iOS app extensions use a plug-in-based architecture where the executable's entry point
 is provided by a system framework.
 However, iOS 14 introduced Widget Extensions that use a traditional `main` entry point
 (typically expressed through Swift's `@main` attribute).""",
+    implementation = _ios_extension_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".appiconset",
@@ -2507,12 +2508,13 @@ not in the top-level bundle.
     ],
 )
 
-ios_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_framework_impl,
+ios_framework = rule_factory.create_apple_rule(
     doc = """Builds and bundles an iOS Dynamic Framework.
 
 To use this framework for your app and extensions, list it in the `frameworks` attributes
 of those `ios_application` and/or `ios_extension` rules.""",
+    implementation = _ios_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -2568,9 +2570,10 @@ use only extension-safe APIs.
     ],
 )
 
-ios_dynamic_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_dynamic_framework_impl,
+ios_dynamic_framework = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS dynamic framework that is consumable by Xcode.",
+    implementation = _ios_dynamic_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -2629,8 +2632,8 @@ that this target depends on.
 
 _STATIC_FRAMEWORK_DEPS_CFG = transition_support.apple_platform_split_transition
 
-ios_static_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_static_framework_impl,
+ios_static_framework = rule_factory.create_apple_rule(
+    cfg = transition_support.apple_platforms_rule_base_transition,
     doc = """Builds and bundles an iOS static framework for third-party distribution.
 
 A static framework is bundled like a dynamic framework except that the embedded
@@ -2668,7 +2671,8 @@ target. Finally, it also bundles a `module.modulemap` file pointing to the
 umbrella header for Objetive-C module compatibility. This umbrella header and
 modulemap can be skipped by disabling the `swift.no_generated_header` feature (
 i.e. `--features=-swift.no_generated_header`).""",
-    cfg = transition_support.apple_platforms_rule_base_transition,
+    implementation = _ios_static_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,
@@ -2735,13 +2739,13 @@ umbrella header will be generated under the same name as this target.
     ],
 )
 
-ios_imessage_application = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_imessage_application_impl,
-    archive_extension = ".ipa",
+ios_imessage_application = rule_factory.create_apple_rule(
     doc = """Builds and bundles an iOS iMessage Application.
 
 iOS iMessage applications do not have any dependencies, as it works mostly as a wrapper
 for either an iOS iMessage extension or a Sticker Pack extension.""",
+    implementation = _ios_imessage_application_impl,
+    predeclared_outputs = {"archive": "%{name}.ipa"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".appiconset",
@@ -2777,9 +2781,10 @@ Required.
     ],
 )
 
-ios_imessage_extension = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_imessage_extension_impl,
+ios_imessage_extension = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS iMessage Extension.",
+    implementation = _ios_imessage_extension_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".appiconset",
@@ -2821,9 +2826,10 @@ that this target depends on.
     ],
 )
 
-ios_sticker_pack_extension = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_sticker_pack_extension_impl,
+ios_sticker_pack_extension = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS Sticker Pack Extension.",
+    implementation = _ios_sticker_pack_extension_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.app_icon_attrs(
             icon_extension = ".stickersiconset",

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -96,28 +96,35 @@ of the target will be used instead.
     ),
 }
 
-def _create_apple_bundling_rule_with_attrs(
+def _create_apple_rule(
         *,
-        archive_extension = ".zip",
-        attrs,
         cfg = transition_support.apple_rule_transition,
         doc,
         implementation,
-        is_executable = False):
+        is_executable = False,
+        predeclared_outputs = {},
+        toolchains = use_cpp_toolchain(),
+        attrs):
     """Creates an Apple bundling rule with additional control of the set of rule attributes.
 
     Args:
-        archive_extension: An extension to be applied to the generated archive file. Optional. This
-            will be `.zip` by default.
-        attrs: A list of dictionaries of attributes to be applied to the generated rule.
         cfg: The rule transition to be applied directly on the generated rule. Optional. This will
             be the Starlark Apple rule transition `transition_support.apple_rule_transition` by
             default.
         doc: The documentation string for the rule itself.
-        implementation: The method to handle the implementation of the given rule.
+        implementation: The method to handle the implementation of the given rule. Optional. True
+            by default.
+        toolchains: List. A list of toolchains that this rule requires. Optional. If not set, adds
+            the cpp toolchain to the rule definition as its sole requirement.
         is_executable: Boolean. If set to True, marks the rule as executable. Optional. False by
             default.
+        predeclared_outputs: A dictionary of any predeclared outputs that the rule is expected to
+            have. Optional. An empty dictionary by default.
+        attrs: A list of dictionaries of attributes to be applied to the generated rule.
     """
+    extra_args = {}
+    if predeclared_outputs:
+        extra_args["outputs"] = predeclared_outputs
 
     return rule(
         implementation = implementation,
@@ -134,11 +141,11 @@ def _create_apple_bundling_rule_with_attrs(
         doc = doc,
         executable = is_executable,
         fragments = ["apple", "cpp", "objc"],
-        outputs = {"archive": "%{name}" + archive_extension},
-        toolchains = use_cpp_toolchain(),
+        toolchains = toolchains,
+        **extra_args
     )
 
-def _create_apple_test_rule(implementation, doc, platform_type):
+def _create_apple_test_rule(*, doc, implementation, platform_type):
     """Creates an Apple test rule."""
 
     # These attrs are exposed for IDE experiences via `bazel query` as long as these test rules are
@@ -168,6 +175,6 @@ def _create_apple_test_rule(implementation, doc, platform_type):
     )
 
 rule_factory = struct(
-    create_apple_bundling_rule_with_attrs = _create_apple_bundling_rule_with_attrs,
+    create_apple_rule = _create_apple_rule,
     create_apple_test_rule = _create_apple_test_rule,
 )

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -87,9 +87,10 @@ def _ios_unit_test_impl(ctx):
     ]
 
 # Declare it with an underscore so it shows up that way in queries.
-_ios_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_ui_test_bundle_impl,
+_ios_internal_ui_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS UI Test Bundle. Internal target not to be depended upon.",
+    implementation = _ios_ui_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -143,7 +144,6 @@ that this target depends on.
 ios_internal_ui_test_bundle = _ios_internal_ui_test_bundle
 
 ios_ui_test = rule_factory.create_apple_test_rule(
-    implementation = _ios_ui_test_impl,
     doc = """iOS UI Test rule.
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -160,13 +160,15 @@ The following is a list of the `ios_ui_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/reference/be/common-definitions#common-attributes-tests).
 """,
+    implementation = _ios_ui_test_impl,
     platform_type = "ios",
 )
 
 # Declare it with an underscore so it shows up that way in queries.
-_ios_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _ios_unit_test_bundle_impl,
+_ios_internal_unit_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an iOS Unit Test Bundle. Internal target not to be depended upon.",
+    implementation = _ios_unit_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -218,7 +220,6 @@ that this target depends on.
 ios_internal_unit_test_bundle = _ios_internal_unit_test_bundle
 
 ios_unit_test = rule_factory.create_apple_test_rule(
-    implementation = _ios_unit_test_impl,
     doc = """Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
 provided test runner when invoked with `bazel test`. When using Tulsi to run
 tests built with this target, `runner` will not be used since Xcode is the test
@@ -240,5 +241,6 @@ To run the same test on multiple simulators/devices see
 The following is a list of the `ios_unit_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/reference/be/common-definitions#common-attributes-tests).""",
+    implementation = _ios_unit_test_impl,
     platform_type = "ios",
 )

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -87,9 +87,10 @@ def _macos_unit_test_impl(ctx):
     ]
 
 # Declare it with an underscore to hint that this is an implementation detail in bazel query-s.
-_macos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _macos_ui_test_bundle_impl,
+_macos_internal_ui_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an macOS UI Test Bundle. Internal target not to be depended upon.",
+    implementation = _macos_ui_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -156,20 +157,21 @@ that this target depends on.
 macos_internal_ui_test_bundle = _macos_internal_ui_test_bundle
 
 macos_ui_test = rule_factory.create_apple_test_rule(
-    implementation = _macos_ui_test_impl,
     doc = """Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
 provided test runner when invoked with `bazel test`. When using Tulsi to run
 tests built with this target, `runner` will not be used since Xcode is the test
 runner in that case.
 
 Note: macOS UI tests are not currently supported in the default test runner.""",
+    implementation = _macos_ui_test_impl,
     platform_type = "macos",
 )
 
 # Declare it with an underscore to hint that this is an implementation detail in bazel query-s.
-_macos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _macos_unit_test_bundle_impl,
+_macos_internal_unit_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an macOS Unit Test Bundle. Internal target not to be depended upon.",
+    implementation = _macos_unit_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -235,7 +237,6 @@ that this target depends on.
 macos_internal_unit_test_bundle = _macos_internal_unit_test_bundle
 
 macos_unit_test = rule_factory.create_apple_test_rule(
-    implementation = _macos_unit_test_impl,
     doc = """Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
 provided test runner when invoked with `bazel test`. When using Tulsi to run
 tests built with this target, `runner` will not be used since Xcode is the test
@@ -248,5 +249,6 @@ will run outside the context of an macOS application. Because of this, certain
 functionalities might not be present (e.g. UI layout, NSUserDefaults). You can
 find more information about testing for Apple platforms
 [here](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/testing_with_xcode/chapters/03-testing_basics.html).""",
+    implementation = _macos_unit_test_impl,
     platform_type = "macos",
 )

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -91,9 +91,10 @@ def _tvos_unit_test_impl(ctx):
     ]
 
 # Declare it with an underscore to hint that this is an implementation detail in bazel query-s.
-_tvos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_ui_test_bundle_impl,
+_tvos_internal_ui_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an tvOS UI Test Bundle. Internal target not to be depended upon.",
+    implementation = _tvos_ui_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -145,7 +146,6 @@ that this target depends on.
 tvos_internal_ui_test_bundle = _tvos_internal_ui_test_bundle
 
 tvos_ui_test = rule_factory.create_apple_test_rule(
-    implementation = _tvos_ui_test_impl,
     doc = """
 Builds and bundles a tvOS UI `.xctest` test bundle. Runs the tests using the
 provided test runner when invoked with `bazel test`. When using Tulsi to run
@@ -158,13 +158,15 @@ The following is a list of the `tvos_ui_test` specific attributes; for a list of
 the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/reference/be/common-definitions#common-attributes-tests).
 """,
+    implementation = _tvos_ui_test_impl,
     platform_type = "tvos",
 )
 
 # Declare it with an underscore so it shows up that way in queries.
-_tvos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_unit_test_bundle_impl,
+_tvos_internal_unit_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an tvOS Unit Test Bundle. Internal target not to be depended upon.",
+    implementation = _tvos_unit_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -215,7 +217,6 @@ that this target depends on.
 tvos_internal_unit_test_bundle = _tvos_internal_unit_test_bundle
 
 tvos_unit_test = rule_factory.create_apple_test_rule(
-    implementation = _tvos_unit_test_impl,
     doc = """
 Builds and bundles a tvOS Unit `.xctest` test bundle. Runs the tests using the
 provided test runner when invoked with `bazel test`. When using Tulsi to run
@@ -236,5 +237,6 @@ The following is a list of the `tvos_unit_test` specific attributes; for a list
 of the attributes inherited by all test rules, please check the
 [Bazel documentation](https://bazel.build/reference/be/common-definitions#common-attributes-tests).
 """,
+    implementation = _tvos_unit_test_impl,
     platform_type = "tvos",
 )

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -87,9 +87,10 @@ def _watchos_unit_test_impl(ctx):
     ]
 
 # Declare it with an underscore to hint that this is an implementation detail in bazel query-s.
-_watchos_internal_ui_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_ui_test_bundle_impl,
+_watchos_internal_ui_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an watchOS UI Test Bundle. Internal target not to be depended upon.",
+    implementation = _watchos_ui_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -141,15 +142,16 @@ that this target depends on.
 watchos_internal_ui_test_bundle = _watchos_internal_ui_test_bundle
 
 watchos_ui_test = rule_factory.create_apple_test_rule(
-    implementation = _watchos_ui_test_impl,
     doc = "watchOS UI Test rule.",
+    implementation = _watchos_ui_test_impl,
     platform_type = "watchos",
 )
 
 # Declare it with an underscore to hint that this is an implementation detail in bazel query-s.
-_watchos_internal_unit_test_bundle = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_unit_test_bundle_impl,
+_watchos_internal_unit_test_bundle = rule_factory.create_apple_rule(
     doc = "Builds and bundles an watchOS Unit Test Bundle. Internal target not to be depended upon.",
+    implementation = _watchos_unit_test_bundle_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -200,7 +202,7 @@ that this target depends on.
 watchos_internal_unit_test_bundle = _watchos_internal_unit_test_bundle
 
 watchos_unit_test = rule_factory.create_apple_test_rule(
-    implementation = _watchos_unit_test_impl,
     doc = "watchOS Unit Test rule.",
+    implementation = _watchos_unit_test_impl,
     platform_type = "watchos",
 )

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -1302,11 +1302,11 @@ def _tvos_static_framework_impl(ctx):
         TvosStaticFrameworkBundleInfo(),
     ] + processor_result.providers
 
-tvos_application = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_application_impl,
-    archive_extension = ".ipa",
+tvos_application = rule_factory.create_apple_rule(
     doc = "Builds and bundles a tvOS Application.",
+    implementation = _tvos_application_impl,
     is_executable = True,
+    predeclared_outputs = {"archive": "%{name}.ipa"},
     attrs = [
         rule_attrs.app_icon_attrs(),
         rule_attrs.binary_linking_attrs(
@@ -1360,9 +1360,10 @@ that this target depends on.
     ],
 )
 
-tvos_dynamic_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_dynamic_framework_impl,
+tvos_dynamic_framework = rule_factory.create_apple_rule(
     doc = "Builds and bundles a tvOS dynamic framework that is consumable by Xcode.",
+    implementation = _tvos_dynamic_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1419,9 +1420,10 @@ that this target depends on.
     ],
 )
 
-tvos_extension = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_extension_impl,
+tvos_extension = rule_factory.create_apple_rule(
     doc = "Builds and bundles a tvOS Extension.",
+    implementation = _tvos_extension_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1460,13 +1462,14 @@ that this target depends on.
     ],
 )
 
-tvos_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_framework_impl,
+tvos_framework = rule_factory.create_apple_rule(
     doc = """
 Builds and bundles a tvOS Dynamic Framework.
 
 To use this framework for your app and extensions, list it in the frameworks attributes of those tvos_application and/or tvos_extension rules.
 """,
+    implementation = _tvos_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1524,8 +1527,7 @@ that this target depends on.
 
 _STATIC_FRAMEWORK_DEPS_CFG = transition_support.apple_platform_split_transition
 
-tvos_static_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _tvos_static_framework_impl,
+tvos_static_framework = rule_factory.create_apple_rule(
     cfg = transition_support.apple_platforms_rule_base_transition,
     doc = """
 Builds and bundles an tvOS static framework for third-party distribution.
@@ -1566,6 +1568,8 @@ umbrella header for Objetive-C module compatibility. This umbrella header and
 modulemap can be skipped by disabling the `swift.no_generated_header` feature (
 i.e. `--features=-swift.no_generated_header`).
 """,
+    implementation = _tvos_static_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -1579,9 +1579,10 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         WatchosApplicationBundleInfo(),
     ] + processor_result.providers
 
-watchos_application = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_application_impl,
+watchos_application = rule_factory.create_apple_rule(
     doc = "Builds and bundles an watchOS Application.",
+    implementation = _watchos_application_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.app_icon_attrs(),
         rule_attrs.binary_linking_attrs(
@@ -1645,9 +1646,10 @@ that this target depends on.
     ],
 )
 
-watchos_extension = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_extension_impl,
+watchos_extension = rule_factory.create_apple_rule(
     doc = "Builds and bundles an watchOS Extension.",
+    implementation = _watchos_extension_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1704,12 +1706,13 @@ that this target depends on.
     ],
 )
 
-watchos_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_framework_impl,
+watchos_framework = rule_factory.create_apple_rule(
     doc = """Builds and bundles a watchOS Dynamic Framework.
 
 To use this framework for your extensions, list it in the `frameworks` attributes of
 those `watchos_extension` rules.""",
+    implementation = _watchos_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1766,9 +1769,10 @@ that this target depends on.
     ],
 )
 
-watchos_dynamic_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_dynamic_framework_impl,
+watchos_dynamic_framework = rule_factory.create_apple_rule(
     doc = "Builds and bundles a watchOS dynamic framework that is consumable by Xcode.",
+    implementation = _watchos_dynamic_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = transition_support.apple_platform_split_transition,
@@ -1827,10 +1831,11 @@ that this target depends on.
 
 _STATIC_FRAMEWORK_DEPS_CFG = transition_support.apple_platform_split_transition
 
-watchos_static_framework = rule_factory.create_apple_bundling_rule_with_attrs(
-    implementation = _watchos_static_framework_impl,
+watchos_static_framework = rule_factory.create_apple_rule(
     cfg = transition_support.apple_platforms_rule_base_transition,
     doc = "Builds and bundles a watchOS Static Framework.",
+    implementation = _watchos_static_framework_impl,
+    predeclared_outputs = {"archive": "%{name}.zip"},
     attrs = [
         rule_attrs.binary_linking_attrs(
             deps_cfg = _STATIC_FRAMEWORK_DEPS_CFG,

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -145,6 +145,18 @@ apple_static_library(<a href="#apple_static_library-name">name</a>, <a href="#ap
 </pre>
 
 
+This rule produces single- or multi-architecture ("fat") static libraries targeting
+Apple platforms.
+
+The `lipo` tool is used to combine files of multiple architectures. One of
+several flags may control which architectures are included in the output,
+depending on the value of the `platform_type` attribute.
+
+NOTE: In most situations, users should prefer the platform- and
+product-type-specific rules, such as `apple_static_xcframework`. This
+rule is being provided for the purpose of transitioning users from the built-in
+implementation of `apple_static_library` in Bazel core so that it can be removed.
+
 
 **ATTRIBUTES**
 
@@ -283,7 +295,7 @@ apple_xcframework(<a href="#apple_xcframework-name">name</a>, <a href="#apple_xc
                   <a href="#apple_xcframework-stamp">stamp</a>, <a href="#apple_xcframework-tvos">tvos</a>, <a href="#apple_xcframework-umbrella_header">umbrella_header</a>, <a href="#apple_xcframework-version">version</a>)
 </pre>
 
-
+Builds and bundles an XCFramework for third-party distribution.
 
 **ATTRIBUTES**
 


### PR DESCRIPTION
PiperOrigin-RevId: 480674056
(cherry picked from commit ca7a5991705871cd3a1456fda8c2cc85541c170e)
