### PR TITLE
Add parallel testing support for failing ios_xctestrun_runner when bundle executes nothing.

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -477,22 +477,26 @@ if grep -q "-parallel-testing-enabled YES" "$testlog"; then
 fi
 
 # Fail when bundle executes nothing
+no_tests_ran=false
 if [[ $parallel_testing_enabled == true ]]; then
   # When executing tests in parallel, test start markers are absent when no
   # tests are run.
   test_execution_count=$(grep -c -e "Test suite '.*' started*" "$testlog")
   if [[ "$test_execution_count" == "0" ]]; then
-    echo "error: no tests were executed, is the test bundle empty?" >&2
-    exit 1
+    no_tests_ran=true
   fi
 else
   # Assume the final 'Executed N tests' or 'Executed 1 test' is the
   # total execution count for the test bundle.
   test_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} tests*," "$testlog" | tail -n1)
   if echo "$test_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
-    echo "error: no tests were executed, is the test bundle empty?" >&2
-    exit 1
+    no_tests_ran=true
   fi
+fi
+
+if [[ $no_tests_ran == true ]]; then
+  echo "error: no tests were executed, is the test bundle empty?" >&2
+  exit 1
 fi
 
 # When tests crash after they have reportedly completed, XCTest marks them as

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -471,12 +471,28 @@ if [[ "$test_exit_code" -ne 0 ]]; then
   exit "$test_exit_code"
 fi
 
-# Assume the final 'Executed N tests' or 'Executed 1 test' is the
-# total execution count for the test bundle.
-test_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} tests*," "$testlog" | tail -n1)
-if echo "$test_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
-  echo "error: no tests were executed, is the test bundle empty?" >&2
-  exit 1
+parallel_testing_enabled=false
+if grep -q "-parallel-testing-enabled YES" "$testlog"; then
+  parallel_testing_enabled=true
+fi
+
+# Fail when bundle executes nothing
+if [[ $parallel_testing_enabled == true ]]; then
+  # When executing tests in parallel, test start markers are absent when no
+  # tests are run.
+  test_execution_count=$(grep -c -e "Test suite '.*' started*" "$testlog")
+  if [[ "$test_execution_count" == "0" ]]; then
+    echo "error: no tests were executed, is the test bundle empty?" >&2
+    exit 1
+  fi
+else
+  # Assume the final 'Executed N tests' or 'Executed 1 test' is the
+  # total execution count for the test bundle.
+  test_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} tests*," "$testlog" | tail -n1)
+  if echo "$test_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
+    echo "error: no tests were executed, is the test bundle empty?" >&2
+    exit 1
+  fi
 fi
 
 # When tests crash after they have reportedly completed, XCTest marks them as


### PR DESCRIPTION
## Summary
* Fixes #2008 where parallel testing stopped working after #1924.
* Now, a test execution with parallel testing enabled is failed when no tests are run.

## Testing

```
** test_ios_unit_test_parallel_testing_no_tests_fail ***************************
$TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_lakshya.kapoor/1b0aa364aeefd09eb69306cdb961f0a3/sandbox/darwin-sandbox/8/execroot/build_bazel_rules_apple/_tmp/f8d0ebbcaf3f9f8ca779b90b08771aac' and max_idle_secs default is '15'.
PASSED: test_ios_unit_test_parallel_testing_no_tests_fail

** test_ios_unit_test_parallel_testing_pass ************************************
$TEST_TMPDIR defined: output root default is '/private/var/tmp/_bazel_lakshya.kapoor/1b0aa364aeefd09eb69306cdb961f0a3/sandbox/darwin-sandbox/8/execroot/build_bazel_rules_apple/_tmp/f8d0ebbcaf3f9f8ca779b90b08771aac' and max_idle_secs default is '15'.
PASSED: test_ios_unit_test_parallel_testing_pass
```

Ran all 30 tests locally to make sure they pass with these changes.