### PR TITLE
Fix unbound variable when printing an `archive_contents_test` failure message

### DIFF
--- a/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
+++ b/test/starlark_tests/verifier_scripts/apple_verification_test_runner.sh.template
@@ -52,6 +52,7 @@ elif [[ -n "$STANDALONE_BINARY" ]]; then
 
   # If only a binary was provided instead of an archive, treat that as the root
   # element for all root "bundle" locations used by the verifier scripts.
+  ARCHIVE_ROOT="$STANDALONE_BINARY"
   BINARY="$STANDALONE_BINARY"
   BUNDLE_ROOT="$STANDALONE_BINARY"
   CONTENT_ROOT="$STANDALONE_BINARY"


### PR DESCRIPTION
In the "standalone binary" branch `ARCHIVE_ROOT` was not set, which causes an error when printing the failure message of an archive_contents_test:

```
test/starlark_tests/verifier_scripts/archive_contents_test.sh: line 103: ARCHIVE_ROOT: unbound variable
-- Test log: -----------------------------------------------------------
(Log file did not exist.)
------------------------------------------------------------------------
 FAILED: Archive did not contain "does not exist" contents were:
 .
```

The xcarchive tests fall into this branch, so you can reproduce by adding a bogus string to it's `contains` array:

```
    archive_contents_test(
        name = "{}_contains_xcarchive_files_simulator".format(name),
        build_type = "simulator",
        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",
        contains = [
            "does not exist",
        ],
        tags = [name],
    )
```