### PR TITLE
Cleanup instances of "needs-xcode-latest-beta" that are no longer needed.

### DIFF
--- a/examples/watchos/HelloWorld/BUILD
+++ b/examples/watchos/HelloWorld/BUILD
@@ -118,10 +118,7 @@ ios_application(
     ],
     infoplists = [":Phone-Info.plist"],
     launch_storyboard = "//examples/resources:Launch.storyboard",
-    minimum_os_version = "9.0",
-    tags = [
-        "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
-    ],
+    minimum_os_version = "11.0",
     version = ":HelloWorldVersion",
     watch_application = ":HelloWorld-SingleTargetWatchApplication",
     deps = [":PhoneSources"],
@@ -136,9 +133,6 @@ watchos_application(
     storyboards = [
         "WatchResources/Interface.storyboard",
     ],
-    tags = [
-        "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
-    ],
     version = ":HelloWorldVersion",
     deps = [":SingleTargetWatchSources"],
 )
@@ -149,18 +143,9 @@ build_test(
     name = "ExamplesBuildTest",
     targets = [
         ":HelloWorld",
-        ":HelloWorld-WatchApplication",
-        ":HelloWorld-WatchExtension",
-    ],
-)
-
-build_test(
-    name = "ExamplesBuildTest-LatestXcodeBeta",
-    tags = [
-        "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
-    ],
-    targets = [
         ":HelloWorld-SingleTargetWatchHost",
         ":HelloWorld-SingleTargetWatchApplication",
+        ":HelloWorld-WatchApplication",
+        ":HelloWorld-WatchExtension",
     ],
 )

--- a/test/starlark_tests/watchos_single_target_application_tests.bzl
+++ b/test/starlark_tests/watchos_single_target_application_tests.bzl
@@ -51,7 +51,6 @@ def watchos_single_target_application_test_suite(name):
         expected_error = "Single-target watchOS applications require a minimum_os_version of 7.0 or greater.",
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )
 
@@ -66,7 +65,6 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
 """,
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )
 
@@ -77,7 +75,7 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         verifier_script = "verifier_scripts/codesign_verifier.sh",
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
+            "never-on-beta",  # TODO(b/249829891): Remove once internal beta testing issue is fixed.
         ],
     )
 
@@ -88,7 +86,7 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         verifier_script = "verifier_scripts/no_custom_fmwks_verifier.sh",
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
+            "never-on-beta",  # TODO(b/249829891): Remove once internal beta testing issue is fixed.
         ],
     )
 
@@ -116,7 +114,7 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         },
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
+            "never-on-beta",  # TODO(b/249829891): Remove once internal beta testing issue is fixed.
         ],
     )
 
@@ -133,7 +131,6 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         ],
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )
 
@@ -151,7 +148,7 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ios_with_swift_single_target_watchos_with_swift_stable_abi",
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
+            "never-on-beta",  # TODO(b/249829891): Remove once internal beta testing issue is fixed.
         ],
     )
 
@@ -159,6 +156,5 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         name = name,
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )

--- a/test/starlark_tests/watchos_single_target_ui_test_tests.bzl
+++ b/test/starlark_tests/watchos_single_target_ui_test_tests.bzl
@@ -44,7 +44,7 @@ def watchos_single_target_ui_test_test_suite(name):
         verifier_script = "verifier_scripts/codesign_verifier.sh",
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
+            "never-on-beta",  # TODO(b/249829891): Remove once internal beta testing issue is fixed.
         ],
     )
 
@@ -55,7 +55,6 @@ def watchos_single_target_ui_test_test_suite(name):
         expected_transitive_dsyms = ["single_target_ui_test.__internal__.__test_bundle_dsyms/single_target_ui_test.xctest"],
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )
 
@@ -82,7 +81,6 @@ def watchos_single_target_ui_test_test_suite(name):
         },
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )
 
@@ -90,6 +88,5 @@ def watchos_single_target_ui_test_test_suite(name):
         name = name,
         tags = [
             name,
-            "needs-xcode-latest-beta",  # TODO(b/246410415): Remove when Xcode 14 is widely available.
         ],
     )


### PR DESCRIPTION
PiperOrigin-RevId: 486697818
(cherry picked from commit cb2b6eb9ec75855126fd65d7a4b0fb8c06aa5111)
