### PR TITLE
Disable swiftinterface compilation support

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -299,7 +299,7 @@ def _apple_dynamic_framework_import_impl(ctx):
         framework_files = depset(framework_imports),
     ))
 
-    if framework.swift_interface_imports:
+    if False and framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -299,7 +299,7 @@ def _apple_dynamic_framework_import_impl(ctx):
         framework_files = depset(framework_imports),
     ))
 
-    if False and framework.swift_interface_imports:
+    if "apple._import_framework_via_swiftinterface" in features and framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
@@ -446,7 +446,7 @@ def _apple_static_framework_import_impl(ctx):
         ),
     )
 
-    if False and framework.swift_interface_imports:
+    if "apple._import_framework_via_swiftinterface" in features and framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -446,7 +446,7 @@ def _apple_static_framework_import_impl(ctx):
         ),
     )
 
-    if framework.swift_interface_imports:
+    if False and framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -530,7 +530,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     )
     providers.append(apple_dynamic_framework_info)
 
-    if xcframework_library.swift_module_interface:
+    if False and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -530,7 +530,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     )
     providers.append(apple_dynamic_framework_info)
 
-    if False and xcframework_library.swift_module_interface:
+    if "apple._import_framework_via_swiftinterface" in features and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(
@@ -671,7 +671,7 @@ def _apple_static_xcframework_import_impl(ctx):
     )
     providers.append(cc_info)
 
-    if False and xcframework_library.swift_module_interface:
+    if "apple._import_framework_via_swiftinterface" in features and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -671,7 +671,7 @@ def _apple_static_xcframework_import_impl(ctx):
     )
     providers.append(cc_info)
 
-    if xcframework_library.swift_module_interface:
+    if False and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
         providers.append(

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2750,7 +2750,10 @@ ios_application(
 
 apple_static_xcframework_import(
     name = "ios_imported_swift_static_xcframework",
-    features = ["-swift.layering_check"],
+    features = [
+        "-swift.layering_check",
+        "apple._import_framework_via_swiftinterface",
+    ],
     tags = common.fixture_tags,
     visibility = ["//visibility:public"],
     xcframework_imports = [":generated_swift_static_xcframework"],


### PR DESCRIPTION
This current behavior fails in the real world and requires some changes
that are potentially unclear. I think if we have a reason to enable it
we can try to push those. We might also need a way for things to disable
this support since some frameworks like Firebase seem to have an invalid
layout for this, likely because they've never needed to make that work
before.
