### PR TITLE
Change tests to verify Swift ABI stability dylibs to verify device flows rather than simulator flows.

### DIFF
--- a/test/starlark_tests/watchos_application_swift_tests.bzl
+++ b/test/starlark_tests/watchos_application_swift_tests.bzl
@@ -30,19 +30,18 @@ def watchos_application_swift_test_suite(name):
       name: the base name to be used in things created by this macro
     """
 
-    # Pre-ABI stability, simulator build, iOS companion app uses Swift but
+    # Pre-ABI stability, device build, iOS companion app uses Swift but
     # watchOS app extension does not: Swift runtime should be bundled in the
-    # iOS app but not in the watch app or in the IPA's root SwiftSupport
-    # directory.
+    # iOS app and the IPA's root SwiftSupport directory but not in the watch app.
     archive_contents_test(
-        name = "{}_simulator_build_ios_swift_watchos_no_swift_test".format(name),
-        build_type = "simulator",
+        name = "{}_device_build_ios_swift_watchos_no_swift_test".format(name),
+        build_type = "device",
         contains = [
+            "$ARCHIVE_ROOT/SwiftSupport/iphoneos/libswiftCore.dylib",
             "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
         ],
         not_contains = [
-            "$ARCHIVE_ROOT/SwiftSupport/iphonesimulator/libswiftCore.dylib",
-            "$ARCHIVE_ROOT/SwiftSupport/watchsimulator/libswiftCore.dylib",
+            "$ARCHIVE_ROOT/SwiftSupport/watchos/libswiftCore.dylib",
             "$BUNDLE_ROOT/Watch/app.app/Frameworks/libswiftCore.dylib",
             "$BUNDLE_ROOT/Watch/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib",
         ],
@@ -50,43 +49,23 @@ def watchos_application_swift_test_suite(name):
         tags = [name],
     )
 
-    # Pre-ABI stability, simulator build, iOS companion app does not use
+    # Pre-ABI stability, device build, iOS companion app does not use
     # Swift but watchOS app extension does: Swift runtime should be bundled in
-    # the watch app (*not* the extension) but not in the iOS app or in the
-    # IPA's root SwiftSupport directory.
+    # the watch app (*not* the extension) and in the IPA's root SwiftSupport
+    # directory but not in the iOS app.
     archive_contents_test(
-        name = "{}_simulator_build_ios_no_swift_watchos_swift_test".format(name),
-        build_type = "simulator",
+        name = "{}_device_build_ios_no_swift_watchos_swift_test".format(name),
+        build_type = "device",
         contains = [
+            "$ARCHIVE_ROOT/SwiftSupport/watchos/libswiftCore.dylib",
             "$BUNDLE_ROOT/Watch/app.app/Frameworks/libswiftCore.dylib",
         ],
         not_contains = [
+            "$ARCHIVE_ROOT/SwiftSupport/iphoneos/libswiftCore.dylib",
             "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
-            "$ARCHIVE_ROOT/SwiftSupport/iphonesimulator/libswiftCore.dylib",
-            "$ARCHIVE_ROOT/SwiftSupport/watchsimulator/libswiftCore.dylib",
             "$BUNDLE_ROOT/Watch/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib",
         ],
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:ios_no_swift_watchos_with_swift",
-        tags = [name],
-    )
-
-    # Pre-ABI stability, simulator build, iOS companion app and watchOS app
-    # extension both use Swift: Swift runtime should be bundled in the iOS app
-    # and in the watch app (*not* the extension) but not in the IPA's root
-    # SwiftSupport directory.
-    archive_contents_test(
-        name = "{}_simulator_build_ios_swift_watchos_swift_test".format(name),
-        build_type = "simulator",
-        contains = [
-            "$BUNDLE_ROOT/Frameworks/libswiftCore.dylib",
-            "$BUNDLE_ROOT/Watch/app.app/Frameworks/libswiftCore.dylib",
-        ],
-        not_contains = [
-            "$ARCHIVE_ROOT/SwiftSupport/iphonesimulator/libswiftCore.dylib",
-            "$ARCHIVE_ROOT/SwiftSupport/watchsimulator/libswiftCore.dylib",
-            "$BUNDLE_ROOT/Watch/app.app/PlugIns/ext.appex/Frameworks/libswiftCore.dylib",
-        ],
-        target_under_test = "//test/starlark_tests/targets_under_test/watchos:ios_with_swift_watchos_with_swift",
         tags = [name],
     )
 


### PR DESCRIPTION
ABI stability affects watchOS 6.0 and later, while Xcode 14 and 15 do not officially support watchOS Simulator before 7.0. These tests do break when run against Xcode 15 beta 1 and 2.

PiperOrigin-RevId: 544025671
(cherry picked from commit e64f6a050556e1dddfe3bd8f65bf8aff84a6af4f)
