### PR TITLE
Upgrade CI to Apple Silicon

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,7 @@ x_defaults:
   # YAML has a feature for "repeated nodes", BazelCI is fine with extra nodes
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
-    platform: macos
+    platform: macos_arm64
     xcode_version: "14.3"
     build_targets:
     - "tools/..."


### PR DESCRIPTION
This is a pre-requisite for https://github.com/bazelbuild/rules_apple/pull/2345 given that Xcode 15.1 is only installed on Apple Silicon build agents.