### PR TITLE
Fix more upstream objc provider changes

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,9 +15,7 @@ x_defaults:
     test_flags:
     - --test_tag_filters=-skipci
   common_last_green: &common_last_green
-    # TODO: switch back to last_green once 
-    # https://github.com/bazelbuild/stardoc/issues/195 is fixed.
-    bazel: e82c1d156fd1fad5f08ee1b014ef02bea86ec632
+    bazel: last_green
     build_flags:
       - --config=visionos
     test_flags:

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -99,10 +99,6 @@ def _sectcreate_objc_provider(label, segname, sectname, file):
     # set.
     linkopts = ["-Wl,-sectcreate,%s,%s,%s" % (segname, sectname, file.path)]
     return [
-        apple_common.new_objc_provider(
-            linkopt = depset(linkopts, order = "topological"),
-            link_inputs = depset([file]),
-        ),
         CcInfo(
             linking_context = cc_common.create_linking_context(
                 linker_inputs = depset([
@@ -114,7 +110,12 @@ def _sectcreate_objc_provider(label, segname, sectname, file):
                 ]),
             ),
         ),
-    ]
+    ] + ([
+        apple_common.new_objc_provider(
+            linkopt = depset(linkopts, order = "topological"),
+            link_inputs = depset([file]),
+        ),
+    ] if _OBJC_PROVIDER_LINKING else [])
 
 def _register_binary_linking_action(
         ctx,

--- a/apple/internal/partials/framework_provider.bzl
+++ b/apple/internal/partials/framework_provider.bzl
@@ -27,6 +27,9 @@ load(
     "framework_import_support",
 )
 
+# TODO: Remove once we drop bazel 7.x
+_OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")
+
 def _framework_provider_partial_impl(
         *,
         actions,
@@ -62,10 +65,13 @@ def _framework_provider_partial_impl(
 
     # TODO(cparsons): These will no longer be necessary once apple_binary
     # uses the values in the dynamic framework provider.
-    legacy_objc_provider = apple_common.new_objc_provider(
-        dynamic_framework_file = depset([] if bundle_only else [framework_file]),
-        providers = [objc_provider],
-    )
+    if _OBJC_PROVIDER_LINKING:
+        legacy_objc_provider = apple_common.new_objc_provider(
+            dynamic_framework_file = depset([] if bundle_only else [framework_file]),
+            providers = [objc_provider],
+        )
+    else:
+        legacy_objc_provider = None
 
     library_to_link = cc_common.create_library_to_link(
         actions = actions,

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -137,6 +137,9 @@ load(
     "sets",
 )
 
+# TODO: Remove once we drop bazel 7.x
+_OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")
+
 def _watchos_framework_impl(ctx):
     """Experimental implementation of watchos_framework."""
     rule_descriptor = rule_support.rule_descriptor(
@@ -651,10 +654,7 @@ def _watchos_dynamic_framework_impl(ctx):
                 feature_configuration = cc_features,
                 libraries = provider.framework_files.to_list(),
             )
-            additional_providers.extend([
-                apple_common.new_objc_provider(
-                    dynamic_framework_file = provider.framework_files,
-                ),
+            additional_providers.append(
                 CcInfo(
                     linking_context = cc_common.create_linking_context(
                         linker_inputs = depset([
@@ -665,7 +665,13 @@ def _watchos_dynamic_framework_impl(ctx):
                         ]),
                     ),
                 ),
-            ])
+            )
+            if _OBJC_PROVIDER_LINKING:
+                additional_providers.append(
+                    apple_common.new_objc_provider(
+                        dynamic_framework_file = provider.framework_files,
+                    ),
+                )
     providers.extend(additional_providers)
 
     return [


### PR DESCRIPTION
This also switches us back to real last_green CI. The other linked issue is fixed at head

This reverts commit 9c0c81a174ef2ecaf8833ac0bf770b5328e13edd.

Fixes https://github.com/bazelbuild/rules_apple/issues/2370