### PR TITLE
Refactor imported framework processor parser.

### DIFF
--- a/tools/imported_dynamic_framework_processor/BUILD
+++ b/tools/imported_dynamic_framework_processor/BUILD
@@ -9,10 +9,30 @@ py_binary(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//tools/imported_dynamic_framework_processor:imported_dynamic_framework_processor_lib",
+    ],
+)
+
+py_library(
+    name = "imported_dynamic_framework_processor_lib",
+    srcs = ["imported_dynamic_framework_processor.py"],
+    srcs_version = "PY3",
+    visibility = [
+        "//apple/internal:__pkg__",
+    ],
+    deps = [
         "//tools/bitcode_strip",
         "//tools/codesigningtool:codesigningtool_lib",
         "//tools/wrapper_common:lipo",
     ],
+)
+
+py_test(
+    name = "imported_dynamic_framework_processor_test",
+    srcs = ["imported_dynamic_framework_processor_test.py"],
+    python_version = "PY3",
+    tags = ["requires-darwin"],
+    deps = [":imported_dynamic_framework_processor_lib"],
 )
 
 # Consumed by bazel tests.

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -193,8 +193,8 @@ def main() -> None:
 
   _strip_or_copy_binary(
       framework_binary=args.framework_binary,
-      strip_bitcode=args.strip_bitcode,
       output_path=args.temp_path,
+      strip_bitcode=args.strip_bitcode,
       requested_archs=args.slice)
 
   for framework_file in args.framework_file:

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor.py
@@ -92,10 +92,11 @@ def _strip_framework_binary(framework_binary, output_path, slices_needed):
   lipo.invoke_lipo(framework_binary, slices_needed, temp_framework_path)
 
 
-def main():
+def _get_parser():
+  """Returns command line arguments parser extending codesigningtool parser."""
   parser = codesigningtool.generate_arg_parser()
   parser.add_argument(
-      "--framework_binary", type=str, required=True, action="append",
+      "--framework_binary", type=str, required=True,
       help="path to a binary file scoped to one of the imported frameworks"
   )
   parser.add_argument(
@@ -107,8 +108,12 @@ def main():
       "bitcode from the imported frameworks."
   )
   parser.add_argument(
-      "--framework_file", type=str, action="append", help="path to a file "
-      "scoped to one of the imported frameworks, distinct from the binary files"
+      "--framework_file",
+      type=str,
+      default=[],
+      action="append",
+      help=("path to a file scoped to one of the imported"
+            " frameworks, distinct from the binary files")
   )
   parser.add_argument(
       "--temp_path", type=str, required=True, help="temporary path to copy "
@@ -118,10 +123,17 @@ def main():
       "--output_zip", type=str, required=True, help="path to save the zip file "
       "containing a codesigned, lipoed version of the imported framework"
   )
+
+  return parser
+
+
+def main() -> None:
+  """Copies/link framework files and copy/thin framework binaries."""
+  parser = _get_parser()
   args = parser.parse_args()
 
   all_binary_archs = args.slice
-  framework_archs, _ = lipo.find_archs_for_binaries(args.framework_binary)
+  framework_archs, _ = lipo.find_archs_for_binaries([args.framework_binary])
 
   if not framework_archs:
     return 1
@@ -133,26 +145,25 @@ def main():
     os.remove(args.output_zip)
   os.makedirs(args.temp_path)
 
-  for framework_binary in args.framework_binary:
-    # If the imported framework is single architecture, and therefore assumed
-    # that it doesn't need to be lipoed, or if the binary architectures match
-    # the framework architectures perfectly, treat as a copy instead of a lipo
-    # operation.
-    if len(framework_archs) == 1 or all_binary_archs == framework_archs:
-      status_code = _copy_framework_file(framework_binary,
-                                         executable=True,
-                                         output_path=args.temp_path)
-    else:
-      slices_needed = framework_archs.intersection(all_binary_archs)
-      if not slices_needed:
-        print("Error: Precompiled framework does not share any binary "
-              "architectures with the binaries that were built.")
-        return 1
-      status_code = _strip_framework_binary(framework_binary,
-                                            args.temp_path,
-                                            slices_needed)
-    if status_code:
+  # If the imported framework is single architecture, and therefore assumed
+  # that it doesn't need to be lipoed, or if the binary architectures match
+  # the framework architectures perfectly, treat as a copy instead of a lipo
+  # operation.
+  if len(framework_archs) == 1 or all_binary_archs == framework_archs:
+    status_code = _copy_framework_file(args.framework_binary,
+                                       executable=True,
+                                       output_path=args.temp_path)
+  else:
+    slices_needed = framework_archs.intersection(all_binary_archs)
+    if not slices_needed:
+      print("Error: Precompiled framework does not share any binary "
+            "architectures with the binaries that were built.")
       return 1
+    status_code = _strip_framework_binary(args.framework_binary,
+                                          args.temp_path,
+                                          slices_needed)
+  if status_code:
+    return 1
 
     # Strip bitcode from the output framework binary
     if args.strip_bitcode:

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
@@ -1,0 +1,107 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for xcframework_processor_tool."""
+
+import unittest
+from unittest import mock
+
+from build_bazel_rules_apple.tools.imported_dynamic_framework_processor import imported_dynamic_framework_processor
+from build_bazel_rules_apple.tools.wrapper_common import lipo
+
+
+class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
+
+  @mock.patch.object(lipo, "find_archs_for_binaries")
+  def test_strip_or_copy_binary_fails_with_no_binary_archs(
+      self, mock_lipo):
+    with self.assertRaisesRegex(
+        ValueError,
+        "Could not find binary architectures for binaries using lipo.*"):
+      mock_lipo.return_value = (None, None)
+      imported_dynamic_framework_processor._strip_or_copy_binary(
+          framework_binary="/tmp/path/to/fake/binary",
+          output_path="/tmp/path/to/outputs",
+          requested_archs=["x86_64"])
+
+  @mock.patch.object(lipo, "find_archs_for_binaries")
+  def test_strip_or_copy_binary_fails_with_no_matching_archs(
+      self, mock_lipo):
+    with self.assertRaisesRegex(
+        ValueError,
+        ".*Precompiled framework does not share any binary architecture.*"):
+      mock_lipo.return_value = (set(["x86_64"]), None)
+      imported_dynamic_framework_processor._strip_or_copy_binary(
+          framework_binary="/tmp/path/to/fake/binary",
+          output_path="/tmp/path/to/outputs",
+          requested_archs=["arm64"])
+
+  @mock.patch.object(lipo, "find_archs_for_binaries")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_copy_framework_file")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_strip_framework_binary")
+  def test_strip_or_copy_binary_thins_framework_binary(
+      self, mock_strip_framework_binary, mock_copy_framework_file, mock_lipo):
+    mock_lipo.return_value = (set(["x86_64", "arm64"]), None)
+    imported_dynamic_framework_processor._strip_or_copy_binary(
+        framework_binary="/tmp/path/to/fake/binary",
+        output_path="/tmp/path/to/outputs",
+        requested_archs=["arm64"])
+
+    mock_copy_framework_file.assert_not_called()
+    mock_strip_framework_binary.assert_called_with(
+        "/tmp/path/to/fake/binary",
+        "/tmp/path/to/outputs",
+        set(["arm64"]))
+
+  @mock.patch.object(lipo, "find_archs_for_binaries")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_copy_framework_file")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_strip_framework_binary")
+  def test_strip_or_copy_binary_skips_lipo_with_single_arch_binary(
+      self, mock_strip_framework_binary, mock_copy_framework_file, mock_lipo):
+    mock_lipo.return_value = (set(["arm64"]), None)
+    imported_dynamic_framework_processor._strip_or_copy_binary(
+        framework_binary="/tmp/path/to/fake/binary",
+        output_path="/tmp/path/to/outputs",
+        requested_archs=["arm64"])
+
+    mock_strip_framework_binary.assert_not_called()
+    mock_copy_framework_file.assert_called_with(
+        "/tmp/path/to/fake/binary",
+        executable=True,
+        output_path="/tmp/path/to/outputs")
+
+  @mock.patch.object(lipo, "find_archs_for_binaries")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_copy_framework_file")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_strip_framework_binary")
+  def test_strip_or_copy_binary_skips_lipo_with_matching_archs_bin(
+      self, mock_strip_framework_binary, mock_copy_framework_file, mock_lipo):
+    mock_lipo.return_value = (set(["x86_64", "arm64"]), None)
+    imported_dynamic_framework_processor._strip_or_copy_binary(
+        framework_binary="/tmp/path/to/fake/binary",
+        output_path="/tmp/path/to/outputs",
+        requested_archs=["x86_64", "arm64"])
+
+    mock_strip_framework_binary.assert_not_called()
+    mock_copy_framework_file.assert_called_with(
+        "/tmp/path/to/fake/binary",
+        executable=True,
+        output_path="/tmp/path/to/outputs")
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
@@ -16,8 +16,8 @@
 import unittest
 from unittest import mock
 
-from build_bazel_rules_apple.tools.imported_dynamic_framework_processor import imported_dynamic_framework_processor
-from build_bazel_rules_apple.tools.wrapper_common import lipo
+from tools.imported_dynamic_framework_processor import imported_dynamic_framework_processor
+from tools.wrapper_common import lipo
 
 
 class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
@@ -32,6 +32,7 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
       imported_dynamic_framework_processor._strip_or_copy_binary(
           framework_binary="/tmp/path/to/fake/binary",
           output_path="/tmp/path/to/outputs",
+          strip_bitcode=False,
           requested_archs=["x86_64"])
 
   @mock.patch.object(lipo, "find_archs_for_binaries")
@@ -44,6 +45,7 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
       imported_dynamic_framework_processor._strip_or_copy_binary(
           framework_binary="/tmp/path/to/fake/binary",
           output_path="/tmp/path/to/outputs",
+          strip_bitcode=False,
           requested_archs=["arm64"])
 
   @mock.patch.object(lipo, "find_archs_for_binaries")
@@ -57,6 +59,7 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
     imported_dynamic_framework_processor._strip_or_copy_binary(
         framework_binary="/tmp/path/to/fake/binary",
         output_path="/tmp/path/to/outputs",
+        strip_bitcode=False,
         requested_archs=["arm64"])
 
     mock_copy_framework_file.assert_not_called()
@@ -76,6 +79,7 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
     imported_dynamic_framework_processor._strip_or_copy_binary(
         framework_binary="/tmp/path/to/fake/binary",
         output_path="/tmp/path/to/outputs",
+        strip_bitcode=False,
         requested_archs=["arm64"])
 
     mock_strip_framework_binary.assert_not_called()
@@ -95,6 +99,7 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
     imported_dynamic_framework_processor._strip_or_copy_binary(
         framework_binary="/tmp/path/to/fake/binary",
         output_path="/tmp/path/to/outputs",
+        strip_bitcode=False,
         requested_archs=["x86_64", "arm64"])
 
     mock_strip_framework_binary.assert_not_called()


### PR DESCRIPTION
Refactors argument parser into it's own method, and removes
the 'append' action to the framework binary, since frameworks
can only have one binary at the '.framework' directory.

PiperOrigin-RevId: 501932106
(cherry picked from commit aa8d34bde6a9b6574f97c770700f7532029abeba)
