### PR TITLE
Roll forward; Add a series of code signing dossier reader arguments to allow for listing entitlements to keep when signing.

### DIFF
--- a/tools/dossier_codesigningtool/BUILD
+++ b/tools/dossier_codesigningtool/BUILD
@@ -42,6 +42,9 @@ py_library(
 py_test(
     name = "dossier_codesigning_reader_test",
     srcs = ["dossier_codesigning_reader_test.py"],
+    data = [
+        "//test/starlark_tests/targets_under_test/ios:app",
+    ],
     python_version = "PY3",
     tags = ["requires-darwin"],
     deps = [

--- a/tools/dossier_codesigningtool/dossier_codesigning_reader.py
+++ b/tools/dossier_codesigningtool/dossier_codesigning_reader.py
@@ -26,6 +26,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import traceback
 
 
 # LINT.IfChange
@@ -140,7 +141,7 @@ class DossierDirectory(object):
   def __enter__(self):
     return self
 
-  def __exit__(self, exception_type, exception_value, traceback):
+  def __exit__(self, exception_type, exception_value, traceback_value):
     if self.unzipped:
       shutil.rmtree(self.path)
 
@@ -168,6 +169,7 @@ MANIFEST_FILENAME = 'manifest.json'
 
 def generate_arg_parser():
   """Generates an argument parser for this tool."""
+
   parser = argparse.ArgumentParser(
       description='Tool for signing iOS bundles using dossiers.',
       fromfile_prefix_chars='@')
@@ -180,7 +182,17 @@ def generate_arg_parser():
       help='Path to input dossier location. Can be a directory or .zip file.')
   sign_parser.add_argument(
       '--codesign', required=True, type=str, help='Path to codesign binary')
+  sign_parser.add_argument(
+      '--allow_entitlement',
+      action='append',
+      type=str,
+      help='Entitlement to allow. If none are specified, the entitlements found'
+      ' in the dossier will be used without additional processing')
   sign_parser.add_argument('bundle', help='Path to the bundle')
+  # TODO(b/259274067): Add additional arguments to allow for an IPA to be used
+  # as a source for signing instead of a bundle, as well as for a future
+  # combined zip file that provides both the bundle and the dossier in one
+  # archive.
   sign_parser.set_defaults(func=_sign_bundle)
 
   return parser
@@ -285,14 +297,14 @@ def _filter_codesign_tool_output(exit_status, codesign_stdout, codesign_stderr):
           _filter_codesign_output(codesign_stderr))
 
 
-def _invoke_codesign(codesign_path, identity, entitlements, force_signing,
+def _invoke_codesign(codesign_path, identity, entitlements_path, force_signing,
                      disable_timestamp, full_path_to_sign):
   """Invokes the codesign tool on the given path to sign.
 
   Args:
     codesign_path: Path to the codesign tool as a string.
     identity: The unique identifier string to identify code signatures.
-    entitlements: Path to the file with entitlement data. Optional.
+    entitlements_path: Path to the file with entitlement data. Optional.
     force_signing: If true, replaces any existing signature on the path given.
     disable_timestamp: If true, disables the use of timestamp services.
     full_path_to_sign: Path to the bundle or binary to code sign as a string.
@@ -301,7 +313,7 @@ def _invoke_codesign(codesign_path, identity, entitlements, force_signing,
   if entitlements:
     cmd.extend([
         '--entitlements',
-        entitlements,
+        entitlements_path,
         '--generate-entitlement-der',
     ])
   if force_signing:
@@ -343,11 +355,44 @@ def _fetch_preferred_signing_identity(manifest,
   return codesign_identity
 
 
+def _generate_entitlements_for_signing(*, src, allowed_entitlements, dest):
+  """Generate entitlements based on the filtered set of allowed entitlements.
+
+  Args:
+    src: A path to the entitlements to source for dossier signing.
+    allowed_entitlements: A list of strings indicating keys that are valid for
+      entitlements. Only the strings listed here will be transferred to the
+      generated entitlements.
+    dest: A path to indicate where the generated entitlements should be placed.
+  """
+
+  try:
+    with open(src, 'rb') as f:
+      original_entitlements = plistlib.load(f)
+  except InvalidFileException as exc:
+    orig_traceback = traceback.format_exc()
+    raise OSError('Unable to read override entitlements: %s\n'
+                  'Original Exception:\n%s' % (src, orig_traceback)) from exc
+
+  new_entitlements = {}
+  for key in original_entitlements:
+    if key in allowed_entitlements:
+      new_entitlements[key] = original_entitlements[key]
+    else:
+      print('WARNING: Invalid entitlement key found: %s' % key)
+
+  # log the entitlements for debug purpose
+  print('Dumping entitlements to %s: %s' % (dest, new_entitlements))
+  with open(dest, 'wb') as f:
+    plistlib.dump(new_entitlements, f)
+
+
 def _sign_bundle_with_manifest(
     root_bundle_path,
     manifest,
     dossier_directory,
     codesign_path,
+    allowed_entitlements,
     override_codesign_identity=None,
     executor=concurrent.futures.ThreadPoolExecutor()):
   """Signs a bundle with a dossier.
@@ -360,6 +405,10 @@ def _sign_bundle_with_manifest(
     manifest: The contents of the manifest in this dossier.
     dossier_directory: Directory of dossier to be used for signing.
     codesign_path: Path to the codesign tool as a string.
+    allowed_entitlements: A list of strings indicating keys that are valid for
+      entitlements. If not None, only the strings listed here will be
+      transferred to the generated entitlements. If None, the entitlements found
+      with the dossier will be used directly for code signing.
     override_codesign_identity: If set, this will override the identity
       specified in the manifest. This is primarily useful when signing an
       embedded bundle, as all bundles must use the same codesigning identity,
@@ -383,26 +432,43 @@ def _sign_bundle_with_manifest(
         'and unable to infer identity.')
 
   entitlements_filename = manifest.get(ENTITLEMENTS_KEY)
-  entitlements_file_path = os.path.join(dossier_directory,
-                                        entitlements_filename)
+  entitlements_source_path = os.path.join(dossier_directory,
+                                          entitlements_filename)
 
-  # submit each embedded manifest to sign concurrently
-  codesign_futures = _sign_embedded_bundles_with_manifest(
-      manifest, root_bundle_path, dossier_directory, codesign_path,
-      codesign_identity, executor)
-  _wait_embedded_manifest_futures(codesign_futures)
+  try:
+    working_dir = tempfile.mkdtemp()
+    print('Working dir for temp signing artifacts created: %s' % working_dir)
+    if allowed_entitlements:
+      _, entitlements_for_signing_path = tempfile.mkstemp(
+          dir=working_dir, suffix='.plist')
 
-  if provisioning_profile_file_path:
-    _copy_embedded_provisioning_profile(
-        provisioning_profile_file_path, root_bundle_path)
+      _generate_entitlements_for_signing(
+          src=entitlements_source_path,
+          allowed_entitlements=allowed_entitlements,
+          dest=entitlements_for_signing_path)
+    else:
+      entitlements_for_signing_path = entitlements_source_path
 
-  _invoke_codesign(
-      codesign_path=codesign_path,
-      identity=codesign_identity,
-      entitlements=entitlements_file_path,
-      force_signing=True,
-      disable_timestamp=False,
-      full_path_to_sign=root_bundle_path)
+    # submit each embedded manifest to sign concurrently
+    codesign_futures = _sign_embedded_bundles_with_manifest(
+        manifest, root_bundle_path, dossier_directory, codesign_path,
+        allowed_entitlements, codesign_identity, executor)
+    _wait_embedded_manifest_futures(codesign_futures)
+
+    if provisioning_profile_file_path:
+      _copy_embedded_provisioning_profile(
+          provisioning_profile_file_path, root_bundle_path)
+
+    _invoke_codesign(
+        codesign_path=codesign_path,
+        identity=codesign_identity,
+        entitlements_path=entitlements_for_signing_path,
+        force_signing=True,
+        disable_timestamp=False,
+        full_path_to_sign=root_bundle_path)
+
+  finally:
+    shutil.rmtree(working_dir)
 
 
 def _sign_embedded_bundles_with_manifest(
@@ -410,6 +476,7 @@ def _sign_embedded_bundles_with_manifest(
     root_bundle_path,
     dossier_directory,
     codesign_path,
+    allowed_entitlements,
     codesign_identity,
     executor):
   """Signs embedded bundles concurrently and returns futures list.
@@ -419,6 +486,10 @@ def _sign_embedded_bundles_with_manifest(
     root_bundle_path: The absolute path to the bundle that will be signed.
     dossier_directory: Directory of dossier to be used for signing.
     codesign_path: Path to the codesign tool as a string.
+    allowed_entitlements: A list of strings indicating keys that are valid for
+      entitlements. If not None, only the strings listed here will be
+      transferred to the generated entitlements. If None, the entitlements found
+      with the dossier will be used directly for code signing.
     codesign_identity: The codesign identity to use for codesigning.
     executor: Asynchronous jobs Executor from concurrent.futures.
 
@@ -433,7 +504,8 @@ def _sign_embedded_bundles_with_manifest(
     codesign_future = executor.submit(_sign_bundle_with_manifest,
                                       embedded_bundle_path, embedded_manifest,
                                       dossier_directory, codesign_path,
-                                      codesign_identity, executor)
+                                      allowed_entitlements, codesign_identity,
+                                      executor)
     codesign_futures.append(codesign_future)
 
   return codesign_futures
@@ -537,12 +609,13 @@ def _sign_bundle(args):
   """
   bundle_path = args.bundle
   codesign_path = args.codesign
+  allowed_entitlements = args.allow_entitlement
   with extract_zipped_dossier_if_required(args.dossier) as dossier_directory:
     if not os.path.exists(bundle_path):
       raise OSError('Bundle doest not exist at path %s' % bundle_path)
     manifest = read_manifest_from_dossier(dossier_directory.path)
     _sign_bundle_with_manifest(bundle_path, manifest, dossier_directory.path,
-                               codesign_path)
+                               codesign_path, allowed_entitlements)
 
 
 def read_manifest_from_dossier(dossier_directory):

--- a/tools/dossier_codesigningtool/dossier_codesigning_reader_test.py
+++ b/tools/dossier_codesigningtool/dossier_codesigning_reader_test.py
@@ -15,8 +15,10 @@
 """Tests for dossier_codesigningtool."""
 
 import concurrent.futures
+import pathlib
+import shutil
+import tempfile
 import unittest
-
 from unittest import mock
 
 from tools.dossier_codesigningtool import dossier_codesigning_reader
@@ -55,6 +57,8 @@ _FAKE_MANIFEST = {
     'entitlements': 'fake.entitlements',
     'provisioning_profile': 'fake.mobileprovision'
 }
+
+_IPA_WORKSPACE_PATH = 'test/starlark_tests/targets_under_test/ios/app.ipa'
 
 
 class DossierCodesigningReaderTest(unittest.TestCase):
@@ -301,6 +305,134 @@ class DossierCodesigningReaderTest(unittest.TestCase):
     mock_future_not_done.cancel.assert_called()
     mock_future_exception.cancel.assert_not_called()
     mock_future_done.cancel.assert_not_called()
+
+  @mock.patch.object(dossier_codesigning_reader, '_sign_bundle_with_manifest')
+  @mock.patch.object(dossier_codesigning_reader, 'read_manifest_from_dossier')
+  @mock.patch.object(dossier_codesigning_reader,
+                     'extract_zipped_dossier_if_required')
+  def test_app_bundle_args(
+      self,
+      mock_extract_dossier,
+      mock_read_manifest,
+      mock_sign_bundle):
+    with tempfile.NamedTemporaryFile() as tmp_fake_codesign, \
+        tempfile.NamedTemporaryFile(suffix='.zip') as tmp_dossier_zip, \
+            tempfile.TemporaryDirectory(suffix='.app') as tmp_app_bundle:
+
+      dossier_dir = (
+          dossier_codesigning_reader.DossierDirectory('/tmp/dossier/', False)
+      )
+
+      mock_read_manifest.return_value = _FAKE_MANIFEST
+      mock_extract_dossier.return_value = dossier_dir
+
+      required_args = [
+          'sign',
+          '--codesign', tmp_fake_codesign.name,
+          '--dossier', tmp_dossier_zip.name,
+          tmp_app_bundle,
+      ]
+
+      args = dossier_codesigning_reader.generate_arg_parser().parse_args(
+          required_args
+      )
+      args.func(args)
+
+      mock_sign_bundle.assert_called_with(
+          tmp_app_bundle,
+          _FAKE_MANIFEST,
+          dossier_dir.path,
+          tmp_fake_codesign.name,
+          None,
+      )
+
+  @mock.patch.object(dossier_codesigning_reader, '_package_ipa')
+  @mock.patch.object(dossier_codesigning_reader, '_sign_bundle_with_manifest')
+  @mock.patch.object(dossier_codesigning_reader, '_extract_ipa')
+  @mock.patch.object(dossier_codesigning_reader, 'read_manifest_from_dossier')
+  @mock.patch.object(dossier_codesigning_reader,
+                     'extract_zipped_dossier_if_required')
+  def test_ipa_args(
+      self,
+      mock_extract_dossier,
+      mock_read_manifest,
+      mock_extract_ipa,
+      mock_sign_bundle,
+      mock_package):
+    with tempfile.NamedTemporaryFile() as tmp_fake_codesign, \
+        tempfile.NamedTemporaryFile(suffix='.zip') as tmp_dossier_zip, \
+            tempfile.NamedTemporaryFile(suffix='.ipa') as tmp_ipa_archive:
+
+      dossier_dir = (
+          dossier_codesigning_reader.DossierDirectory('/tmp/dossier/', False)
+      )
+
+      tmp_app_bundle = tempfile.TemporaryDirectory(suffix='.app')
+
+      mock_read_manifest.return_value = _FAKE_MANIFEST
+      mock_extract_dossier.return_value = dossier_dir
+      mock_extract_ipa.return_value = tmp_app_bundle
+
+      required_args = [
+          'sign',
+          '--codesign', tmp_fake_codesign.name,
+          '--dossier', tmp_dossier_zip.name,
+          '--output_artifact', '/tmp/dossier_output/output.ipa',
+          tmp_ipa_archive.name,
+      ]
+
+      args = dossier_codesigning_reader.generate_arg_parser().parse_args(
+          required_args
+      )
+      args.func(args)
+
+      mock_sign_bundle.assert_called_with(
+          tmp_app_bundle,
+          _FAKE_MANIFEST,
+          dossier_dir.path,
+          tmp_fake_codesign.name,
+          None,
+      )
+      mock_package.assert_called_once()
+
+  def test_combined_zip_args(self):
+    required_args = [
+        'sign',
+        '--codesign', '/usr/bin/codesign',
+        '--output_artifact', '/tmp/dossier_output/output.zip',
+        'input.zip',
+    ]
+
+    args = dossier_codesigning_reader.generate_arg_parser().parse_args(
+        required_args
+    )
+    with self.assertRaises(OSError):
+      args.func(args)
+
+  def test_ipa_extract_and_package_flow(self):
+    try:
+      working_dir = tempfile.mkdtemp()
+
+      extracted_bundle = dossier_codesigning_reader._extract_ipa(
+          working_dir, _IPA_WORKSPACE_PATH
+      )
+      extracted_bundle_path = pathlib.Path(extracted_bundle)
+      self.assertListEqual(
+          ['Payload', 'app.app'], list(extracted_bundle_path.parts)[-2:]
+      )
+      try:
+        output_dir = tempfile.mkdtemp()
+        output_ipa_path = pathlib.Path(output_dir, 'output.ipa')
+        dossier_codesigning_reader._package_ipa(
+            working_dir, str(output_ipa_path)
+        )
+        if not output_ipa_path.is_file():
+          self.fail('output ipa was not created!')
+      finally:
+        shutil.rmtree(output_dir)
+    finally:
+      shutil.rmtree(working_dir)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
PiperOrigin-RevId: 494790202
(cherry picked from commit 9a9726b206d4a020697dfff1192ebb4d8713734f)
