### PR TITLE
Fix up test that should be pointing at `watchos`

### DIFF
--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -122,7 +122,7 @@ def watchos_extension_test_suite(name):
 
     dsyms_test(
         name = "{}_dsyms_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/tvos:ext",
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
         expected_direct_dsyms = ["ext_dsyms/ext.appex"],
         expected_transitive_dsyms = ["ext_dsyms/ext.appex"],
         tags = [name],


### PR DESCRIPTION
PiperOrigin-RevId: 515152228
(cherry picked from commit 8529d48bc2e1ef966756f300d2069312ba8d9bba)
