### PR TITLE
Ignore more variants of codesigning output

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -37,7 +37,7 @@ from tools.wrapper_common import execute
 # * Executable=/{path to signed target}
 # * using the deprecated --resource-rules flag
 _BENIGN_CODESIGN_OUTPUT_REGEX = re.compile(
-    r"(signed.*Mach-O (universal|thin)|libswift.*\.dylib: replacing existing signature|signed generic|Executable=/|Warning: --resource-rules has been deprecated)"
+    r"(: replacing existing signature|signed generic|Executable=/|Warning: --resource-rules has been deprecated)"
 )
 
 

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -37,7 +37,7 @@ from tools.wrapper_common import execute
 # * Executable=/{path to signed target}
 # * using the deprecated --resource-rules flag
 _BENIGN_CODESIGN_OUTPUT_REGEX = re.compile(
-    r"(: replacing existing signature|signed generic|Executable=/|Warning: --resource-rules has been deprecated)"
+    r"(signed.*Mach-O (universal|thin)|: replacing existing signature|signed generic|Executable=/|Warning: --resource-rules has been deprecated)"
 )
 
 


### PR DESCRIPTION
I don't think users ever need to see any "replacing existing signature"
message. The previous regex didn't match this case:

```
bazel-out/...__internal__.__test_bundle_archive-root/Foo.xctest/: replacing existing signature
```
