### PR TITLE
Use `test_rule` name to derive `bundle_rule` name

### DIFF
--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -92,6 +92,8 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
     elif not runner and not runners:
         fail("Must specify one of runner or runners.")
 
+    test_bundle_name = name + ".__internal__.__test_bundle"
+
     test_attrs = {k: v for (k, v) in kwargs.items() if k not in _BUNDLE_ATTRS}
     bundle_attrs = {k: v for (k, v) in kwargs.items() if k in _BUNDLE_ATTRS}
 
@@ -102,8 +104,6 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
 
     # `bundle_name` is either provided or the default is `name`.
     bundle_name = bundle_attrs.pop("bundle_name", name)
-
-    test_bundle_name = bundle_name + ".__internal__.__test_bundle"
 
     # Ideally this target should be private, but the outputs should not be private, so we're
     # explicitly using the same visibility as the test (or None if none was set).


### PR DESCRIPTION
This reverts part of 5150ef97f52e4044c0702b16c4b7c0b758204f70.

Without this change you can’t have two test targets in the same package with the same bundle name.