### PR TITLE
Take upstream runner dsym changes

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -473,6 +473,8 @@ def _ios_application_impl(ctx):
         rule_descriptor = rule_descriptor,
     )
 
+    dsyms = outputs.dsyms(processor_result = processor_result)
+
     return [
         # TODO(b/121155041): Should we do the same for ios_framework and ios_extension?
         coverage_common.instrumented_files_info(ctx, dependency_attributes = ["deps"]),
@@ -481,6 +483,7 @@ def _ios_application_impl(ctx):
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
                 files = [archive],
+                transitive_files = dsyms,
             ),
         ),
         new_iosapplicationbundleinfo(),

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -418,6 +418,7 @@ def _macos_application_impl(ctx):
         predeclared_outputs = predeclared_outputs,
         rule_descriptor = rule_descriptor,
     )
+    dsyms = outputs.dsyms(processor_result = processor_result)
 
     return [
         coverage_common.instrumented_files_info(ctx, dependency_attributes = ["deps"]),
@@ -425,7 +426,7 @@ def _macos_application_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [archive],
+                files = [archive] + dsyms,
             ),
         ),
         new_macosapplicationbundleinfo(),
@@ -1986,6 +1987,8 @@ def _macos_command_line_application_impl(ctx):
     if clang_rt_dylibs.should_package_clang_runtime(features = features):
         runfiles = clang_rt_dylibs.get_from_toolchain(ctx)
 
+    dsyms = outputs.dsyms(processor_result = processor_result)
+
     return [
         new_applebinaryinfo(
             binary = output_file,
@@ -1998,7 +2001,7 @@ def _macos_command_line_application_impl(ctx):
                 depset([output_file]),
                 processor_result.output_files,
             ]),
-            runfiles = ctx.runfiles(runfiles),
+            runfiles = ctx.runfiles(runfiles + dsyms),
         ),
         OutputGroupInfo(
             **outputs.merge_output_groups(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -426,7 +426,8 @@ def _macos_application_impl(ctx):
             executable = executable,
             files = processor_result.output_files,
             runfiles = ctx.runfiles(
-                files = [archive] + dsyms,
+                files = [archive],
+                transitive_files = dsyms,
             ),
         ),
         new_macosapplicationbundleinfo(),
@@ -2001,7 +2002,10 @@ def _macos_command_line_application_impl(ctx):
                 depset([output_file]),
                 processor_result.output_files,
             ]),
-            runfiles = ctx.runfiles(runfiles + dsyms),
+            runfiles = ctx.runfiles(
+                files = runfiles,
+                transitive_files = dsyms,
+            ),
         ),
         OutputGroupInfo(
             **outputs.merge_output_groups(

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -99,6 +99,14 @@ def _executable(*, actions, label_name):
     """Returns a file reference for the executable that would be invoked with `bazel run`."""
     return actions.declare_file(label_name)
 
+def _dsyms(*, processor_result):
+    """Returns a list of all of the dsyms from the result."""
+    dsyms = []
+    for provider in processor_result.providers:
+        if getattr(provider, "dsyms", None):
+            dsyms.extend(provider.dsyms.to_list())
+    return dsyms
+
 def _infoplist(*, actions, label_name, output_discriminator):
     """Returns a file reference for this target's Info.plist file."""
     return intermediates.file(
@@ -171,6 +179,7 @@ outputs = struct(
     archive = _archive,
     archive_for_embedding = _archive_for_embedding,
     binary = _binary,
+    dsyms = _dsyms,
     executable = _executable,
     infoplist = _infoplist,
     merge_output_groups = _merge_output_groups,

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -100,12 +100,12 @@ def _executable(*, actions, label_name):
     return actions.declare_file(label_name)
 
 def _dsyms(*, processor_result):
-    """Returns a list of all of the dsyms from the result."""
+    """Returns a depset of all of the dsyms from the result."""
     dsyms = []
     for provider in processor_result.providers:
         if getattr(provider, "dsyms", None):
-            dsyms.extend(provider.dsyms.to_list())
-    return dsyms
+            dsyms.append(provider.dsyms)
+    return depset(transitive = dsyms)
 
 def _infoplist(*, actions, label_name, output_discriminator):
     """Returns a file reference for this target's Info.plist file."""

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -67,7 +67,7 @@ AppleSimulatorUDID = collections.abc.Generator[str, None, None]
 logging.basicConfig(
     format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.DEBUG,
+    level=logging.INFO,
 )
 logger = logging.getLogger(__name__)
 
@@ -484,6 +484,10 @@ def register_dsyms(dsyms_dir: str):
   """
   symbolscache_command = [
       "/usr/bin/symbolscache",
+      "delete",
+      "--tag",
+      "Bazel",
+      "compact",
       "add",
       "--tag",
       "Bazel",

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -49,6 +49,7 @@ import json
 import logging
 import os
 import os.path
+import pathlib
 import platform
 import plistlib
 import shutil
@@ -66,7 +67,7 @@ AppleSimulatorUDID = collections.abc.Generator[str, None, None]
 logging.basicConfig(
     format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.INFO,
+    level=logging.DEBUG,
 )
 logger = logging.getLogger(__name__)
 
@@ -475,6 +476,34 @@ def temporary_simulator(
     subprocess.run([simctl_path, "delete", udid], check=True)
 
 
+def register_dsyms(dsyms_dir: str):
+  """Adds all dSYMs in `dsyms_dir` to the symbolscache.
+
+  Args:
+    dsyms_dir: Path to directory potentially containing dSYMs
+  """
+  symbolscache_command = [
+      "/usr/bin/symbolscache",
+      "add",
+      "--tag",
+      "Bazel",
+  ] + [
+      a
+      for a in pathlib.Path(dsyms_dir).glob(
+          "**/*.dSYM/Contents/Resources/DWARF/*"
+      )
+  ]
+  logger.debug("Running command: %s", symbolscache_command)
+  result = subprocess.run(
+      symbolscache_command,
+      capture_output=True,
+      check=True,
+      encoding="utf-8",
+      text=True,
+  )
+  logger.debug("symbolscache output: %s", result.stdout)
+
+
 @contextlib.contextmanager
 def extracted_app(
     application_output_path: str, app_name: str
@@ -627,6 +656,8 @@ def run_app_in_simulator(
       simctl_path=simctl_path,
       udid=simulator_udid,
   )
+  root_dir = os.path.dirname(application_output_path)
+  register_dsyms(root_dir)
   with extracted_app(application_output_path, app_name) as app_path:
     logger.debug("Installing app %s to simulator %s", app_path, simulator_udid)
     subprocess.run(

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -66,12 +66,14 @@ AppleSimulatorUDID = collections.abc.Generator[str, None, None]
 logging.basicConfig(
     format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
-    level=logging.INFO)
+    level=logging.INFO,
+)
 logger = logging.getLogger(__name__)
 
 if platform.system() != "Darwin":
   raise Exception(
-      "Cannot run Apple platform application targets on a non-mac machine.")
+      "Cannot run Apple platform application targets on a non-mac machine."
+  )
 
 
 class DeviceType(collections.abc.Mapping):
@@ -118,7 +120,8 @@ class DeviceType(collections.abc.Mapping):
       return self.is_apple_watch()
     else:
       raise ValueError(
-          f"Apple platform type not supported for simulator: {platform_type}.")
+          f"Apple platform type not supported for simulator: {platform_type}."
+      )
 
   def is_apple_tv(self) -> bool:
     return self.has_product_family_or_identifier("Apple TV")
@@ -203,7 +206,8 @@ def discover_best_compatible_simulator(
     simctl_path: str,
     minimum_os: str,
     sim_device: str,
-    sim_os_version: str) -> (Optional[DeviceType], Optional[Device]):
+    sim_os_version: str,
+) -> (Optional[DeviceType], Optional[Device]):
   """Discovers the best compatible simulator device type and device.
 
   Args:
@@ -211,8 +215,8 @@ def discover_best_compatible_simulator(
     simctl_path: The path to the `simctl` binary.
     minimum_os: The minimum OS version required by the *_application() target.
     sim_device: Optional name of the device (e.g. "iPhone 8 Plus").
-    sim_os_version: Optional version of the Apple platform runtime
-      (e.g. "13.2").
+    sim_os_version: Optional version of the Apple platform runtime (e.g.
+      "13.2").
 
   Returns:
     A tuple (device_type, device) containing the DeviceType and Device
@@ -239,7 +243,7 @@ def discover_best_compatible_simulator(
   # `simctl list` orders device types from oldest to newest. Remember
   # the index of each device type to preserve that ordering when
   # sorting device types.
-  for (simctl_list_index, device_type) in enumerate(simctl_data["devicetypes"]):
+  for simctl_list_index, device_type in enumerate(simctl_data["devicetypes"]):
     device_type = DeviceType(device_type, simctl_list_index)
     if not device_type.supports_platform_type(platform_type):
       continue
@@ -252,8 +256,9 @@ def discover_best_compatible_simulator(
       continue
     compatible_device_types.append(device_type)
   compatible_device_types.sort()
-  logger.debug("Found %d compatible device types.",
-               len(compatible_device_types))
+  logger.debug(
+      "Found %d compatible device types.", len(compatible_device_types)
+  )
   compatible_runtime_identifiers = set()
   for runtime in simctl_data["runtimes"]:
     if not runtime["isAvailable"]:
@@ -295,7 +300,8 @@ def persistent_simulator(
     simctl_path: str,
     minimum_os: str,
     sim_device: str,
-    sim_os_version: str) -> str:
+    sim_os_version: str,
+) -> str:
   """Finds or creates a persistent compatible Apple simulator.
 
   Boots the simulator if needed. Does not shut down or delete the simulator when
@@ -306,8 +312,8 @@ def persistent_simulator(
     simctl_path: The path to the `simctl` binary.
     minimum_os: The minimum OS version required by the *_application() target.
     sim_device: Optional name of the device (e.g. "iPhone 8 Plus").
-    sim_os_version: Optional version of the Apple platform runtime
-      (e.g. "13.2").
+    sim_os_version: Optional version of the Apple platform runtime (e.g.
+      "13.2").
 
   Returns:
     The UDID of the compatible Apple simulator.
@@ -315,13 +321,15 @@ def persistent_simulator(
   Raises:
     Exception: if a compatible simulator was not found.
   """
-  (best_compatible_device_type,
-   best_compatible_device) = discover_best_compatible_simulator(
-       platform_type=platform_type,
-       simctl_path=simctl_path,
-       minimum_os=minimum_os,
-       sim_device=sim_device,
-       sim_os_version=sim_os_version)
+  (best_compatible_device_type, best_compatible_device) = (
+      discover_best_compatible_simulator(
+          platform_type=platform_type,
+          simctl_path=simctl_path,
+          minimum_os=minimum_os,
+          sim_device=sim_device,
+          sim_os_version=sim_os_version,
+      )
+  )
   if best_compatible_device:
     udid = best_compatible_device["udid"]
     if best_compatible_device.is_shutdown():
@@ -338,14 +346,16 @@ def persistent_simulator(
         [simctl_path, "create", device_name, device_id],
         encoding="utf-8",
         stdout=subprocess.PIPE,
-        check=True)
+        check=True,
+    )
     udid = create_result.stdout.rstrip()
     logger.debug("Created new simulator: %s", udid)
     return udid
   raise Exception(
       f"Could not find or create a simulator for the {platform_type} platform"
       f"compatible with minimum OS version {minimum_os} (device name "
-      f"{sim_device}, OS version {sim_os_version})")
+      f"{sim_device}, OS version {sim_os_version})"
+  )
 
 
 def wait_for_sim_to_boot(simctl_path: str, udid: str) -> bool:
@@ -365,10 +375,12 @@ def wait_for_sim_to_boot(simctl_path: str, udid: str) -> bool:
     # iPhone 5s (E946FA1C-26AB-465C-A7AC-24750D520BEA) (Shutdown)
     # TestDevice (8491C4BC-B18E-4E2D-934A-54FA76365E48) (Booted)
     # So if there's any booted simulator, $booted_device will not be empty.
-    simctl_list_result = subprocess.run([simctl_path, "list", "devices"],
-                                        encoding="utf-8",
-                                        check=True,
-                                        stdout=subprocess.PIPE)
+    simctl_list_result = subprocess.run(
+        [simctl_path, "list", "devices"],
+        encoding="utf-8",
+        check=True,
+        stdout=subprocess.PIPE,
+    )
     for line in simctl_list_result.stdout.split("\n"):
       if line.find(udid) != -1 and line.find("Booted") != -1:
         logger.debug("Simulator is booted.")
@@ -379,8 +391,7 @@ def wait_for_sim_to_boot(simctl_path: str, udid: str) -> bool:
   return False
 
 
-def boot_simulator(
-    *, developer_path: str, simctl_path: str, udid: str) -> None:
+def boot_simulator(*, developer_path: str, simctl_path: str, udid: str) -> None:
   """Launches the Apple simulator for the given identifier.
 
   Ensures the Simulator process is in the foreground.
@@ -406,7 +417,8 @@ def boot_simulator(
   simulator_path = os.path.join(developer_path, "Applications/Simulator.app")
   subprocess.run(
       ["open", "-a", simulator_path, "--args", "-CurrentDeviceUDID", udid],
-      check=True)
+      check=True,
+  )
   logger.debug("Simulator launched.")
   if not wait_for_sim_to_boot(simctl_path, udid):
     raise Exception("Failed to launch simulator with UDID: " + udid)
@@ -414,11 +426,8 @@ def boot_simulator(
 
 @contextlib.contextmanager
 def temporary_simulator(
-    *,
-    platform_type: str,
-    simctl_path: str,
-    device: str,
-    version: str) -> AppleSimulatorUDID:
+    *, platform_type: str, simctl_path: str, device: str, version: str
+) -> AppleSimulatorUDID:
   """Creates a temporary Apple simulator, cleaned up automatically upon close.
 
   Args:
@@ -444,37 +453,39 @@ def temporary_simulator(
               prefix="com.apple.CoreSimulator.SimRuntime",
               runtime_platform=runtime_platform,
               runtime_version_name=runtime_version_name,
-          )
+          ),
       ],
       encoding="utf-8",
       check=True,
-      stdout=subprocess.PIPE)
+      stdout=subprocess.PIPE,
+  )
   udid = simctl_create_result.stdout.rstrip()
   try:
     logger.info("Killing all running simulators...")
-    subprocess.run(["pkill", "Simulator"],
-                   stderr=subprocess.DEVNULL,
-                   check=False)
+    subprocess.run(
+        ["pkill", "Simulator"], stderr=subprocess.DEVNULL, check=False
+    )
     yield udid
   finally:
     logger.info("Shutting down simulator with udid: %s", udid)
-    subprocess.run([simctl_path, "shutdown", udid],
-                   stderr=subprocess.DEVNULL,
-                   check=False)
+    subprocess.run(
+        [simctl_path, "shutdown", udid], stderr=subprocess.DEVNULL, check=False
+    )
     logger.info("Deleting simulator with udid: %s", udid)
     subprocess.run([simctl_path, "delete", udid], check=True)
 
 
 @contextlib.contextmanager
 def extracted_app(
-    application_output_path: str, app_name: str) -> AppleSimulatorUDID:
+    application_output_path: str, app_name: str
+) -> AppleSimulatorUDID:
   """Extracts Foo.app from *_application() output and makes it writable.
 
   Args:
-    application_output_path: Path to the output of an `*_application()`.
-      If the path is a directory, copies it to a temporary directory and makes
-      the contents writable, as `simctl install` fails to install an `.app` that
-      is read-only. If the path is an .ipa archive, unzips it to a temporary
+    application_output_path: Path to the output of an `*_application()`. If the
+      path is a directory, copies it to a temporary directory and makes the
+      contents writable, as `simctl install` fails to install an `.app` that is
+      read-only. If the path is an .ipa archive, unzips it to a temporary
       directory.
     app_name: The name of the application (e.g. "Foo" for "Foo.app").
 
@@ -499,14 +510,18 @@ def extracted_app(
         os.path.realpath(application_output_path),
         dst_dir,
     ]
-    logger.debug("Found app directory: %s, running command: %s",
-                 application_output_path, rsync_command)
+    logger.debug(
+        "Found app directory: %s, running command: %s",
+        application_output_path,
+        rsync_command,
+    )
     result = subprocess.run(
         rsync_command,
         capture_output=True,
         check=True,
         encoding="utf-8",
-        text=True)
+        text=True,
+    )
     logger.debug("rsync output: %s", result.stdout)
     yield os.path.join(dst_dir, app_name + ".app")
   else:
@@ -514,8 +529,9 @@ def extracted_app(
     # afterwards (there's no efficient way to "sync" an unzip, so this
     # can't re-use the output directory).
     with tempfile.TemporaryDirectory(prefix="bazel_temp") as temp_dir:
-      logger.debug("Unzipping IPA from %s to %s", application_output_path,
-                   temp_dir)
+      logger.debug(
+          "Unzipping IPA from %s to %s", application_output_path, temp_dir
+      )
       with zipfile.ZipFile(application_output_path) as ipa_zipfile:
         ipa_zipfile.extractall(temp_dir)
         yield os.path.join(temp_dir, "Payload", app_name + ".app")
@@ -556,7 +572,8 @@ def apple_simulator(
     simctl_path: str,
     minimum_os: str,
     sim_device: str,
-    sim_os_version: str) -> AppleSimulatorUDID:
+    sim_os_version: str,
+) -> AppleSimulatorUDID:
   """Finds either a temporary or persistent Apple simulator based on args.
 
   Args:
@@ -564,8 +581,8 @@ def apple_simulator(
     simctl_path: The path to the `simctl` binary.
     minimum_os: The minimum OS version required by the *_application() target.
     sim_device: Optional name of the device (e.g. "iPhone 8 Plus").
-    sim_os_version: Optional version of the Apple platform runtime
-      (e.g. "13.2").
+    sim_os_version: Optional version of the Apple platform runtime (e.g.
+      "13.2").
 
   Yields:
     The UDID of the simulator.
@@ -575,7 +592,8 @@ def apple_simulator(
         platform_type=platform_type,
         simctl_path=simctl_path,
         device=sim_device,
-        version=sim_os_version) as udid:
+        version=sim_os_version,
+    ) as udid:
       yield udid
   else:
     yield persistent_simulator(
@@ -583,7 +601,8 @@ def apple_simulator(
         simctl_path=simctl_path,
         minimum_os=minimum_os,
         sim_device=sim_device,
-        sim_os_version=sim_os_version)
+        sim_os_version=sim_os_version,
+    )
 
 
 def run_app_in_simulator(
@@ -592,7 +611,8 @@ def run_app_in_simulator(
     developer_path: str,
     simctl_path: str,
     application_output_path: str,
-    app_name: str) -> None:
+    app_name: str,
+) -> None:
   """Installs and runs an app in the specified simulator.
 
   Args:
@@ -605,16 +625,23 @@ def run_app_in_simulator(
   boot_simulator(
       developer_path=developer_path,
       simctl_path=simctl_path,
-      udid=simulator_udid)
+      udid=simulator_udid,
+  )
   with extracted_app(application_output_path, app_name) as app_path:
     logger.debug("Installing app %s to simulator %s", app_path, simulator_udid)
-    subprocess.run([simctl_path, "install", simulator_udid, app_path],
-                   check=True)
+    subprocess.run(
+        [simctl_path, "install", simulator_udid, app_path], check=True
+    )
     app_bundle_id = bundle_id(app_path)
-    logger.info("Launching app %s in simulator %s", app_bundle_id,
-                simulator_udid)
+    logger.info(
+        "Launching app %s in simulator %s", app_bundle_id, simulator_udid
+    )
     args = [
-        simctl_path, "launch", "--console-pty", simulator_udid, app_bundle_id
+        simctl_path,
+        "launch",
+        "--console-pty",
+        simulator_udid,
+        app_bundle_id,
     ]
     subprocess.run(args, env=simctl_launch_environ(), check=False)
 
@@ -626,7 +653,8 @@ def main(
     minimum_os: str,
     platform_type: str,
     sim_device: str,
-    sim_os_version: str):
+    sim_os_version: str,
+):
   """Main entry point to `bazel run` for *_application() targets.
 
   Args:
@@ -637,10 +665,12 @@ def main(
     sim_device: The name of the device (e.g. "iPhone 8 Plus").
     sim_os_version: The version of the Apple platform runtime (e.g. "13.2").
   """
-  xcode_select_result = subprocess.run(["xcode-select", "-p"],
-                                       encoding="utf-8",
-                                       check=True,
-                                       stdout=subprocess.PIPE)
+  xcode_select_result = subprocess.run(
+      ["xcode-select", "-p"],
+      encoding="utf-8",
+      check=True,
+      stdout=subprocess.PIPE,
+  )
   developer_path = xcode_select_result.stdout.rstrip()
   simctl_path = os.path.join(developer_path, "usr", "bin", "simctl")
 
@@ -649,14 +679,15 @@ def main(
       simctl_path=simctl_path,
       minimum_os=minimum_os,
       sim_device=sim_device,
-      sim_os_version=sim_os_version) as simulator_udid:
-
+      sim_os_version=sim_os_version,
+  ) as simulator_udid:
     run_app_in_simulator(
         simulator_udid=simulator_udid,
         developer_path=developer_path,
         simctl_path=simctl_path,
         application_output_path=application_output_path,
-        app_name=app_name)
+        app_name=app_name,
+    )
 
 
 if __name__ == "__main__":
@@ -668,7 +699,8 @@ if __name__ == "__main__":
         minimum_os="%minimum_os%",
         platform_type="%platform_type%",
         sim_device="%sim_device%",
-        sim_os_version="%sim_os_version%")
+        sim_os_version="%sim_os_version%",
+    )
   except subprocess.CalledProcessError as e:
     logger.error("%s exited with error code %d", e.cmd, e.returncode)
   except KeyboardInterrupt:

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -33,15 +33,13 @@ else
   readonly APP_DIR="${TEMP_DIR}/%app_name%.app"
 fi
 
-for dsym in $(find -L "$(dirname %app_path%)" -type d -name "*.dSYM"); do
-  # This adds the symbols to the CoreSymbolication so they can be easily found
-  # without having spotlight index them.
-  # Tagged with "bazel" for easy deletions of all bazel symbols should we want
-  # to add a cleanup mechanism.
-  # Not cleaning up as part of the trap because the symbols may be accessed
-  # after the trap has run in the case of a crash.
-  symbolscache add --tag Bazel "${dsym}/Contents/Resources/DWARF/"*
-done
+# Clean out all the old symbols from previous runs.
+symbolscache --quiet delete --tag Bazel compact
+# This adds the symbols to the CoreSymbolication so they can be easily found
+# without having spotlight index them.
+# Not cleaning up as part of a trap because the symbols may be accessed
+# after the trap has run in the case of a crash.
+find -L "$(dirname %app_path%)" -path "*.dSYM/Contents/Resources/DWARF/*" -exec symbolscache --quiet add --tag Bazel {} \;
 
 # Get the bundle executable name of the app. Read this from the plist in case it
 # differs from the app name.

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -39,6 +39,4 @@ readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
 readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
 
 # Launch the app binary
-# Do *not* use `exec` here becaues we need the clean up done by the trap to run after the 
-# executable has been run.
-"${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"
+exec "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eu
+set -eux
 
 if [[ "$(uname)" != Darwin ]]; then
   echo "Cannot run macOS targets on a non-mac machine."
@@ -24,14 +24,37 @@ fi
 if [ -d '%app_path%' ]; then
   # App bundles are directories with the .app extension
   readonly APP_DIR="%app_path%"
+  readonly DSYM_PATH="%app_path%.dSYM"
 else
   readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
-  trap 'rm -rf "${TEMP_DIR}"' ERR EXIT
+  trap 'rm -rf "${TEMP_DIR}"' EXIT
   # The app bundle is contained within an compressed archive (zip)
   # Unpack the archive
   unzip -qq '%app_path%' -d "${TEMP_DIR}"
   readonly APP_DIR="${TEMP_DIR}/%app_name%.app"
+
+  # Copy the dsym if there is one
+  readonly DSYM_NAME='%app_name%.app.dSYM'
+  readonly DSYM_DIR="$(dirname %app_path%)"
+  readonly DSYM_PATH="${DSYM_DIR}/${DSYM_NAME}"
+  if [ -d "${DSYM_PATH}" ]; then
+    pushd "${DSYM_DIR}"
+    # pax does a much faster copy than cp and is more dependable than cp -c
+    # https://github.com/nico/hack/blob/main/notes/copydir.md
+    pax -rwl "${DSYM_NAME}" "${TEMP_DIR}"
+    popd
+  fi
 fi
+
+if [ -d "${DSYM_PATH}" ]; then
+  # This adds the symbols to the CoreSymbolication so they can be easily found
+  # without having spotlight index them.
+  # Tagged with "bazel" for easy deletions of all bazel symbols should we want
+  # to add a cleanup mechanism.
+  # Not cleaning up as part of the trap because the symbols may be accessed
+  # after the trap has run in the case of a crash.
+  symbolscache add --tag Bazel "${APP_DIR}.dSYM/Contents/Resources/DWARF/"*
+ fi
 
 # Get the bundle executable name of the app. Read this from the plist in case it
 # differs from the app name.
@@ -39,4 +62,6 @@ readonly BUNDLE_INFO_PLIST="${APP_DIR}/Contents/Info.plist"
 readonly BUNDLE_EXECUTABLE=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "${BUNDLE_INFO_PLIST}")
 
 # Launch the app binary
-exec "${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"
+# Do *not* use exec here because we want the trap above to execute after the
+# executable has run.
+"${APP_DIR}/Contents/MacOS/${BUNDLE_EXECUTABLE}" "$@"

--- a/apple/internal/templates/macos.template.sh
+++ b/apple/internal/templates/macos.template.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eux
+set -eu
 
 if [[ "$(uname)" != Darwin ]]; then
   echo "Cannot run macOS targets on a non-mac machine."
@@ -24,7 +24,6 @@ fi
 if [ -d '%app_path%' ]; then
   # App bundles are directories with the .app extension
   readonly APP_DIR="%app_path%"
-  readonly DSYM_PATH="%app_path%.dSYM"
 else
   readonly TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bazel_temp.XXXXXX")
   trap 'rm -rf "${TEMP_DIR}"' EXIT
@@ -32,29 +31,17 @@ else
   # Unpack the archive
   unzip -qq '%app_path%' -d "${TEMP_DIR}"
   readonly APP_DIR="${TEMP_DIR}/%app_name%.app"
-
-  # Copy the dsym if there is one
-  readonly DSYM_NAME='%app_name%.app.dSYM'
-  readonly DSYM_DIR="$(dirname %app_path%)"
-  readonly DSYM_PATH="${DSYM_DIR}/${DSYM_NAME}"
-  if [ -d "${DSYM_PATH}" ]; then
-    pushd "${DSYM_DIR}"
-    # pax does a much faster copy than cp and is more dependable than cp -c
-    # https://github.com/nico/hack/blob/main/notes/copydir.md
-    pax -rwl "${DSYM_NAME}" "${TEMP_DIR}"
-    popd
-  fi
 fi
 
-if [ -d "${DSYM_PATH}" ]; then
+for dsym in $(find -L "$(dirname %app_path%)" -type d -name "*.dSYM"); do
   # This adds the symbols to the CoreSymbolication so they can be easily found
   # without having spotlight index them.
   # Tagged with "bazel" for easy deletions of all bazel symbols should we want
   # to add a cleanup mechanism.
   # Not cleaning up as part of the trap because the symbols may be accessed
   # after the trap has run in the case of a crash.
-  symbolscache add --tag Bazel "${APP_DIR}.dSYM/Contents/Resources/DWARF/"*
- fi
+  symbolscache add --tag Bazel "${dsym}/Contents/Resources/DWARF/"*
+done
 
 # Get the bundle executable name of the app. Read this from the plist in case it
 # differs from the app name.

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -291,8 +291,8 @@ def macos_application_test_suite(name):
         name = "{}_runfiles_dsym_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         expected_runfiles = [
-            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Resources/DWARF/app_x86_64",
-            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Info.plist",
+            "test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Resources/DWARF/app",
+            "test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Info.plist",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -27,6 +27,10 @@ load(
     "analysis_output_group_info_files_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_runfiles_test.bzl",
+    "analysis_runfiles_dsym_test",
+)
+load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_test",
 )
@@ -279,6 +283,16 @@ def macos_application_test_suite(name):
         ],
         expected_transitive_dsyms = [
             "dSYMs/app.app.dSYM",
+        ],
+        tags = [name],
+    )
+
+    analysis_runfiles_dsym_test(
+        name = "{}_runfiles_dsym_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        expected_runfiles = [
+            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Resources/DWARF/app_x86_64",
+            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/app.app.dSYM/Contents/Info.plist",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -23,6 +23,10 @@ load(
     "analysis_output_group_info_files_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_runfiles_test.bzl",
+    "analysis_runfiles_dsym_test",
+)
+load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
     "apple_dsym_bundle_info_test",
 )
@@ -186,6 +190,16 @@ def macos_command_line_application_test_suite(name):
             "DTSDKName": "macosx*",
             "LSMinimumSystemVersion": "10.13",
         },
+        tags = [name],
+    )
+
+    analysis_runfiles_dsym_test(
+        name = "{}_runfiles_dsym_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
+        expected_runfiles = [
+            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Resources/DWARF/cmd_app_basic_x86_64",
+            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Info.plist",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -197,7 +197,7 @@ def macos_command_line_application_test_suite(name):
         name = "{}_runfiles_dsym_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
         expected_runfiles = [
-            "test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Resources/DWARF/cmd_app_basic_x86_64",
+            "test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Resources/DWARF/cmd_app_basic",
             "test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Info.plist",
         ],
         tags = [name],

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -197,8 +197,8 @@ def macos_command_line_application_test_suite(name):
         name = "{}_runfiles_dsym_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
         expected_runfiles = [
-            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Resources/DWARF/cmd_app_basic_x86_64",
-            "third_party/bazel_rules/rules_apple/test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Info.plist",
+            "test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Resources/DWARF/cmd_app_basic_x86_64",
+            "test/starlark_tests/targets_under_test/macos/cmd_app_basic.dSYM/Contents/Info.plist",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/rules/analysis_runfiles_test.bzl
+++ b/test/starlark_tests/rules/analysis_runfiles_test.bzl
@@ -35,12 +35,34 @@ def _analysis_runfiles_test_impl(ctx):
 
     return analysistest.end(env)
 
-analysis_runfiles_test = analysistest.make(
-    _analysis_runfiles_test_impl,
-    attrs = {
-        "expected_runfiles": attr.string_list(
-            mandatory = True,
-            doc = "A list of runfiles expected to be found in the given target.",
-        ),
-    },
-)
+def make_analysis_runfiles_test_rule(
+        *,
+        config_settings = {}):
+    """Returns a new `provider_test`-like rule for a specific provider with custom settings.
+
+    Args:
+        config_settings: A dictionary of configuration settings and their values
+            that should be applied during tests.
+
+    Returns:
+        A rule returned by `analysistest.make` that has the `provider_test` interface with the
+        given attrs, and config settings.
+    """
+    return analysistest.make(
+        _analysis_runfiles_test_impl,
+        attrs = {
+            "expected_runfiles": attr.string_list(
+                mandatory = True,
+                doc = "A list of runfiles expected to be found in the given target.",
+            ),
+        },
+        config_settings = config_settings,
+    )
+
+# A generic analysis_runfiles_test with no custom settings.
+analysis_runfiles_test = make_analysis_runfiles_test_rule()
+
+# An analysis_runfiles_test that generates dsyms.
+analysis_runfiles_dsym_test = make_analysis_runfiles_test_rule(config_settings = {
+    "//command_line_option:apple_generate_dsym": "true",
+})


### PR DESCRIPTION
Seems that the goal of these changes is to get macOS to discover the dsyms when running directly through bazel