### PR TITLE
Add `header_map` rule

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -255,6 +255,12 @@ bzl_library(
     deps = ["//apple/internal:docc"],
 )
 
+bzl_library(
+    name = "header_map",
+    srcs = ["header_map.bzl"],
+    deps = ["//apple/internal:header_map"],
+)
+
 cc_toolchain_forwarder(
     name = "default_cc_toolchain_forwarder",
 )

--- a/apple/header_map.bzl
+++ b/apple/header_map.bzl
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Rules for creating header maps.
+"""
+
+load(
+    "@build_bazel_rules_apple//apple/internal:header_map.bzl",
+    _header_map = "header_map",
+)
+
+header_map = _header_map

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -808,6 +808,28 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "header_map",
+    srcs = ["header_map.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        "@build_bazel_rules_swift//swift",
+    ],
+)
+
+bzl_library(
+    name = "header_map_support",
+    srcs = ["header_map_support.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+    ],
+    deps = [
+        ":header_map",
+    ],
+)
+
 # Consumed by bazel tests.
 filegroup(
     name = "for_bazel_tests",

--- a/apple/internal/header_map.bzl
+++ b/apple/internal/header_map.bzl
@@ -1,0 +1,171 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for creating header_maps."""
+
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
+
+HeaderMapInfo = provider(
+    doc = "Provides information about created `.hmap` (header map) files",
+    fields = {
+        "public_header_maps": "depset of paths of any public header maps",
+    },
+)
+
+def _write_header_map(actions, header_map_tool, output, module_name, hdrs_lists):
+    """Makes a binary hmap file by executing the header_map tool.
+
+    Args:
+        actions: a ctx.actions struct
+        header_map_tool: an executable pointing to @bazel_build_rules_ios//rules/hmap:hmaptool
+        output: the output file that will contain the built hmap
+        module_name: the prefix to be used for header imports
+        hdrs_lists: an array of enumerables containing headers to be added to the hmap
+    """
+
+    args = actions.args()
+    if module_name:
+        args.add("--module_name", module_name)
+
+    args.add("--output", output)
+
+    for hdrs in hdrs_lists:
+        args.add_all(hdrs)
+
+    args.set_param_file_format(format = "multiline")
+    args.use_param_file("@%s")
+
+    actions.run(
+        mnemonic = "HmapWrite",
+        arguments = [args],
+        executable = header_map_tool,
+        outputs = [output],
+    )
+
+def _header_map_impl(ctx):
+    """Implementation of the header_map() rule.
+
+    It creates a text file with mappings and creates an action that calls out to the header_map tool
+    to convert it to a binary header_map file.
+    """
+    hdrs_lists = [ctx.files.hdrs] if ctx.files.hdrs else []
+
+    for dep in ctx.attr.deps:
+        found_headers = []
+        if apple_common.Objc in dep:
+            found_headers.append(getattr(dep[apple_common.Objc], "direct_headers", []))
+        if CcInfo in dep:
+            found_headers.append(dep[CcInfo].compilation_context.direct_headers)
+        if not found_headers:
+            fail("Direct header provider: '%s' listed in 'deps' does not have any direct headers to provide." % dep)
+        hdrs_lists.extend(found_headers)
+
+    hdrs_lists = [[h for h in hdrs if h.basename.endswith(".h")] for hdrs in hdrs_lists]
+
+    _write_header_map(
+        actions = ctx.actions,
+        header_map_tool = ctx.executable._hmaptool,
+        output = ctx.outputs.header_map,
+        module_name = ctx.attr.module_name,
+        hdrs_lists = hdrs_lists,
+    )
+
+    return [
+        apple_common.new_objc_provider(),
+        swift_common.create_swift_info(),
+        CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                headers = depset([ctx.outputs.header_map]),
+            ),
+        ),
+        HeaderMapInfo(
+            public_header_maps = depset([ctx.outputs.header_map]),
+        ),
+    ]
+
+header_map = rule(
+    implementation = _header_map_impl,
+    output_to_genfiles = True,
+    attrs = {
+        "module_name": attr.string(
+            mandatory = False,
+            doc = "The prefix to be used for header imports",
+        ),
+        "hdrs": attr.label_list(
+            mandatory = False,
+            allow_files = True,
+            doc = "The list of headers included in the header_map",
+        ),
+        "deps": attr.label_list(
+            mandatory = False,
+            providers = [[apple_common.Objc], [CcInfo]],
+            doc = "Targets whose direct headers should be added to the list of hdrs and rooted at the module_name",
+        ),
+        "_hmaptool": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//tools/hmaptool:hmaptool"),
+        ),
+    },
+    outputs = {
+        "header_map": "%{name}.hmap",
+    },
+    doc = """\
+Creates a binary `.hmap` file from the given headers suitable for passing to clang.
+
+Headermaps can be used in `-I` and `-iquote` compile flags (as well as in `includes`) to tell clang where to find headers.
+This can be used to allow headers to be imported at a consistent path regardless of the package structure being used.
+
+For example, if you have a package structure like this:
+
+    ```
+    MyLib/
+        headers/
+            MyLib.h
+        MyLib.c
+        BUILD
+    ```
+
+And you want to import `MyLib.h` from `MyLib.c` using angle bracket imports: `#import <MyLib/MyLib.h>`
+You can create a header map like this:
+
+    ```bzl
+    header_map(
+        name = "MyLib.hmap",
+        hdrs = ["headers/MyLib.h"],
+    )
+    ```
+
+This generates a binary headermap that looks like:
+
+    ```
+    MyLib.h -> headers/MyLib.h
+    MyLib/MyLib.h -> headers/MyLib.h
+    ```
+
+Then update `deps`, `copts` and `includes` to use the header map:
+
+    ```bzl
+    objc_library(
+        name = "MyLib",
+        module_name = "MyLib",
+        srcs = ["MyLib.c"],
+        hdrs = ["headers/MyLib.h"],
+        deps = [":MyLib.hmap"],
+        copts = ["-I.]
+        includes = ["MyLib.hmap"]
+    )
+    ```
+    """,
+)

--- a/apple/internal/header_map_support.bzl
+++ b/apple/internal/header_map_support.bzl
@@ -1,0 +1,80 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides utilities for working with header_maps within macros and rules"""
+
+load("//apple/internal:header_map.bzl", "header_map")
+
+def _create_header_map_context(
+        name,
+        module_name,
+        hdrs,
+        deps):
+    """
+    Creates header_map(s) for the target with the given name.
+
+    Args:
+        name: The name of the target.
+        module_name: The name of the module to use in the header map.
+        hdrs: The public headers to include in the header mapm, these will be rooted
+            under module_name and flattened.
+        deps: The direct dependencies to include in the header map, any headers in the deps will be rooted
+            under this `module_name` and flattened.
+
+    Returns a struct (or `None` if no headers) with the following attributes:
+        copts: The compiler options to use when compiling a C family library with header maps.
+        includes: The includes to use when compiling a C family library with header maps.
+        swift_copts: The compiler options to use when compiling a Swift library with the header map.
+        header_maps: The labels to any generated header maps, these should be the inputs used with the `copts`.
+    """
+
+    public_hdrs_filegroup = name + ".public.hmap_hdrs"
+    public_hmap_name = name + ".public"
+
+    native.filegroup(
+        name = public_hdrs_filegroup,
+        srcs = hdrs,
+    )
+
+    header_map(
+        name = public_hmap_name,
+        module_name = module_name,
+        hdrs = [public_hdrs_filegroup],
+        deps = deps,
+    )
+
+    copts = [
+        "-I.",  # makes the package's bin dir available for use with #import <foo/foo.h>
+    ]
+    includes = [
+        "{}.hmap".format(public_hmap_name),  # propogates the header map include to target and things that depend on it
+    ]
+    header_maps = [
+        ":{}".format(public_hmap_name),
+    ]
+
+    swift_copts = []
+    for copt in copts:
+        swift_copts.extend(["-Xcc", copt])
+
+    return struct(
+        copts = copts,
+        includes = includes,
+        swift_copts = swift_copts,
+        header_maps = header_maps,
+    )
+
+header_map_support = struct(
+    create_header_map_context = _create_header_map_context,
+)

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -10,6 +10,7 @@ _RULES_DOC_SRCS = [
     "apple",
     "docc",
     "dtrace",
+    "header_map",
     "ios.doc",
     "macos.doc",
     "resources",

--- a/doc/README.md
+++ b/doc/README.md
@@ -106,7 +106,7 @@ below.
   </thead>
   <tbody>
     <tr>
-      <th align="left" valign="top" rowspan="5">General</th>
+      <th align="left" valign="top" rowspan="6">General</th>
       <tr>
         <td valign="top"><code>@build_bazel_rules_apple//apple:apple.bzl</code></td>
         <td valign="top">
@@ -127,6 +127,12 @@ below.
         <td valign="top"><code>@build_bazel_rules_apple//apple:docc.bzl</code></td>
         <td valign="top">
           <code><a href="rules-docc.md#docc_archive">docc_archive</a></code>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top"><code>@build_bazel_rules_apple//apple:header_map.bzl</code></td>
+        <td valign="top">
+          <code><a href="rules-header_map.md#header_map">header_map</a></code>
         </td>
       </tr>
       <tr>

--- a/doc/rules-header_map.md
+++ b/doc/rules-header_map.md
@@ -1,0 +1,69 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Rules for creating header maps.
+
+<a id="header_map"></a>
+
+## header_map
+
+<pre>
+header_map(<a href="#header_map-name">name</a>, <a href="#header_map-deps">deps</a>, <a href="#header_map-hdrs">hdrs</a>, <a href="#header_map-module_name">module_name</a>)
+</pre>
+
+Creates a binary `.hmap` file from the given headers suitable for passing to clang.
+
+Headermaps can be used in `-I` and `-iquote` compile flags (as well as in `includes`) to tell clang where to find headers.
+This can be used to allow headers to be imported at a consistent path regardless of the package structure being used.
+
+For example, if you have a package structure like this:
+
+    ```
+    MyLib/
+        headers/
+            MyLib.h
+        MyLib.c
+        BUILD
+    ```
+
+And you want to import `MyLib.h` from `MyLib.c` using angle bracket imports: `#import <MyLib/MyLib.h>`
+You can create a header map like this:
+
+    ```bzl
+    header_map(
+        name = "MyLib.hmap",
+        hdrs = ["headers/MyLib.h"],
+    )
+    ```
+
+This generates a binary headermap that looks like:
+
+    ```
+    MyLib.h -> headers/MyLib.h
+    MyLib/MyLib.h -> headers/MyLib.h
+    ```
+
+Then update `deps`, `copts` and `includes` to use the header map:
+
+    ```bzl
+    objc_library(
+        name = "MyLib",
+        module_name = "MyLib",
+        srcs = ["MyLib.c"],
+        hdrs = ["headers/MyLib.h"],
+        deps = [":MyLib.hmap"],
+        copts = ["-I.]
+        includes = ["MyLib.hmap"]
+    )
+    ```
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="header_map-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="header_map-deps"></a>deps |  Targets whose direct headers should be added to the list of hdrs and rooted at the module_name   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="header_map-hdrs"></a>hdrs |  The list of headers included in the header_map   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="header_map-module_name"></a>module_name |  The prefix to be used for header imports   | String | optional |  `""`  |
+
+

--- a/examples/multi_platform/MixedLibWithHeaderMap/BUILD
+++ b/examples/multi_platform/MixedLibWithHeaderMap/BUILD
@@ -1,0 +1,78 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+load("//apple:apple.bzl", "experimental_mixed_language_library")
+load("//apple:header_map.bzl", "header_map")
+load("//apple:ios.bzl", "ios_unit_test")
+
+filegroup(
+    name = "MixedAnswer.public_headers.h",
+    srcs = [
+        "MixedAnswer.h",
+    ],
+)
+
+experimental_mixed_language_library(
+    name = "MixedAnswer",
+    srcs = [
+        "MixedAnswer.m",
+        "MixedAnswer.swift",
+    ],
+    hdrs = [
+        ":MixedAnswer.public_headers.h",
+    ],
+    enable_modules = True,
+    includes = [
+        "MixedAnswerHeaderMap.hmap",
+    ],
+    # TODO: remove once we have https://github.com/bazelbuild/rules_apple/issues/2371
+    objc_copts = ["-I."],
+    deps = [
+        ":MixedAnswerHeaderMap",
+    ],
+)
+
+header_map(
+    name = "MixedAnswerHeaderMap",
+    hdrs = [
+        ":MixedAnswer.public_headers.h",
+    ],
+    module_name = "MixedAnswer",
+)
+
+swift_library(
+    name = "SwiftLibDependingOnMixedLibWithHeaderMap",
+    srcs = [
+        "SwiftLibDependingOnMixedLibWithHeaderMap.swift",
+    ],
+    deps = [":MixedAnswer"],
+)
+
+objc_library(
+    name = "ObjcLibDependingOnMixedLibWithHeaderMap",
+    srcs = [
+        "ObjcLibDependingOnMixedLibWithHeaderMap.m",
+    ],
+    hdrs = [
+        "ObjcLibDependingOnMixedLibWithHeaderMap.h",
+    ],
+    copts = ["-I."],  # Enable importing headers via angle bracket import from the current directory.
+    enable_modules = True,
+    deps = [":MixedAnswer"],
+)
+
+experimental_mixed_language_library(
+    name = "MixedTestsLib",
+    testonly = True,
+    srcs = [
+        "MixedTests.m",
+        "MixedTests.swift",
+    ],
+)
+
+ios_unit_test(
+    name = "MixedTests",
+    minimum_os_version = "9.0",
+    deps = [":MixedTestsLib"],
+)

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.h
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface MixedAnswerObjc : NSObject
+
++ (NSString *)mixedAnswerObjc;
+
+@end

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.m
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.m
@@ -1,0 +1,11 @@
+#import <MixedAnswer/MixedAnswer.h>
+
+#import "examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer-Swift.h"
+
+@implementation MixedAnswerObjc
+
++ (NSString *)mixedAnswerObjc {
+    return [NSString stringWithFormat:@"%@_%@", @"mixedAnswerObjc", [MixedAnswerSwift swiftToObjcMixedAnswer]];
+}
+
+@end

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.swift
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+@objc
+public class MixedAnswerSwift: NSObject {
+
+    public
+    static func swiftMixedAnswer() -> String {
+        "\(MixedAnswerObjc.mixedAnswerObjc() ?? "invalid")_swiftMixedAnswer"
+    }
+
+    @objc
+    public
+    static func swiftToObjcMixedAnswer() -> String {
+        "swiftToObjcMixedAnswer"
+    }
+}

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedTests.m
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedTests.m
@@ -1,0 +1,27 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+@interface MixedTests : XCTestCase
+@end
+
+@implementation MixedTests
+
+- (void)testAlwaysPass {
+  XCTAssertTrue(YES);
+}
+
+@end

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedTests.swift
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedTests.swift
@@ -1,0 +1,21 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+class MixedTests: XCTestCase {
+  func testAlwaysPass() {
+    XCTAssertTrue(true)
+  }
+}

--- a/examples/multi_platform/MixedLibWithHeaderMap/ObjcLibDependingOnMixedLibWithHeaderMap.h
+++ b/examples/multi_platform/MixedLibWithHeaderMap/ObjcLibDependingOnMixedLibWithHeaderMap.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjcLibDependingOnMixedLibWithHeaderMap : NSObject
+
++ (void)doSomething;
+
+@end

--- a/examples/multi_platform/MixedLibWithHeaderMap/ObjcLibDependingOnMixedLibWithHeaderMap.m
+++ b/examples/multi_platform/MixedLibWithHeaderMap/ObjcLibDependingOnMixedLibWithHeaderMap.m
@@ -1,0 +1,14 @@
+@import Foundation;
+
+#import <MixedAnswer/MixedAnswer.h>
+
+#import "ObjcLibDependingOnMixedLibWithHeaderMap.h"
+
+@implementation ObjcLibDependingOnMixedLibWithHeaderMap
+
++ (void)doSomething {
+  MixedAnswerObjc *objcAnswer __unused = [[MixedAnswerObjc alloc] init];
+  return;
+}
+
+@end

--- a/examples/multi_platform/MixedLibWithHeaderMap/SwiftLibDependingOnMixedLibWithHeaderMap.swift
+++ b/examples/multi_platform/MixedLibWithHeaderMap/SwiftLibDependingOnMixedLibWithHeaderMap.swift
@@ -1,0 +1,11 @@
+import MixedAnswer
+
+class SwiftLibDependingOnMixedLibWithHeaderMap {
+    static func callSwiftMixedAnswer() -> String {
+        MixedAnswerSwift.swiftMixedAnswer()
+    }
+
+    static func callObjcMixedAnswer() -> String? {
+        MixedAnswerObjc.mixedAnswerObjc()
+    }
+}

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -42,6 +42,7 @@ load(
     "dummy_test_runner",
 )
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//apple:header_map.bzl", "header_map")
 
 licenses(["notice"])
 
@@ -1404,4 +1405,51 @@ swift_apple_core_ml_library(
     name = "SampleSwiftCoreML",
     mlmodel = "//test/testdata/resources:sample.mlmodel",
     tags = common.fixture_tags,
+)
+
+# ---------------------------------------------------------------------------------------
+# Targets for header map rule tests.
+
+objc_library(
+    name = "header_map_objc_lib",
+    srcs = [
+        "//test/starlark_tests/resources:shared.m",
+    ],
+    hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = common.fixture_tags,
+)
+
+swift_library(
+    name = "header_map_swift_lib",
+    srcs = ["DummyFmwk.swift"],
+    generates_header = True,
+    tags = common.fixture_tags,
+)
+
+header_map(
+    name = "header_map_with_header",
+    hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = common.fixture_tags,
+)
+
+header_map(
+    name = "header_map_with_objc_lib_dep",
+    hdrs = [],
+    tags = common.fixture_tags,
+    deps = [
+        ":header_map_objc_lib",
+    ],
+)
+
+header_map(
+    name = "header_map_with_swift_lib_dep",
+    hdrs = [],
+    tags = common.fixture_tags,
+    deps = [
+        ":header_map_swift_lib",
+    ],
 )

--- a/tools/hmaptool/BUILD
+++ b/tools/hmaptool/BUILD
@@ -1,0 +1,21 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
+
+package(default_visibility = ["//apple/internal:__subpackages__"])
+
+swift_library(
+    name = "BinaryHeaderMapTool",
+    srcs = [
+        "BinaryHeaderMap.swift",
+        "BinaryHeaderMapEncoder.swift",
+        "BinaryHeaderMapTool.swift",
+    ],
+)
+
+swift_binary(
+    name = "hmaptool",
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+    deps = [":BinaryHeaderMapTool"],
+)

--- a/tools/hmaptool/BinaryHeaderMap.swift
+++ b/tools/hmaptool/BinaryHeaderMap.swift
@@ -1,0 +1,88 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Interface for creating binary header maps.
+public struct BinaryHeaderMap {
+    public struct Entry {
+        public let key: String
+        public let prefix: String
+        public let suffix: String
+
+        public init(key: String, prefix: String, suffix: String) {
+            self.key = key
+            self.prefix = prefix
+            self.suffix = suffix
+        }
+    }
+
+    public typealias EntryIndex = [Data: Entry]
+    public let entries: EntryIndex
+
+    public init(entries: [Entry]) {
+        self.entries = makeIndexedEntries(from: entries)
+    }
+
+    public subscript(key: String) -> BinaryHeaderMap.Entry? {
+        guard let lowercasedBytes = try? key.clangLowercasedBytes() else {
+            return nil
+        }
+
+        return entries[lowercasedBytes]
+    }
+}
+
+// MARK: - Hashable
+
+extension BinaryHeaderMap.Entry: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(key)
+        hasher.combine(prefix)
+        hasher.combine(suffix)
+    }
+
+    public static func == (lhs: BinaryHeaderMap.Entry, rhs: BinaryHeaderMap.Entry) -> Bool {
+        return lhs.key == rhs.key &&
+            lhs.prefix == rhs.prefix &&
+            lhs.suffix == rhs.suffix
+    }
+}
+
+// MARK: - Internal/Private
+
+extension String {
+    func clangLowercasedBytes() throws -> Data {
+        guard let charBytes = data(using: BinaryHeaderMapEncoder.encoding) else {
+            fatalError("Unable to encode string")
+        }
+
+        let lowercasedBytes = charBytes.map { $0.asciiLowercased }
+        return Data(lowercasedBytes)
+    }
+}
+
+private extension UInt8 {
+    var asciiLowercased: UInt8 {
+        let isUppercase = (65 <= self && self <= 90)
+        return self + (isUppercase ? 32 : 0)
+    }
+}
+
+private func makeIndexedEntries(from entries: [BinaryHeaderMap.Entry]) -> BinaryHeaderMap.EntryIndex {
+    return Dictionary(
+        sanitize(headerEntries: entries).map { (try! $0.key.clangLowercasedBytes(), $0) },
+        uniquingKeysWith: { $1 }
+    )
+}

--- a/tools/hmaptool/BinaryHeaderMapEncoder.swift
+++ b/tools/hmaptool/BinaryHeaderMapEncoder.swift
@@ -1,0 +1,353 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+public enum BinaryHeaderMapEncoder {
+    static let encoding: String.Encoding = .utf8
+
+    public static func encode(_ headerMap: BinaryHeaderMap) throws -> Data {
+        let entries: [BinaryHeaderMap.Entry] = headerMap.entries.map { $0.value }
+        return try makeHeaderMapBinaryData(withEntries: entries)
+    }
+}
+
+private func makeHeaderMapBinaryData(withEntries unsafeEntries: [BinaryHeaderMap.Entry]) throws -> Data {
+    let safeEntries = sanitize(headerEntries: unsafeEntries)
+    let allStrings = Set(safeEntries.flatMap { [$0.key, $0.prefix, $0.suffix] })
+    let stringSection = try makeStringSection(allStrings: allStrings)
+    let bucketSection = try makeBucketSection(
+        forEntries: safeEntries,
+        stringSection: stringSection
+    )
+
+    let maxValueLength = safeEntries
+        .max(by: { lhs, rhs in lhs.valueLength < rhs.valueLength })
+        .map { $0.valueLength } ?? 0
+
+    let headerSize = DataHeader.packedSize
+    let stringSectionOffset = headerSize + bucketSection.data.count
+
+    let header = DataHeader(
+        magic: .hmap,
+        version: .version1,
+        reserved: .none,
+        stringSectionOffset: UInt32(stringSectionOffset),
+        stringCount: UInt32(stringSection.stringCount),
+        bucketCount: UInt32(bucketSection.bucketCount),
+        maxValueLength: UInt32(maxValueLength)
+    )
+
+    let encoder = ByteBufferEncoder()
+    encoder.encode(header.magic.rawValue)
+    encoder.encode(header.version.rawValue)
+    encoder.encode(header.reserved.rawValue)
+    encoder.encode(header.stringSectionOffset)
+    encoder.encode(header.stringCount)
+    encoder.encode(header.bucketCount)
+    encoder.encode(header.maxValueLength)
+    encoder.append(bucketSection.data)
+    encoder.append(stringSection.data)
+
+    return encoder.bytes
+}
+
+private protocol Packable {
+    static var packedSize: Int { get }
+}
+
+private struct DataHeader: Packable {
+    typealias MagicType = Magic
+    typealias VersionType = Version
+    typealias ReservedType = Reserved
+    typealias StringSectionOffsetType = UInt32
+    typealias StringCountType = UInt32
+    typealias BucketCountType = UInt32
+    typealias MaxValueLengthType = UInt32
+
+    let magic: MagicType
+    let version: VersionType
+    let reserved: ReservedType
+    let stringSectionOffset: StringSectionOffsetType
+    let stringCount: StringCountType
+    let bucketCount: BucketCountType // Must be power of 2
+    let maxValueLength: MaxValueLengthType
+
+    static var packedSize: Int {
+        MemoryLayout<Magic.RawValue>.size +
+            MemoryLayout<Version.RawValue>.size +
+            MemoryLayout<Reserved.RawValue>.size +
+            MemoryLayout<UInt32>.size +
+            MemoryLayout<UInt32>.size +
+            MemoryLayout<UInt32>.size +
+            MemoryLayout<UInt32>.size
+    }
+
+    static func headerPlusBucketsSize(bucketCount: DataHeader.BucketCountType) -> Int {
+        let bucketsSectionSize = Int(bucketCount) * Bucket.packedSize
+        return packedSize + bucketsSectionSize
+    }
+}
+
+private enum Magic: UInt32 {
+    case hmap = 0x68_6D_61_70 // 'hmap'
+}
+
+private enum Version: UInt16 {
+    case version1 = 1
+}
+
+private enum Reserved: UInt16 {
+    case none = 0
+}
+
+private struct Bucket: Packable {
+    typealias OffsetType = StringSectionOffset
+
+    let key: OffsetType
+    let prefix: OffsetType
+    let suffix: OffsetType
+
+    static var packedSize: Int {
+        OffsetType.packedSize * 3
+    }
+}
+
+private struct StringSectionOffset: Packable {
+    typealias OffsetType = UInt32
+
+    /** Indicates an invalid offset */
+    static let reserved = OffsetType(0)
+
+    let offset: OffsetType
+
+    init?(offset: OffsetType) {
+        if offset == StringSectionOffset.reserved {
+            // The first byte is reserved and means 'empty'.
+            return nil
+        }
+
+        self.offset = offset
+    }
+
+    static var packedSize: Int {
+        return MemoryLayout<OffsetType>.size
+    }
+}
+
+private struct BucketSection {
+    let data: Data
+    let bucketCount: Int
+}
+
+private struct StringSection {
+    let data: Data
+    let stringCount: Int
+    let offsets: [String: StringSectionOffset]
+}
+
+private func makeStringSection(allStrings: Set<String>) throws -> StringSection {
+
+    var buffer = Data()
+    var offsets: [String: StringSectionOffset] = [:]
+
+    if !allStrings.isEmpty {
+        buffer.append(UInt8(StringSectionOffset.reserved))
+    }
+
+    for string in allStrings {
+        guard let stringBytes = string.data(using: BinaryHeaderMapEncoder.encoding) else {
+            fatalError("Unable to get data in proper encoding")
+        }
+
+        let bufferCount = UInt32(buffer.count)
+        let offset = StringSectionOffset(offset: bufferCount)!
+
+        offsets[string] = offset
+        buffer.append(stringBytes)
+        buffer.append(0x0) // NUL character
+    }
+
+    return StringSection(
+        data: buffer,
+        stringCount: allStrings.count,
+        offsets: offsets
+    )
+}
+
+private func isBucketSlotEmpty(
+    bytePointer: UnsafeMutablePointer<UInt8>,
+    index: UInt32
+) -> Bool {
+
+    let slotOffset = Int(index) * Bucket.packedSize
+    let slotPointer = bytePointer.advanced(by: slotOffset)
+    return slotPointer.withMemoryRebound(
+        to: StringSectionOffset.OffsetType.self,
+        capacity: 1
+    ) {
+        return $0.pointee == StringSectionOffset.reserved
+    }
+}
+
+private func writeTo<T>(bytePointer: UnsafeMutablePointer<UInt8>, value: T) {
+    var mutableValue = value
+    withUnsafeBytes(of: &mutableValue) { (pointer) in
+        let valueBytes = Array(pointer[0..<pointer.count])
+        for (index, byte) in valueBytes.enumerated() {
+            bytePointer.advanced(by: index).pointee = byte
+        }
+    }
+}
+
+private func makeBucketSection(
+    forEntries entries: [BinaryHeaderMap.Entry],
+    stringSection: StringSection
+) throws -> BucketSection {
+
+    let bucketCount = numberOfBuckets(forEntryCount: entries.count)
+    var bytes = Data(count: bucketCount * Bucket.packedSize)
+    bytes.withUnsafeMutableBytes { (rawBytes: UnsafeMutableRawBufferPointer) in
+
+        guard let rawBasePointer = rawBytes.baseAddress else {
+            fatalError("Empty data buffer")
+        }
+
+        let bytePointer = rawBasePointer.bindMemory(to: UInt8.self, capacity: rawBytes.count)
+
+        for entry in entries {
+            guard let keyHash = entry.key.headerMapHash else {
+                fatalError("Unable to hash key")
+            }
+
+            guard
+                let keyOffset = stringSection.offsets[entry.key],
+                let prefixOffset = stringSection.offsets[entry.prefix],
+                let suffixOffset = stringSection.offsets[entry.suffix]
+            else {
+                fatalError("Unable to find string offset")
+            }
+
+            let maybeEmptySlotIndex: UInt32? = probeHashTable(
+                bucketCount: UInt32(bucketCount),
+                start: keyHash
+            ) { (probeIndex) in
+                if isBucketSlotEmpty(bytePointer: bytePointer, index: probeIndex) {
+                    return .stop(value: probeIndex)
+                }
+                return .keepProbing
+            }
+
+            guard let emptySlotIndex = maybeEmptySlotIndex else {
+                fatalError("Unable to find empty slot in hash table")
+            }
+
+            let slotPointer = bytePointer.advanced(by: Int(emptySlotIndex) * Bucket.packedSize)
+            let fieldSize = MemoryLayout<Bucket.OffsetType>.size
+
+            writeTo(bytePointer: slotPointer, value: keyOffset.offset)
+            writeTo(bytePointer: slotPointer.advanced(by: fieldSize), value: prefixOffset.offset)
+            writeTo(bytePointer: slotPointer.advanced(by: 2 * fieldSize), value: suffixOffset.offset)
+        }
+    }
+
+    return BucketSection(
+        data: bytes,
+        bucketCount: bucketCount
+    )
+}
+
+private func numberOfBuckets(forEntryCount entryCount: Int) -> Int {
+    let minimumSlots = Int(ceil(Double(entryCount) * (1.0 / 0.7)))
+    var bucketCount = 1
+    while bucketCount < minimumSlots {
+        bucketCount <<= 1
+    }
+    return bucketCount
+}
+
+func sanitize(headerEntries entries: [BinaryHeaderMap.Entry]) -> [BinaryHeaderMap.Entry] {
+    var allKeys = Set<String>()
+    return entries.compactMap { (entry) in
+        guard !allKeys.contains(entry.key) else { return nil }
+        allKeys.insert(entry.key)
+        return entry
+    }
+}
+
+private extension BinaryHeaderMap.Entry {
+    var valueLength: Int {
+        prefix.lengthOfBytes(using: BinaryHeaderMapEncoder.encoding) +
+            suffix.lengthOfBytes(using: BinaryHeaderMapEncoder.encoding)
+    }
+}
+
+private extension String {
+    var headerMapHash: UInt32? {
+        guard
+            let characterBytes = try? clangLowercasedBytes()
+        else { return nil }
+
+        return characterBytes.withUnsafeBytes { (charBytes: UnsafeRawBufferPointer) -> UInt32 in
+            var result = UInt32(0)
+            for i in 0 ..< charBytes.count {
+                result += UInt32(charBytes[i]) * 13
+            }
+            return result
+        }
+    }
+}
+
+private enum ProbeAction<T> {
+    case keepProbing
+    case stop(value: T?)
+}
+
+private func probeHashTable<T>(
+    bucketCount: DataHeader.BucketCountType,
+    start: UInt32,
+    _ body: (UInt32) -> ProbeAction<T>
+) -> T? {
+    var probeAttempts = DataHeader.BucketCountType(0)
+    var nextUnboundedBucketIndex = start
+    while probeAttempts < bucketCount {
+        let nextBucketIndex = nextUnboundedBucketIndex & (bucketCount - 1)
+        switch body(nextBucketIndex) {
+        case .keepProbing:
+            break
+        case .stop(let value):
+            return value
+        }
+        nextUnboundedBucketIndex += 1
+        probeAttempts += 1
+    }
+
+    return nil
+}
+
+private final class ByteBufferEncoder {
+    private(set) var bytes = Data()
+
+    func encode<T>(_ value: T) {
+        var mutableValue = value
+        withUnsafeBytes(of: &mutableValue) { (pointer) in
+            let valueBytes = Array(pointer[0..<pointer.count])
+            bytes.append(contentsOf: valueBytes)
+        }
+    }
+
+    func append(_ data: Data) {
+        bytes.append(data)
+    }
+}

--- a/tools/hmaptool/BinaryHeaderMapTool.swift
+++ b/tools/hmaptool/BinaryHeaderMapTool.swift
@@ -1,0 +1,92 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@main
+struct BinaryHeaderMapTool {
+    struct Arguments {
+        var output: URL
+        var moduleName: String?
+        var headers: [String]
+
+        init(arguments: [String]) {
+            var arguments = arguments
+            var output: URL?
+
+            if let outputIndex = arguments.firstIndex(of: "--output") {
+                guard outputIndex + 1 < arguments.count else {
+                    fatalError("Missing output path after --output")
+                }
+                output = URL(fileURLWithPath: arguments[outputIndex + 1])
+                arguments.removeSubrange(outputIndex...outputIndex + 1)
+            }
+
+            if let moduleNameIndex = arguments.firstIndex(of: "--module_name") {
+                guard moduleNameIndex + 1 < arguments.count else {
+                    fatalError("Missing module_name argument after --module_name")
+                }
+                self.moduleName = arguments[moduleNameIndex + 1]
+                arguments.removeSubrange(moduleNameIndex...moduleNameIndex + 1)
+            }
+
+            guard let output = output else {
+                fatalError("Missing output path")
+            }
+
+            self.output = output
+            self.headers = arguments
+        }
+    }
+
+    static func main() {
+        let arguments = Arguments(arguments: Array(CommandLine.arguments.dropFirst()))
+        var entries: [BinaryHeaderMap.Entry] = []
+
+        // Parse entries into a list of BinaryHeaderMap.Entry
+        // Following the format:
+        // <key=[module_name]/basename> <prefix=dir path> <suffix=filename>
+        for header in arguments.headers {
+            // Get the basename
+            let basename = header.components(separatedBy: "/").last!
+            let `prefix` = header.replacingOccurrences(of: basename, with: "")
+            let suffix = basename
+            // Add an entry with just the basename for the key
+            entries.append(
+                BinaryHeaderMap.Entry(
+                    key: basename,
+                    prefix: `prefix`,
+                    suffix: suffix
+                )
+            )
+            // If a module name was provided, add an entry with the module name and basename for the key
+            if let moduleName = arguments.moduleName {
+                entries.append(
+                    BinaryHeaderMap.Entry(
+                        key: "\(moduleName)/\(basename)",
+                        prefix: `prefix`,
+                        suffix: suffix
+                    )
+                )
+            }
+        }
+
+        do {
+            let data = try BinaryHeaderMapEncoder.encode(BinaryHeaderMap(entries: entries))
+            try data.write(to: arguments.output)
+        } catch {
+            fatalError("Failed to encode header map: \(error)")
+        }
+    }
+}

--- a/tools/hmaptool/README.md
+++ b/tools/hmaptool/README.md
@@ -1,0 +1,4 @@
+# hmaptool
+
+This is a tool which creates binary headermaps to enable angle bracket imports of headers when building with Bazel.
+Required to mimic Xcode's behavior of generating headermaps by default which projects rely on.


### PR DESCRIPTION
This adds a new `header_map` rule for creating binary `.hmap` files which are required to support `#import <Foo/Foo.h>` semantics without restructuring an entire project.

Header maps are generated by default when using Xcode, so projects built in Xcode tend to end up relying on them. When migrating an existing project to use Bazel this lack of header map support has been a source of confusion in several threads on the Bazel Slack. Users either end up using `rules_ios`, which this implementation comes from, or they end up copying the header map rule locally. 

By adding it to `rules_apple` we can help folks who are migrating existing projects. Along with documentation to make this less confusing.

My goal here is to start a discussion around the addition of the rule and it's implementation and eventually extend `experimental_mixed_language_library` to support generating these header maps (with this rule) when requested.

Closes #1757 

## Open questions

~~- Do we want to use the C implementation from rules_ios? [There is a Swift implementation](https://github.com/milend/hmap/blob/master/Sources/HeaderMapCore/BinaryHeaderMap.swift) we could look at taking from~~
~~- If we do want to use the C implementation, should we spend some time getting the dependencies (lines/uthash) as Bazel modules (or at least consumed via download) vs. copying the sources into the source tree?~~

Decided on using Swift implementation
