### PR TITLE
Upgrade the warning to a fail for the purposes of detecting watchos_application targets that need to migrate to the new bundle format + watchOS single target app delegate.

### DIFF
--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -688,12 +688,8 @@ def _watchos_extension_based_application_impl(ctx):
 
     minimum_os = apple_common.dotted_version(ctx.attr.minimum_os_version)
     if minimum_os >= apple_common.dotted_version("9.0"):
-        # There is no way to issue a warning, so print is the only way to message before fail-ing.
-        # buildifier: disable=print
-        print("""
-WARNING: Building an app extension-based watchOS 2 application for watchOS 9.0 or later.
-
-This will soon be an error.
+        fail("""
+Error: Building an app extension-based watchOS 2 application for watchOS 9.0 or later.
 
 watchOS applications for watchOS 9.0 or later MUST be single-target watchOS applications, relying on
 an app delegate via deps rather than a watchOS 2 extension.

--- a/test/starlark_tests/common.bzl
+++ b/test/starlark_tests/common.bzl
@@ -61,6 +61,7 @@ _min_os_watchos = struct(
     arm64_support = "9.0",
     arm_sim_support = "7.0",
     baseline = "4.0",
+    requires_single_target_app = "9.0",
     single_target_app = "7.0",
     stable_swift_abi = "6.0",
     test_runner_support = "7.4",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -58,6 +58,19 @@ watchos_application(
 )
 
 watchos_application(
+    name = "app_with_ext_with_invalid_watchos_version",
+    app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
+    bundle_id = "com.google.example",
+    extension = ":ext",
+    infoplists = [
+        "//test/starlark_tests/resources:WatchosAppInfo.plist",
+    ],
+    minimum_os_version = common.min_os_watchos.requires_single_target_app,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+)
+
+watchos_application(
     name = "single_target_app",
     app_icons = ["//test/starlark_tests/resources:WatchAppIcon.xcassets"],
     bundle_id = "com.google.example",

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "common",
 )
 load(
+    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -211,6 +215,13 @@ def watchos_application_test_suite(name):
         expected_values = {
             "CFBundleIdentifier": "com.bazel.app.example.watchkitapp",
         },
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_test_watchos_single_target_application_required_error".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_ext_with_invalid_watchos_version",
+        expected_error = "Error: Building an app extension-based watchOS 2 application for watchOS 9.0 or later.",
         tags = [name],
     )
 


### PR DESCRIPTION
PiperOrigin-RevId: 544385913
(cherry picked from commit 790cee9fdfd14d7f12fc9c577e37c8a165d13fbb)
