### PR TITLE
Include dSYMs for any bundled extension targets in the app's xcarchive

### DIFF
--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1130,6 +1130,12 @@ ios_application(
     ],
 )
 
+xcarchive(
+    name = "app_with_ext.xcarchive",
+    bundle = ":app_with_ext",
+    tags = common.fixture_tags,
+)
+
 ios_application(
     name = "app_with_swift_ext",
     bundle_id = "com.google.example",

--- a/test/starlark_tests/xcarchive_tests.bzl
+++ b/test/starlark_tests/xcarchive_tests.bzl
@@ -48,6 +48,51 @@ def xcarchive_test_suite(name):
         tags = [name],
     )
     archive_contents_test(
+        name = "{}_contains_xcarchive_files_simulator_dsyms".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",
+        contains = [
+            "$BUNDLE_ROOT/dSYMs/app_minimal.app.dSYM",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Products/Applications/app_minimal.app",
+        ],
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
+            "ApplicationProperties:ApplicationPath": "Applications/app_minimal.app",
+            "ApplicationProperties:ArchiveVersion": "2",
+            "ApplicationProperties:CFBundleIdentifier": "com.google.example",
+            "ApplicationProperties:CFBundleShortVersionString": "1.0",
+            "ApplicationProperties:CFBundleVersion": "1.0",
+            "Name": "app_minimal",
+            "SchemeName": "app_minimal",
+        },
+        apple_generate_dsym = True,
+        tags = [name],
+    )
+    archive_contents_test(
+        name = "{}_contains_xcarchive_files_simulator_dsyms_extensions".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_ext.xcarchive",
+        contains = [
+            "$BUNDLE_ROOT/dSYMs/app_with_ext.app.dSYM",
+            "$BUNDLE_ROOT/dSYMs/ext.appex.dSYM",
+            "$BUNDLE_ROOT/Info.plist",
+            "$BUNDLE_ROOT/Products/Applications/app_with_ext.app",
+        ],
+        plist_test_file = "$BUNDLE_ROOT/Info.plist",
+        plist_test_values = {
+            "ApplicationProperties:ApplicationPath": "Applications/app_with_ext.app",
+            "ApplicationProperties:ArchiveVersion": "2",
+            "ApplicationProperties:CFBundleIdentifier": "com.google.example",
+            "ApplicationProperties:CFBundleShortVersionString": "1.0",
+            "ApplicationProperties:CFBundleVersion": "1.0",
+            "Name": "app_with_ext",
+            "SchemeName": "app_with_ext",
+        },
+        apple_generate_dsym = True,
+        tags = [name],
+    )
+    archive_contents_test(
         name = "{}_contains_xcarchive_files_simulator_linkmaps".format(name),
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",


### PR DESCRIPTION
Includes dSYMs for transitive targets in a generated xcarchive.  

I added tests to ensure dSYMs are included when `apple_generate_dsym = True` for apps with and without extensions.