### PR TITLE
Add messaging for watchOS extension-based applications for watchOS 9.0 or later, and migrate extension-based tests for watchOS 9.0 or later to the single-target application format.

### DIFF
--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -682,6 +682,25 @@ def _watchos_application_impl(ctx):
 def _watchos_extension_based_application_impl(ctx):
     """Implementation of watchos_application for watchOS 2 extension-based application bundles."""
 
+    minimum_os = apple_common.dotted_version(ctx.attr.minimum_os_version)
+    if minimum_os >= apple_common.dotted_version("9.0"):
+        # There is no way to issue a warning, so print is the only way to message before fail-ing.
+        # buildifier: disable=print
+        print("""
+WARNING: Building an app extension-based watchOS 2 application for watchOS 9.0 or later.
+
+This will soon be an error.
+
+watchOS applications for watchOS 9.0 or later MUST be single-target watchOS applications, relying on
+an app delegate via deps rather than a watchOS 2 extension.
+
+Attempting to ship an extension-based watchOS 2 application to the App Store for watchOS 9.0 or
+later will be met with a rejection.
+
+Please remove the assigned watchOS 2 app `extension` and make sure a valid watchOS application
+delegate is referenced in the single-target `watchos_application`'s `deps`.
+""")
+
     rule_descriptor = rule_support.rule_descriptor(
         platform_type = ctx.attr.platform_type,
         product_type = apple_product_type.watch2_application,

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -274,7 +274,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         name = "{}_links_watchos_arm64_macho_load_cmd_for_simulator_test".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_xcframework",
-        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_xcframework.appex/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
         binary_test_architecture = "arm64",
         cpus = {"watchos_cpus": ["arm64"]},
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOSSIMULATOR"],
@@ -283,7 +283,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_xcframework",
-        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_xcframework.appex/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
         binary_test_architecture = "arm64_32",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
     )

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -167,8 +167,8 @@ def apple_static_xcframework_import_test_suite(name):
         build_type = "simulator",
         cpus = {"watchos_cpus": ["arm64"]},
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_static_xcframework",
-        not_contains = ["$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/Frameworks"],
-        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/ext_with_imported_static_xcframework",
+        not_contains = ["$BUNDLE_ROOT/Frameworks"],
+        binary_test_file = "$BUNDLE_ROOT/app_with_imported_static_xcframework",
         binary_test_architecture = "arm64",
         binary_contains_symbols = [
             "-[SharedClass doSomethingShared]",
@@ -180,8 +180,8 @@ def apple_static_xcframework_import_test_suite(name):
         name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_static_xcframework",
-        not_contains = ["$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/Frameworks"],
-        binary_test_file = "$BUNDLE_ROOT/PlugIns/ext_with_imported_static_xcframework.appex/ext_with_imported_static_xcframework",
+        not_contains = ["$BUNDLE_ROOT/Frameworks"],
+        binary_test_file = "$BUNDLE_ROOT/app_with_imported_static_xcframework",
         binary_test_architecture = "arm64_32",
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
         binary_contains_symbols = [

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -1013,29 +1013,15 @@ watchos_application(
     name = "app_with_imported_xcframework",
     app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
     bundle_id = "com.google.example",
-    extension = ":ext_with_imported_xcframework",
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],
     minimum_os_version = common.min_os_watchos.arm64_support,
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
-)
-
-watchos_extension(
-    name = "ext_with_imported_xcframework",
-    bundle_id = "com.google.example.ext",
-    entitlements = "//test/starlark_tests/resources:entitlements.plist",
-    infoplists = [
-        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
-    ],
-    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
-    minimum_os_version = common.min_os_watchos.arm64_support,
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = common.fixture_tags,
     deps = [
         ":dynamic_xcframework_depending_lib",
-        "//test/starlark_tests/resources:watchkit_ext_main_lib",
+        "//test/starlark_tests/resources:watchkit_single_target_app_main_lib",
     ],
 )
 
@@ -1082,28 +1068,15 @@ watchos_application(
     name = "app_with_imported_static_xcframework",
     app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
     bundle_id = "com.google.example",
-    extension = ":ext_with_imported_static_xcframework",
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],
     minimum_os_version = common.min_os_watchos.arm64_support,
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
-)
-
-watchos_extension(
-    name = "ext_with_imported_static_xcframework",
-    bundle_id = "com.google.example.ext",
-    entitlements = "//test/starlark_tests/resources:entitlements.plist",
-    infoplists = [
-        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
-    ],
-    minimum_os_version = common.min_os_watchos.arm64_support,
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = common.fixture_tags,
     deps = [
         ":static_xcframework_depending_lib",
-        "//test/starlark_tests/resources:watchkit_ext_main_lib",
+        "//test/starlark_tests/resources:watchkit_single_target_app_main_lib",
     ],
 )
 
@@ -1160,37 +1133,6 @@ watchos_application(
     tags = common.fixture_tags,
     deps = [
         "//test/starlark_tests/resources:watchkit_single_target_app_main_lib",
-    ],
-)
-
-watchos_application(
-    name = "app_with_ext_with_app_intents",
-    app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
-    bundle_id = "com.google.example",
-    extension = ":ext_with_app_intents",
-    infoplists = [
-        "//test/starlark_tests/resources:WatchosAppInfo.plist",
-    ],
-    minimum_os_version = common.min_os_watchos.app_intents_support,
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = common.fixture_tags,
-)
-
-watchos_extension(
-    name = "ext_with_app_intents",
-    app_intents = [
-        "//test/starlark_tests/resources:app_intent",
-    ],
-    bundle_id = "com.google.example.ext",
-    entitlements = "//test/starlark_tests/resources:entitlements.plist",
-    infoplists = [
-        "//test/starlark_tests/resources:WatchosExtensionInfo.plist",
-    ],
-    minimum_os_version = common.min_os_watchos.app_intents_support,
-    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
-    tags = common.fixture_tags,
-    deps = [
-        "//test/starlark_tests/resources:watchkit_ext_main_lib",
     ],
 )
 

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -205,19 +205,6 @@ def watchos_application_test_suite(name):
         tags = [name],
     )
 
-    # Test app bundles transitive Metadata.appintents bundle from extension.
-    archive_contents_test(
-        name = "{}_with_ext_contains_app_intents_metadata_bundle".format(name),
-        build_type = "simulator",
-        cpus = {"watchos_cpus": ["arm64"]},
-        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_ext_with_app_intents",
-        contains = [
-            "$BUNDLE_ROOT/PlugIns/ext_with_app_intents.appex/Metadata.appintents/extract.actionsdata",
-            "$BUNDLE_ROOT/PlugIns/ext_with_app_intents.appex/Metadata.appintents/version.json",
-        ],
-        tags = [name],
-    )
-
     infoplist_contents_test(
         name = "{}_capability_set_derived_bundle_id_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_ext_with_capability_set_derived_bundle_id",

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -277,19 +277,6 @@ def watchos_extension_test_suite(name):
         tags = [name],
     )
 
-    # Test app with App Intents generates and bundles Metadata.appintents bundle.
-    archive_contents_test(
-        name = "{}_contains_app_intents_metadata_bundle".format(name),
-        build_type = "simulator",
-        cpus = {"watchos_cpus": ["arm64"]},
-        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext_with_app_intents",
-        contains = [
-            "$BUNDLE_ROOT/Metadata.appintents/extract.actionsdata",
-            "$BUNDLE_ROOT/Metadata.appintents/version.json",
-        ],
-        tags = [name],
-    )
-
     infoplist_contents_test(
         name = "{}_capability_set_derived_bundle_id_plist_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ext_with_capability_set_derived_bundle_id",


### PR DESCRIPTION
Some tests relying on watchOS arm64 support and watchOS App Intents support were composed as watchOS 2 app extension-based tests. This is not valid for the app store; those underlying targets for test instances have been migrated to the single-target watchOS application formats or removed where applicable.

PiperOrigin-RevId: 543781026
(cherry picked from commit f20f750562a18cfa4a36de91f216f5b570673075)
