### PR TITLE
Write out the build version and short version strings into the AppleBundleVersionInfo provider, allowing for their direct use at analysis time rather than requiring digging into the JSON form at execution time.

### DIFF
--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -137,9 +137,40 @@ target.
     },
 )
 
-AppleBundleVersionInfo = provider(
+def _apple_bundle_version_info_init(
+        *_,
+        **kwargs):
+    """Ensures that the short_version_string is set based on build_version, if it is unset."""
+
+    if "short_version_string" in kwargs and kwargs["short_version_string"]:
+        # Prevent setting short_version_string without build_version.
+        if "build_version" not in kwargs or not kwargs["build_version"]:
+            fail(
+                """
+Internal Error: short_version_string was assigned as {short_version_string} on
+AppleBundleVersionInfo but no value for build_version was set. build_version is mandatory if
+short_version_string is present.
+""".format(
+                    short_version_string = kwargs["short_version_string"],
+                ),
+            )
+    elif "build_version" in kwargs and kwargs["build_version"]:
+        kwargs["short_version_string"] = kwargs["build_version"]
+
+    # TODO(b/281687115): Consider making all fields besides short_version_string mandatory when it
+    # is feasible.
+    return kwargs
+
+AppleBundleVersionInfo, _ = provider(
     doc = "Provides versioning information for an Apple bundle.",
     fields = {
+        "build_version": """
+'String'. A version string for an Info.plist which corresponds to `CFBundleVersion`. Mandatory if
+`short_version_string` is set.
+""",
+        "short_version_string": """
+'String'. A version string for an Info.plist which corresponds to `CFBundleShortVersionString`.
+""",
         "version_file": """
 A `File` containing JSON-formatted text describing the version
 number information propagated by the target.
@@ -151,6 +182,7 @@ It contains two keys:
 *   `short_version_string`, which corresponds to `CFBundleShortVersionString`.
 """,
     },
+    init = _apple_bundle_version_info_init,
 )
 
 AppleDsymBundleInfo = provider(

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -145,7 +145,11 @@ def _apple_bundle_version_impl(ctx):
     )
 
     return [
-        AppleBundleVersionInfo(version_file = bundle_version_file),
+        AppleBundleVersionInfo(
+            build_version = ctx.attr.build_version,
+            short_version_string = ctx.attr.short_version_string,
+            version_file = bundle_version_file,
+        ),
         DefaultInfo(files = depset([bundle_version_file])),
     ]
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -122,7 +122,7 @@ rules (applications, extensions, frameworks, test bundles, and so forth).
 ## AppleBundleVersionInfo
 
 <pre>
-AppleBundleVersionInfo(<a href="#AppleBundleVersionInfo-version_file">version_file</a>)
+AppleBundleVersionInfo(<a href="#AppleBundleVersionInfo-build_version">build_version</a>, <a href="#AppleBundleVersionInfo-short_version_string">short_version_string</a>, <a href="#AppleBundleVersionInfo-version_file">version_file</a>)
 </pre>
 
 Provides versioning information for an Apple bundle.
@@ -132,6 +132,8 @@ Provides versioning information for an Apple bundle.
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="AppleBundleVersionInfo-build_version"></a>build_version |  'String'. A version string for an Info.plist which corresponds to <code>CFBundleVersion</code>. Mandatory if <code>short_version_string</code> is set.    |
+| <a id="AppleBundleVersionInfo-short_version_string"></a>short_version_string |  'String'. A version string for an Info.plist which corresponds to <code>CFBundleShortVersionString</code>.    |
 | <a id="AppleBundleVersionInfo-version_file"></a>version_file |  A <code>File</code> containing JSON-formatted text describing the version number information propagated by the target.<br><br>It contains two keys:<br><br>*   <code>build_version</code>, which corresponds to <code>CFBundleVersion</code>.<br><br>*   <code>short_version_string</code>, which corresponds to <code>CFBundleShortVersionString</code>.    |
 
 

--- a/test/starlark_tests/apple_bundle_version_tests.bzl
+++ b/test/starlark_tests/apple_bundle_version_tests.bzl
@@ -19,6 +19,10 @@ load(
     "analysis_failure_message_test",
 )
 load(
+    "//test/starlark_tests/rules:apple_bundle_version_info_test.bzl",
+    "apple_bundle_version_info_test",
+)
+load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -132,6 +136,24 @@ def apple_bundle_version_test_suite(name):
             "CFBundleVersion": "1.2.3",
             "CFBundleShortVersionString": "1.2",
         },
+        tags = [name],
+    )
+
+    apple_bundle_version_info_test(
+        name = "{}_full_bundle_version_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:manual_1_2_build_1_2_3_version",
+        expected_build_version = "1.2.3",
+        expected_short_version_string = "1.2",
+        expected_version_file = "manual_1_2_build_1_2_3_version.bundle_version",
+        tags = [name],
+    )
+
+    apple_bundle_version_info_test(
+        name = "{}_only_build_version_bundle_version_info_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:only_build_version_1_2_3_version",
+        expected_build_version = "1.2.3",
+        expected_short_version_string = "1.2.3",
+        expected_version_file = "only_build_version_1_2_3_version.bundle_version",
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/apple_bundle_version_info_test.bzl
+++ b/test/starlark_tests/rules/apple_bundle_version_info_test.bzl
@@ -1,0 +1,91 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starlark test rules for bundle version info providers."""
+
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleVersionInfo",
+)
+load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
+    "make_provider_test_rule",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+)
+
+visibility("//test/starlark_tests/...")
+
+def _assert_contains_version_info(
+        ctx,
+        env,
+        apple_bundle_version_info):
+    """Assert AppleBundleVersionInfo contains the correct strings and the expected filename."""
+
+    if ctx.attr.expected_build_version != apple_bundle_version_info.build_version:
+        fail("Found mismatched build_version string; expected '{}' but found '{}'".format(
+            ctx.attr.expected_build_version,
+            apple_bundle_version_info.build_version,
+        ))
+
+    if ctx.attr.expected_short_version_string != apple_bundle_version_info.short_version_string:
+        fail("Found mismatched short_version_string string; expected '{}' but found '{}'".format(
+            ctx.attr.expected_short_version_string,
+            apple_bundle_version_info.short_version_string,
+        ))
+
+    target_under_test = analysistest.target_under_test(env)
+    version_file_path = paths.relativize(
+        apple_bundle_version_info.version_file.short_path,
+        target_under_test.label.package,
+    )
+
+    if ctx.attr.expected_version_file != version_file_path:
+        fail("Found mismatched version_file file name; expected '{}' but found '{}'".format(
+            ctx.attr.expected_version_file,
+            version_file_path,
+        ))
+
+apple_bundle_version_info_test = make_provider_test_rule(
+    provider = AppleBundleVersionInfo,
+    assertion_fn = _assert_contains_version_info,
+    attrs = {
+        "expected_build_version": attr.string(
+            mandatory = True,
+            doc = """
+A string expected to match the value of build_version found in the AppleBundleVersionInfo provider.
+""",
+        ),
+        "expected_short_version_string": attr.string(
+            mandatory = True,
+            doc = """
+A string expected to match the value of short_version_string found in the AppleBundleVersionInfo
+provider.
+""",
+        ),
+        "expected_version_file": attr.string(
+            mandatory = True,
+            doc = """
+A string representing the file name of the JSON file expected to propagate version information from
+the AppleBundleVersionInfo provider.
+""",
+        ),
+    },
+)


### PR DESCRIPTION
PiperOrigin-RevId: 530754845
(cherry picked from commit a14a368f200e828310974937ad2afd9a5198db7f)
