### PR TITLE
Removing --experimental_strict_conflict_checks flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,6 @@
 # NOTE: These are mainly just for the BazelCI setup so they don't have
 # to be repeated multiple times in .bazelci/presubmit.yml.
 
-# https://github.com/bazelbuild/bazel/issues/16729
-build --experimental_strict_conflict_checks
-
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 


### PR DESCRIPTION
Removing --experimental_strict_conflict_checks as  flag was deleted from Bazel@HEAD: https://github.com/bazelbuild/bazel/commit/febfa54dbe62d719ad6dbbfdd12bd6f8c0923b7a 

Fixes : https://github.com/bazelbuild/rules_apple/issues/2337