### PR TITLE
Use `latest` instead of `last_rc` in CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -25,8 +25,8 @@ x_defaults:
 # of these tasks, they are listed in the .bazelrc instead.
 tasks:
   macos_latest:
-    name: "Latest Bazel"
-    bazel: last_rc
+    name: "Current LTS"
+    bazel: latest
     <<: *common
 
   macos_last_green:


### PR DESCRIPTION
Now that Bazel 7 rc1 has been cut, we need to change this in order to still test Bazel 6. After Bazel 7 is out we probably want to create an “LTS-1” job.