### PR TITLE
Use canonical label string for some more analysis tests

### DIFF
--- a/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
+++ b/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
@@ -24,10 +24,15 @@ load(
 
 def _analysis_incoming_watchos_platform_mismatch_test_impl(ctx):
     env = analysistest.begin(ctx)
-    asserts.expect_failure(env, """
+    asserts.expect_failure(
+        env,
+        """
 ERROR: Unexpected resolved platform:
-Expected Apple platform type of \"{0}\", but that was not found in @build_bazel_apple_support//platforms:watchos_x86_64.
-""".format(ctx.attr.expected_platform_type))
+Expected Apple platform type of \"{expected}\", but that was not found in {platform}.
+""".format(
+        expected = ctx.attr.expected_platform_type,
+        platform = Label("@build_bazel_apple_support//platforms:watchos_x86_64"),
+    ))
     return analysistest.end(env)
 
 analysis_incoming_watchos_platform_mismatch_test = analysistest.make(
@@ -41,16 +46,23 @@ analysis_incoming_watchos_platform_mismatch_test = analysistest.make(
     },
     config_settings = {
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": True,
-        "//command_line_option:platforms": ["@build_bazel_apple_support//platforms:watchos_x86_64"],
+        "//command_line_option:platforms": [
+            str(Label("@build_bazel_apple_support//platforms:watchos_x86_64")),
+        ],
     },
 )
 
 def _analysis_incoming_ios_platform_mismatch_test_impl(ctx):
     env = analysistest.begin(ctx)
-    asserts.expect_failure(env, """
+    asserts.expect_failure(
+        env,
+        """
 ERROR: Unexpected resolved platform:
-Expected Apple platform type of \"{0}\", but that was not found in @build_bazel_apple_support//platforms:ios_sim_arm64.
-""".format(ctx.attr.expected_platform_type))
+Expected Apple platform type of \"{expected}\", but that was not found in {platform}.
+""".format(
+        expected = ctx.attr.expected_platform_type,
+        platform = Label("@build_bazel_apple_support//platforms:ios_sim_arm64"),
+    ))
     return analysistest.end(env)
 
 analysis_incoming_ios_platform_mismatch_test = analysistest.make(
@@ -64,6 +76,8 @@ analysis_incoming_ios_platform_mismatch_test = analysistest.make(
     },
     config_settings = {
         "//command_line_option:incompatible_enable_apple_toolchain_resolution": True,
-        "//command_line_option:platforms": ["@build_bazel_apple_support//platforms:ios_sim_arm64"],
+        "//command_line_option:platforms": [
+            str(Label("@build_bazel_apple_support//platforms:ios_sim_arm64")),
+        ],
     },
 )

--- a/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
+++ b/test/starlark_tests/rules/analysis_mismatched_platform_test.bzl
@@ -30,9 +30,10 @@ def _analysis_incoming_watchos_platform_mismatch_test_impl(ctx):
 ERROR: Unexpected resolved platform:
 Expected Apple platform type of \"{expected}\", but that was not found in {platform}.
 """.format(
-        expected = ctx.attr.expected_platform_type,
-        platform = Label("@build_bazel_apple_support//platforms:watchos_x86_64"),
-    ))
+            expected = ctx.attr.expected_platform_type,
+            platform = Label("@build_bazel_apple_support//platforms:watchos_x86_64"),
+        ),
+    )
     return analysistest.end(env)
 
 analysis_incoming_watchos_platform_mismatch_test = analysistest.make(
@@ -60,9 +61,10 @@ def _analysis_incoming_ios_platform_mismatch_test_impl(ctx):
 ERROR: Unexpected resolved platform:
 Expected Apple platform type of \"{expected}\", but that was not found in {platform}.
 """.format(
-        expected = ctx.attr.expected_platform_type,
-        platform = Label("@build_bazel_apple_support//platforms:ios_sim_arm64"),
-    ))
+            expected = ctx.attr.expected_platform_type,
+            platform = Label("@build_bazel_apple_support//platforms:ios_sim_arm64"),
+        ),
+    )
     return analysistest.end(env)
 
 analysis_incoming_ios_platform_mismatch_test = analysistest.make(


### PR DESCRIPTION
Needed when Bzlmod becomes enabled in Bazel 7.