### PR TITLE
Lock buildifier for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,4 +39,4 @@ tasks:
     - "doc/..."
     <<: *common_last_green
 
-buildifier: v6.3.2
+buildifier: 6.3.2

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -39,4 +39,4 @@ tasks:
     - "doc/..."
     <<: *common_last_green
 
-buildifier: latest
+buildifier: v6.3.2


### PR DESCRIPTION
Hoping the upstream branch takes the import default change to reduce
conflicts
