### PR TITLE
Migrate the provider for Apple bundle version info to the new provider initializer format.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -197,8 +197,8 @@ bzl_library(
     name = "versioning",
     srcs = ["versioning.bzl"],
     deps = [
-        ":providers",
         "//apple/internal:apple_toolchains",
+        "//apple/internal:providers",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/apple/internal/providers.bzl
+++ b/apple/internal/providers.bzl
@@ -155,6 +155,44 @@ set to true for the extension but false for the application.
     init = _make_banned_init(provider_name = "AppleBundleInfo"),
 )
 
+AppleBundleVersionInfo, new_applebundleversioninfo = provider(
+    doc = "Provides versioning information for an Apple bundle.",
+    fields = {
+        "version_file": """
+Required. A `File` containing JSON-formatted text describing the version number information
+propagated by the target.
+
+It contains two keys:
+
+*   `build_version`, which corresponds to `CFBundleVersion`.
+
+*   `short_version_string`, which corresponds to `CFBundleShortVersionString`.
+""",
+    },
+    init = _make_banned_init(
+        provider_name = "AppleBundleVersionInfo",
+        preferred_public_factory = "make_apple_bundle_version_info(...)",
+    ),
+)
+
+def make_apple_bundle_version_info(*, version_file):
+    """Creates a new instance of the `AppleBundleVersionInfo` provider.
+
+    Args:
+        version_file: Required. See the docs on `AppleBundleVersionInfo`.
+
+    Returns:
+        A new `AppleBundleVersionInfo` provider based on the supplied arguments.
+    """
+    if type(version_file) != "File":
+        fail("""
+Error: Expected "version_file" to be of type "File".
+
+Received unexpected type "{actual_type}".
+""".format(actual_type = type(version_file)))
+
+    return new_applebundleversioninfo(version_file = version_file)
+
 AppleDsymBundleInfo, new_appledsymbundleinfo = provider(
     doc = "Provides information for an Apple dSYM bundle.",
     fields = {
@@ -441,14 +479,12 @@ def make_apple_test_runner_info(**kwargs):
         A new `AppleTestRunnerInfo` provider based on the supplied arguments.
     """
     if "test_runner_template" not in kwargs or not kwargs["test_runner_template"]:
-        fail(
-            """
+        fail("""
 Error: Could not find the required argument "test_runner_template" needed to build an
 AppleTestRunner provider.
 
 Received the following arguments for make_apple_test_runner_info: {kwargs}
-""".format(kwargs = ", ".join(kwargs.keys())),
-        )
+""".format(kwargs = ", ".join(kwargs.keys())))
 
     return new_appletestrunnerinfo(**kwargs)
 

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -34,6 +34,7 @@ load(
     _AppleBaseBundleIdInfo = "AppleBaseBundleIdInfo",
     _AppleBinaryInfo = "AppleBinaryInfo",
     _AppleBundleInfo = "AppleBundleInfo",
+    _AppleBundleVersionInfo = "AppleBundleVersionInfo",
     _AppleDsymBundleInfo = "AppleDsymBundleInfo",
     _AppleExtraOutputsInfo = "AppleExtraOutputsInfo",
     _AppleFrameworkBundleInfo = "AppleFrameworkBundleInfo",
@@ -70,15 +71,57 @@ load(
     _WatchosApplicationBundleInfo = "WatchosApplicationBundleInfo",
     _WatchosExtensionBundleInfo = "WatchosExtensionBundleInfo",
     _WatchosXcTestBundleInfo = "WatchosXcTestBundleInfo",
+    _make_apple_bundle_version_info = "make_apple_bundle_version_info",
     _make_apple_test_runner_info = "make_apple_test_runner_info",
     _merge_apple_framework_import_info = "merge_apple_framework_import_info",
 )
 
 AppleBaseBundleIdInfo = _AppleBaseBundleIdInfo
-
 AppleBundleInfo = _AppleBundleInfo
-
 AppleBinaryInfo = _AppleBinaryInfo
+AppleBundleVersionInfo = _AppleBundleVersionInfo
+AppleDsymBundleInfo = _AppleDsymBundleInfo
+AppleExtraOutputsInfo = _AppleExtraOutputsInfo
+AppleFrameworkBundleInfo = _AppleFrameworkBundleInfo
+AppleFrameworkImportInfo = _AppleFrameworkImportInfo
+ApplePlatformInfo = _ApplePlatformInfo
+AppleResourceBundleInfo = _AppleResourceBundleInfo
+AppleResourceInfo = _AppleResourceInfo
+AppleSharedCapabilityInfo = _AppleSharedCapabilityInfo
+AppleStaticXcframeworkBundleInfo = _AppleStaticXcframeworkBundleInfo
+AppleTestInfo = _AppleTestInfo
+AppleTestRunnerInfo = _AppleTestRunnerInfo
+AppleXcframeworkBundleInfo = _AppleXcframeworkBundleInfo
+IosAppClipBundleInfo = _IosAppClipBundleInfo
+IosApplicationBundleInfo = _IosApplicationBundleInfo
+IosExtensionBundleInfo = _IosExtensionBundleInfo
+IosFrameworkBundleInfo = _IosFrameworkBundleInfo
+IosImessageApplicationBundleInfo = _IosImessageApplicationBundleInfo
+IosImessageExtensionBundleInfo = _IosImessageExtensionBundleInfo
+IosStaticFrameworkBundleInfo = _IosStaticFrameworkBundleInfo
+IosXcTestBundleInfo = _IosXcTestBundleInfo
+MacosApplicationBundleInfo = _MacosApplicationBundleInfo
+MacosBundleBundleInfo = _MacosBundleBundleInfo
+MacosExtensionBundleInfo = _MacosExtensionBundleInfo
+MacosKernelExtensionBundleInfo = _MacosKernelExtensionBundleInfo
+MacosQuickLookPluginBundleInfo = _MacosQuickLookPluginBundleInfo
+MacosSpotlightImporterBundleInfo = _MacosSpotlightImporterBundleInfo
+MacosXPCServiceBundleInfo = _MacosXPCServiceBundleInfo
+MacosXcTestBundleInfo = _MacosXcTestBundleInfo
+TvosApplicationBundleInfo = _TvosApplicationBundleInfo
+TvosExtensionBundleInfo = _TvosExtensionBundleInfo
+TvosFrameworkBundleInfo = _TvosFrameworkBundleInfo
+TvosStaticFrameworkBundleInfo = _TvosStaticFrameworkBundleInfo
+TvosXcTestBundleInfo = _TvosXcTestBundleInfo
+WatchosApplicationBundleInfo = _WatchosApplicationBundleInfo
+WatchosExtensionBundleInfo = _WatchosExtensionBundleInfo
+WatchosXcTestBundleInfo = _WatchosXcTestBundleInfo
+
+apple_provider = struct(
+    make_apple_bundle_version_info = _make_apple_bundle_version_info,
+    make_apple_test_runner_info = _make_apple_test_runner_info,
+    merge_apple_framework_import_info = _merge_apple_framework_import_info,
+)
 
 AppleBinaryInfoplistInfo = provider(
     doc = """
@@ -91,30 +134,6 @@ target.
 """,
     },
 )
-
-AppleBundleVersionInfo = provider(
-    doc = "Provides versioning information for an Apple bundle.",
-    fields = {
-        "version_file": """
-Required. A `File` containing JSON-formatted text describing the version number information
-propagated by the target.
-
-It contains two keys:
-
-*   `build_version`, which corresponds to `CFBundleVersion`.
-
-*   `short_version_string`, which corresponds to `CFBundleShortVersionString`.
-""",
-    },
-)
-
-AppleDsymBundleInfo = _AppleDsymBundleInfo
-
-AppleExtraOutputsInfo = _AppleExtraOutputsInfo
-
-AppleFrameworkBundleInfo = _AppleFrameworkBundleInfo
-
-AppleFrameworkImportInfo = _AppleFrameworkImportInfo
 
 AppleProvisioningProfileInfo = provider(
     doc = "Provides information about a provisioning profile.",
@@ -131,20 +150,6 @@ known at analysis time.
 """,
     },
 )
-
-ApplePlatformInfo = _ApplePlatformInfo
-
-AppleResourceBundleInfo = _AppleResourceBundleInfo
-
-AppleResourceInfo = _AppleResourceInfo
-
-AppleSharedCapabilityInfo = _AppleSharedCapabilityInfo
-
-AppleStaticXcframeworkBundleInfo = _AppleStaticXcframeworkBundleInfo
-
-AppleTestInfo = _AppleTestInfo
-
-AppleTestRunnerInfo = _AppleTestRunnerInfo
 
 IosStickerPackExtensionBundleInfo = provider(
     doc = """
@@ -209,35 +214,4 @@ a dependency is an macOS static framework should use this provider to describe
 that requirement.
 """,
     fields = {},
-)
-
-AppleXcframeworkBundleInfo = _AppleXcframeworkBundleInfo
-IosAppClipBundleInfo = _IosAppClipBundleInfo
-IosApplicationBundleInfo = _IosApplicationBundleInfo
-IosExtensionBundleInfo = _IosExtensionBundleInfo
-IosFrameworkBundleInfo = _IosFrameworkBundleInfo
-IosImessageApplicationBundleInfo = _IosImessageApplicationBundleInfo
-IosImessageExtensionBundleInfo = _IosImessageExtensionBundleInfo
-IosStaticFrameworkBundleInfo = _IosStaticFrameworkBundleInfo
-IosXcTestBundleInfo = _IosXcTestBundleInfo
-MacosApplicationBundleInfo = _MacosApplicationBundleInfo
-MacosBundleBundleInfo = _MacosBundleBundleInfo
-MacosExtensionBundleInfo = _MacosExtensionBundleInfo
-MacosKernelExtensionBundleInfo = _MacosKernelExtensionBundleInfo
-MacosQuickLookPluginBundleInfo = _MacosQuickLookPluginBundleInfo
-MacosSpotlightImporterBundleInfo = _MacosSpotlightImporterBundleInfo
-MacosXPCServiceBundleInfo = _MacosXPCServiceBundleInfo
-MacosXcTestBundleInfo = _MacosXcTestBundleInfo
-TvosApplicationBundleInfo = _TvosApplicationBundleInfo
-TvosExtensionBundleInfo = _TvosExtensionBundleInfo
-TvosFrameworkBundleInfo = _TvosFrameworkBundleInfo
-TvosStaticFrameworkBundleInfo = _TvosStaticFrameworkBundleInfo
-TvosXcTestBundleInfo = _TvosXcTestBundleInfo
-WatchosApplicationBundleInfo = _WatchosApplicationBundleInfo
-WatchosExtensionBundleInfo = _WatchosExtensionBundleInfo
-WatchosXcTestBundleInfo = _WatchosXcTestBundleInfo
-
-apple_provider = struct(
-    make_apple_test_runner_info = _make_apple_test_runner_info,
-    merge_apple_framework_import_info = _merge_apple_framework_import_info,
 )

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -15,8 +15,8 @@
 """# Rules related to Apple bundle versioning."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleVersionInfo",
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "new_applebundleversioninfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -145,7 +145,7 @@ def _apple_bundle_version_impl(ctx):
     )
 
     return [
-        AppleBundleVersionInfo(
+        new_applebundleversioninfo(
             version_file = bundle_version_file,
         ),
         DefaultInfo(files = depset([bundle_version_file])),

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -1087,6 +1087,28 @@ is a watchOS .xctest bundle should use this provider to describe that requiremen
 
 
 
+<a id="apple_provider.make_apple_bundle_version_info"></a>
+
+## apple_provider.make_apple_bundle_version_info
+
+<pre>
+apple_provider.make_apple_bundle_version_info(<a href="#apple_provider.make_apple_bundle_version_info-version_file">version_file</a>)
+</pre>
+
+Creates a new instance of the `AppleBundleVersionInfo` provider.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="apple_provider.make_apple_bundle_version_info-version_file"></a>version_file |  Required. See the docs on <code>AppleBundleVersionInfo</code>.   |  none |
+
+**RETURNS**
+
+A new `AppleBundleVersionInfo` provider based on the supplied arguments.
+
+
 <a id="apple_provider.make_apple_test_runner_info"></a>
 
 ## apple_provider.make_apple_test_runner_info


### PR DESCRIPTION
PiperOrigin-RevId: 544087729
(cherry picked from commit d9d722e45f9706e56afa96787d959a0f5d997f99)
