### PR TITLE
Add example googletest on iOS hack

### DIFF
--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -1,3 +1,8 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(
+    "//apple/testing/default_runner:ios_googletest_runner.bzl",
+    "ios_googletest_runner",
+)
 load(
     "//apple/testing/default_runner:ios_test_runner.bzl",
     "ios_test_runner",
@@ -22,7 +27,6 @@ load(
     "//apple/testing/default_runner:watchos_test_runner.bzl",
     "watchos_test_runner",
 )
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 licenses(["notice"])
 
@@ -117,6 +121,11 @@ ios_xctestrun_runner(
 ios_xctestrun_runner(
     name = "ios_xctestrun_ordered_runner",
     random = False,
+    visibility = ["//visibility:public"],
+)
+
+ios_googletest_runner(
+    name = "ios_googletest_runner",
     visibility = ["//visibility:public"],
 )
 

--- a/apple/testing/default_runner/ios_googletest_runner.bzl
+++ b/apple/testing/default_runner/ios_googletest_runner.bzl
@@ -1,0 +1,117 @@
+"""
+An iOS test runner rule that uses xctestrun files to run unit test bundles on
+simulators. This rule currently doesn't support UI tests or running on device.
+"""
+
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "apple_provider",
+)
+
+def _get_template_substitutions(
+        *,
+        device_type,
+        os_version,
+        simulator_creator,
+        reuse_simulator):
+    substitutions = {
+        "device_type": device_type,
+        "os_version": os_version,
+        "simulator_creator.py": simulator_creator,
+        "reuse_simulator": reuse_simulator,
+    }
+
+    return {"%({})s".format(key): value for key, value in substitutions.items()}
+
+def _get_execution_environment(ctx):
+    xcode_version = str(ctx.attr._xcode_config[apple_common.XcodeVersionConfig].xcode_version())
+    if not xcode_version:
+        fail("error: No xcode_version in _xcode_config")
+
+    return {"XCODE_VERSION_OVERRIDE": xcode_version}
+
+def _impl(ctx):
+    os_version = str(ctx.attr.os_version or ctx.fragments.objc.ios_simulator_version or
+                     ctx.attr._xcode_config[apple_common.XcodeProperties].default_ios_sdk_version)
+
+    # TODO: Ideally we would be smarter about picking a device, but we don't know what the current version of Xcode supports
+    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or "iPhone 12"
+
+    if not os_version:
+        fail("error: os_version must be set on ios_xctestrun_runner, or passed with --ios_simulator_version")
+    if not device_type:
+        fail("error: device_type must be set on ios_xctestrun_runner, or passed with --ios_simulator_device")
+
+    ctx.actions.expand_template(
+        template = ctx.file._test_template,
+        output = ctx.outputs.test_runner_template,
+        substitutions = _get_template_substitutions(
+            device_type = device_type,
+            os_version = os_version,
+            simulator_creator = ctx.executable._simulator_creator.short_path,
+            reuse_simulator = "true" if ctx.attr.reuse_simulator else "false",
+        ),
+    )
+
+    return [
+        apple_provider.make_apple_test_runner_info(
+            execution_environment = _get_execution_environment(ctx),
+            execution_requirements = {"requires-darwin": ""},
+            test_runner_template = ctx.outputs.test_runner_template,
+        ),
+        DefaultInfo(
+            runfiles = ctx.attr._simulator_creator[DefaultInfo].default_runfiles,
+        ),
+    ]
+
+ios_googletest_runner = rule(
+    _impl,
+    attrs = {
+        "device_type": attr.string(
+            default = "",
+            doc = """
+The device type of the iOS simulator to run test. The supported types correspond
+to the output of `xcrun simctl list devicetypes`. E.g., iPhone X, iPad Air.
+By default, it reads from --ios_simulator_device or falls back to some device.
+""",
+        ),
+        "os_version": attr.string(
+            default = "",
+            doc = """
+The os version of the iOS simulator to run test. The supported os versions
+correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5.
+By default, it reads --ios_simulator_version and then falls back to the latest
+supported version.
+""",
+        ),
+        "reuse_simulator": attr.bool(
+            default = True,
+            doc = """
+Toggle simulator reuse. The default behavior is to reuse an existing device of the same type and OS version. When disabled, a new simulator is created before testing starts and shutdown when the runner completes.
+""",
+        ),
+        "_simulator_creator": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator",
+            ),
+            executable = True,
+            cfg = "exec",
+        ),
+        "_test_template": attr.label(
+            default = Label(
+                "@build_bazel_rules_apple//apple/testing/default_runner:ios_googletest_runner.template.sh",
+            ),
+            allow_single_file = True,
+        ),
+        "_xcode_config": attr.label(
+            default = configuration_field(
+                name = "xcode_config_label",
+                fragment = "apple",
+            ),
+        ),
+    },
+    outputs = {
+        "test_runner_template": "%{name}.sh",
+    },
+    fragments = ["apple", "objc"],
+)

--- a/apple/testing/default_runner/ios_googletest_runner.template.sh
+++ b/apple/testing/default_runner/ios_googletest_runner.template.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# This script replaces the variables in the templated xctestrun file with the
+# the specific paths to the test bundle, and the optionally test host
+
+set -euo pipefail
+
+if [[ -z "${DEVELOPER_DIR:-}" ]]; then
+  echo "error: Missing \$DEVELOPER_DIR" >&2
+  exit 1
+fi
+
+if [[ -n "${DEBUG_XCTESTRUNNER:-}" ]]; then
+  set -x
+fi
+
+simulator_name=""
+while [[ $# -gt 0 ]]; do
+  arg="$1"
+  case $arg in
+    --simulator_name=*)
+      simulator_name="${arg##*=}"
+      ;;
+    *)
+      echo "error: Unsupported argument '${arg}'" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Retrieve the basename of a file or folder with an extension.
+basename_without_extension() {
+  local filename
+  filename=$(basename "$1")
+  echo "${filename%.*}"
+}
+
+test_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/test_tmp_dir.XXXXXX")"
+if [[ -z "${NO_CLEAN:-}" ]]; then
+  trap 'rm -rf "${test_tmp_dir}"' EXIT
+else
+  test_tmp_dir="${TMPDIR:-/tmp}/test_tmp_dir"
+  rm -rf "$test_tmp_dir"
+  mkdir -p "$test_tmp_dir"
+  echo "note: keeping test dir around at: $test_tmp_dir"
+fi
+
+test_bundle_path="%(test_bundle_path)s"
+test_bundle_name=$(basename_without_extension "$test_bundle_path")
+
+if [[ "$test_bundle_path" == *.xctest ]]; then
+  cp -cRL "$test_bundle_path" "$test_tmp_dir"
+  # Need to modify permissions as Bazel will set all files to non-writable, and
+  # Xcode's test runner requires the files to be writable.
+  chmod -R 777 "$test_tmp_dir/$test_bundle_name.xctest"
+else
+  unzip -qq -d "${test_tmp_dir}" "${test_bundle_path}"
+fi
+
+# Basic XML character escaping for environment variable substitution.
+function escape() {
+  local escaped=${1//&/&amp;}
+  escaped=${escaped//</&lt;}
+  escaped=${escaped//>/&gt;}
+  escaped=${escaped//'"'/&quot;}
+  echo "$escaped"
+}
+
+# Add the test environment variables into the xctestrun file to propagate them
+# to the test runner
+test_env="%(test_env)s"
+if [[ -n "$test_env" ]]; then
+  test_env="$test_env,TEST_SRCDIR=$TEST_SRCDIR,TEST_UNDECLARED_OUTPUTS_DIR=$TEST_UNDECLARED_OUTPUTS_DIR"
+else
+  test_env="TEST_SRCDIR=$TEST_SRCDIR,TEST_UNDECLARED_OUTPUTS_DIR=$TEST_UNDECLARED_OUTPUTS_DIR"
+fi
+
+passthrough_env=()
+saved_IFS=$IFS
+IFS=","
+for test_env_key_value in ${test_env}; do
+  IFS="=" read -r key value <<< "$test_env_key_value"
+  passthrough_env+=("SIMCTL_CHILD_$key=$value")
+done
+IFS=$saved_IFS
+
+simulator_creator_args=(
+  "%(os_version)s" \
+  "%(device_type)s" \
+  --name "$simulator_name"
+)
+
+reuse_simulator="%(reuse_simulator)s"
+if [[ "$reuse_simulator" == true ]]; then
+  simulator_creator_args+=(--reuse-simulator)
+else
+  simulator_creator_args+=(--no-reuse-simulator)
+fi
+
+simulator_id="$("./%(simulator_creator.py)s" "${simulator_creator_args[@]}")"
+
+test_exit_code=0
+readonly testlog=$test_tmp_dir/test.log
+
+platform_developer_dir="$(xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer"
+SIMCTL_CHILD_DYLD_LIBRARY_PATH="$platform_developer_dir/usr/lib" \
+  SIMCTL_CHILD_DYLD_FALLBACK_FRAMEWORK_PATH="$platform_developer_dir/Library/Frameworks" \
+  xcrun simctl \
+  spawn \
+  "$simulator_id" \
+  "$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name" \
+  2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
+  || test_exit_code=$?
+
+if [[ "$reuse_simulator" == false ]]; then
+  # Delete will shutdown down the simulator if it's still currently running.
+  xcrun simctl delete "$simulator_id"
+fi
+
+if [[ "$test_exit_code" -ne 0 ]]; then
+  echo "error: tests exited with '$test_exit_code'" >&2
+  exit "$test_exit_code"
+fi

--- a/examples/ios/googletest/BUILD
+++ b/examples/ios/googletest/BUILD
@@ -1,0 +1,17 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("//apple:ios.bzl", "ios_unit_test")
+
+swift_library(
+    name = "lib",
+    testonly = True,
+    srcs = ["tests.swift"],
+    tags = ["manual"],
+)
+
+ios_unit_test(
+    name = "tests",
+    linkopts = ["-execute"],
+    minimum_os_version = "15.0",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_googletest_runner",
+    deps = [":lib"],
+)

--- a/examples/ios/googletest/tests.swift
+++ b/examples/ios/googletest/tests.swift
@@ -1,0 +1,7 @@
+@main
+struct Test {
+    static func main() {
+        print("This is a test")
+        exit(42)
+    }
+}

--- a/examples/ios/googletest/tests.swift
+++ b/examples/ios/googletest/tests.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 @main
 struct Test {
     static func main() {


### PR DESCRIPTION
This uses a custom test runner to exec a googletest based binary (or any
binary where the test is defined by exiting non-zero) on iOS.
