### PR TITLE
Change xcarchive ApplicationPath

### DIFF
--- a/test/starlark_tests/xcarchive_tests.bzl
+++ b/test/starlark_tests/xcarchive_tests.bzl
@@ -37,7 +37,7 @@ def xcarchive_test_suite(name):
         ],
         plist_test_file = "$BUNDLE_ROOT/Info.plist",
         plist_test_values = {
-            "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
+            "ApplicationProperties:ApplicationPath": "Applications/app_minimal.app",
             "ApplicationProperties:ArchiveVersion": "2",
             "ApplicationProperties:CFBundleIdentifier": "com.google.example",
             "ApplicationProperties:CFBundleShortVersionString": "1.0",
@@ -57,7 +57,7 @@ def xcarchive_test_suite(name):
         ],
         plist_test_file = "$BUNDLE_ROOT/Info.plist",
         plist_test_values = {
-            "ApplicationProperties:ApplicationPath": "Products/Applications/app_minimal.app",
+            "ApplicationProperties:ApplicationPath": "Applications/app_minimal.app",
             "ApplicationProperties:ArchiveVersion": "2",
             "ApplicationProperties:CFBundleIdentifier": "com.google.example",
             "ApplicationProperties:CFBundleShortVersionString": "1.0",

--- a/tools/xcarchivetool/make_xcarchive.py
+++ b/tools/xcarchivetool/make_xcarchive.py
@@ -113,9 +113,9 @@ def _main(
     short_version = infoplist["CFBundleShortVersionString"]
 
   # Create the .xcarchive directory.
-  bundle_dest_dir = os.path.join(output_path, "Products", "Applications")
-  bundle_dest_path = os.path.join(
-    output_path, "Products", "Applications", bundle_name + ".app")
+  products_dest_dir = os.path.join(output_path, "Products")
+  bundle_dest_dir = os.path.join(products_dest_dir, "Applications")
+  bundle_dest_path = os.path.join(bundle_dest_dir, bundle_name + ".app")
   os.makedirs(bundle_dest_dir, exist_ok=True)
 
   # If is an .ipa, extract and copy .app to destination
@@ -137,7 +137,7 @@ def _main(
 
   # Create the Info.plist for the .xcarchive.
   creation_date = datetime.datetime.now().isoformat()
-  app_relative_path = os.path.relpath(bundle_dest_path, output_path)
+  app_relative_path = os.path.relpath(bundle_dest_path, products_dest_dir)
   info_plist = {
     "ApplicationProperties": {
       "ApplicationPath": app_relative_path,


### PR DESCRIPTION
Removes an unused component `Products` from the info.plist of the built xcarchive. This change allows xcarchives to be processed by certain services

Related #2278 