### PR TITLE
Correctly add `.swiftinterface` files to imported dynamic xcframework `public_hdrs`

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -281,6 +281,7 @@ def _apple_dynamic_framework_import_impl(ctx):
         kind = "dynamic",
         label = label,
         libraries = [] if ctx.attr.bundle_only else framework.binary_imports,
+        swiftinterface_imports = framework.swift_interface_imports,
         swiftmodule_imports = framework.swift_module_imports,
     )
     providers.append(cc_info)
@@ -434,6 +435,7 @@ def _apple_static_framework_import_impl(ctx):
             label = label,
             libraries = framework.binary_imports,
             linkopts = linkopts,
+            swiftinterface_imports = framework.swift_interface_imports,
             swiftmodule_imports = framework.swift_module_imports,
         ),
     )

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -522,6 +522,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
         kind = "dynamic",
         label = label,
         libraries = [] if ctx.attr.bundle_only else [xcframework_library.binary],
+        swiftinterface_imports = [xcframework_library.swift_module_interface] if xcframework_library.swift_module_interface else [],
         swiftmodule_imports = xcframework_library.swiftmodule,
     )
     providers.append(cc_info)
@@ -667,6 +668,7 @@ def _apple_static_xcframework_import_impl(ctx):
         libraries = [xcframework_library.binary],
         framework_includes = xcframework_library.framework_includes,
         linkopts = sdk_linkopts + linkopts,
+        swiftinterface_imports = [],
         swiftmodule_imports = [],
         includes = xcframework_library.includes + ctx.attr.includes,
     )

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -43,6 +43,7 @@ def _cc_info_with_dependencies(
         libraries,
         linkopts = [],
         includes = [],
+        swiftinterface_imports = [],
         swiftmodule_imports = [],
         is_framework = True):
     """Returns a new CcInfo which includes transitive Cc dependencies.
@@ -63,6 +64,8 @@ def _cc_info_with_dependencies(
         label: Label of the target being built.
         libraries: The list of framework libraries.
         linkopts: List of linker flags strings to propagate as linker input.
+        swiftinterface_imports: List of imported Swift interface files to include
+            during build phase, but aren't processed in any way.
         swiftmodule_imports: List of imported Swift module files to include during build phase,
             but aren't processed in any way.
         is_framework: Whether the target is a framework vs library.
@@ -83,6 +86,7 @@ def _cc_info_with_dependencies(
     public_hdrs = []
     public_hdrs.extend(header_imports)
     public_hdrs.extend(swiftmodule_imports)
+    public_hdrs.extend(swiftinterface_imports)
     (compilation_context, _compilation_outputs) = cc_common.compile(
         name = label.name,
         actions = actions,
@@ -178,17 +182,9 @@ def _classify_file_imports(config_vars, import_files):
             module_map_imports.append(file)
             continue
         if file_extension == "swiftmodule":
-            # Add Swift's module files to header_imports so
-            # that they are correctly included in the build
-            # by Bazel but they aren't processed in any way
-            header_imports.append(file)
             swift_module_imports.append(file)
             continue
         if file_extension == "swiftinterface":
-            # Add Swift's interface files to header_imports so
-            # that they are correctly included in the build
-            # by Bazel but they aren't processed in any way
-            header_imports.append(file)
             swift_interface_imports.append(file)
             continue
         if file_extension in ["swiftdoc", "swiftsourceinfo"]:


### PR DESCRIPTION
5926b990842514cea21cb27f2ca70b70179bb4e8 broke importing xcframeworks that have swiftinterface files when using `parse_xcframework_info_plist`. We didn’t notice it before because the tests were using an invalid build setting name (https://github.com/bazelbuild/rules_apple/pull/2265).

This change prevents the `.swiftinterface` files from breaking in `xcframework_processor_tool.py`, while still including them in the `CcInfo`.

I mimicked where we were setting `swiftmodule_imports` before (in particular I didn’t set it for `xcframework_static_import`). It seems we might be over setting it in some places (or under-setting it there).