### PR TITLE
Update rules_xcodeproj version on ios-app.md

### DIFF
--- a/doc/tutorials/ios-app.md
+++ b/doc/tutorials/ios-app.md
@@ -277,8 +277,8 @@ Open the `WORKSPACE` file again and add the following:
 ```starlark
 http_archive(
     name = "rules_xcodeproj",
-    sha256 = "7967b372bd1777214ce65c87a82ac0630150b7504b443de0315ea52e45758e0c",
-    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/1.3.3/release.tar.gz",
+    sha256 = "f5c1f4bea9f00732ef9d54d333d9819d574de7020dbd9d081074232b93c10b2c",
+    url = "https://github.com/MobileNativeFoundation/rules_xcodeproj/releases/download/1.13.0/release.tar.gz",
 )
 
 load(


### PR DESCRIPTION
Just try to learn Bazel and after following the documentation I have some issue on xcodeproj section, and I realize that cause of version 1.3.3 of rules_xcodeproj don't have `bazel_features` there.

Here is the error
<img width="900" alt="Screenshot 2023-11-27 at 16 37 43" src="https://github.com/bazelbuild/rules_apple/assets/46535474/c9b4a98f-a2e2-4230-a228-1c0e07d7d8f3">
