### PR TITLE
Fix the test_file location for UITests

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -65,6 +65,7 @@ fi
 
 test_bundle_path="%(test_bundle_path)s"
 test_bundle_name=$(basename_without_extension "$test_bundle_path")
+test_bundle_binary="$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name"
 
 if [[ "$test_bundle_path" == *.xctest ]]; then
   cp -cRL "$test_bundle_path" "$test_tmp_dir"
@@ -173,6 +174,7 @@ if [[ -n "$test_host_path" ]]; then
     plugins_path="$test_tmp_dir/$runner_app/PlugIns"
     mkdir -p "$plugins_path"
     mv "$test_tmp_dir/$test_bundle_name.xctest" "$plugins_path"
+    test_bundle_binary="$plugins_path/$test_bundle_name.xctest/$test_bundle_name"
     mkdir -p "$plugins_path/$test_bundle_name.xctest/Frameworks"
     # We need this dylib for 14.x OSes. This intentionally doesn't use `test_execution_platform`
     # since this file isn't present in the `iPhoneSimulator.platform`.
@@ -341,12 +343,7 @@ fi
 
 test_exit_code=0
 readonly testlog=$test_tmp_dir/test.log
-
-test_file=$(file "$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name")
-if [[ "$test_type" = "XCUITEST" ]]; then
-  plugins_path="$test_tmp_dir/$runner_app/PlugIns"
-  test_file=$(file "$plugins_path/$test_bundle_name.xctest/$test_bundle_name")
-fi
+test_file=$(file "$test_bundle_binary")
 
 intel_simulator_hack=false
 architecture="arm64"

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -343,6 +343,11 @@ test_exit_code=0
 readonly testlog=$test_tmp_dir/test.log
 
 test_file=$(file "$test_tmp_dir/$test_bundle_name.xctest/$test_bundle_name")
+if [[ "$test_type" = "XCUITEST" ]]; then
+  plugins_path="$test_tmp_dir/$runner_app/PlugIns"
+  test_file=$(file "$plugins_path/$test_bundle_name.xctest/$test_bundle_name")
+fi
+
 intel_simulator_hack=false
 architecture="arm64"
 if [[ $(arch) == arm64 && "$test_file" != *arm64* ]]; then


### PR DESCRIPTION
UITests place their test file inside of a runner app PlugIns folder. This PR prevents a warning like the following:

```bash
++ file /tmp/bazel_tmp/test_tmp_dir/AddUserPluginUITests.xctest/AddUserPluginUITests
+ test_file='/tmp/bazel_tmp/test_tmp_dir/AddUserPluginUITests.xctest/AddUserPluginUITests: cannot open `/tmp/bazel_tmp/test_tmp_dir/AddUserPluginUITests.xctest/AddUserPluginUITests'\'' (No such file or directory)'
+ intel_simulator_hack=false
+ architecture=arm64
++ arch
+ [[ arm64 == arm64 ]]
+ [[ /tmp/bazel_tmp/test_tmp_dir/AddUserPluginUITests.xctest/AddUserPluginUITests: cannot open `/tmp/bazel_tmp/test_tmp_dir/AddUserPluginUITests.xctest/AddUserPluginUITests' (No such file or directory) != *arm64* ]]
+ intel_simulator_hack=true
+ architecture=x86_64
```

which seems to lock the architecture to x86_64 when running UI tests.