### PR TITLE
Properly reference the contents of Headers in an XCFramework library bundle, within the import rules.

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -218,7 +218,12 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
     if xcframework.bundle_type == _BUNDLE_TYPE.frameworks:
         framework_includes = [paths.dirname(f.dirname) for f in binaries]
     else:
-        includes = [h.dirname for h in headers]
+        # For library XCFrameworks, in Xcode the contents of "Headers" are copied to an intermediate
+        # directory for referencing artifacts to include in the build; to replicate this behavior,
+        # make sure "includes" is set at the point where "Headers" is found, adjacent to any
+        # binaries.
+        if headers:
+            includes = [paths.join(f.dirname, "Headers") for f in binaries]
 
     return struct(
         binary = binaries[0],

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -293,7 +293,7 @@ def _generate_static_xcframework_impl(ctx):
         )
 
         library_path = library_identifier
-        headers_path = paths.join(library_path, "Headers")
+        headers_path = paths.join(library_path, "Headers", label.name)
 
         if not swift_library:
             # Compile library

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -492,7 +492,6 @@ def _copy_framework_headers_and_modulemap(
         headers = headers,
         headers_path = headers_path,
         label = label,
-        is_framework_umbrella_header = True,
     )
     framework_headers.append(umbrella_header)
 
@@ -613,8 +612,7 @@ def _generate_umbrella_header(
         bundle_name,
         headers,
         headers_path,
-        label,
-        is_framework_umbrella_header = False):
+        label):
     """Generates a single umbrella header given a sequence of header files.
 
     Args:
@@ -623,14 +621,12 @@ def _generate_umbrella_header(
         headers: List of header files for the framework bundle.
         headers_path: Base path for the generated umbrella header file.
         label: Label of the target being built.
-        is_framework_umbrella_header: Boolean to indicate if the generated umbrella header is for an
-          Apple framework. Defaults to `False`.
     Returns:
         File for the generated umbrella header.
     """
     header_text = "#import <Foundation/Foundation.h>\n"
 
-    header_prefix = bundle_name if is_framework_umbrella_header else ""
+    header_prefix = bundle_name
     for header in headers:
         header_text += "#import <{}>\n".format(paths.join(header_prefix, header.basename))
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2533,7 +2533,7 @@ write_file(
     name = "objc_with_static_xcframework_src",
     out = "ObjcWithXCFrameworkStaticLibrary.m",
     content = ["""
-#import <generated_static_xcframework_with_headers.h>
+#import <generated_static_xcframework_with_headers/generated_static_xcframework_with_headers.h>
 
 int objc_with_static_xcframework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
@@ -2574,7 +2574,7 @@ write_file(
     name = "objc_with_swift_static_xcframework_src",
     out = "ObjcWithSwiftXCFrameworkStaticLibrary.m",
     content = ["""
-#import <generated_swift_static_xcframework.h>
+#import <generated_swift_static_xcframework/generated_swift_static_xcframework.h>
 
 int objc_with_swift_static_xcframework_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];
@@ -2615,7 +2615,7 @@ write_file(
     name = "objc_with_swift_static_xcframework_without_swiftmodule_src",
     out = "ObjcWithSwiftXCFrameworkStaticLibraryWithoutSwiftmodule.m",
     content = ["""
-#import <generated_swift_static_xcframework_without_swiftmodule.h>
+#import <generated_swift_static_xcframework_without_swiftmodule/generated_swift_static_xcframework_without_swiftmodule.h>
 
 int objc_with_swift_static_xcframework_without_swiftmodule_function() {
   SharedClass *sharedClass = [[SharedClass alloc] init];

--- a/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool_test.py
@@ -127,11 +127,14 @@ class XcframeworkProcessorToolTest(unittest.TestCase):
         output_directories=["/path/to/bazel/declared/directory/"],
         xcframework_files=[
             "/path/to/imported.xcframework/ios-arm64/libstatic.a",
-            "/path/to/imported.xcframework/ios-arm64/Headers/umbrella.h",
+            "/path/to/imported.xcframework/ios-arm64/Headers/stray.h",
+            "/path/to/imported.xcframework/ios-arm64/Headers/libname/umbrella.h",
             "/path/to/imported.xcframework/ios-arm64_x86_64/libstatic.a",
-            "/path/to/imported.xcframework/ios-arm64_x86_64/Headers/umbrella.h",
+            "/path/to/imported.xcframework/ios-arm64_x86_64/Headers/stray.h",
+            "/path/to/imported.xcframework/ios-arm64_x86_64/Headers/libname/umbrella.h",
             "/path/to/imported.xcframework/watchos-x86_64/libstatic.a",
-            "/path/to/imported.xcframework/watchos-x86_64/Headers/umbrella.h",
+            "/path/to/imported.xcframework/watchos-x86_64/Headers/stray.h",
+            "/path/to/imported.xcframework/watchos-x86_64/Headers/libname/umbrella.h",
         ])
 
     expected_mkdirs_calls = [
@@ -142,8 +145,10 @@ class XcframeworkProcessorToolTest(unittest.TestCase):
     expected_copy_calls = [
         mock.call("/path/to/imported.xcframework/ios-arm64/libstatic.a",
                   "/path/to/bazel/declared/directory/libstatic.a"),
-        mock.call("/path/to/imported.xcframework/ios-arm64/Headers/umbrella.h",
-                  "/path/to/bazel/declared/directory/Headers/umbrella.h")
+        mock.call("/path/to/imported.xcframework/ios-arm64/Headers/stray.h",
+                  "/path/to/bazel/declared/directory/Headers/stray.h"),
+        mock.call("/path/to/imported.xcframework/ios-arm64/Headers/libname/umbrella.h",
+                  "/path/to/bazel/declared/directory/Headers/libname/umbrella.h")
     ]
     mock_copy.assert_has_calls(expected_copy_calls, any_order=True)
 


### PR DESCRIPTION
PiperOrigin-RevId: 552500832
(cherry picked from commit a2e581603f5eb5275db4a32f144472f412e5feb2)
