### PR TITLE
Remove the unused entitlements attribute from test bundling rules.

### DIFF
--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -108,7 +108,6 @@ _ios_internal_ui_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),
@@ -186,7 +185,6 @@ _ios_internal_unit_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -110,7 +110,6 @@ _macos_internal_ui_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.macos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),
@@ -191,7 +190,6 @@ _macos_internal_unit_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.macos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -114,7 +114,6 @@ _tvos_internal_ui_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.tvos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),
@@ -186,7 +185,6 @@ _tvos_internal_unit_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.tvos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -110,7 +110,6 @@ _watchos_internal_ui_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.watchos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),
@@ -171,7 +170,6 @@ _watchos_internal_unit_test_bundle = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.watchos,
             is_mandatory = False,
         ),
-        rule_attrs.entitlements_attrs,
         rule_attrs.infoplist_attrs(
             default_infoplist = rule_attrs.defaults.test_bundle_infoplist,
         ),


### PR DESCRIPTION
PiperOrigin-RevId: 525189960
(cherry picked from commit 3188dfe248cee2073772cebfe22aa897ba862e9a)
