### PR TITLE
Add support to test file permissions to archive_content_test

### DIFF
--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -667,3 +667,43 @@ function assert_strings_is_text() {
   local path_in_archive="$2"
   assert_plist_is_text "$archive" "$path_in_archive"
 }
+
+
+# Usage: assert_permissions_equal <file> <expected_permissions>
+#
+# Asserts a file (numerical) permissions from `file` are equal to an
+# expected (numerical) permissions.
+#
+# This functions allows two types of assertions:
+#
+#   1) Test using 'user', 'group', and 'other' permissions bits.
+#
+#     Example: 755 -> rwxr-xr-x
+#
+#   2) Test using all permissions bits:
+#     - file type bits.
+#     - sticky bit.
+#     - (user, group, and other) permissions bits.
+#
+#     Examples:
+#       120755 -> lrwxr-xr-x (symbolic link)
+#       100755 -> -rwxr-xr-x (regular file)
+#       40755 -> drwxr-xr-x (directory)
+function assert_permissions_equal() {
+  local file="$1"
+  local expected_permissions="$2"
+
+  local actual_permissions
+  # Check if the expected permissions string has 3 digits.
+  # If true, assertion will use user/group/other permissions bits.
+  # Otherwise assertion will use all permissions bits.
+  if [[ ${#expected_permissions} == 3 ]]; then
+    # Test using 'user', 'group', and 'other' permissions bits.
+    actual_permissions=$(stat -f "%Lp" "$file")
+  else
+    # Test using all permissions bits.
+    actual_permissions=$(stat -f "%p" "$file")
+  fi
+
+  assert_equals "$expected_permissions" "$actual_permissions"
+}

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -163,6 +163,11 @@ def macos_application_test_suite(name):
             "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Headers/SharedClass.h",
             "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Modules/module.modulemap",
         ],
+        assert_file_permissions = {
+            "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Resources": "755",
+            "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/Resources/Info.plist": "644",
+            "$CONTENT_ROOT/Frameworks/generated_macos_dynamic_fmwk.framework/generated_macos_dynamic_fmwk": "755",
+        },
         tags = [name],
     )
 

--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -23,43 +23,68 @@ newline=$'\n'
 # variables.
 #
 # Supported operations:
-#  CONTAINS: takes a list of files to test for existance. The filename will be
+#
+#  Archive contents tests:
+#
+#  - CONTAINS: takes a list of files to test for existance. The filename will be
 #      expanded with bash and can contain variables (e.g. $BUNDLE_ROOT)
-#  NOT_CONTAINS: takes a list of files to test for non-existance. The filename
+#  - NOT_CONTAINS: takes a list of files to test for non-existance. The filename
 #      will be expanded with bash and can contain variables (e.g. $BUNDLE_ROOT)
-#  IS_BINARY_PLIST: takes a list of paths to plist files and checks that they
+#
+#  Binary plist tests:
+#
+#  - IS_BINARY_PLIST: takes a list of paths to plist files and checks that they
 #      are `binary` format. Filenames are expanded with bash.
-#  IS_NOT_BINARY_PLIST: takes a list of paths to plist files and checks that
+#  - IS_NOT_BINARY_PLIST: takes a list of paths to plist files and checks that
 #      they are not `binary` format. Filenames are expanded with bash.
+#
+#  Property list (.plist) file tests:
+#
 #  PLIST_TEST_FILE: The plist file to test with `PLIST_TEST_VALUES`.
 #  PLIST_TEST_VALUES: Array for keys and values in the format "KEY VALUE" where
 #      the key is in PlistBuddy format(which can't contain spaces), followed by
 #      by a single space, followed by the value to test. * can be used as a
 #      wildcard value.
-#  ASSET_CATALOG_FILE: The Asset.car file to test with `ASSET_CATALOG_CONTAINS`.
-#  ASSET_CATALOG_CONTAINS: Array of asset names that should exist.
-#  ASSET_CATALOG_NOT_CONTAINS: Array of asset names that should not exist.
-#  TEXT_TEST_FILE: The text file to test with `TEXT_TEST_VALUES`.
-#  TEXT_TEST_VALUES: Array for regular expressions to test the contents of the
+#
+#  Asset catalog file tests:
+#
+#  - ASSET_CATALOG_FILE: The Asset.car file to test against.
+#  - ASSET_CATALOG_CONTAINS: Array of asset names that should exist.
+#  - ASSET_CATALOG_NOT_CONTAINS: Array of asset names that should not exist.
+#
+#  Text file tests:
+#
+#  - TEXT_TEST_FILE: The text file to test with `TEXT_TEST_VALUES`.
+#  - TEXT_TEST_VALUES: Array for regular expressions to test the contents of the
 #      text file with. Regular expressions must follow POSIX Basic Regular
 #      Expression (BRE) syntax.
-#  BINARY_NOT_CONTAINS_ARCHITECTURES: The architectures to verify are not in the
-#      assembled binary.
-#  BINARY_TEST_FILE: The file to test with `BINARY_TEST_SYMBOLS`
-#  BINARY_TEST_ARCHITECTURE: The architecture to use with `BINARY_TEST_SYMBOLS`.
-#  BINARY_CONTAINS_SYMBOLS: Array of symbols that should be present.
-#  BINARY_NOT_CONTAINS_SYMBOLS: Array of symbols that should not be present.
-#  BINARY_CONTAINS_REGEX_SYMBOLS: Array of regular expressions for symbols that
-#      should be present. Regular expressions must follow POSIX Extended Regular
-#      Expression (ERE) syntax.
-#  CODESIGN_INFO_CONTAINS: Array of codesign information that should
+#
+#  Linked binary file tests:
+#
+#  - BINARY_NOT_CONTAINS_ARCHITECTURES: The architectures to verify are not in
+#      the assembled binary.
+#  - BINARY_TEST_FILE: The binary file to test against.
+#  - BINARY_TEST_ARCHITECTURE: Architecture to use with `BINARY_TEST_SYMBOLS`.
+#  - BINARY_CONTAINS_SYMBOLS: Array of symbols that should be present.
+#  - BINARY_NOT_CONTAINS_SYMBOLS: Array of symbols that should not be present.
+#  - CODESIGN_INFO_CONTAINS: Array of codesign information that should
 #      be present.
-#  CODESIGN_INFO_NOT_CONTAINS: Array of codesign information that should
+#  - CODESIGN_INFO_NOT_CONTAINS: Array of codesign information that should
 #      not be present.
-#  MACHO_LOAD_COMMANDS_CONTAIN: Array of Mach-O load commands that should
+#
+#  Mach-O file tests:
+#
+#  - MACHO_LOAD_COMMANDS_CONTAIN: Array of Mach-O load commands that should
 #      be present.
-#  MACHO_LOAD_COMMANDS_NOT_CONTAIN: Array of Mach-O load commands that should
+#  - MACHO_LOAD_COMMANDS_NOT_CONTAIN: Array of Mach-O load commands that should
 #      not be present.
+#
+#  Archive file permissions tests:
+#  - ASSERT_FILE_PERMISSIONS: Array of "KEY VALUE" formatted strings where key
+#      specifies a bundle file path, and value is the expected numerical file
+#      permissions bits. See apple_shell_testutils' assert_permissions_equal
+#      for supported formats.
+
 
 something_tested=false
 
@@ -155,25 +180,6 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
       done
     fi
 
-    if [[ -n "${BINARY_CONTAINS_REGEX_SYMBOLS-}" ]]; then
-      for test_regex in "${BINARY_CONTAINS_REGEX_SYMBOLS[@]}"
-      do
-        something_tested=true
-        symbol_found=false
-        for actual_symbol in "${actual_symbols[@]}"
-        do
-          if [[ "$actual_symbol" =~ $test_regex ]]; then
-            symbol_found=true
-            break
-          fi
-        done
-        if [[ "$symbol_found" = false ]]; then
-            fail "Expected symbol \"$test_regex\" was not found. The " \
-              "symbols in the binary were:$newline${actual_symbols[@]}"
-        fi
-      done
-    fi
-
     if [[ -n "${BINARY_NOT_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
       do
@@ -196,10 +202,6 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       fail "Rule Misconfigured: Supposed to look for symbols," \
         "but no arch was set to check: ${BINARY_CONTAINS_SYMBOLS[@]}"
-    fi
-    if [[ -n "${BINARY_CONTAINS_REGEX_SYMBOLS-}" ]]; then
-      fail "Rule Misconfigured: Supposed to look for symbols," \
-        "but no arch was set to check: ${BINARY_CONTAINS_REGEX_SYMBOLS[@]}"
     fi
     if [[ -n "${BINARY_NOT_CONTAINS_SYMBOLS-}" ]]; then
       fail "Rule Misconfigured: Supposed to look for missing symbols," \
@@ -319,10 +321,6 @@ else
     fail "Rule Misconfigured: Supposed to look for missing symbols," \
       "but no binary was set to check: ${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
   fi
-  if [[ -n "${BINARY_CONTAINS_REGEX_SYMBOLS-}" ]]; then
-    fail "Rule Misconfigured: Supposed to look for regex symbols," \
-      "but no binary was set to check: ${BINARY_CONTAINS_REGEX_SYMBOLS[@]}"
-  fi
   if [[ -n "${MACHO_LOAD_COMMANDS_CONTAIN-}" ]]; then
     fail "Rule Misconfigured: Supposed to look for macho load commands," \
       "but no binary was set to check: ${BINARY_NOT_CONTAINS_SYMBOLS[@]}"
@@ -401,6 +399,18 @@ if [[ -n "${PLIST_TEST_VALUES-}" ]]; then
     if [[ "$value" != $expected_value ]]; then
       fail "Expected plist value \"$value\" at key \"$key\" to be \"$expected_value\""
     fi
+  done
+fi
+
+if [[ -n "${ASSERT_FILE_PERMISSIONS-}" ]]; then
+  for test_values in "${ASSERT_FILE_PERMISSIONS[@]}"
+  do
+    something_tested=true
+    # Keys and expected-values are in the format "KEY VALUE".
+    IFS=':' read -r path expected_permissions <<< "$test_values"
+
+    expanded_path=$(eval echo "$path")
+    assert_permissions_equal "$expanded_path" "$expected_permissions"
   done
 fi
 

--- a/test/starlark_tests/xcarchive_tests.bzl
+++ b/test/starlark_tests/xcarchive_tests.bzl
@@ -38,7 +38,7 @@ def xcarchive_test_suite(name):
         plist_test_file = "$BUNDLE_ROOT/Info.plist",
         plist_test_values = {
             "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
-            "ApplicationProperties:ArchiveVersion": 2,
+            "ApplicationProperties:ArchiveVersion": "2",
             "ApplicationProperties:CFBundleIdentifier": "com.google.example",
             "ApplicationProperties:CFBundleShortVersionString": "1.0",
             "ApplicationProperties:CFBundleVersion": "1.0",
@@ -58,7 +58,7 @@ def xcarchive_test_suite(name):
         plist_test_file = "$BUNDLE_ROOT/Info.plist",
         plist_test_values = {
             "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
-            "ApplicationProperties:ArchiveVersion": 2,
+            "ApplicationProperties:ArchiveVersion": "2",
             "ApplicationProperties:CFBundleIdentifier": "com.google.example",
             "ApplicationProperties:CFBundleShortVersionString": "1.0",
             "ApplicationProperties:CFBundleVersion": "1.0",


### PR DESCRIPTION
This change adds functionality to assert file permissions set
to a bundle file. Assertions allow testing against two types
of file permissions:

1) Test using 'user', 'group', and 'other' permissions bits.

  Example: 755 -> rwxr-xr-x

2) Test using all permissions bits:
  - file type bits.
  - sticky bit.
  - (user, group, and other) permissions bits.

  Examples:
    120755 -> lrwxr-xr-x (symbolic link)
    100755 -> -rwxr-xr-x (regular file)
    40755 -> drwxr-xr-x (directory)

PiperOrigin-RevId: 492296577
(cherry picked from commit 7df676fd5563fee6f2b29d647e0ccbe376c0d1ed)
