### PR TITLE
Remove Generator typing workaround for Python <3.9

### DIFF
--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -53,19 +53,14 @@ import platform
 import plistlib
 import shutil
 import subprocess
-import sys
 import tempfile
 import time
-from typing import Dict, Generator, Optional
+from typing import Dict, Optional
 import zipfile
 
 
 # Custom type for methods yielding an Apple simulator UDID.
-# TODO(b/256029048): Remove once Xcode 14 is the minimum supported version.
-if sys.version_info >= (3, 9):
-  AppleSimulatorUDID = collections.abc.Generator[str, None, None]
-else:
-  AppleSimulatorUDID = Generator[str, None, None]
+AppleSimulatorUDID = collections.abc.Generator[str, None, None]
 
 
 logging.basicConfig(


### PR DESCRIPTION
Now that applications submitted to the App Store must be built
with Xcode >14.1 (which includes Python >3.9) it should be safe
to remove this workaround.

PiperOrigin-RevId: 527629669
(cherry picked from commit df87e1967137738c9df564e6b8cfeb987d00a731)
