### PR TITLE
Add support to generate test macOS versioned frameworks.

### DIFF
--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -9,6 +9,8 @@ load(":apple_universal_binary_tests.bzl", "apple_universal_binary_test_suite")
 load(":apple_xcframework_import_tests.bzl", "apple_xcframework_import_test_suite")
 load(":apple_xcframework_tests.bzl", "apple_xcframework_test_suite")
 load(":dtrace_compile_tests.bzl", "dtrace_compile_test_suite")
+load(":generate_dynamic_xcframework_tests.bzl", "generate_dynamic_xcframework_test_suite")
+load(":generate_import_framework_tests.bzl", "generate_import_framework_test_suite")
 load(":ios_app_clip_tests.bzl", "ios_app_clip_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
@@ -73,6 +75,10 @@ apple_xcframework_test_suite(name = "apple_xcframework")
 apple_xcframework_import_test_suite(name = "apple_xcframework_import")
 
 dtrace_compile_test_suite(name = "dtrace_compile")
+
+generate_dynamic_xcframework_test_suite(name = "generate_dynamic_xcframework")
+
+generate_import_framework_test_suite(name = "generate_import_framework")
 
 ios_application_resources_test_suite(name = "ios_application_resources")
 
@@ -161,9 +167,7 @@ watchos_unit_test_test_suite(name = "watchos_unit_test")
 
 xcarchive_test_suite(name = "xcarchive")
 
-test_suite(
-    name = "all_tests",
-)
+test_suite(name = "all_tests")
 
 bzl_library(
     name = "starlark_tests_bzls",

--- a/test/starlark_tests/generate_dynamic_xcframework_tests.bzl
+++ b/test/starlark_tests/generate_dynamic_xcframework_tests.bzl
@@ -1,0 +1,78 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""generate_dynamic_xcframework Starlark tests."""
+
+load(
+    "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
+    "analysis_target_outputs_test",
+)
+
+def generate_dynamic_xcframework_test_suite(name):
+    """Test suite for generate_dynamic_xcframework.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+    analysis_target_outputs_test(
+        name = "{}_ios_frameworks_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:generated_dynamic_xcframework_with_headers",
+        expected_outputs = [
+            "generated_dynamic_xcframework_with_headers.xcframework/Info.plist",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_x86_64-simulator/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_x86_64-simulator/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_x86_64-simulator/generated_dynamic_xcframework_with_headers.framework/Headers/SharedClass.h",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_x86_64-simulator/generated_dynamic_xcframework_with_headers.framework/Headers/generated_dynamic_xcframework_with_headers.h",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_x86_64-simulator/generated_dynamic_xcframework_with_headers.framework/Modules/module.modulemap",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_arm64e/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_arm64e/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_arm64e/generated_dynamic_xcframework_with_headers.framework/Headers/SharedClass.h",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_arm64e/generated_dynamic_xcframework_with_headers.framework/Headers/generated_dynamic_xcframework_with_headers.h",
+            "generated_dynamic_xcframework_with_headers.xcframework/ios-arm64_arm64e/generated_dynamic_xcframework_with_headers.framework/Modules/module.modulemap",
+        ],
+        tags = [name],
+    )
+
+    analysis_target_outputs_test(
+        name = "{}_macos_versioned_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:generated_dynamic_macos_versioned_xcframework",
+        expected_outputs = [
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Headers/SharedClass.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Headers/generated_dynamic_macos_versioned_xcframework.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Modules/module.modulemap",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Resources/Info.plist",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/Headers/SharedClass.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/Headers/generated_dynamic_macos_versioned_xcframework.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/Modules/module.modulemap",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/Resources/Info.plist",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/generated_dynamic_macos_versioned_xcframework",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/B/Headers/SharedClass.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/B/Headers/generated_dynamic_macos_versioned_xcframework.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/B/Modules/module.modulemap",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/B/Resources/Info.plist",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/B/generated_dynamic_macos_versioned_xcframework",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/Headers/SharedClass.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/Headers/generated_dynamic_macos_versioned_xcframework.h",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/Modules/module.modulemap",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/Resources/Info.plist",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/generated_dynamic_macos_versioned_xcframework",
+            "generated_dynamic_macos_versioned_xcframework.xcframework/macos-arm64/generated_dynamic_macos_versioned_xcframework.framework/generated_dynamic_macos_versioned_xcframework",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/generate_import_framework_tests.bzl
+++ b/test/starlark_tests/generate_import_framework_tests.bzl
@@ -1,0 +1,122 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""generate_import_framework Starlark tests."""
+
+load(
+    "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
+    "analysis_target_outputs_test",
+    "make_analysis_target_outputs_test",
+)
+
+analysis_target_outputs_with_ios_platform_test = make_analysis_target_outputs_test(
+    config_settings = {
+        "//command_line_option:ios_multi_cpus": "x86_64",
+    },
+)
+
+def generate_import_framework_test_suite(name):
+    """Test suite for generate_import_framework.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+    analysis_target_outputs_test(
+        name = "{}_dynamic_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSDynamicFramework",
+        expected_outputs = [
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/iOSDynamicFramework",
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/Info.plist",
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/Headers/SharedClass.h",
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/Headers/iOSDynamicFramework.h",
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/Modules/module.modulemap",
+            "iOSDynamicFramework-intermediates/iOSDynamicFramework.framework/Resources/iOSDynamicFramework.bundle/Info.plist",
+        ],
+        tags = [name],
+    )
+
+    analysis_target_outputs_test(
+        name = "{}_static_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSStaticFramework",
+        expected_outputs = [
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/Headers/SharedClass.h",
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/Headers/iOSStaticFramework.h",
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/Modules/module.modulemap",
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/Resources/iOSStaticFramework.bundle/Info.plist",
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/iOSStaticFramework",
+            "iOSStaticFramework-intermediates/iOSStaticFramework.framework/Info.plist",
+        ],
+        tags = [name],
+    )
+
+    analysis_target_outputs_with_ios_platform_test(
+        name = "{}_swift_static_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSSwiftStaticFramework",
+        expected_outputs = [
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/iOSSwiftStaticFramework",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Info.plist",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Headers/swift_library-Swift.h",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Headers/iOSSwiftStaticFramework.h",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Modules/module.modulemap",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64.swiftinterface",
+            "iOSSwiftStaticFramework-intermediates/iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
+        ],
+        tags = [name],
+    )
+
+    analysis_target_outputs_with_ios_platform_test(
+        name = "{}_swift_without_module_interfaces_static_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSSwiftStaticFrameworkWithoutModuleInterfaces",
+        expected_outputs = [
+            "iOSSwiftStaticFrameworkWithoutModuleInterfaces-intermediates/iOSSwiftStaticFrameworkWithoutModuleInterfaces.framework/iOSSwiftStaticFrameworkWithoutModuleInterfaces",
+            "iOSSwiftStaticFrameworkWithoutModuleInterfaces-intermediates/iOSSwiftStaticFrameworkWithoutModuleInterfaces.framework/Info.plist",
+            "iOSSwiftStaticFrameworkWithoutModuleInterfaces-intermediates/iOSSwiftStaticFrameworkWithoutModuleInterfaces.framework/Headers/swift_library-Swift.h",
+            "iOSSwiftStaticFrameworkWithoutModuleInterfaces-intermediates/iOSSwiftStaticFrameworkWithoutModuleInterfaces.framework/Headers/iOSSwiftStaticFrameworkWithoutModuleInterfaces.h",
+            "iOSSwiftStaticFrameworkWithoutModuleInterfaces-intermediates/iOSSwiftStaticFrameworkWithoutModuleInterfaces.framework/Modules/module.modulemap",
+        ],
+        tags = [name],
+    )
+
+    analysis_target_outputs_test(
+        name = "{}_versioned_frameworks_outputs_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:generated_macos_dynamic_versioned_fmwk",
+        expected_outputs = [
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Headers/SharedClass.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Headers/generated_macos_dynamic_versioned_fmwk.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Modules/module.modulemap",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Resources/Info.plist",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/Headers/SharedClass.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/Headers/generated_macos_dynamic_versioned_fmwk.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/Modules/module.modulemap",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/Resources/Info.plist",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/generated_macos_dynamic_versioned_fmwk",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/B/Headers/SharedClass.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/B/Headers/generated_macos_dynamic_versioned_fmwk.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/B/Modules/module.modulemap",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/B/Resources/Info.plist",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/B/generated_macos_dynamic_versioned_fmwk",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/Headers/SharedClass.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/Headers/generated_macos_dynamic_versioned_fmwk.h",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/Modules/module.modulemap",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/Resources/Info.plist",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/generated_macos_dynamic_versioned_fmwk",
+            "generated_macos_dynamic_versioned_fmwk-intermediates/generated_macos_dynamic_versioned_fmwk.framework/generated_macos_dynamic_versioned_fmwk",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/rules/generate_framework.bzl
+++ b/test/starlark_tests/rules/generate_framework.bzl
@@ -49,6 +49,7 @@ def _generate_import_framework_impl(ctx):
 
     include_module_interface_files = ctx.attr.include_module_interface_files
     include_resource_bundle = ctx.attr.include_resource_bundle
+    include_versioned_frameworks = ctx.attr.include_versioned_frameworks
 
     target_os = _SDK_TO_OS[sdk]
 
@@ -154,13 +155,16 @@ def _generate_import_framework_impl(ctx):
     # Create framework bundle
     framework_files = generation_support.create_framework(
         actions = actions,
+        apple_fragment = apple_fragment,
         bundle_name = label.name,
         headers = headers,
         include_resource_bundle = include_resource_bundle,
+        include_versioned_frameworks = include_versioned_frameworks,
         label = label,
         library = library,
         module_interfaces = module_interfaces,
         target_os = target_os,
+        xcode_config = xcode_config,
     )
 
     return [
@@ -247,6 +251,16 @@ Flag to indicate if the Swift module interface files (i.e. `.swiftmodule` direct
 `swift_library` target should be included in the XCFramework bundle or discarded for testing
 purposes.
 """,
+        ),
+        # TODO(b/158696451): Remove attr and generate versioned frameworks for macOS/Catalyst by
+        # default when importing versioned frameworks is supported by both framework and XCFramework
+        # import rules.
+        "include_versioned_frameworks": attr.bool(
+            default = False,
+            doc = """
+Flag to indicate if the framework should include additional versions of the framework under the
+Versions directory. This is only supported for macOS platform.
+                """,
         ),
     }),
     fragments = ["apple"],

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -253,18 +253,22 @@ def _create_dynamic_library(
 def _create_framework(
         *,
         actions,
+        apple_fragment,
         base_path = "",
         bundle_name,
         label,
         library,
         headers,
         include_resource_bundle = False,
+        include_versioned_frameworks = False,
         module_interfaces = [],
-        target_os):
+        target_os,
+        xcode_config):
     """Creates an Apple platform framework bundle.
 
     Args:
         actions: The actions provider from `ctx.actions`.
+        apple_fragment: An Apple fragment (ctx.fragments.apple).
         base_path: Base path for the generated archive file (optional).
         bundle_name: Name of the framework bundle.
         label: Label of the target being built.
@@ -272,15 +276,140 @@ def _create_framework(
         headers: List of header files for the framework bundle.
         include_resource_bundle: Boolean to indicate if a resource bundle should be added to
             the framework bundle (optional).
+        include_versioned_frameworks: Boolean to indicate if the framework should include additional
+            versions of the framework under the Versions directory.
         module_interfaces: List of Swift module interface files for the framework bundle (optional).
         target_os: The target Apple OS for the generated framework bundle.
+        xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
     Returns:
         List of files for a .framework bundle.
     """
     framework_files = []
-    framework_directory = paths.join(base_path, bundle_name + ".framework")
-    resources_directory = paths.join(framework_directory, "Resources")
+    bundle_directory = paths.join(base_path, bundle_name + ".framework")
 
+    is_macos_framework = target_os == "macos"
+
+    # macOS frameworks can include multiple framework versions under:
+    #     MyFramework.framework/Versions
+    #
+    # This directory can contain N framework versions, and special
+    # Current version whose contents are symlinks to the effective
+    # current framework version files (e.g. Versions/A). Finally,
+    # all top-level bundle files, are symlinks to the special
+    # Versions/Current directory.
+    framework_directories = [bundle_directory]
+    versions_directory = paths.join(bundle_directory, "Versions")
+
+    if is_macos_framework and include_versioned_frameworks:
+        framework_directories = [
+            paths.join(versions_directory, "A"),
+            paths.join(versions_directory, "B"),
+        ]
+
+    for framework_directory in framework_directories:
+        framework_files.append(
+            _copy_framework_library(
+                actions = actions,
+                apple_fragment = apple_fragment,
+                bundle_name = bundle_name,
+                framework_directory = framework_directory,
+                label = label,
+                library = library,
+                xcode_config = xcode_config,
+            ),
+        )
+
+    for framework_directory in framework_directories:
+        resources_directory = paths.join(framework_directory, "Resources")
+        infoplist_directory = resources_directory if is_macos_framework else framework_directory
+        framework_plist = intermediates.file(
+            actions = actions,
+            file_name = paths.join(infoplist_directory, "Info.plist"),
+            output_discriminator = None,
+            target_name = label.name,
+        )
+        actions.write(
+            output = framework_plist,
+            content = _FRAMEWORK_PLIST_TEMPLATE.format(bundle_name),
+        )
+        framework_files.append(framework_plist)
+
+    if headers:
+        for framework_directory in framework_directories:
+            framework_files.extend(
+                _copy_framework_headers_and_modulemap(
+                    actions = actions,
+                    headers = headers,
+                    bundle_name = bundle_name,
+                    framework_directory = framework_directory,
+                    label = label,
+                ),
+            )
+
+    if module_interfaces:
+        for framework_directory in framework_directories:
+            modules_path = paths.join(framework_directory, "Modules", bundle_name + ".swiftmodule")
+            framework_files.extend([
+                _copy_file(
+                    actions = actions,
+                    base_path = modules_path,
+                    file = interface_file,
+                    label = label,
+                )
+                for interface_file in module_interfaces
+            ])
+
+    if include_resource_bundle:
+        for framework_directory in framework_directories:
+            resources_directory = paths.join(framework_directory, "Resources")
+            resources_path = paths.join(resources_directory, bundle_name + ".bundle")
+
+            resource_file = intermediates.file(
+                actions = actions,
+                file_name = paths.join(resources_path, "Info.plist"),
+                output_discriminator = None,
+                target_name = label.name,
+            )
+            actions.write(output = resource_file, content = "Mock resource bundle")
+            framework_files.append(resource_file)
+
+    if is_macos_framework and include_versioned_frameworks:
+        framework_files.extend(
+            _create_macos_framework_symlinks(
+                actions = actions,
+                bundle_directory = bundle_directory,
+                framework_files = framework_files,
+                label = label,
+                versions_directory = versions_directory,
+            ),
+        )
+
+    return framework_files
+
+def _copy_framework_library(
+        *,
+        actions,
+        apple_fragment,
+        bundle_name,
+        framework_directory,
+        label,
+        library,
+        xcode_config):
+    """Copies a framework library into a target framework directory.
+
+    For macOS frameworks this requires updating the rpath to add the version path.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        apple_fragment: An Apple fragment (ctx.fragments.apple).
+        bundle_name: Name of the framework/XCFramework bundle.
+        framework_directory: Target .framework directory to copy files to.
+        label: Label of the target being built.
+        library: The library for the framework bundle.
+        xcode_config: The `apple_common.XcodeVersionConfig` provider from the context.
+    Returns:
+        File referencing copied framework library.
+    """
     framework_binary = intermediates.file(
         actions = actions,
         file_name = paths.join(framework_directory, bundle_name),
@@ -288,83 +417,148 @@ def _create_framework(
         target_name = label.name,
     )
 
-    actions.symlink(
-        output = framework_binary,
-        target_file = library,
-    )
-
-    infoplist_directory = resources_directory if target_os == "macos" else framework_directory
-    framework_plist = intermediates.file(
-        actions = actions,
-        file_name = paths.join(infoplist_directory, "Info.plist"),
-        output_discriminator = None,
-        target_name = label.name,
-    )
-    actions.write(
-        output = framework_plist,
-        content = _FRAMEWORK_PLIST_TEMPLATE.format(bundle_name),
-    )
-
-    framework_files.extend([framework_binary, framework_plist])
-
-    if headers:
-        headers_path = paths.join(framework_directory, "Headers")
-        framework_files.extend([
-            _copy_file(
-                actions = actions,
-                base_path = headers_path,
-                file = header,
-                label = label,
-            )
-            for header in headers
-        ])
-        umbrella_header = _generate_umbrella_header(
-            actions = actions,
-            bundle_name = bundle_name,
-            headers = headers,
-            headers_path = headers_path,
-            label = label,
-            is_framework_umbrella_header = True,
+    # Copy and modify binary rpath for macOS versioned framework.
+    # For all other platforms, symlink the framework binary as is.
+    if ".framework/Versions/" in framework_directory:
+        cp_command = "cp {src} {dest}".format(
+            src = library.path,
+            dest = framework_binary.path,
         )
-        framework_files.append(umbrella_header)
-
-        module_map_path = paths.join(framework_directory, "Modules")
-        framework_files.append(
-            _generate_module_map(
-                actions = actions,
-                bundle_name = bundle_name,
-                is_framework_module = True,
-                label = label,
-                module_map_path = module_map_path,
-                umbrella_header = umbrella_header,
+        install_name_tool_command = "install_name_tool -id {name} {file}".format(
+            name = "@rpath/{name}.framework/Versions/{version}/{name}".format(
+                name = bundle_name,
+                version = paths.basename(framework_directory),
+            ),
+            file = framework_binary.path,
+        )
+        apple_support.run_shell(
+            actions = actions,
+            apple_fragment = apple_fragment,
+            xcode_config = xcode_config,
+            outputs = [framework_binary],
+            inputs = [library],
+            command = "{cp_command} && {install_name_tool_command}".format(
+                cp_command = cp_command,
+                install_name_tool_command = install_name_tool_command,
             ),
         )
-
-    if module_interfaces:
-        modules_path = paths.join(framework_directory, "Modules", bundle_name + ".swiftmodule")
-        framework_files.extend([
-            _copy_file(
-                actions = actions,
-                base_path = modules_path,
-                file = interface_file,
-                label = label,
-            )
-            for interface_file in module_interfaces
-        ])
-
-    if include_resource_bundle:
-        resources_path = paths.join(resources_directory, bundle_name + ".bundle")
-
-        resource_file = intermediates.file(
-            actions = actions,
-            file_name = paths.join(resources_path, "Info.plist"),
-            output_discriminator = None,
-            target_name = label.name,
+    else:
+        actions.symlink(
+            output = framework_binary,
+            target_file = library,
         )
-        actions.write(output = resource_file, content = "Mock resource bundle")
-        framework_files.append(resource_file)
 
-    return framework_files
+    return framework_binary
+
+def _copy_framework_headers_and_modulemap(
+        *,
+        actions,
+        bundle_name,
+        framework_directory,
+        headers,
+        label):
+    """Copies headers and generates umbrella header and modulemap for a framework bundle.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        bundle_name: Name of the framework/XCFramework bundle.
+        framework_directory: Target .framework directory to copy files to.
+        headers: List of files referencing Objective-C(++) headers for the framework.
+        label: Label of the target being built.
+    Returns:
+        List of files referencing headers and modulemap for the framework bundle.
+    """
+    headers_path = paths.join(framework_directory, "Headers")
+    framework_headers = [
+        _copy_file(
+            actions = actions,
+            base_path = headers_path,
+            file = header,
+            label = label,
+        )
+        for header in headers
+    ]
+    umbrella_header = _generate_umbrella_header(
+        actions = actions,
+        bundle_name = bundle_name,
+        headers = headers,
+        headers_path = headers_path,
+        label = label,
+        is_framework_umbrella_header = True,
+    )
+    framework_headers.append(umbrella_header)
+
+    module_map_path = paths.join(framework_directory, "Modules")
+    framework_headers.append(
+        _generate_module_map(
+            actions = actions,
+            bundle_name = bundle_name,
+            is_framework_module = True,
+            label = label,
+            module_map_path = module_map_path,
+            umbrella_header = umbrella_header,
+        ),
+    )
+
+    return framework_headers
+
+def _create_macos_framework_symlinks(
+        *,
+        actions,
+        bundle_directory,
+        framework_files,
+        label,
+        versions_directory):
+    """Creates macOS framework symlinks for top-level and Current files.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        bundle_directory: Top-level directory for the target framework/XCFramework bundle.
+        framework_files: Target .framework directory to copy files to.
+        label: Label of the target being built.
+        versions_directory: 'Versions' directory for the target framework/XCFramework bundle.
+
+    Returns:
+        List of files referencing framework symlinks.
+    """
+    framework_symlinks = []
+    version_prefix = ".framework/Versions/A/"
+
+    current_framework_files = [f for f in framework_files if version_prefix in f.short_path]
+    current_version_dir = paths.join(versions_directory, "Current")
+
+    # We currently symlink each framework file into Versions/Current/<file_relpath>,
+    # instead of only symlinking Versions/Current -> Versions/A, due to Bazel limitations
+    # to create symlinks for a given path instead of a file. Once symlinking to a target
+    # path is out of experimental, this can be revisited to symlink directories.
+    for framework_file in current_framework_files:
+        rfind_index = framework_file.short_path.rfind(version_prefix)
+        file_relpath = framework_file.short_path[rfind_index + len(version_prefix):]
+        file_relpath_dir = paths.dirname(file_relpath)
+
+        versions_current_file = _copy_file(
+            actions = actions,
+            base_path = paths.join(
+                current_version_dir,
+                file_relpath_dir,
+            ),
+            file = framework_file,
+            label = label,
+        )
+        top_level_file = _copy_file(
+            actions = actions,
+            base_path = paths.join(
+                bundle_directory,
+                file_relpath_dir,
+            ),
+            file = versions_current_file,
+            label = label,
+        )
+
+        framework_symlinks.append(versions_current_file)
+        framework_symlinks.append(top_level_file)
+
+    return framework_symlinks
 
 def _copy_file(*, actions, base_path = "", file, label, target_filename = None):
     """Copies file to a target directory.

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2090,6 +2090,16 @@ generate_import_framework(
     tags = common.fixture_tags,
 )
 
+generate_import_framework(
+    name = "generated_macos_dynamic_versioned_fmwk",
+    archs = ["x86_64"],
+    include_versioned_frameworks = True,
+    libtype = "dynamic",
+    minimum_os_version = common.min_os_macos.baseline,
+    sdk = "macosx",
+    tags = common.fixture_tags,
+)
+
 # ---------------------------------------------------------------------------------------
 # Targets for Apple dynamic XCFramework import tests.
 
@@ -2134,6 +2144,21 @@ generate_dynamic_xcframework(
             "arm64",
             "arm64e",
             "x86_64",
+        ],
+    },
+)
+
+generate_dynamic_xcframework(
+    name = "generated_dynamic_macos_versioned_xcframework",
+    srcs = ["//test/starlark_tests/resources/frameworks:SharedClass.m"],
+    hdrs = ["//test/starlark_tests/resources/frameworks:SharedClass.h"],
+    include_versioned_frameworks = True,
+    minimum_os_versions = {
+        "macos": common.min_os_macos.arm64_support,
+    },
+    platforms = {
+        "macos": [
+            "arm64",
         ],
     },
 )


### PR DESCRIPTION
This change add support to generate versioned frameworks to
both generate_dynamic_xcframework and generate_import_framework
test rules.

Adding support to generate test versioned frameworks allows us
to test importing macOS versioned frameworks to importing rules
when support is added to all bundling rules.

PiperOrigin-RevId: 501680635
(cherry picked from commit 9e8cafa0ecc65bff2485c5a3ab2b6d26f850626c)
