### PR TITLE
Fix warning in doccarchive example using directory

### DIFF
--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -513,7 +513,10 @@ filegroup(
 
 filegroup(
     name = "basic_docc_bundle_files",
-    srcs = ["basic.docc"],
+    srcs = glob(
+        ["basic.docc/**"],
+        exclude_directories = 0,
+    ),
 )
 
 filegroup(


### PR DESCRIPTION
The doccarchive example was using a directory as a dependency in `filegroup`. Use `glob` with `exclude_directories = 0` instead.

Fixes:

```sh
(15:15:17) WARNING: /Users/buildkite/builds/bk-imacpro-12/bazel/rules-apple-darwin/test/starlark_tests/targets_under_test/ios/BUILD:4832:13: input 'test/starlark_tests/resources/basic.docc' to //test/starlark_tests/targets_under_test/ios:basic_framework_with_docc_bundle.doccarchive is a directory; dependency checking of directories is unsound
```