### PR TITLE
Add support to run `visionos_application` in simulator via `bazel run`

### DIFF
--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -119,6 +119,8 @@ class DeviceType(collections.abc.Mapping):
       return self.is_apple_tv()
     elif platform_type == "watchos":
       return self.is_apple_watch()
+    elif platform_type == "visionos":
+      return self.is_apple_vision()
     else:
       raise ValueError(
           f"Apple platform type not supported for simulator: {platform_type}."
@@ -129,6 +131,9 @@ class DeviceType(collections.abc.Mapping):
 
   def is_apple_watch(self) -> bool:
     return self.has_product_family_or_identifier("Apple Watch")
+  
+  def is_apple_vision(self) -> bool:
+    return self.has_product_family_or_identifier("Apple Vision")
 
   def is_iphone(self) -> bool:
     return self.has_product_family_or_identifier("iPhone")


### PR DESCRIPTION
Before:
```
$ bazelisk run //examples/visionos/HelloWorld --//:supports_visionos=true
ValueError: Apple platform type not supported for simulator: visionos.
```
After:
```
$ bazelisk run //examples/visionos/HelloWorld --//:supports_visionos=true
INFO: Running command line: bazel-bin/examples/visionos/HelloWorld/HelloWorld
2023-11-15 13:15:54.824 INFO Launching simulator with udid: 89250DD1-D261-415E-8922-EAA2132DD433
2023-11-15 13:15:54.965 INFO Waiting for simulator to boot...
2023-11-15 13:15:55.589 INFO Launching app com.example.hello-world in simulator 89250DD1-D261-415E-8922-EAA2132DD433
com.example.hello-world: 88651
...
```