### PR TITLE
Test remove objc from new_executable_binary_provider

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 # NOTE: These are mainly just for the BazelCI setup so they don't have
 # to be repeated multiple times in .bazelci/presubmit.yml.
 
+common --incompatible_objc_provider_remove_linking_info=false
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -117,9 +117,8 @@ Resolved Xcode is version {xcode_version}.
     if binary_type == "executable":
         providers.append(
             apple_common.new_executable_binary_provider(
-                cc_info = link_result.cc_info,
-                objc = link_result.objc,
                 binary = binary_artifact,
+                cc_info = link_result.cc_info,
             ),
         )
 

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -497,7 +497,6 @@ def _ios_application_impl(ctx):
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,
@@ -788,7 +787,6 @@ def _ios_app_clip_impl(ctx):
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,
@@ -1329,7 +1327,7 @@ def _ios_extension_impl(ctx):
         ),
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
-            objc = link_result.objc,
+            cc_info = link_result.cc_info,
         ),
         new_iosextensionbundleinfo(),
         OutputGroupInfo(

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -438,7 +438,6 @@ def _macos_application_impl(ctx):
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,
@@ -932,7 +931,7 @@ def _macos_extension_impl(ctx):
         ),
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
-            objc = link_result.objc,
+            cc_info = link_result.cc_info,
         ),
         new_macosextensionbundleinfo(),
         OutputGroupInfo(
@@ -2027,7 +2026,6 @@ def _macos_command_line_application_impl(ctx):
         apple_common.new_executable_binary_provider(
             binary = output_file,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -433,7 +433,6 @@ def _tvos_application_impl(ctx):
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,
@@ -1246,7 +1245,7 @@ def _tvos_extension_impl(ctx):
         ),
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
-            objc = link_result.objc,
+            cc_info = link_result.cc_info,
         ),
         new_tvosextensionbundleinfo(),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -435,7 +435,6 @@ Resolved Xcode is version {xcode_version}.
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
             cc_info = link_result.cc_info,
-            objc = link_result.objc,
         ),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.
         link_result.debug_outputs_provider,
@@ -1242,7 +1241,7 @@ def _visionos_extension_impl(ctx):
         ),
         apple_common.new_executable_binary_provider(
             binary = binary_artifact,
-            objc = link_result.objc,
+            cc_info = link_result.cc_info,
         ),
         new_visionosextensionbundleinfo(),
         # TODO(b/228856372): Remove when downstream users are migrated off this provider.


### PR DESCRIPTION
This was removed from bazel head and I'm hoping to see how it is used
with older versions
