### PR TITLE
Upgrade to Xcode 15.1

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos
-    xcode_version: "14.3"
+    xcode_version: "15.1"
     build_targets:
     - "tools/..."
     - "test/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,7 @@ x_defaults:
   # YAML has a feature for "repeated nodes", BazelCI is fine with extra nodes
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
-    platform: macos
+    platform: macos_arm64
     xcode_version: "15.1"
     build_targets:
     - "tools/..."

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -523,21 +523,19 @@ function is_device_build() {
 }
 
 
-# Usage: print_debug_entitlements <binary_path>
+# Usage: print_debug_entitlements <binary_path> <output>
 #
-# Extracts and prints the debug entitlements from the appropriate Mach-O
-# section of the given binary.
+# Extracts and prints the debug entitlements from the the given binary
+# using segedit.
 function print_debug_entitlements() {
   local binary="$1"
-
-  # This monstrosity uses objdump to dump the hex content of the entitlements
-  # section, strips off the leading addresses (and ignores lines that don't
-  # look like hex), then runs it through `xxd` to turn the hex into ASCII.
-  # The results should be the entitlements plist text, which we can compare
-  # against.
-  xcrun llvm-objdump --macho --section=__TEXT,__entitlements "$binary" | \
-      sed -e 's/^[0-9a-f][0-9a-f]*[[:space:]][[:space:]]*//' \
-          -e 'tx' -e 'd' -e ':x' | xxd -r -p
+  local output="$2"
+  local archs=($(lipo -archs "$binary"))
+  local thin_binary="tempdir/thin_binary"
+  mkdir -p tempdir
+  lipo -thin ${archs[0]} "$binary" -output "$thin_binary"
+  xcrun segedit "$thin_binary" -extract __TEXT __entitlements "$output"
+  rm -rf tempdir
 }
 
 

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -288,8 +288,8 @@ EOF
     # For simulator builds, entitlements are added as a Mach-O section in
     # the binary.
     do_build ios "$@" //app:app || fail "Should build"
-    unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/app" | \
-        print_debug_entitlements - > "${TEST_TMPDIR}/dumped_entitlements"
+    unzip_single_file "test-bin/app/app.ipa" "Payload/app.app/app" > "${TEST_TMPDIR}/binary"
+    print_debug_entitlements "${TEST_TMPDIR}/binary" "${TEST_TMPDIR}/dumped_entitlements"
 
     readonly FILE_TO_CHECK="${TEST_TMPDIR}/dumped_entitlements"
 
@@ -380,9 +380,9 @@ EOF
     do_build ios //app:app-with-hyphen || fail "Should build"
 
     unzip_single_file "test-bin/app/app-with-hyphen.ipa" \
-        "Payload/app-with-hyphen.app/app-with-hyphen" | \
-        print_debug_entitlements - | \
-        grep -sq "<key>test-an-entitlement</key>" || \
+        "Payload/app-with-hyphen.app/app-with-hyphen" > "${TEST_TMPDIR}/binary"
+    print_debug_entitlements "${TEST_TMPDIR}/binary" "${TEST_TMPDIR}/dumped_entitlements"
+    grep -sq "<key>test-an-entitlement</key>" "${TEST_TMPDIR}/dumped_entitlements" || \
         fail "Failed to find custom entitlement"
   fi
 }

--- a/test/ios_coverage_test.sh
+++ b/test/ios_coverage_test.sh
@@ -267,18 +267,18 @@ function test_standalone_unit_test_coverage_coverage_manifest() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:coverage_manifest_test || fail "Should build"
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test/coverage.dat"
-  assert_contains "SF:./app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
+  assert_contains "SF:app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test/coverage.dat"
   cat "test-testlogs/app/coverage_manifest_test/coverage.dat"
-  (! grep "SF:" "test-testlogs/app/coverage_manifest_test/coverage.dat" | grep -v "SF:./app/SharedLogic.m") || fail "Should not contain any other files"
+  (! grep "SF:" "test-testlogs/app/coverage_manifest_test/coverage.dat" | grep -v "SF:app/SharedLogic.m") || fail "Should not contain any other files"
 }
 
 function test_standalone_unit_test_coverage_coverage_manifest_new_runner() {
   create_common_files
   do_coverage ios --test_output=errors --ios_minimum_os=9.0 --experimental_use_llvm_covmap //app:coverage_manifest_test_new_runner || fail "Should build"
   assert_contains "SharedLogic.m:-\[SharedLogic doSomething\]" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat"
-  assert_contains "SF:./app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat"
+  assert_contains "SF:app/SharedLogic.m" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat"
   cat test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat
-  (! grep "SF:" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat" | grep -v "SF:./app/SharedLogic.m") || fail "Should not contain other files"
+  (! grep "SF:" "test-testlogs/app/coverage_manifest_test_new_runner/coverage.dat" | grep -v "SF:app/SharedLogic.m") || fail "Should not contain other files"
 }
 
 function test_hosted_unit_test_coverage() {

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -41,7 +41,7 @@ load(
 
 ios_test_runner(
     name = "ios_x86_64_sim_runner",
-    device_type = "iPhone 8",
+    device_type = "iPhone 12",
 )
 EOF
 }

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -233,7 +233,7 @@ def apple_static_xcframework_import_test_suite(name):
             "-[SharedClass doSomethingShared]",
             "_OBJC_CLASS_$_SharedClass",
         ],
-        macho_load_commands_contain = ["cmd LC_VERSION_MIN_TVOS"],
+        macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform TVOSSIMULATOR"],
         tags = [name],
     )
 

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -23,10 +23,6 @@ load(
     "apple_verification_test",
 )
 load(
-    "//test/starlark_tests/rules:common_verification_tests.bzl",
-    "archive_contents_test",
-)
-load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
 )
@@ -68,15 +64,6 @@ def ios_sticker_pack_extension_test_suite(name):
             "NSExtension:NSExtensionPointIdentifier": "com.apple.message-payload-provider",
             "UIDeviceFamily:0": "1",
         },
-        tags = [name],
-    )
-
-    archive_contents_test(
-        name = "{}_strip_bitcode_test".format(name),
-        build_type = "device",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:sticker_ext",
-        binary_test_file = "$BUNDLE_ROOT/sticker_ext",
-        macho_load_commands_contain = ["segname __LLVM"],  # TODO: This might need to change in the future to not contain bitcode
         tags = [name],
     )
 


### PR DESCRIPTION
Xcode 15.1 was recently installed on the build agents thanks to https://github.com/bazelbuild/continuous-integration/issues/1780. Let's see how this goes.