### PR TITLE
Add/omit the HeadersPath Info.plist key for XCFramework with static libraries.

### DIFF
--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -22,6 +22,10 @@ load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
+load(
+    "//test/starlark_tests/rules:infoplist_contents_test.bzl",
+    "infoplist_contents_test",
+)
 
 def apple_static_xcframework_test_suite(name):
     """Test suite for apple_static_xcframework.
@@ -29,6 +33,99 @@ def apple_static_xcframework_test_suite(name):
     Args:
       name: the base name to be used in things created by this macro
     """
+
+    # Test Objective-C(++) XCFramework Info.plist contents with and without public headers.
+    infoplist_contents_test(
+        name = "{}_objc_without_public_headers_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_objc_with_no_public_headers",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64",
+            "AvailableLibraries:0:LibraryPath": "ios_static_xcframework_objc_with_no_public_headers.a",
+            "AvailableLibraries:0:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:0:SupportedPlatform": "ios",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-arm64_x86_64-simulator",
+            "AvailableLibraries:1:LibraryPath": "ios_static_xcframework_objc_with_no_public_headers.a",
+            "AvailableLibraries:1:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:1:SupportedArchitectures:1": "x86_64",
+            "AvailableLibraries:1:SupportedPlatform": "ios",
+            "AvailableLibraries:1:SupportedPlatformVariant": "simulator",
+            "CFBundlePackageType": "XFWK",
+            "XCFrameworkFormatVersion": "1.0",
+        },
+        not_expected_keys = [
+            "AvailableLibraries:0:HeadersPath",
+            "AvailableLibraries:1:HeadersPath",
+        ],
+        tags = [name],
+    )
+    infoplist_contents_test(
+        name = "{}_objc_with_public_headers_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcframework_oldest_supported",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64",
+            "AvailableLibraries:0:LibraryPath": "ios_static_xcframework_oldest_supported.a",
+            "AvailableLibraries:0:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:0:SupportedPlatform": "ios",
+            "AvailableLibraries:0:HeadersPath": "Headers",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-arm64_x86_64-simulator",
+            "AvailableLibraries:1:LibraryPath": "ios_static_xcframework_oldest_supported.a",
+            "AvailableLibraries:1:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:1:SupportedArchitectures:1": "x86_64",
+            "AvailableLibraries:1:SupportedPlatform": "ios",
+            "AvailableLibraries:1:SupportedPlatformVariant": "simulator",
+            "AvailableLibraries:1:HeadersPath": "Headers",
+            "CFBundlePackageType": "XFWK",
+            "XCFrameworkFormatVersion": "1.0",
+        },
+        tags = [name],
+    )
+
+    # Test Swift XCFramework Info.plist contents with and without Swift generated headers.
+    infoplist_contents_test(
+        name = "{}_swift_without_generated_headers_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcfmwk_with_swift",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64",
+            "AvailableLibraries:0:LibraryPath": "ios_static_xcfmwk_with_swift.a",
+            "AvailableLibraries:0:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:0:SupportedPlatform": "ios",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-arm64_x86_64-simulator",
+            "AvailableLibraries:1:LibraryPath": "ios_static_xcfmwk_with_swift.a",
+            "AvailableLibraries:1:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:1:SupportedArchitectures:1": "x86_64",
+            "AvailableLibraries:1:SupportedPlatform": "ios",
+            "AvailableLibraries:1:SupportedPlatformVariant": "simulator",
+            "CFBundlePackageType": "XFWK",
+            "XCFrameworkFormatVersion": "1.0",
+        },
+        not_expected_keys = [
+            "AvailableLibraries:0:HeadersPath",
+            "AvailableLibraries:1:HeadersPath",
+        ],
+        tags = [name],
+    )
+    infoplist_contents_test(
+        name = "{}_with_swift_generated_header_infoplist_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_static_xcfmwk_with_swift_generated_headers",
+        expected_values = {
+            "AvailableLibraries:0:LibraryIdentifier": "ios-arm64",
+            "AvailableLibraries:0:LibraryPath": "ios_static_xcfmwk_with_swift_generated_headers.a",
+            "AvailableLibraries:0:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:0:SupportedPlatform": "ios",
+            "AvailableLibraries:0:HeadersPath": "Headers",
+            "AvailableLibraries:1:LibraryIdentifier": "ios-arm64_x86_64-simulator",
+            "AvailableLibraries:1:LibraryPath": "ios_static_xcfmwk_with_swift_generated_headers.a",
+            "AvailableLibraries:1:SupportedArchitectures:0": "arm64",
+            "AvailableLibraries:1:SupportedArchitectures:1": "x86_64",
+            "AvailableLibraries:1:SupportedPlatform": "ios",
+            "AvailableLibraries:1:SupportedPlatformVariant": "simulator",
+            "AvailableLibraries:1:HeadersPath": "Headers",
+            "CFBundlePackageType": "XFWK",
+            "XCFrameworkFormatVersion": "1.0",
+        },
+        tags = [name],
+    )
+
     archive_contents_test(
         name = "{}_ios_root_plist_test".format(name),
         build_type = "device",

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1002,6 +1002,25 @@ apple_static_xcframework(
 )
 
 apple_static_xcframework(
+    name = "ios_static_xcframework_objc_with_no_public_headers",
+    # TODO(b/239957001): Remove this when the rule no longer forces library
+    # evolution.
+    features = ["apple.no_legacy_swiftinterface"],
+    ios = {
+        "simulator": [
+            "x86_64",
+            "arm64",
+        ],
+        "device": ["arm64"],
+    },
+    minimum_os_versions = {
+        "ios": common.min_os_ios.oldest_supported,
+    },
+    tags = common.fixture_tags,
+    deps = [":fmwk_lib"],
+)
+
+apple_static_xcframework(
     name = "ios_static_xcfmwk_with_avoid_deps",
     avoid_deps = [":StaticFmwkLowerLib"],
     ios = {
@@ -1078,9 +1097,6 @@ apple_static_xcframework(
     minimum_os_versions = {
         "ios": common.min_os_ios.baseline,
     },
-    public_hdrs = [
-        "//test/starlark_tests/resources:shared.h",
-    ],
     tags = common.fixture_tags,
     deps = [":swift_lib_for_static_xcfmwk_with_headers"],
 )


### PR DESCRIPTION
An XCFramework with static libraries can include public
Objective-C(++) headers using the `public_hdrs` rule attribute,
or generated headers from the underlying Swift module.

This change updates the XCFramework Info.plist generation logic
to add or omit the `HeadersPath` key if there are any header files.

PiperOrigin-RevId: 499574821
(cherry picked from commit e00404ac6a4d1949674e6ed9e47d456660cd5d26)
