### PR TITLE
Fix script error resulting in xcodebuild always being used

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -351,7 +351,7 @@ if [[ $(arch) == arm64 && "$test_file" != *arm64* ]]; then
 fi
 
 should_use_xcodebuild=false
-if [[ -n "$build_for_device" ]]; then
+if [[ "$build_for_device" == true  ]]; then
   echo "note: Using 'xcodebuild' because build for device was requested"
   should_use_xcodebuild=true
 fi


### PR DESCRIPTION
`build_for_device`, like `create_xcresult_bundle`, is always true or false, but never unset.

This was leading `xcodebuild` to be used for all tests as of 2.5.0