### PR TITLE
Add Starlark tests for 'linkmaps' output group files.

### DIFF
--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -28,6 +28,10 @@ load(
     "analysis_output_group_info_files_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
+)
+load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )


### PR DESCRIPTION
This change introduces a new analysis phase Starlark test to verify
OutputGroupInfo files refactoring how analysis_target_outputs_test
verifies expected files from DefaultInfo to standarize across tests
asserting all files are found from the expected provider.

Additionally it introduces analysis_provider_test to allow extending
tests where we need to assert info from providers is correctly built.

PiperOrigin-RevId: 522665662
(cherry picked from commit 856b3e9f339052ce78a1d176eda89c22da1354cb)
