### PR TITLE
Add Starlark tests for 'linkmaps' output group files.

### DIFF
--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -28,6 +28,10 @@ load(
     "make_analysis_failure_message_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -299,12 +303,21 @@ def apple_xcframework_test_suite(name):
         architectures = ["arm64"],
         tags = [name],
     )
-
     linkmap_test(
         name = "{}_simulator_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
         expected_linkmap_names = ["ios_dynamic_xcframework_ios_simulator"],
         architectures = ["x86_64"],
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "ios_dynamic_xcframework_ios_simulator_x86_64.linkmap",
+            "ios_dynamic_xcframework_ios_device_arm64.linkmap",
+        ],
         tags = [name],
     )
 
@@ -315,12 +328,23 @@ def apple_xcframework_test_suite(name):
         architectures = ["arm64", "arm64e"],
         tags = [name],
     )
-
     linkmap_test(
         name = "{}_fat_simulator_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_xcframework",
         expected_linkmap_names = ["ios_dynamic_lipoed_xcframework_ios_simulator"],
         architectures = ["x86_64", "arm64"],
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_multiple_architectures_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_lipoed_xcframework",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "ios_dynamic_lipoed_xcframework_ios_device_arm64.linkmap",
+            "ios_dynamic_lipoed_xcframework_ios_device_arm64e.linkmap",
+            "ios_dynamic_lipoed_xcframework_ios_simulator_arm64.linkmap",
+            "ios_dynamic_lipoed_xcframework_ios_simulator_x86_64.linkmap",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -19,6 +19,10 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -92,6 +96,16 @@ def ios_app_clip_test_suite(name):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_clip",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "app_clip_x86_64.linkmap",
+            "app_clip_arm64.linkmap",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -45,6 +45,10 @@ load(
     "entitlements_contents_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:dsyms_test.bzl",
     "dsyms_test",
 )
@@ -554,6 +558,16 @@ def ios_application_test_suite(name):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "app_x86_64.linkmap",
+            "app_arm64.linkmap",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -19,6 +19,10 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -134,6 +138,16 @@ def ios_extension_test_suite(name):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "ext_x86_64.linkmap",
+            "ext_arm64.linkmap",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
+++ b/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
@@ -1,0 +1,68 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark test rule for OutputGroupInfo output group files."""
+
+load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "assertions",
+)
+load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
+    "make_provider_test_rule",
+)
+
+visibility("//test/starlark_tests/...")
+
+def _get_output_group_files(ctx, provider):
+    """Returns list of files from a given output group from OutputGroupInfo."""
+    output_group_name = ctx.attr.output_group_name
+    if not hasattr(provider, output_group_name):
+        fail(
+            "OutputGroupInfo does not have output group: %s, available output groups are: %s" % (
+                output_group_name,
+                [x for x in dir(provider) if x not in ["to_json", "to_proto"]],
+            ),
+        )
+
+    return getattr(provider, output_group_name).to_list()
+
+analysis_output_group_info_files_test = make_provider_test_rule(
+    provider = OutputGroupInfo,
+    provider_fn = _get_output_group_files,
+    assertion_fn = (
+        lambda ctx, env, output_group_files: assertions.contains_files(
+            env = env,
+            expected_files = ctx.attr.expected_outputs,
+            actual_files = output_group_files,
+        )
+    ),
+    attrs = {
+        "output_group_name": attr.string(
+            mandatory = True,
+            doc = "Name of the output group to source files from.",
+        ),
+        "expected_outputs": attr.string_list(
+            mandatory = True,
+            doc = "List of relative output file paths expected as outputs of the output group.",
+        ),
+    },
+    config_settings = {
+        "//command_line_option:objc_generate_linkmap": "true",  # output_group: linkmaps
+        "//command_line_option:macos_cpus": "arm64,x86_64",
+        "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
+        "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
+        "//command_line_option:watchos_cpus": "arm64,x86_64",
+    },
+)

--- a/test/starlark_tests/rules/analysis_provider_test.bzl
+++ b/test/starlark_tests/rules/analysis_provider_test.bzl
@@ -1,0 +1,74 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark test macro to create `provider_test`-like rules."""
+
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+)
+
+visibility("//test/starlark_tests/...")
+
+def _make_provider_test_impl(provider, provider_fn, assertion_fn):
+    def _provider_test_impl(ctx):
+        env = analysistest.begin(ctx)
+        target_under_test = analysistest.target_under_test(env)
+
+        if provider not in target_under_test:
+            fail("Provider %s not found in target: %s" % (provider, target_under_test))
+
+        provider_info = target_under_test[provider]
+        provider_data = provider_fn(ctx, provider_info)
+        assertion_fn(ctx, env, provider_data)
+        return analysistest.end(env)
+
+    return _provider_test_impl
+
+def make_provider_test_rule(
+        *,
+        provider,
+        provider_fn = lambda _ctx, p: p,
+        assertion_fn,
+        attrs,
+        config_settings = {}):
+    """Returns a new `provider_test`-like rule for a specific provider with custom settings.
+
+    Args:
+        provider: Provider to key from target_under_test.
+        provider_fn: Callable to get information from provider, this callable should intake
+            two parameters:
+            - ctx: Rule context.
+            - provider: Provider keyed from target_under_test (ie. `target_under_test[provider]`).
+        assertion_fn: Callable to perform assertions against the provider info.
+            This callable should conform to the following signature `callable(ctx, env, provider)`:
+            - ctx: Rule context.
+            - env: analysistest environment (ie. `analysistest.begin()`)
+        attrs: Dictionary of rule attrs for the analysis phase test.
+        config_settings: A dictionary of configuration settings and their values
+            that should be applied during tests.
+
+    Returns:
+        A rule returned by `analysistest.make` that has the `provider_test` interface with the
+        given attrs, and config settings.
+    """
+    return analysistest.make(
+        _make_provider_test_impl(
+            provider = provider,
+            provider_fn = provider_fn,
+            assertion_fn = assertion_fn,
+        ),
+        attrs = attrs,
+        config_settings = config_settings,
+    )

--- a/test/starlark_tests/rules/analysis_target_outputs_test.bzl
+++ b/test/starlark_tests/rules/analysis_target_outputs_test.bzl
@@ -19,35 +19,22 @@ load(
     "build_settings_labels",
 )
 load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "assertions",
+)
+load(
     "@bazel_skylib//lib:unittest.bzl",
     "analysistest",
-    "asserts",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
 )
 
 def _analysis_target_outputs_test_impl(ctx):
     env = analysistest.begin(ctx)
-    expected_outputs = sets.make(ctx.attr.expected_outputs)
     target_under_test = analysistest.target_under_test(env)
-    target_files = target_under_test.files.to_list()
-    all_outputs = sets.make([
-        paths.relativize(file.short_path, target_under_test.label.package)
-        for file in target_files
-    ])
 
-    # Test that the expected outputs are contained within actual outputs
-    asserts.new_set_equals(
-        env,
-        expected_outputs,
-        sets.intersection(all_outputs, expected_outputs),
-        "{} not contained in {}".format(sets.to_list(expected_outputs), sets.to_list(all_outputs)),
+    assertions.contains_files(
+        env = env,
+        expected_files = ctx.attr.expected_outputs,
+        actual_files = target_under_test.files.to_list(),
     )
 
     return analysistest.end(env)

--- a/test/starlark_tests/rules/assertions.bzl
+++ b/test/starlark_tests/rules/assertions.bzl
@@ -1,0 +1,54 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark analysis test assertions for tests."""
+
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+    "asserts",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
+)
+
+visibility("//test/starlark_tests/...")
+
+def _contains_files(env, expected_files, actual_files):
+    target_under_test = analysistest.target_under_test(env)
+    expected_set = sets.make(expected_files)
+
+    all_outputs = sets.make([
+        paths.relativize(
+            file.short_path,
+            target_under_test.label.package,
+        )
+        for file in actual_files
+    ])
+
+    # Test that the expected outputs are contained within actual outputs
+    asserts.set_equals(
+        env,
+        expected_set,
+        sets.intersection(all_outputs, expected_set),
+    )
+
+assertions = struct(
+    contains_files = _contains_files,
+)

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -231,6 +235,16 @@ def tvos_application_test_suite(name):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "app_x86_64.linkmap",
+            "app_arm64.linkmap",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -23,6 +23,10 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -169,6 +173,16 @@ def watchos_extension_test_suite(name):
     linkmap_test(
         name = "{}_linkmap_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
+        tags = [name],
+    )
+    analysis_output_group_info_files_test(
+        name = "{}_linkmaps_output_group_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext",
+        output_group_name = "linkmaps",
+        expected_outputs = [
+            "ext_x86_64.linkmap",
+            "ext_arm64.linkmap",
+        ],
         tags = [name],
     )
 


### PR DESCRIPTION
This change introduces a new analysis phase Starlark test to verify
OutputGroupInfo files refactoring how analysis_target_outputs_test
verifies expected files from DefaultInfo to standarize across tests
asserting all files are found from the expected provider.

Additionally it introduces analysis_provider_test to allow extending
tests where we need to assert info from providers is correctly built.

PiperOrigin-RevId: 522665662
(cherry picked from commit 856b3e9f339052ce78a1d176eda89c22da1354cb)
