### PR TITLE
Give better error message when supplying bad data for families

### DIFF
--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -45,9 +45,15 @@ def _ui_device_family_plist_value(*, platform_prerequisites):
     families = platform_prerequisites.device_families
 
     for f in families:
-        number = _DEVICE_FAMILY_VALUES[f]
-        if number:
+        number = _DEVICE_FAMILY_VALUES.get(f, -1)
+        if number == -1:
+            fail("Unknown family value:`{}`. Valid values are:{}".format(
+                f,
+                _DEVICE_FAMILY_VALUES.keys(),
+            ))
+        elif number:
             family_ids.append(number)
+
     if family_ids:
         return family_ids
     return None


### PR DESCRIPTION
Before:
`Error: key "iPhone" not found in dictionary`

After:
`Error in fail: Unknown family value:'iPhone'. Valid values are:["iphone", "ipad", "tv", "watch", "mac"]`
PiperOrigin-RevId: 514773994

(cherry picked from commit 3db87ec8c30cc4944d39af91084da4ff74a96b78)
