### PR TITLE
Make appintentsmetadataprocessor error with no output

### DIFF
--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -77,6 +77,9 @@ if [[ "$exit_status" -ne 0 ]]; then
 elif [[ "$output" == *error:* ]]; then
   echo "$output" >&2
   exit 1
+elif [[ "$output" == *"skipping writing output"* ]]; then
+  echo "$output" >&2
+  exit 1
 fi
 ''',
         inputs = depset([bundle_binary], transitive = [depset(source_files)]),


### PR DESCRIPTION
In the case this tool finds no app intents in the binary that was
passed, it exits 0. In the bazel case where you have to be explicit
about what binaries you want to search this just leads to confusion.
