### PR TITLE
Add a sed in archive_contents_test and binary_contents_test to strip out the `.hidden` column present in specific rows of the output of objdump to continue matching symbols in the *_contents_test shell scripts.

### DIFF
--- a/test/starlark_tests/verifier_scripts/archive_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/archive_contents_test.sh
@@ -173,8 +173,9 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     fi
 
     # Filter out undefined symbols from the objdump mach-o symbol output and
-    # return the rightmost value; these binary symbols will not have spaces.
-    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
+    # return the fifth from rightmost values, with the `.hidden` column stripped
+    # where applicable.
+    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}' | sed 's/.hidden *//'))
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_CONTAINS_SYMBOLS[@]}"
       do

--- a/test/starlark_tests/verifier_scripts/binary_contents_test.sh
+++ b/test/starlark_tests/verifier_scripts/binary_contents_test.sh
@@ -76,8 +76,9 @@ if [[ -n "${BINARY_TEST_FILE-}" ]]; then
     fi
 
     # Filter out undefined symbols from the objdump mach-o symbol output and
-    # return the rightmost value; these binary symbols will not have spaces.
-    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}'))
+    # return the fifth from rightmost values, with the `.hidden` column stripped
+    # where applicable.
+    IFS=$'\n' actual_symbols=($(objdump --syms --macho --arch="$arch" "$path" | grep -v "*UND*" | awk '{print substr($0,index($0,$5))}' | sed 's/.hidden *//'))
     if [[ -n "${BINARY_CONTAINS_SYMBOLS-}" ]]; then
       for test_symbol in "${BINARY_CONTAINS_SYMBOLS[@]}"
       do


### PR DESCRIPTION
PiperOrigin-RevId: 551526850
(cherry picked from commit 439e871995994d1b74be534d1a8cb4ca1f9f895d)
