### PR TITLE
HACK: fix swiftinterface import support

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -446,6 +446,7 @@ def _apple_static_framework_import_impl(ctx):
         ),
     )
 
+    fail("not here")
     if framework.swift_interface_imports:
         # Create SwiftInfo provider
         swift_toolchain = ctx.attr._swift_toolchain[SwiftToolchainInfo]
@@ -463,6 +464,7 @@ def _apple_static_framework_import_impl(ctx):
                 module_name = framework.bundle_name,
                 swift_toolchain = swift_toolchain,
                 swiftinterface_file = swiftinterface_files[0],
+                module_map_files = framework.module_map_imports,
             ),
         )
     else:


### PR DESCRIPTION
This fixes passing `-F` and `-fmodule-map-file` to the compile for the
case that your module is multi-language. It also handles passing the
right module_name in the case the .swiftmodule differs from the
.framework bundle in name (not sure this should work, it doesn't work in
Xcode).
