### PR TITLE
Set defaults for register_binary_linking_action parameters.

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -101,9 +101,9 @@ def _register_binary_linking_action(
         entitlements = None,
         extra_linkopts = [],
         extra_link_inputs = [],
-        platform_prerequisites,
-        rule_descriptor,
-        stamp):
+        platform_prerequisites = None,
+        rule_descriptor = None,
+        stamp = -1):
     """Registers linking actions using the Starlark Apple binary linking API.
 
     This method will add the linkopts as added on the rule descriptor, in addition to any extra
@@ -126,7 +126,9 @@ def _register_binary_linking_action(
             of the binary.
         extra_linkopts: Extra linkopts to add to the linking action.
         extra_link_inputs: Extra link inputs to add to the linking action.
-        platform_prerequisites: The platform prerequisites.
+        platform_prerequisites: The platform prerequisites if one exists for the given rule. This
+            will define additional linking sections for entitlements. If `None`, entitlements
+            sections are not included.
         rule_descriptor: The rule descriptor if one exists for the given rule. For convenience, This
             will define additional parameters required for linking, such as `rpaths`. If `None`,
             these additional parameters will not be set on the linked binary.


### PR DESCRIPTION
This allows avoid depending on the `stamp` rule attribute, as well as the
platform_prerequisites and rule_descriptor model.

PiperOrigin-RevId: 496723931
(cherry picked from commit ff8d5e5d9830ebb83aebda8c191e12d0fc59ae01)
