### PR TITLE
Add analysis failure for imported macOS versioned frameworks.

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -207,6 +207,14 @@ def _apple_dynamic_framework_import_impl(ctx):
     # TODO(b/207475773): Remove grep-includes once it's no longer required for cc_common APIs.
     grep_includes = ctx.file._grep_includes
 
+    target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
+    has_versioned_framework_files = framework_import_support.has_versioned_framework_files(
+        framework_imports,
+    )
+    if target_triplet.os == "macos" and has_versioned_framework_files:
+        # TODO(b/158696451): Add support to import macOS versioned frameworks.
+        fail("apple_dynamic_framework_import rule does not yet support macOS versioned frameworks.")
+
     providers = []
     framework = framework_import_support.classify_framework_imports(
         ctx.var,
@@ -223,7 +231,6 @@ def _apple_dynamic_framework_import_impl(ctx):
     )
 
     # Create AppleFrameworkImportInfo provider.
-    target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
     providers.append(framework_import_support.framework_import_info_with_dependencies(
         build_archs = [target_triplet.architecture],
         deps = deps,

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -450,9 +450,15 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     xcframework_imports = ctx.files.xcframework_imports
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
-    xcframework = _classify_xcframework_imports(ctx.var, xcframework_imports)
     target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
+    has_versioned_framework_files = framework_import_support.has_versioned_framework_files(
+        xcframework_imports,
+    )
+    if target_triplet.os == "macos" and has_versioned_framework_files:
+        # TODO(b/158696451): Add support to import XCFrameworks with macOS versioned frameworks.
+        fail("apple_dynamic_xcframework_import rule does not yet support macOS versioned frameworks.")
 
+    xcframework = _classify_xcframework_imports(ctx.var, xcframework_imports)
     if xcframework.bundle_type == _BUNDLE_TYPE.libraries:
         fail("Importing XCFrameworks with dynamic libraries is not supported.")
 

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -400,6 +400,19 @@ def _get_swift_module_files_with_target_triplet(target_triplet, swift_module_fil
 
     return filtered_files
 
+def _has_versioned_framework_files(framework_files):
+    """Returns True if there are any versioned framework files (i.e. under Versions/ directory).
+
+    Args:
+        framework_files: List of File references for imported framework or XCFramework files.
+    Returns:
+        True if framework files include any versioned frameworks. False otherwise.
+    """
+    for f in framework_files:
+        if ".framework/Versions/" in f.short_path:
+            return True
+    return False
+
 def _objc_provider_with_dependencies(
         *,
         additional_objc_provider_fields = {},
@@ -522,6 +535,7 @@ framework_import_support = struct(
     classify_framework_imports = _classify_framework_imports,
     framework_import_info_with_dependencies = _framework_import_info_with_dependencies,
     get_swift_module_files_with_target_triplet = _get_swift_module_files_with_target_triplet,
+    has_versioned_framework_files = _has_versioned_framework_files,
     objc_provider_with_dependencies = _objc_provider_with_dependencies,
     swift_info_from_module_interface = _swift_info_from_module_interface,
     swift_interop_info_with_dependencies = _swift_interop_info_with_dependencies,

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -372,6 +372,14 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify importing XCFramework with versioned frameworks fails.
+    analysis_failure_message_test(
+        name = "{}_fails_with_versioned_frameworks_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_versioned_xcframework",
+        expected_error = "apple_dynamic_xcframework_import rule does not yet support macOS versioned frameworks.",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -19,6 +19,14 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -34,10 +42,6 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
-)
-load(
-    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
-    "analysis_target_actions_test",
 )
 
 def macos_application_test_suite(name):
@@ -245,6 +249,14 @@ def macos_application_test_suite(name):
         expected_values = {
             "LSMinimumSystemVersion": "11.0",
         },
+        tags = [name],
+    )
+
+    # Verify importing macOS versioned framework fails.
+    analysis_failure_message_test(
+        name = "{}_fails_with_versioned_framework_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_versioned_fmwk",
+        expected_error = "apple_dynamic_framework_import rule does not yet support macOS versioned frameworks.",
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2200,6 +2200,7 @@ objc_library(
 
 apple_dynamic_xcframework_import(
     name = "imported_dynamic_versioned_xcframework",
+    tags = common.fixture_tags,
     visibility = ["//visibility:public"],
     xcframework_imports = [":generated_dynamic_macos_versioned_xcframework"],
 )

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2090,6 +2090,33 @@ generate_import_framework(
     tags = common.fixture_tags,
 )
 
+macos_application(
+    name = "app_with_imported_versioned_fmwk",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_versioned_fmwk_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_versioned_fmwk_depending_lib",
+    tags = common.fixture_tags,
+    deps = [":imported_dynamic_versioned_fmwk"],
+)
+
+apple_dynamic_framework_import(
+    name = "imported_dynamic_versioned_fmwk",
+    framework_imports = [":generated_macos_dynamic_versioned_fmwk"],
+    tags = common.fixture_tags,
+)
+
 generate_import_framework(
     name = "generated_macos_dynamic_versioned_fmwk",
     archs = ["x86_64"],
@@ -2146,6 +2173,35 @@ generate_dynamic_xcframework(
             "x86_64",
         ],
     },
+)
+
+macos_application(
+    name = "app_with_imported_dynamic_versioned_xcframework",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_versioned_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_versioned_xcframework_depending_lib",
+    tags = common.fixture_tags,
+    deps = [
+        ":imported_dynamic_versioned_xcframework",
+    ],
+)
+
+apple_dynamic_xcframework_import(
+    name = "imported_dynamic_versioned_xcframework",
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_dynamic_macos_versioned_xcframework"],
 )
 
 generate_dynamic_xcframework(


### PR DESCRIPTION
Since framework and XCFramework import rules do not support importing
macOS versioned frameworks, and the rest of the rules do not support
hanlding symbolic links from versioned frameworks, this change adds
an analysis failure when import rules detect versioned frameworks.

PiperOrigin-RevId: 501693445
(cherry picked from commit 39a5ea59b3de05b7f1bd8292a1f7a847303f20d5)
