### PR TITLE
Give the targets depended on by ios_static_framework tests that need to test Swift modules and the targets depended on by XCFramework import tests that need to test Swift modules different module names.

### DIFF
--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -83,16 +83,16 @@ def apple_dynamic_xcframework_import_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_swift_xcframework",
         contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Info.plist",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
         ],
         not_contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Headers/",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Modules/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Modules/",
         ],
         binary_test_file = "$BINARY",
         macho_load_commands_contain = [
-            "name @rpath/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader (offset 24)",
+            "name @rpath/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader (offset 24)",
         ],
         tags = [name],
     )
@@ -101,16 +101,16 @@ def apple_dynamic_xcframework_import_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_with_imported_swift_xcframework",
         contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Info.plist",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
         ],
         not_contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Headers/",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Modules/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Modules/",
         ],
         binary_test_file = "$BINARY",
         macho_load_commands_contain = [
-            "name @rpath/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader (offset 24)",
+            "name @rpath/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader (offset 24)",
         ],
         tags = [name],
     )
@@ -164,7 +164,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         name = "{}_xcframework_swift_binary_file_info_test_fat".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_swift_xcframework",
-        binary_test_file = "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+        binary_test_file = "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
         binary_contains_file_info = ["Mach-O 64-bit dynamically linked shared library x86_64"],
         tags = [name],
     )
@@ -215,16 +215,16 @@ def apple_dynamic_xcframework_import_test_suite(name):
         },
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_with_imported_swift_xcframework",
         contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Info.plist",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
         ],
         not_contains = [
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Headers/",
-            "$BUNDLE_ROOT/Frameworks/SwiftFmwkWithGenHeader.framework/Modules/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/Swift3PFmwkWithGenHeader.framework/Modules/",
         ],
         binary_test_file = "$BINARY",
         macho_load_commands_contain = [
-            "name @rpath/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader (offset 24)",
+            "name @rpath/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader (offset 24)",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -185,10 +185,10 @@ def ios_static_framework_test_suite(name):
         compilation_mode = "opt",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:static_framework_with_generated_header",
         contains = [
-            "$BUNDLE_ROOT/Headers/SwiftFmwkWithGenHeader.h",
+            "$BUNDLE_ROOT/Headers/SwiftStaticFmwkWithGenHeader.h",
             "$BUNDLE_ROOT/Modules/module.modulemap",
-            "$BUNDLE_ROOT/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
-            "$BUNDLE_ROOT/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+            "$BUNDLE_ROOT/Modules/SwiftStaticFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+            "$BUNDLE_ROOT/Modules/SwiftStaticFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
         ],
         tags = [name],
     )
@@ -221,12 +221,12 @@ def ios_static_framework_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:static_framework_with_generated_header",
         contains = [
-            "$ARCHIVE_ROOT/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
+            "$ARCHIVE_ROOT/SwiftStaticFmwkWithGenHeader.framework/SwiftStaticFmwkWithGenHeader",
         ],
         text_test_file = "$BUNDLE_ROOT/Modules/module.modulemap",
         text_test_values = [
-            "module SwiftFmwkWithGenHeader",
-            "header \"SwiftFmwkWithGenHeader.h\"",
+            "module SwiftStaticFmwkWithGenHeader",
+            "header \"SwiftStaticFmwkWithGenHeader.h\"",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -854,6 +854,37 @@ apple_xcframework(
     deps = [":SwiftFmwkWithGenHeader"],
 )
 
+# Reserved as an input for import_dynamic_(xc)framework rules; must be referenced as a List of Files
+# as an input to one of such rules.
+apple_xcframework(
+    name = "ios_swift_3p_xcframework_with_generated_header",
+    bundle_id = "com.google.example",
+    bundle_name = "Swift3PFmwkWithGenHeader",
+    # TODO(b/239957001): Remove this when the rule no longer forces library
+    # evolution.
+    features = ["apple.no_legacy_swiftinterface"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": [
+            "arm64",
+        ],
+    },
+    minimum_os_versions = {
+        "ios": common.min_os_ios.baseline,
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = common.fixture_tags,
+    deps = [":Swift3PFmwkWithGenHeader"],
+)
+
 apple_xcframework(
     name = "ios_dynamic_xcframework_with_umbrella_header_conflict",
     bundle_id = "com.google.example",
@@ -1202,6 +1233,17 @@ swift_library(
     srcs = ["DummyFmwk.swift"],
     generates_header = True,
     module_name = "SwiftFmwkWithGenHeader",
+    tags = common.fixture_tags,
+)
+
+# Reserved as an input for import_dynamic_(xc)framework rules; referenced by an apple_xcframework
+# rule treated as a List of Files that properly declares a bundle_name matching this module_name.
+swift_library(
+    name = "Swift3PFmwkWithGenHeader",
+    srcs = ["DummyFmwk.swift"],
+    features = ["swift.enable_library_evolution"],
+    generates_header = True,
+    module_name = "Swift3PFmwkWithGenHeader",
     tags = common.fixture_tags,
 )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2318,7 +2318,7 @@ write_file(
     name = "objc_with_framework_src",
     out = "ObjcWithFramework.m",
     content = ["""
-#import <SwiftFmwkWithGenHeader/SwiftFmwkWithGenHeader.h>
+#import <Swift3PFmwkWithGenHeader/Swift3PFmwkWithGenHeader.h>
 
 int objc_with_framework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
@@ -2359,10 +2359,10 @@ write_file(
     name = "swift_with_dynamic_swift_framework_src",
     out = "SwiftWithDynamicSwiftFramework.swift",
     content = ["""
-import SwiftFmwkWithGenHeader
+import Swift3PFmwkWithGenHeader
 
 func swift_with_dynamic_swift_framework_function() {
-  let sc = SwiftFmwkWithGenHeader.SharedClass()
+  let sc = Swift3PFmwkWithGenHeader.SharedClass()
   sc.doSomethingShared()
 }
 """],
@@ -2379,25 +2379,25 @@ apple_dynamic_xcframework_import(
 
 genrule(
     name = "ios_swift_dynamic_xcframework",
-    srcs = ["//test/starlark_tests/targets_under_test/apple:ios_swift_xcframework_with_generated_header"],
+    srcs = ["//test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_with_generated_header"],
     outs = [
-        "SwiftFmwkWithGenHeader.xcframework/Info.plist",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Info.plist",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/SwiftFmwkWithGenHeader",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Headers/SwiftFmwkWithGenHeader.h",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Info.plist",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/SwiftFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
-        "SwiftFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/SwiftFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "Swift3PFmwkWithGenHeader.xcframework/Info.plist",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        "Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
     ],
-    cmd = "unzip -qq $(execpath //test/starlark_tests/targets_under_test/apple:ios_swift_xcframework_with_generated_header) -d $(RULEDIR)",
+    cmd = "unzip -qq $(execpath //test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_with_generated_header) -d $(RULEDIR)",
     tags = common.fixture_tags,
 )
 
@@ -3780,10 +3780,13 @@ ios_static_framework(
 
 ios_static_framework(
     name = "static_framework_with_generated_header",
-    bundle_name = "SwiftFmwkWithGenHeader",
+    bundle_name = "SwiftStaticFmwkWithGenHeader",
+    # TODO(b/239957001): Remove this when the rule no longer forces library
+    # evolution.
+    features = ["apple.no_legacy_swiftinterface"],
     minimum_os_version = common.min_os_ios.baseline,
     tags = common.fixture_tags,
-    deps = [":SwiftFmwkWithGenHeader"],
+    deps = [":SwiftStaticFmwkWithGenHeader"],
 )
 
 ios_static_framework(
@@ -3876,10 +3879,11 @@ swift_library(
 )
 
 swift_library(
-    name = "SwiftFmwkWithGenHeader",
+    name = "SwiftStaticFmwkWithGenHeader",
     srcs = [":dummy_swift"],
+    features = ["swift.enable_library_evolution"],
     generates_header = True,
-    module_name = "SwiftFmwkWithGenHeader",
+    module_name = "SwiftStaticFmwkWithGenHeader",
     tags = common.fixture_tags,
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 547462304
(cherry picked from commit b9ca981e3acd50bcee6cb2f25945a0142dbf23b9)
