### PR TITLE
Add support for clang modules in experimental_mixed_language_library

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -195,6 +195,7 @@ def experimental_mixed_language_library(
         name,
         srcs,
         deps = [],
+        enable_modules = False,
         module_name = None,
         objc_copts = [],
         swift_copts = [],
@@ -212,13 +213,14 @@ def experimental_mixed_language_library(
     it easier to migrate codebases with mixed language modules to Bazel without
     having to demix them first.
 
-    This macro only supports a very simple use case of mixed language
-    modules---it does not support for header maps or Clang modules.
+    This macro only supports a simple use case of mixed language
+    modules, it does not support header maps.
 
     Args:
         name: A unique name for this target.
         deps: A list of targets that are dependencies of the target being
             built, which will be linked into that target.
+        enable_modules: Enables clang module support for the Objective-C target.
         module_name: The name of the mixed language module being built.
             If left unspecified, the module name will be the name of the
             target.
@@ -267,6 +269,7 @@ target only contains Objective-C files.""")
     swift_library_name = name + ".internal.swift"
 
     objc_deps = []
+    objc_copts = [] + objc_copts
     swift_deps = [] + deps
 
     swift_copts = swift_copts + [
@@ -274,6 +277,12 @@ target only contains Objective-C files.""")
         "-enable-objc-interop",
         "-import-underlying-module",
     ]
+
+    # Modules is not enabled if a custom module map is present even with
+    # `enable_modules` set to `True` in `objc_library`. This enables it via copts.
+    # See: https://github.com/bazelbuild/bazel/issues/20703
+    if enable_modules:
+        objc_copts.append("-fmodules")
 
     objc_deps = [":" + swift_library_name]
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -375,8 +375,8 @@ ios_application(
 ## experimental_mixed_language_library
 
 <pre>
-experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>, <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>,
-                                    <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-testonly">testonly</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
+experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-enable_modules">enable_modules</a>, <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>,
+                                    <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>, <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-testonly">testonly</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
 </pre>
 
 Compiles and links Objective-C and Swift code into a static library.
@@ -390,8 +390,8 @@ mixed language modules in some old codebases. This macro is meant to make
 it easier to migrate codebases with mixed language modules to Bazel without
 having to demix them first.
 
-This macro only supports a very simple use case of mixed language
-modules---it does not support for header maps or Clang modules.
+This macro only supports a simple use case of mixed language
+modules, it does not support header maps.
 
 
 **PARAMETERS**
@@ -402,6 +402,7 @@ modules---it does not support for header maps or Clang modules.
 | <a id="experimental_mixed_language_library-name"></a>name |  A unique name for this target.   |  none |
 | <a id="experimental_mixed_language_library-srcs"></a>srcs |  The list of Objective-C and Swift source files to compile.   |  none |
 | <a id="experimental_mixed_language_library-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will be linked into that target.   |  `[]` |
+| <a id="experimental_mixed_language_library-enable_modules"></a>enable_modules |  Enables clang module support for the Objective-C target.   |  `False` |
 | <a id="experimental_mixed_language_library-module_name"></a>module_name |  The name of the mixed language module being built. If left unspecified, the module name will be the name of the target.   |  `None` |
 | <a id="experimental_mixed_language_library-objc_copts"></a>objc_copts |  Additional compiler options that should be passed to `clang`.   |  `[]` |
 | <a id="experimental_mixed_language_library-swift_copts"></a>swift_copts |  Additional compiler options that should be passed to `swiftc`. These strings are subject to `$(location ...)` and "Make" variable expansion.   |  `[]` |

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -12,6 +12,7 @@ experimental_mixed_language_library(
         "MixedAnswer.swift",
     ],
     hdrs = ["MixedAnswer.h"],
+    enable_modules = True,
 )
 
 swift_library(

--- a/examples/multi_platform/MixedLib/MixedAnswer.h
+++ b/examples/multi_platform/MixedLib/MixedAnswer.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+@import Foundation;
 
 @interface MixedAnswerObjc : NSObject
 


### PR DESCRIPTION
This adds support for `@import` when using `experimental_mixed_language_library`. There seems to be a "bug" (or at least a usability issue) in Bazel where if `module_map` is set on `objc_library` then the `enable_modules` attr does nothing.

This enables modules via copts instead, similar to how it was done in [rules_apple_line](https://github.com/line/rules_apple_line/blob/63f50b29616e7a439c47a140cadd59c3ccf4066f/apple/mixed_static_framework.bzl#L279).