### PR TITLE
Update test runner tests to iPhone Xs

### DIFF
--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -41,7 +41,7 @@ load(
 
 ios_test_runner(
     name = "ios_x86_64_sim_runner",
-    device_type = "iPhone 8",
+    device_type = "iPhone Xs",
 )
 
 EOF

--- a/test/ios_xctestrun_runner_ui_test.sh
+++ b/test/ios_xctestrun_runner_ui_test.sh
@@ -42,7 +42,7 @@ load(
 
 ios_xctestrun_runner(
     name = "ios_x86_64_sim_runner",
-    device_type = "iPhone 8",
+    device_type = "iPhone Xs",
 )
 
 EOF

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -41,12 +41,12 @@ load(
 
 ios_xctestrun_runner(
     name = "ios_x86_64_sim_runner",
-    device_type = "iPhone 8",
+    device_type = "iPhone Xs",
 )
 
 ios_xctestrun_runner(
     name = "ios_x86_64_sim_reuse_disabled_runner",
-    device_type = "iPhone 8",
+    device_type = "iPhone Xs",
     reuse_simulator = False,
 )
 


### PR DESCRIPTION
To make it a bit easier to use the latest Xcode 15 with the default runtimes, migrate to the iPhone Xs instead of the iPhone 8.