### PR TITLE
Avoid duplicate symbols in different libraries.

### DIFF
--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -440,7 +440,6 @@ apple_resource_group(
 
 objc_library(
     name = "structured_resources_in_resources_lib",
-    srcs = ["main.m"],
     data = [
         ":structured_resources_in_resources",
     ],
@@ -456,7 +455,6 @@ apple_resource_group(
 
 objc_library(
     name = "processed_resources_in_structured_resources_lib",
-    srcs = ["main.m"],
     data = [
         ":processed_resources_in_structured_resources",
     ],
@@ -591,7 +589,6 @@ objc_library(
 
 objc_library(
     name = "ios_non_localized_assets_lib",
-    srcs = ["main.m"],
     data = [
         ":assets",
         ":mapping_model",
@@ -625,7 +622,6 @@ objc_library(
 
 objc_library(
     name = "ios_localized_assets_lib",
-    srcs = ["main.m"],
     data = [
         ":localized_generic_resources",
         ":localized_plists",
@@ -638,7 +634,6 @@ objc_library(
 
 objc_library(
     name = "apple_non_localized_assets_lib",
-    srcs = ["main.m"],
     data = [
         ":mapping_model",
         ":nonlocalized.plist",
@@ -652,7 +647,6 @@ objc_library(
 
 objc_library(
     name = "apple_localized_assets_lib",
-    srcs = ["main.m"],
     data = [
         ":localized_generic_resources",
         ":localized_plists",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -774,11 +774,20 @@ objc_library(
 
 objc_library(
     name = "main_lib_with_fmwk_lib_dep",
-    srcs = [
-        "//test/starlark_tests/resources:main.m",
-    ],
+    srcs = [":main_lib_with_fmwk_lib_dep_file"],
     tags = common.fixture_tags,
     deps = [":fmwk_lib"],
+)
+
+write_file(
+    name = "main_lib_with_fmwk_lib_dep_file",
+    out = "main_lib_with_fmwk_lib_dep_file.m",
+    content = ["""
+int main() {
+  return 0;
+}
+"""],
+    tags = common.fixture_tags,
 )
 
 # ---------------------------------------------------------------------------------------
@@ -1801,7 +1810,7 @@ write_file(
     content = ["""
 #import <iOSDynamicFramework/iOSDynamicFramework.h>
 
-int main() {
+int dynamic_fmwk_depending_lib_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -1842,7 +1851,7 @@ write_file(
     content = ["""
 import iOSDynamicFramework
 
-func main() {
+func dynamic_fmwk_depending_swift_lib_function() {
   let sharedClass = SharedClass()
   sharedClass.doSomethingShared()
 }
@@ -1958,7 +1967,7 @@ write_file(
     content = ["""
 #import <iOSStaticFramework/iOSStaticFramework.h>
 
-int main() {
+int static_fmwk_depending_lib_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -1999,7 +2008,7 @@ write_file(
     content = ["""
 #import <iOSSwiftStaticFramework/iOSSwiftStaticFramework.h>
 
-int main() {
+int swift_static_fmwk_depending_lib_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2037,7 +2046,7 @@ write_file(
     content = ["""
 #import <iOSSwiftStaticFrameworkWithoutModuleInterfaces/iOSSwiftStaticFrameworkWithoutModuleInterfaces.h>
 
-int main() {
+int swift_static_without_module_interfaces_fmwk_depending_lib_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2079,7 +2088,7 @@ write_file(
     content = ["""
 import iOSSwiftStaticFramework
 
-func main() {
+func swift_static_fmwk_depending_swift_lib_function() {
   let sharedClass = SharedClass()
   sharedClass.doSomethingShared()
 }
@@ -2159,7 +2168,7 @@ write_file(
     content = ["""
 #import <generated_dynamic_xcframework_with_headers/generated_dynamic_xcframework_with_headers.h>
 
-int main() {
+int dynamic_xcframework_depending_lib_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2200,7 +2209,7 @@ write_file(
     content = ["""
 import generated_dynamic_xcframework_with_headers
 
-func main() {
+func swift_with_framework_function() {
   let sc = generated_dynamic_xcframework_with_headers.SharedClass()
   sc.doSomethingShared()
 }
@@ -2270,7 +2279,7 @@ write_file(
     content = ["""
 #import <SwiftFmwkWithGenHeader/SwiftFmwkWithGenHeader.h>
 
-int main() {
+int objc_with_framework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2311,7 +2320,7 @@ write_file(
     content = ["""
 import SwiftFmwkWithGenHeader
 
-func main() {
+func swift_with_dynamic_swift_framework_function() {
   let sc = SwiftFmwkWithGenHeader.SharedClass()
   sc.doSomethingShared()
 }
@@ -2383,7 +2392,7 @@ write_file(
     content = ["""
 import iOSStaticFramework
 
-func main() {
+func static_fmwk_depending_swift_lib_cuntion() {
   let sharedClass = SharedClass()
   sharedClass.doSomethingShared()
 }
@@ -2463,7 +2472,7 @@ write_file(
     content = ["""
 #import <generated_static_xcframework_with_headers.h>
 
-int main() {
+int objc_with_static_xcframework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2504,7 +2513,7 @@ write_file(
     content = ["""
 #import <generated_swift_static_xcframework.h>
 
-int main() {
+int objc_with_swift_static_xcframework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2545,7 +2554,7 @@ write_file(
     content = ["""
 #import <generated_swift_static_xcframework_without_swiftmodule.h>
 
-int main() {
+int objc_with_swift_static_xcframework_without_swiftmodule_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
   [sharedClass doSomethingShared];
   return 0;
@@ -2597,7 +2606,7 @@ write_file(
     content = ["""
 import generated_static_xcframework_with_headers
 
-func main() {
+func static_xcframework_depending_swift_lib_funtion_function() {
   let sc = generated_static_xcframework_with_headers.SharedClass()
   sc.doSomethingShared()
 }
@@ -2711,7 +2720,7 @@ write_file(
     content = ["""
 import generated_swift_static_xcframework
 
-func main() {
+func static_swift_xcframework_depending_swift_lib_function() {
   let sc = generated_swift_static_xcframework.SharedClass()
   sc.doSomethingShared()
 }
@@ -3880,9 +3889,20 @@ ios_application(
 
 objc_library(
     name = "objc_lib_with_inner_lib_with_ios_framework",
-    srcs = ["//test/starlark_tests/resources:main.m"],
+    srcs = [":objc_lib_with_inner_lib_with_ios_framework_file"],
     tags = common.fixture_tags,
     deps = [":objc_lib_with_ios_framework"],
+)
+
+write_file(
+    name = "objc_lib_with_inner_lib_with_ios_framework_file",
+    out = "objc_lib_with_inner_lib_with_ios_framework_file.m",
+    content = ["""
+int objc_lib_with_inner_lib_with_ios_framework_function() {
+  return 0;
+}
+"""],
+    tags = common.fixture_tags,
 )
 
 objc_library(

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -32,6 +32,7 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
 )
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 licenses(["notice"])
 
@@ -1317,15 +1318,37 @@ tvos_application(
 
 objc_library(
     name = "objc_lib_with_inner_lib_with_tvos_framework",
-    srcs = ["//test/starlark_tests/resources:main.m"],
+    srcs = [":objc_lib_with_inner_lib_with_tvos_framework_file"],
     tags = common.fixture_tags,
     deps = [":objc_lib_with_tvos_framework"],
 )
 
+write_file(
+    name = "objc_lib_with_inner_lib_with_tvos_framework_file",
+    out = "objc_lib_with_inner_lib_with_tvos_framework_file.m",
+    content = ["""
+int objc_lib_with_inner_lib_with_tvos_framework_function() {
+  return 0;
+}
+"""],
+    tags = common.fixture_tags,
+)
+
 objc_library(
     name = "objc_lib_with_tvos_framework",
-    srcs = ["//test/starlark_tests/resources:main.m"],
+    srcs = [":objc_lib_with_tvos_framework_file"],
     data = [":fmwk_with_structured_resources"],
+    tags = common.fixture_tags,
+)
+
+write_file(
+    name = "objc_lib_with_tvos_framework_file",
+    out = "objc_lib_with_tvos_framework_file.m",
+    content = ["""
+int main() {
+  return 0;
+}
+"""],
     tags = common.fixture_tags,
 )
 


### PR DESCRIPTION
Generally, avoid sticking `main` in lots of things and instead make it
explicit used when expected.

PiperOrigin-RevId: 521473417
(cherry picked from commit 1c62ebd8123b3a12c0deced393fee00c0ca00004)
