### PR TITLE
Pass launch arguments to simctl launch command

### DIFF
--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -54,6 +54,7 @@ import platform
 import plistlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from typing import Dict, Optional
@@ -683,6 +684,8 @@ def run_app_in_simulator(
         simulator_udid,
         app_bundle_id,
     ]
+    # Append optional launch arguments.
+    args.extend(sys.argv[1:])
     subprocess.run(args, env=simctl_launch_environ(), check=False)
 
 


### PR DESCRIPTION
This allows passing launch arguments when doing `bazel run` directly. There's a way to provide environment variables, but from what I could see, we didn't support passing launch arguments. This adds support for doing the following for example:
```
$ bazel run //:app -- -AppleLanguages (fr)
```
