### PR TITLE
Introduce custom_transition_allowlist_attr on rule_attrs

### DIFF
--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -77,10 +77,6 @@ The `lipo` tool is used to combine built binaries of multiple architectures.
         rule_attrs.common_attrs,
         rule_attrs.platform_attrs(),
         {
-            # Required to use the Apple Starlark rule and split transitions.
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
             "binary": attr.label(
                 mandatory = True,
                 cfg = transition_support.apple_platform_split_transition,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -2462,11 +2462,8 @@ Targets created with `macos_command_line_application` can be executed using
         rule_attrs.provisioning_profile_attrs(
             profile_extension = ".provisionprofile",
         ),
+        rule_attrs.custom_transition_allowlist_attr,
         {
-            # Required to use the Apple Starlark rule and split transitions.
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
             "infoplists": attr.label_list(
                 allow_files = [".plist"],
                 doc = """
@@ -2513,6 +2510,7 @@ macos_dylib = rule_factory.create_apple_rule(
         ),
         rule_attrs.bundle_id_attrs(is_mandatory = False),
         rule_attrs.common_tool_attrs,
+        rule_attrs.custom_transition_allowlist_attr,
         rule_attrs.platform_attrs(
             add_environment_plist = True,
             platform_type = "macos",
@@ -2521,10 +2519,6 @@ macos_dylib = rule_factory.create_apple_rule(
             profile_extension = ".provisionprofile",
         ),
         {
-            # Required to use the Apple Starlark rule and split transitions.
-            "_allowlist_function_transition": attr.label(
-                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
             "infoplists": attr.label_list(
                 allow_files = [".plist"],
                 doc = """

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -73,6 +73,13 @@ _COMMON_TOOL_ATTRS = dicts.add(
     apple_toolchain_utils.shared_attrs(),
 )
 
+# Returns required attribute to use Starlark defined custom transitions
+_CUSTOM_TRANSITION_ALLOWLIST_ATTR = {
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}
+
 def _cc_toolchain_forwarder_attrs(*, deps_cfg):
     """Returns dictionary with the cc_toolchain_forwarder attribute for toolchain and platform info.
 
@@ -611,6 +618,7 @@ _test_bundle_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBun
 rule_attrs = struct(
     common_attrs = _COMMON_ATTRS,
     common_tool_attrs = _COMMON_TOOL_ATTRS,
+    custom_transition_allowlist_attr = _CUSTOM_TRANSITION_ALLOWLIST_ATTR,
     cc_toolchain_forwarder_attrs = _cc_toolchain_forwarder_attrs,
     static_library_linking_attrs = _static_library_linking_attrs,
     binary_linking_attrs = _binary_linking_attrs,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -128,8 +128,7 @@ def _create_apple_rule(
 
     # Add required attribute for allowlisting custom Starlark transition.
     # attrs is redefined to allow define their own custom transition allowlist attr.
-    if cfg != apple_common.multi_arch_split:
-        attrs = [rule_attrs.custom_transition_allowlist_attr] + attrs
+    attrs = [rule_attrs.custom_transition_allowlist_attr] + attrs
 
     return rule(
         implementation = implementation,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -126,17 +126,14 @@ def _create_apple_rule(
     if predeclared_outputs:
         extra_args["outputs"] = predeclared_outputs
 
+    # Add required attribute for allowlisting custom Starlark transition.
+    # attrs is redefined to allow define their own custom transition allowlist attr.
+    if cfg != apple_common.multi_arch_split:
+        attrs = [rule_attrs.custom_transition_allowlist_attr] + attrs
+
     return rule(
         implementation = implementation,
-        attrs = dicts.add(
-            {
-                # Required to use the Apple Starlark rule and split transitions.
-                "_allowlist_function_transition": attr.label(
-                    default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-                ),
-            },
-            *attrs
-        ),
+        attrs = dicts.add(*attrs),
         cfg = cfg,
         doc = doc,
         executable = is_executable,


### PR DESCRIPTION
This change adds a new shared rule attribute on rule_attrs to reference
Starlark custom transition allowlist attr required for rules using custom
transitions.

Similarly, modified rule_factory to only include that attribute if the
rule configuration is not apple_common.multi_arch_split.

PiperOrigin-RevId: 496724364
(cherry picked from commit f5889bf51bff449092b97d532cf015fc9fe7c301)
