### PR TITLE
Fix codesigningtool to work with openssl 3

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -124,7 +124,7 @@ def _certificate_fingerprint(identity):
       "-fingerprint",
   ], inputstr=identity, raise_on_failure=True)
   fingerprint = fingerprint.strip()
-  fingerprint = fingerprint.replace("SHA1 Fingerprint=", "")
+  fingerprint = re.sub("sha1 Fingerprint=", "", fingerprint, flags=re.IGNORECASE)
   fingerprint = fingerprint.replace(":", "")
   return fingerprint
 


### PR DESCRIPTION
Hello maintainers,

I'm submitting this pull request to address an issue that occurs when the version of openssl is upgraded to 3+. codingsigningtool.py could not calculate the sha1 fingerprint correctly. 

Steps to Reproduce:
1. brew install openssl@3
   ensure 'which openssl' point to openssl@3
2. any ios_app using local_provisioning_profile
3. bazel build would fail with
ERROR: Unable to find an identity on the system matching the ones in xxxx.mobileprovision

Expected Behavior:
No error

Reason:
The output of openssl is changed.
```
openssl3
openssl x509 -sha1 -inform PEM -noout -fingerprint -in certificate.pem
sha1 Fingerprint=DF:4B:EA:DB:C9:76:38:55:B8:5B:30:0B:6A:88:CF:E4:9F:XX:XX:XX
openssl 1.1
SHA1 Fingerprint=DF:4B:EA:DB:C9:76:38:55:B8:5B:30:0B:6A:88:CF:E4:9F:XX:XX:XX
```

Proposed Solution:
```
fingerprint = fingerprint.replace("SHA1 Fingerprint=", "")
++fingerprint = fingerprint.replace("sha1 Fingerprint=", "")
```

Best regards,
Jichao
