### PR TITLE
Remove bzl visibility for now

### DIFF
--- a/apple/internal/providers.bzl
+++ b/apple/internal/providers.bzl
@@ -23,11 +23,6 @@ These should build from the raw initializer where possible, but not export it, t
 boundary with well-defined public APIs for broader usage.
 """
 
-visibility([
-    "//apple/...",
-    "//test/...",
-])
-
 def _make_banned_init(*, preferred_public_factory = None, provider_name):
     """Generates a lambda with a fail(...) for providers to dictate preferred initializer patterns.
 


### PR DESCRIPTION
We're mostly not using this feature, there are some APIs here that folks
are using. Rather than upgrading them to public API this allows us to
acknowledge they're private API but not hard block folks from using
them (they could always just disable this feature if they wanted to
anyways).
