### PR TITLE
Fix app intents metadata generation for Xcode 15 beta 6.

### DIFF
--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -59,6 +59,10 @@ def generate_app_intents_metadata_bundle(
     args.add("--toolchain-dir", "{xcode_path}/Toolchains/XcodeDefault.xctoolchain".format(
         xcode_path = apple_support.path_placeholders.xcode(),
     ))
+    if xcode_version_config.xcode_version() >= apple_common.dotted_version("15.0"):
+        # TODO(b/295227222): Generate app intents metadata with --compile-time-extraction using
+        # .swiftconstvals instead of --legacy-extraction at the earliest convenience.
+        args.add("--legacy-extraction")
 
     apple_support.run(
         actions = actions,


### PR DESCRIPTION
The new metadata generation depends on swiftconstvalues files as inputs; use the legacy extraction strategy as a fallback until we are able to handle those files.

PiperOrigin-RevId: 555296788
(cherry picked from commit a1571ecc629599b00aa35db6b30deb16d092b78e)
