### PR TITLE
Fix create-xcframework with Xcode 15

### DIFF
--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -154,6 +154,7 @@ def _create_xcframework(
         apple_fragment = apple_fragment,
         command = " ".join(args),
         inputs = depset(inputs),
+        execution_requirements = {"no-sandbox": "1"},
         mnemonic = "GenerateXCFrameworkXcodebuild",
         outputs = outputs,
         progress_message = "Generating XCFramework using xcodebuild",


### PR DESCRIPTION
Xcode 15 changed the validation of files when creating a xcframework to
require some files to be there and not be symlinks, and require access
to the original files which seems to be a sandboxing problem.

Otherwise you get errors like this:

```
error: cannot compute path of binary 'Path(str: "/private/var/tmp/_bazel_ksmiley/8bb44cfa6c99754483f544270fd84cc4/execroot/build_bazel_rules_apple/bazel-out/watchos-arm64-min9.0-applebin_watchos-watchos_arm64-fastbuild-ST-1bbdd066272f/bin/test/starlark_tests/targets_under_test/watchos/generated_static_watchos_xcframework-intermediates/watchos-arm64_32_armv7k/generated_static_watchos_xcframework.a")' relative to that of '/private/var/tmp/_bazel_ksmiley/8bb44cfa6c99754483f544270fd84cc4/sandbox/darwin-sandbox/3243/execroot/build_bazel_rules_apple/bazel-out/watchos-arm64-min9.0-applebin_watchos-watchos_arm64-fastbuild-ST-1bbdd066272f/bin/test/starlark_tests/targets_under_test/watchos/generated_static_watchos_xcframework-intermediates/watchos-arm64_32_armv7k/generated_static_watchos_xcframework.a'
```

Where the only difference is the root of the sandbox path.
