### PR TITLE
Include explicit dep on `@bazel_tools//tools/bash/runfiles`

### DIFF
--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -24,6 +24,17 @@
 # test_script: The name of the test script to execute inside the test
 #     directory.
 
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=;
+# --- end runfiles.bash initialization v3 ---
+
 test_script="$1"; shift
 
 # Use the image's default Xcode version when running tests to avoid flakes

--- a/test/test_rules.bzl
+++ b/test/test_rules.bzl
@@ -109,7 +109,9 @@ def apple_shell_test(
             "//test/testdata/provisioning:integration_testing_profiles",
             "//test:unittest.bash",
         ] + (data or []),
-        deps = deps or [],
+        deps = [
+            "@bazel_tools//tools/bash/runfiles",
+        ] + (deps or []),
         tags = ["requires-darwin"] + (tags or []),
         **kwargs
     )


### PR DESCRIPTION
This is needed for Bzlmod support.