### PR TITLE
Make PLATFORM_build_test rules point to build_test in some cases.

### DIFF
--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -62,6 +62,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
+        "//apple/internal:providers",
         "//apple/internal:transition_support",
     ],
 )

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -18,20 +18,44 @@ load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
 )
+load(
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "AppleBinaryInfo",
+    "AppleDsymBundleInfo",
+)
 
 _PASSING_TEST_SCRIPT = """\
 #!/bin/bash
 exit 0
 """
 
+# These providers mark major Apple targets that already contain transitions so
+# there is no reason for a `PLATFORM_build_test` to wrap one of these, instead
+# a plan `build_test` should be used.
+_BLOCKED_PROVIDERS = [
+    AppleBinaryInfo,
+    AppleDsymBundleInfo,
+]
+
 def _apple_build_test_rule_impl(ctx):
     if ctx.attr.platform_type != ctx.attr._platform_type:
         fail((
             "The 'platform_type' attribute of '{}' is an implementation " +
             "detail and will be removed in the future; do not change it."
-        ).format(ctx.rule.kind))
+        ).format(ctx.attr._platform_type + "_build_test"))
 
     targets = ctx.attr.targets
+    for target in targets:
+        for p in _BLOCKED_PROVIDERS:
+            if p in target:
+                fail((
+                    "'{target_label}' builds a bundle and should just be " +
+                    " wrapped with a 'build_test' and not '{rule_kind}'."
+                ).format(
+                    target_label = target.label,
+                    rule_kind = ctx.attr._platform_type + "_build_test",
+                ))
+
     transitive_files = [target[DefaultInfo].files for target in targets]
 
     # The test's executable is a vacuously passing script. We pass all of the


### PR DESCRIPTION
The extra transition is a waste for the bundles, to error and point
folks at a stock build_test instead for those targets.

PiperOrigin-RevId: 552805620
(cherry picked from commit 686d202d67ef7d72e26b041c362156af7d5d3e61)
