### PR TITLE
Eliminate armv7k dropped arch warnings for rules_apple tests that assemble targets for watchOS 9+.

### DIFF
--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -285,6 +285,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_xcframework",
         binary_test_file = "$BUNDLE_ROOT/Frameworks/generated_dynamic_watchos_xcframework.framework/generated_dynamic_watchos_xcframework",
         binary_test_architecture = "arm64_32",
+        cpus = {"watchos_cpus": ["arm64_32"]},
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform WATCHOS"],
     )
 

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -179,6 +179,7 @@ def apple_static_xcframework_import_test_suite(name):
     archive_contents_test(
         name = "{}_links_watchos_arm64_32_macho_load_cmd_for_device_test".format(name),
         build_type = "device",
+        cpus = {"watchos_cpus": ["arm64_32"]},
         target_under_test = "//test/starlark_tests/targets_under_test/watchos:app_with_imported_static_xcframework",
         not_contains = ["$BUNDLE_ROOT/Frameworks"],
         binary_test_file = "$BUNDLE_ROOT/app_with_imported_static_xcframework",


### PR DESCRIPTION
PiperOrigin-RevId: 562806168
(cherry picked from commit a333759215cfaff5c2094cd5d51cc1dc66dc4638)