### PR TITLE
Remove platform_mappings from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,8 @@ repository.
 
 ## Quick setup
 
-1. Copy the latest `MODULE.bazel` or `WORKSPACE` snippet from [the releases
+Copy the latest `MODULE.bazel` or `WORKSPACE` snippet from [the releases
 page](https://github.com/bazelbuild/rules_apple/releases).
-2. Copy the
-[`platform_mappings`](https://github.com/bazelbuild/rules_apple/blob/master/platform_mappings)
-file to the root of your repo (only required for bazel 6.x)
 
 ## Examples
 


### PR DESCRIPTION
From what I understand this was needed only during rules_apple 3.0 RC and no longer needed. 