### PR TITLE
Use ditto instead of shutil to archive processed imported frameworks

### DIFF
--- a/tools/imported_dynamic_framework_processor/BUILD
+++ b/tools/imported_dynamic_framework_processor/BUILD
@@ -11,6 +11,7 @@ py_binary(
     deps = [
         "//tools/bitcode_strip",
         "//tools/codesigningtool:codesigningtool_lib",
+        "//tools/wrapper_common:execute",
         "//tools/wrapper_common:lipo",
     ],
 )

--- a/tools/wrapper_common/BUILD
+++ b/tools/wrapper_common/BUILD
@@ -8,6 +8,7 @@ py_library(
         "//tools/bitcode_strip:__pkg__",
         "//tools/codesigningtool:__pkg__",
         "//tools/dossier_codesigningtool:__pkg__",
+        "//tools/imported_dynamic_framework_processor:__pkg__",
         "//tools/swift_stdlib_tool:__pkg__",
         "//tools/xcarchivetool:__pkg__",
         "//tools/xctoolrunner:__pkg__",


### PR DESCRIPTION
This change adopts ditto instead of shutil to archive imported
frameworks to the imported_dynamic_framework_processor tool.

PiperOrigin-RevId: 501931683
(cherry picked from commit 1d25a1bad4d9bd5093e1b985987600cce72e9f9a)
