### PR TITLE
Add swiftinterface_imports to apple_static_xcframework_import

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -668,8 +668,8 @@ def _apple_static_xcframework_import_impl(ctx):
         libraries = [xcframework_library.binary],
         framework_includes = xcframework_library.framework_includes,
         linkopts = sdk_linkopts + linkopts,
-        swiftinterface_imports = [],
-        swiftmodule_imports = [],
+        swiftinterface_imports = [xcframework_library.swift_module_interface] if xcframework_library.swift_module_interface else [],
+        swiftmodule_imports = xcframework_library.swiftmodule,
         includes = xcframework_library.includes + ctx.attr.includes,
     )
     providers.append(cc_info)


### PR DESCRIPTION
Without this static xcframeworks which have a swiftinterface file will
fail to compile when sandboxing is enabled since their swiftinterface
won't be copied to the xcframework bundle.

This changed in https://github.com/bazelbuild/rules_apple/pull/2266
which was mirroring the swiftmodule_imports behavior that I believe is
also wrong so I fixed that here too.
