### PR TITLE
Correct the cpus used to test apple_static_library via make_analysis_target_actions_Test(...) to be exclusively simulator cpus, rather than device cpus.

### DIFF
--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -46,7 +46,7 @@ analysis_target_actions_with_multi_cpus_test = make_analysis_target_actions_test
         "//command_line_option:macos_cpus": "arm64,x86_64",
         "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
         "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
-        "//command_line_option:watchos_cpus": "arm64_32,armv7k",
+        "//command_line_option:watchos_cpus": "arm64,x86_64",
     },
 )
 


### PR DESCRIPTION
The watchOS test that leans on this test's output down below is intended to be for simulator cpus. This makes the full list of config_settings provided for this rule consistent.

PiperOrigin-RevId: 561086910
(cherry picked from commit e25414c6f13379fe19ff2faeab6b10f8285af349)