### PR TITLE
Added swift_module param in partials to use it in xibs, storyboards and datamodels compilation

### DIFF
--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -184,12 +184,12 @@ def _resources_partial_impl(
         resource_deps,
         rule_descriptor,
         rule_label,
+        swift_module,
         top_level_infoplists,
         top_level_resources,
         targets_to_avoid,
         version,
-        version_keys_required,
-        swift_module):
+        version_keys_required):
     """Implementation for the resource processing partial."""
     providers = []
 
@@ -391,11 +391,11 @@ def resources_partial(
         resource_deps,
         rule_descriptor,
         rule_label,
+        swift_module = None,
         targets_to_avoid = [],
         top_level_infoplists = [],
         top_level_resources = {},
         version,
-        swift_module = None,
         version_keys_required = True):
     """Constructor for the resources processing partial.
 
@@ -430,6 +430,7 @@ def resources_partial(
         resource_deps: A list of dependencies that the resource aspect has been applied to.
         rule_descriptor: A rule descriptor for platform and product types from the rule context.
         rule_label: The label of the target being analyzed.
+        swift_module: Module name to be used for xibs, storyboards and datamodels compilation.
         targets_to_avoid: List of targets containing resources that should be deduplicated from the
             target being processed.
         top_level_infoplists: A list of collected resources found from Info.plist attributes.
@@ -437,7 +438,6 @@ def resources_partial(
             where keys are targets, and values are list of `File`s depsets. This can be obtained
             using the `apple/internal/resources.collect` API.
         version: A label referencing AppleBundleVersionInfo, if provided by the rule.
-        swift_module: Module name to be used for xibs, storyboards and datamodels compilation.
         version_keys_required: Whether to validate that the Info.plist version keys are correctly
             configured.
 
@@ -462,10 +462,10 @@ def resources_partial(
         resource_deps = resource_deps,
         rule_descriptor = rule_descriptor,
         rule_label = rule_label,
+        swift_module = swift_module,
         targets_to_avoid = targets_to_avoid,
         top_level_infoplists = top_level_infoplists,
         top_level_resources = top_level_resources,
         version = version,
-        swift_module = swift_module,
         version_keys_required = version_keys_required,
     )

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -188,7 +188,8 @@ def _resources_partial_impl(
         top_level_resources,
         targets_to_avoid,
         version,
-        version_keys_required):
+        version_keys_required,
+        swift_module):
     """Implementation for the resource processing partial."""
     providers = []
 
@@ -203,6 +204,7 @@ def _resources_partial_impl(
         providers.append(resources.bucketize(
             owner = str(rule_label),
             resources = top_level_resources,
+            swift_module = swift_module,
         ))
 
     if top_level_infoplists:
@@ -263,7 +265,7 @@ def _resources_partial_impl(
 
     def _deduplicated_field_handler(field, deduplicated):
         processing_func, requires_swift_module = provider_field_to_action[field]
-        for parent_dir, swift_module, files in deduplicated:
+        for parent_dir, module_name, files in deduplicated:
             if locales_requested:
                 locale = bundle_paths.locale_for_path(parent_dir)
                 if sets.contains(locales_requested, locale):
@@ -292,7 +294,7 @@ def _resources_partial_impl(
             # Only pass the Swift module name if the type of resource to process
             # requires it.
             if requires_swift_module:
-                processing_args["swift_module"] = swift_module
+                processing_args["swift_module"] = swift_module or module_name
 
             result = processing_func(**processing_args)
             if hasattr(result, "files"):
@@ -393,6 +395,7 @@ def resources_partial(
         top_level_infoplists = [],
         top_level_resources = {},
         version,
+        swift_module = None,
         version_keys_required = True):
     """Constructor for the resources processing partial.
 
@@ -434,6 +437,7 @@ def resources_partial(
             where keys are targets, and values are list of `File`s depsets. This can be obtained
             using the `apple/internal/resources.collect` API.
         version: A label referencing AppleBundleVersionInfo, if provided by the rule.
+        swift_module: Module name to be used for xibs, storyboards and datamodels compilation.
         version_keys_required: Whether to validate that the Info.plist version keys are correctly
             configured.
 
@@ -462,5 +466,6 @@ def resources_partial(
         top_level_infoplists = top_level_infoplists,
         top_level_resources = top_level_resources,
         version = version,
+        swift_module = swift_module,
         version_keys_required = version_keys_required,
     )


### PR DESCRIPTION
**What has changed❓** 
In this PR I added `swift_module` as new param to partials, so it could be used to compile xibs, storyboards, datamodels, etc.

**Why this is needed❓**
I faced with a problem when tried to build 2 different targets with same `module_name` and when using `precompiled_apple_resource_bundle` rule. 
[rules_apple](https://github.com/bazelbuild/rules_apple) fail because of conflicting actions when creating `Info.plist-root-control` file under same path: `/Path/ModuleName-intermediates/Info.plist-root.control`
After this change will be merged, I'm going to create second PR to remove `fake_rule_label` [from precompiled_apple_resource_bundle](https://github.com/bazel-ios/rules_ios/blob/789a8625a44d62f51fb733d98470d7fea9428358/rules/precompiled_apple_resource_bundle.bzl#L53) 
and plist files will be stored at: `/Path/TargetName-intermediates/Info.plist-root.control` but the resources are going to be compiled with proper `module_name`.

**Other notes 📓** 
Right now [fake_rule_label](https://github.com/bazel-ios/rules_ios/blob/789a8625a44d62f51fb733d98470d7fea9428358/rules/precompiled_apple_resource_bundle.bzl#L53) is used there as `module_name`. I think this was a workaround and it would be good to remove it finally 🙏 