### PR TITLE
Use Bazel rolling release for dev

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,1 @@
+rolling


### PR DESCRIPTION
Otherwise stardoc 0.6.2 fails on our module extension.