### PR TITLE
Switch BCR CI to single macOS target

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,10 +3,4 @@ tasks:
     name: Verify build targets
     platform: macos
     test_targets:
-    - '@rules_apple//examples/...'
-    # TODO(balestrapatrick): Re-enable these tests as soon as xctestrunner is bzlmod-compatible.
-    - '-@rules_apple//examples/ios/Squarer:SquarerTests'
-    - '-@rules_apple//examples/ios/PrenotCalculator:PrenotCalculatorTests'
-    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsUITests'
-    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsTests'
-    - '-@rules_apple//examples/multi_platform/Buttons:ButtonsLogicTests'
+      - '@rules_apple//examples/macos/CommandLine:ExamplesBuildTest'


### PR DESCRIPTION
Really we just need to know that the rules work at all from another
workspace, so this should avoid any issues with machine configs when
testing non macOS platform types

Fixes https://buildkite.com/bazel/bcr-presubmit/builds/1877
