### PR TITLE
Add validation for platform type attribute in `apple_{,static}_xcframework` rule

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -681,6 +681,11 @@ def _xcframework_transition_impl(settings, attr):
             target_environments = target_environments,
         )
         output_dictionary = dicts.add(command_line_options, output_dictionary)
+
+    if not output_dictionary:
+        fail("Missing a platform type attribute. At least one of 'ios', " +
+             "'tvos', 'visionos', 'watchos', or 'macos' attribute is mandatory.")
+
     return output_dictionary
 
 _xcframework_transition = transition(


### PR DESCRIPTION
The platform type attributes (`ios`, `tvos`,...) aren't mandatory, but
at least one of them has to be set. It wasn't clear in the documentation
that one of these is required, because there is another attribute
`minimum_os_versions` which also mentions platform types.

Previously not setting any of these led to an error in:

```
Error in link_multi_arch_static_library: unexpected empty key in split transition
```

which wasn't that much useful.
