### PR TITLE
Avoid the deprecated --product_type argument for actool actions, use the new arguments for the sticker icons for messages extensions.

### DIFF
--- a/apple/internal/resource_actions/BUILD
+++ b/apple/internal/resource_actions/BUILD
@@ -20,7 +20,6 @@ bzl_library(
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_apple_support//lib:xcode_support",
     ],
 )
 

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -15,10 +15,6 @@
 """ACTool related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:xcode_support.bzl",
-    "xcode_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -79,9 +75,10 @@ def _actool_args_for_special_file_types(
         appicon_extension = "stickersiconset"
         icon_files = [f for f in asset_files if ".stickersiconset/" in f.path]
 
-        # TODO(kaipi): We might be processing a resource bundle inside an
-        # ios_extension, in which case the bundle ID might not be appropriate here.
         args.extend([
+            "--include-sticker-content",
+            "--stickers-icon-role",
+            "extension",
             "--sticker-pack-identifier-prefix",
             bundle_id + ".sticker-pack.",
         ])
@@ -234,10 +231,6 @@ def compile_asset_catalog(
         platform_prerequisites.minimum_os,
         "--compress-pngs",
     ]
-
-    if xcode_support.is_xcode_at_least_version(platform_prerequisites.xcode_version_config, "8"):
-        if product_type:
-            args.extend(["--product-type", product_type])
 
     args.extend(_actool_args_for_special_file_types(
         asset_files = asset_files,

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -620,7 +620,6 @@ def ios_application_resources_test_suite(name):
         expected_argv = [
             "xctoolrunner actool --compile",
             "--minimum-deployment-target " + common.min_os_ios.baseline,
-            "--product-type com.apple.product-type.application",
             "--platform iphonesimulator",
         ],
         tags = [name],

--- a/test/starlark_tests/ios_imessage_extension_tests.bzl
+++ b/test/starlark_tests/ios_imessage_extension_tests.bzl
@@ -23,6 +23,10 @@ load(
     "analysis_failure_message_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
+)
+load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -48,6 +52,22 @@ def ios_imessage_extension_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:imessage_ext",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests xcasset tool is passed the correct arguments.
+    analysis_target_actions_test(
+        name = "{}_xcasset_actool_argv".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:imessage_ext",
+        target_mnemonic = "AssetCatalogCompile",
+        expected_argv = [
+            "xctoolrunner actool --compile",
+            "--include-sticker-content",
+            "--stickers-icon-role",
+            "extension",
+            "--minimum-deployment-target " + common.min_os_ios.baseline,
+            "--platform iphonesimulator",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -328,7 +328,6 @@ def macos_application_test_suite(name):
         expected_argv = [
             "xctoolrunner actool --compile",
             "--minimum-deployment-target " + common.min_os_macos.baseline,
-            "--product-type com.apple.product-type.application",
             "--platform macosx",
         ],
         tags = [name],

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -173,7 +173,6 @@ def tvos_application_test_suite(name):
         expected_argv = [
             "xctoolrunner actool --compile",
             "--minimum-deployment-target " + common.min_os_tvos.baseline,
-            "--product-type com.apple.product-type.application",
             "--platform appletvsimulator",
         ],
         tags = [name],

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -95,7 +95,6 @@ def watchos_application_test_suite(name):
         expected_argv = [
             "xctoolrunner actool --compile",
             "--minimum-deployment-target " + common.min_os_watchos.baseline,
-            "--product-type com.apple.product-type.application.watchapp2",
             "--platform watchsimulator",
         ],
         tags = [name],

--- a/test/starlark_tests/watchos_single_target_application_tests.bzl
+++ b/test/starlark_tests/watchos_single_target_application_tests.bzl
@@ -126,7 +126,6 @@ delegate is referenced in the single-target `watchos_application`'s `deps`.
         expected_argv = [
             "xctoolrunner actool --compile",
             "--minimum-deployment-target " + common.min_os_watchos.single_target_app,
-            "--product-type com.apple.product-type.application",
             "--platform watchsimulator",
         ],
         tags = [


### PR DESCRIPTION
PiperOrigin-RevId: 578309305
(cherry picked from commit e8e7a0c0a039c35449585b786b099b0443cd7a81)