### PR TITLE
Avoid failure when shutting down a simulator already in the shutdown state

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -462,7 +462,7 @@ else
 fi
 
 if [[ "$reuse_simulator" == false ]]; then
-  xcrun simctl shutdown "$simulator_id"
+  # Delete will shutdown down the simulator if it's still currently running.
   xcrun simctl delete "$simulator_id"
 fi
 


### PR DESCRIPTION
When performing parallel testing in Xcode 15, some or all simulators may automatically shutdown at the end of the test run. Calling `simctl shutdown` on a simulator already in the shutdown state causes a non-zero exist status, causing the test run to fail even if the tests themselves ran successfully. Instead of calling `shutdown` we can instead rely upon `delete` to shutdown the simulator regardless of its current state.