### PR TITLE
Migrate all uses of extra_linkopts from rule_support.bzl to their respective implementations.

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -663,7 +663,6 @@ bzl_library(
         "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:sets",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",
-        "@build_bazel_apple_support//lib:xcode_support",
     ],
 )
 

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1044,7 +1044,11 @@ def _ios_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    extra_linkopts = []
+    extra_linkopts = [
+        "-fapplication-extension",
+        "-e",
+        "_NSExtensionMain",
+    ]
     if ctx.attr.sdk_frameworks:
         extra_linkopts.extend(
             collections.before_each("-framework", ctx.attr.sdk_frameworks),
@@ -1911,10 +1915,17 @@ def _ios_imessage_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
+    extra_linkopts = [
+        "-fapplication-extension",
+        "-e",
+        "_NSExtensionMain",
+    ]
+
     link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = entitlements.linking,
+        extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -128,9 +128,8 @@ def _register_binary_linking_action(
         extra_link_inputs: Extra link inputs to add to the linking action.
         platform_prerequisites: The platform prerequisites.
         rule_descriptor: The rule descriptor if one exists for the given rule. For convenience, This
-            will define additional parameters required for linking, such as `rpaths` and
-            `extra_linkopts`. If `None`, these additional parameters will not be set on the linked
-            binary.
+            will define additional parameters required for linking, such as `rpaths`. If `None`,
+            these additional parameters will not be set on the linked binary.
         stamp: Whether to include build information in the linked binary. If 1, build
             information is always included. If 0, the default build information is always
             excluded. If -1, the default behavior is used, which may be overridden by the
@@ -196,11 +195,10 @@ def _register_binary_linking_action(
             )
             link_inputs.append(der_entitlements)
 
-    # TODO(b/248317958): Migrate rule_descriptor.rpaths and rule_descriptor.extra_linkopts as direct
-    # inputs of the extra_linkopts arg on this method.
+    # TODO(b/248317958): Migrate rule_descriptor.rpaths as direct inputs of the extra_linkopts arg
+    # on this method.
     if rule_descriptor:
         linkopts.extend(["-Wl,-rpath,{}".format(rpath) for rpath in rule_descriptor.rpaths])
-        linkopts.extend(rule_descriptor.extra_linkopts)
 
     linkopts.extend(extra_linkopts)
     link_inputs.extend(extra_link_inputs)

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -697,10 +697,17 @@ def _macos_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
+    extra_linkopts = [
+        "-fapplication-extension",
+        "-e",
+        "_NSExtensionMain",
+    ]
+
     link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = entitlements.linking,
+        extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,
@@ -1158,9 +1165,18 @@ def _macos_kernel_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
+    # This was added for b/122473338, and should be removed eventually once symbol stripping is
+    # better-handled. It's redundant with an option added in the CROSSTOOL for the
+    # "kernel_extension" feature, but for now it's necessary to detect kext linking so
+    # CompilationSupport.java can apply the correct type of symbol stripping.
+    extra_linkopts = [
+        "-Wl,-kext",
+    ]
+
     link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = entitlements.linking,
+        extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -75,7 +75,6 @@ def _describe_rule_type(
         bundle_locations = None,
         bundle_package_type = None,
         codesigning_exceptions = _CODESIGNING_EXCEPTIONS.none,
-        extra_linkopts = [],
         expose_non_archive_relative_output = False,
         product_type = None,
         requires_pkginfo = False,
@@ -99,7 +98,6 @@ def _describe_rule_type(
         expose_non_archive_relative_output: Whether or not to expose an output archive that ignores
             the `archive_relative` bundle location, to permit embedding within another target. Has no
             effect if `archive_relative` is empty.
-        extra_linkopts: Extra options to pass to the linker.
         product_type: The product type for this rule.
         requires_pkginfo: Whether the PkgInfo file should be included inside the rule's bundle.
         requires_signing_for_device: Whether signing is required when building for devices (as
@@ -127,7 +125,6 @@ def _describe_rule_type(
         bundle_package_type = bundle_package_type,
         codesigning_exceptions = codesigning_exceptions,
         expose_non_archive_relative_output = expose_non_archive_relative_output,
-        extra_linkopts = extra_linkopts,
         product_type = product_type,
         requires_pkginfo = requires_pkginfo,
         requires_signing_for_device = requires_signing_for_device,
@@ -143,7 +140,7 @@ _DEFAULT_MACOS_BUNDLE_LOCATIONS = _describe_bundle_locations(
 )
 
 # Descriptors for all possible platform/product type combinations.
-# TODO(b/248317958): Migrate extra_linkopts and rpaths to args on the linking_support methods.
+# TODO(b/248317958): Migrate rpaths to args on the linking_support methods.
 _RULE_TYPE_DESCRIPTORS = {
     "ios": {
         # ios_application
@@ -183,11 +180,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            extra_linkopts = [
-                "-fapplication-extension",
-                "-e",
-                "_NSExtensionMain",
-            ],
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
@@ -231,11 +223,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            extra_linkopts = [
-                "-fapplication-extension",
-                "-e",
-                "_NSExtensionMain",
-            ],
             product_type = apple_product_type.messages_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
@@ -267,10 +254,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["iphone", "ipad"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.ui_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -287,10 +270,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["iphone", "ipad"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.unit_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -341,11 +320,6 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".appex",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            extra_linkopts = [
-                "-fapplication-extension",
-                "-e",
-                "_NSExtensionMain",
-            ],
             product_type = apple_product_type.app_extension,
             requires_signing_for_device = False,
             rpaths = [
@@ -389,13 +363,6 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".kext",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.kernel_extension,
-            # This was added for b/122473338, and should be removed eventually once symbol
-            # stripping is better-handled. It's redundant with an option added in the CROSSTOOL
-            # for the "kernel_extension" feature, but for now it's necessary to detect kext
-            # linking so CompilationSupport.java can apply the correct type of symbol stripping.
-            extra_linkopts = [
-                "-Wl,-kext",
-            ],
             product_type = apple_product_type.kernel_extension,
             requires_signing_for_device = False,
         ),
@@ -432,10 +399,6 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".xctest",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.ui_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -453,10 +416,6 @@ _RULE_TYPE_DESCRIPTORS = {
             bundle_extension = ".xctest",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.unit_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -514,13 +473,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            extra_linkopts = [
-                "-e",
-                "_TVExtensionMain",
-                "-fapplication-extension",
-                "-framework",
-                "TVServices",
-            ],
             product_type = apple_product_type.app_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
@@ -558,10 +510,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["tv"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.ui_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -578,10 +526,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["tv"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.unit_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -626,9 +570,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allows_locale_trimming = True,
             bundle_extension = ".appex",
             bundle_package_type = bundle_package_type.extension_or_xpc,
-            extra_linkopts = [
-                "-fapplication-extension",
-            ],
             product_type = apple_product_type.watch2_extension,
             rpaths = [
                 # Extension binaries live in Application.app/PlugIns/Extension.appex/Extension
@@ -666,10 +607,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["watch"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.ui_test_bundle,
             requires_signing_for_device = False,
             rpaths = [
@@ -686,10 +623,6 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["watch"],
             bundle_extension = ".xctest",
             bundle_package_type = bundle_package_type.bundle,
-            extra_linkopts = [
-                "-framework",
-                "XCTest",
-            ],
             product_type = apple_product_type.unit_test_bundle,
             requires_signing_for_device = False,
             rpaths = [

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -334,7 +334,11 @@ def _apple_test_bundle_impl(*, ctx, product_type):
     else:
         bundle_loader = None
 
-    extra_linkopts = ["-bundle"]
+    extra_linkopts = [
+        "-framework",
+        "XCTest",
+        "-bundle",
+    ]
     extra_link_inputs = []
 
     if "apple.swizzle_absolute_xcttestsourcelocation" in features:
@@ -359,8 +363,8 @@ def _apple_test_bundle_impl(*, ctx, product_type):
         bundle_loader = bundle_loader,
         # Unit/UI tests do not use entitlements.
         entitlements = None,
-        extra_linkopts = extra_linkopts,
         extra_link_inputs = extra_link_inputs,
+        extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -991,10 +991,19 @@ def _tvos_extension_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
+    extra_linkopts = [
+        "-e",
+        "_TVExtensionMain",
+        "-fapplication-extension",
+        "-framework",
+        "TVServices",
+    ]
+
     link_result = linking_support.register_binary_linking_action(
         ctx,
         avoid_deps = ctx.attr.frameworks,
         entitlements = entitlements.linking,
+        extra_linkopts = extra_linkopts,
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -955,12 +955,26 @@ def _watchos_extension_impl(ctx):
     )
     product_type = rule_descriptor.product_type
 
+    entitlements = entitlements_support.process_entitlements(
+        actions = actions,
+        apple_mac_toolchain_info = apple_mac_toolchain_info,
+        bundle_id = bundle_id,
+        entitlements_file = ctx.file.entitlements,
+        platform_prerequisites = platform_prerequisites,
+        product_type = product_type,
+        provisioning_profile = provisioning_profile,
+        rule_label = label,
+        validation_mode = ctx.attr.entitlements_validation,
+    )
+
     # This extension should be treated as an App Extension instead of a WatchKit Extension.
     if ctx.attr.application_extension:
         extra_linkopts = ["-e", "_NSExtensionMain"]
         product_type = apple_product_type.app_extension
     else:
         extra_linkopts = ["-e", "_WKExtensionMain"]
+
+    extra_linkopts.append("-fapplication-extension")
 
     # This is required when building with watchOS SDK 6.0 or higher but with a minimum
     # deployment version lower than 6.0. See
@@ -978,18 +992,6 @@ def _watchos_extension_impl(ctx):
             # it already resolved the symbol from the framework.
             "-Wl,-force_load,/usr/lib/libWKExtensionMainLegacy.a",
         )
-
-    entitlements = entitlements_support.process_entitlements(
-        actions = actions,
-        apple_mac_toolchain_info = apple_mac_toolchain_info,
-        bundle_id = bundle_id,
-        entitlements_file = ctx.file.entitlements,
-        platform_prerequisites = platform_prerequisites,
-        product_type = product_type,
-        provisioning_profile = provisioning_profile,
-        rule_label = label,
-        validation_mode = ctx.attr.entitlements_validation,
-    )
 
     link_result = linking_support.register_binary_linking_action(
         ctx,


### PR DESCRIPTION
PiperOrigin-RevId: 482342453
(cherry picked from commit 954ee1e2c144eee637083fba25a7b870b2e14a0d)
