### PR TITLE
Fix/support implementation deps in objc library

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -279,7 +279,7 @@ def _apple_resource_aspect_impl(target, ctx):
     apple_debug_infos = []
     apple_dsym_bundle_infos = []
     inherited_apple_resource_infos = []
-    provider_deps = ["deps", "private_deps"] + collect_args.get("res_attrs", [])
+    provider_deps = ["deps", "private_deps", "implementation_deps"] + collect_args.get("res_attrs", [])
     for attr in provider_deps:
         if hasattr(ctx.rule.attr, attr):
             targets = getattr(ctx.rule.attr, attr)
@@ -351,7 +351,7 @@ def _apple_resource_aspect_impl(target, ctx):
 
 apple_resource_aspect = aspect(
     implementation = _apple_resource_aspect_impl,
-    attr_aspects = ["data", "deps", "private_deps", "resources", "structured_resources"],
+    attr_aspects = ["data", "deps", "private_deps", "implementation_deps", "resources", "structured_resources"],
     attrs = dicts.add(
         apple_support.action_required_attrs(),
         apple_toolchain_utils.shared_attrs(),


### PR DESCRIPTION
Bazel 6.3 supported  implementation_deps in objc_library https://github.com/bazelbuild/bazel/issues/18298 and it seems that we left out https://github.com/bazelbuild/rules_swift/issues/1081#issuecomment-1636811401 in fix missing resource collect in private_deps https://github.com/bazelbuild/rules_apple/pull/2118

I just added implementation_deps in resource collect and test for these two cases