### PR TITLE
Recursively set the write permission on copied outputs of an Apple bundle rule's tree artifact, ensuring they can always be safely removed.

### DIFF
--- a/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
+++ b/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
@@ -36,6 +36,8 @@ if [[ -n "$ARCHIVE_PATH" ]]; then
   if [ -d "$ARCHIVE_PATH/" ];
   then
     cp -rf "$ARCHIVE_PATH" "$ARCHIVE_ROOT"
+    # Set write permission to allow for safe file removal in test cleanup.
+    chmod -R +w "$ARCHIVE_ROOT"
   else
     unzip -qq "$ARCHIVE_PATH" -d "$ARCHIVE_ROOT"
   fi


### PR DESCRIPTION
PiperOrigin-RevId: 520445162
(cherry picked from commit 7c16ac8f5a2c07e7252d999a4889ed48b5cc8e4c)
