### PR TITLE
Make AppIntentsMetadataProcessor fail if it outputs errors

### DIFF
--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -65,7 +65,16 @@ def generate_app_intents_metadata_bundle(
         actions = actions,
         apple_fragment = apple_fragment,
         arguments = [args],
-        command = 'set -euo pipefail; if ! output=$($@ --sdk-root "$SDKROOT" --toolchain-dir "$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain" 2>&1); then echo "$output"  >&2 && exit 1; fi',
+        command = '''\
+set -exuo pipefail
+
+exit_status=0
+output=$($@ --sdk-root "$SDKROOT" --toolchain-dir "$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain" 2>&1 || exit_status=$?)
+if [[ "$output" == *error:* || "$exit_status" -ne 0 ]]; then
+  echo "$output" >&2
+  exit 1
+fi
+''',
         inputs = depset([bundle_binary], transitive = [depset(source_files)]),
         outputs = [output],
         mnemonic = "AppIntentsMetadataProcessor",

--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -66,7 +66,7 @@ def generate_app_intents_metadata_bundle(
         apple_fragment = apple_fragment,
         arguments = [args],
         command = '''\
-set -exuo pipefail
+set -euo pipefail
 
 exit_status=0
 output=$($@ --sdk-root "$SDKROOT" --toolchain-dir "$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain" 2>&1 || exit_status=$?)

--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -70,7 +70,11 @@ set -euo pipefail
 
 exit_status=0
 output=$($@ --sdk-root "$SDKROOT" --toolchain-dir "$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain" 2>&1 || exit_status=$?)
-if [[ "$output" == *error:* || "$exit_status" -ne 0 ]]; then
+
+if [[ "$exit_status" -ne 0 ]]; then
+  echo "$output" >&2
+  exit $exit_status
+elif [[ "$output" == *error:* ]]; then
   echo "$output" >&2
   exit 1
 fi


### PR DESCRIPTION
Seems like the exit code of this tool is 0 even if there are failures:

```
2023-09-15 12:02:16.951 appintentsmetadataprocessor[58307:18815125] warning: No swift const values found. If SWIFT_ENABLE_EMIT_CONST_VALUES = NO, AppIntents metadata cannot be extracted.
2023-09-15 12:02:16.951 appintentsmetadataprocessor[58307:18815125] Using legacy extraction
2023-09-15 12:02:17.233 appintentsmetadataprocessor[58307:18815125] error: At least one halting error produced during export. No AppIntents metadata have been exported and this target is not usable with AppIntents until errors are resolved. error: Unable to map action parameter of AppIntents.IntentParameter<Foo.Bar> to a valueType'
```

Since this is outputting a tree artifact it doesn't seem to case bazel to fail
either even though it doesn't produce any files in that case.
