### PR TITLE
Fix minor issues with module_map rule

### DIFF
--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -1,9 +1,9 @@
-load("//apple:apple.bzl", "experimental_mixed_language_library")
-load("//apple:ios.bzl", "ios_unit_test")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
 )
+load("//apple:apple.bzl", "experimental_mixed_language_library")
+load("//apple:ios.bzl", "ios_unit_test")
 
 experimental_mixed_language_library(
     name = "MixedAnswer",


### PR DESCRIPTION
Fixes some issues I noticed while I was copying `module_map` to our internal project.

- Sort `load`
- `break` in loop after finding swift generated header
- Remove duplicate `umbrella_header` being added to output
- Use `:` prefix for umbrella header label