### PR TITLE
Add visionOS support to apple_static_library, currently feature flagged as a WIP feature until a fully functional visionos_application rule is established.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -47,6 +47,7 @@ bzl_library(
     name = "apple_binary",
     srcs = ["apple_binary.bzl"],
     deps = [
+        "//apple/internal:apple_toolchains",
         "//apple/internal:linking_support",
         "//apple/internal:rule_attrs",
         "//apple/internal:rule_factory",
@@ -59,6 +60,7 @@ bzl_library(
     srcs = ["apple_static_library.bzl"],
     deps = [
         ":providers",
+        "//apple/internal:apple_toolchains",
         "//apple/internal:linking_support",
         "//apple/internal:providers",
         "//apple/internal:rule_attrs",

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -15,6 +15,10 @@
 """Starlark implementation of `apple_binary` to transition from native Bazel."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "apple_toolchain_utils",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
     "linking_support",
 )
@@ -49,6 +53,19 @@ def _linker_flag_for_sdk_dylib(dylib):
     return "-l{}".format(dylib)
 
 def _apple_binary_impl(ctx):
+    # Fail early if using the not yet fully supported visionOS platform type outside of testing.
+    apple_xplat_toolchain_info = apple_toolchain_utils.get_xplat_toolchain(ctx)
+    if ctx.attr.platform_type == "visionos":
+        if not apple_xplat_toolchain_info.build_settings.enable_wip_features:
+            fail("visionOS support for the apple_binary rule is still a work in progress.")
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+        if xcode_version_config.xcode_version() < apple_common.dotted_version("15.0"):
+            fail("""
+visionOS binaries require a visionOS SDK provided by Xcode 15 or later.
+
+Resolved Xcode is version {xcode_version}.
+""".format(xcode_version = str(xcode_version_config.xcode_version())))
+
     binary_type = ctx.attr.binary_type
     bundle_loader = ctx.attr.bundle_loader
 

--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -15,8 +15,8 @@
 """apple_static_library Starlark implementation"""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
-    "transition_support",
+    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "apple_toolchain_utils",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -35,11 +35,28 @@ load(
     "rule_factory",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "ApplePlatformInfo",
 )
 
 def _apple_static_library_impl(ctx):
+    # Fail early if using the not yet fully supported visionOS platform type outside of testing.
+    apple_xplat_toolchain_info = apple_toolchain_utils.get_xplat_toolchain(ctx)
+    if ctx.attr.platform_type == "visionos":
+        if not apple_xplat_toolchain_info.build_settings.enable_wip_features:
+            fail("visionOS support for the apple_static_library rule is still a work in progress.")
+        xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+        if xcode_version_config.xcode_version() < apple_common.dotted_version("15.0"):
+            fail("""
+visionOS static libraries require a visionOS SDK provided by Xcode 15 or later.
+
+Resolved Xcode is version {xcode_version}.
+""".format(xcode_version = str(xcode_version_config.xcode_version())))
+
     # Most validation of the platform type and minimum version OS currently happens in
     # `transition_support.apple_platform_split_transition`, either implicitly through native
     # `dotted_version` or explicitly through `fail` on an unrecognized platform type value.
@@ -161,6 +178,7 @@ binaries/libraries will be created combining all architectures specified by
 *   `ios`: architectures gathered from `--ios_multi_cpus`.
 *   `macos`: architectures gathered from `--macos_cpus`.
 *   `tvos`: architectures gathered from `--tvos_cpus`.
+*   `visionos`: architectures gathered from `--visionos_cpus`.
 *   `watchos`: architectures gathered from `--watchos_cpus`.
 """,
             ),

--- a/apple/cc_toolchain_forwarder.bzl
+++ b/apple/cc_toolchain_forwarder.bzl
@@ -25,6 +25,7 @@ def _target_os_from_rule_ctx(ctx):
     ios_constraint = ctx.attr._ios_constraint[platform_common.ConstraintValueInfo]
     macos_constraint = ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]
     tvos_constraint = ctx.attr._tvos_constraint[platform_common.ConstraintValueInfo]
+    visionos_constraint = ctx.attr._visionos_constraint[platform_common.ConstraintValueInfo]
     watchos_constraint = ctx.attr._watchos_constraint[platform_common.ConstraintValueInfo]
 
     if ctx.target_platform_has_constraint(ios_constraint):
@@ -33,6 +34,8 @@ def _target_os_from_rule_ctx(ctx):
         return str(apple_common.platform_type.macos)
     elif ctx.target_platform_has_constraint(tvos_constraint):
         return str(apple_common.platform_type.tvos)
+    elif ctx.target_platform_has_constraint(visionos_constraint):
+        return str(apple_common.platform_type.visionos)
     elif ctx.target_platform_has_constraint(watchos_constraint):
         return str(apple_common.platform_type.watchos)
     fail("ERROR: A valid Apple platform constraint could not be found from the resolved toolchain.")
@@ -91,6 +94,9 @@ cc_toolchain_forwarder = rule(
         ),
         "_tvos_constraint": attr.label(
             default = Label("@platforms//os:tvos"),
+        ),
+        "_visionos_constraint": attr.label(
+            default = Label("@platforms//os:visionos"),
         ),
         "_watchos_constraint": attr.label(
             default = Label("@platforms//os:watchos"),

--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -15,8 +15,8 @@
 """apple_static_library Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
+    "//apple/build_settings:build_settings.bzl",
+    "build_settings_labels",
 )
 load(
     "//test/starlark_tests/rules:analysis_mismatched_platform_test.bzl",
@@ -39,6 +39,10 @@ load(
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "binary_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 analysis_target_actions_with_multi_cpus_test = make_analysis_target_actions_test(
@@ -337,6 +341,27 @@ def apple_static_library_test_suite(name):
         binary_contains_symbols = ["_doStuff"],
         binary_not_contains_symbols = ["_frameworkDependent"],
         tags = [name],
+    )
+
+    # Test that the output binary is identified as visionOS simulator (PLATFORM_XROSSIMULATOR) via
+    # the Mach-O load command LC_BUILD_VERSION for an arm64 binary.
+    binary_contents_test(
+        name = "{}_visionos_binary_contents_arm_simulator_platform_test".format(name),
+        build_settings = {
+            build_settings_labels.enable_wip_features: "True",
+        },
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_vision_library",
+        cpus = {
+            "visionos_cpus": ["sim_arm64"],
+        },
+        binary_test_file = "$BINARY",
+        binary_test_architecture = "arm64",
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "minos " + common.min_os_visionos.baseline, "platform XROSSIMULATOR"],
+        tags = [
+            name,
+            "needs-xcode-latest-beta",
+        ],
     )
 
     native.test_suite(

--- a/test/starlark_tests/common.bzl
+++ b/test/starlark_tests/common.bzl
@@ -56,6 +56,11 @@ _min_os_tvos = struct(
     stable_swift_abi = "12.2",
 )
 
+_min_os_visionos = struct(
+    baseline = "1.0",
+    oldest_supported = "1.0",
+)
+
 _min_os_watchos = struct(
     app_intents_support = "9.0",
     arm64_support = "9.0",
@@ -72,6 +77,7 @@ common = struct(
     min_os_ios = _min_os_ios,
     min_os_macos = _min_os_macos,
     min_os_tvos = _min_os_tvos,
+    min_os_visionos = _min_os_visionos,
     min_os_watchos = _min_os_watchos,
     skip_ci_tags = _skip_ci_tags,
 )

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -70,12 +70,14 @@ Internal Error: A verification test should only specify `apple_platforms` or `cp
             "//command_line_option:ios_multi_cpus": "x86_64",
             "//command_line_option:tvos_cpus": "x86_64",
             "//command_line_option:watchos_cpus": "x86_64",
+            "//command_line_option:visionos_cpus": "sim_arm64",
         })
     else:
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "arm64,arm64e",
             "//command_line_option:tvos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
+            "//command_line_option:visionos_cpus": "arm64",
         })
 
     if has_apple_platforms:
@@ -127,6 +129,7 @@ apple_verification_transition = transition(
         "//command_line_option:ios_multi_cpus",
         "//command_line_option:macos_cpus",
         "//command_line_option:tvos_cpus",
+        "//command_line_option:visionos_cpus",
         "//command_line_option:watchos_cpus",
         "//command_line_option:compilation_mode",
         "//command_line_option:features",

--- a/test/starlark_tests/targets_under_test/apple/static_library/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/static_library/BUILD
@@ -64,3 +64,11 @@ apple_static_library(
     tags = common.fixture_tags,
     deps = ["//test/starlark_tests/targets_under_test/apple:StaticFmwkCcUpperLib"],
 )
+
+apple_static_library(
+    name = "example_vision_library",
+    minimum_os_version = common.min_os_visionos.baseline,
+    platform_type = "visionos",
+    tags = common.fixture_tags,
+    deps = [":main_lib"],
+)


### PR DESCRIPTION
PiperOrigin-RevId: 561066909
(cherry picked from commit f3bf0abe4397864e8a0935bc606778431ecc6b0f)