### PR TITLE
Add support for headermap to experimental_mixed_language_library

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -81,6 +81,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
+        "//apple/internal:header_map_support",
         "@bazel_skylib//lib:paths",
         "@build_bazel_rules_swift//swift",
     ],

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -375,8 +375,9 @@ ios_application(
 ## experimental_mixed_language_library
 
 <pre>
-experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-enable_modules">enable_modules</a>, <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>,
-                                    <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>, <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-testonly">testonly</a>, <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
+experimental_mixed_language_library(<a href="#experimental_mixed_language_library-name">name</a>, <a href="#experimental_mixed_language_library-srcs">srcs</a>, <a href="#experimental_mixed_language_library-deps">deps</a>, <a href="#experimental_mixed_language_library-enable_modules">enable_modules</a>, <a href="#experimental_mixed_language_library-enable_header_map">enable_header_map</a>,
+                                    <a href="#experimental_mixed_language_library-module_name">module_name</a>, <a href="#experimental_mixed_language_library-objc_copts">objc_copts</a>, <a href="#experimental_mixed_language_library-swift_copts">swift_copts</a>, <a href="#experimental_mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#experimental_mixed_language_library-testonly">testonly</a>,
+                                    <a href="#experimental_mixed_language_library-kwargs">kwargs</a>)
 </pre>
 
 Compiles and links Objective-C and Swift code into a static library.
@@ -403,6 +404,7 @@ modules, it does not support header maps.
 | <a id="experimental_mixed_language_library-srcs"></a>srcs |  The list of Objective-C and Swift source files to compile.   |  none |
 | <a id="experimental_mixed_language_library-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will be linked into that target.   |  `[]` |
 | <a id="experimental_mixed_language_library-enable_modules"></a>enable_modules |  Enables clang module support for the Objective-C target.   |  `False` |
+| <a id="experimental_mixed_language_library-enable_header_map"></a>enable_header_map |  Enables header map support for the Swift and Objective-C target.   |  `False` |
 | <a id="experimental_mixed_language_library-module_name"></a>module_name |  The name of the mixed language module being built. If left unspecified, the module name will be the name of the target.   |  `None` |
 | <a id="experimental_mixed_language_library-objc_copts"></a>objc_copts |  Additional compiler options that should be passed to `clang`.   |  `[]` |
 | <a id="experimental_mixed_language_library-swift_copts"></a>swift_copts |  Additional compiler options that should be passed to `swiftc`. These strings are subject to `$(location ...)` and "Make" variable expansion.   |  `[]` |

--- a/examples/multi_platform/MixedLibWithHeaderMap/BUILD
+++ b/examples/multi_platform/MixedLibWithHeaderMap/BUILD
@@ -3,7 +3,6 @@ load(
     "swift_library",
 )
 load("//apple:apple.bzl", "experimental_mixed_language_library")
-load("//apple:header_map.bzl", "header_map")
 load("//apple:ios.bzl", "ios_unit_test")
 
 filegroup(
@@ -22,23 +21,8 @@ experimental_mixed_language_library(
     hdrs = [
         ":MixedAnswer.public_headers.h",
     ],
+    enable_header_map = True,
     enable_modules = True,
-    includes = [
-        "MixedAnswerHeaderMap.hmap",
-    ],
-    # TODO: remove once we have https://github.com/bazelbuild/rules_apple/issues/2371
-    objc_copts = ["-I."],
-    deps = [
-        ":MixedAnswerHeaderMap",
-    ],
-)
-
-header_map(
-    name = "MixedAnswerHeaderMap",
-    hdrs = [
-        ":MixedAnswer.public_headers.h",
-    ],
-    module_name = "MixedAnswer",
 )
 
 swift_library(

--- a/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.m
+++ b/examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer.m
@@ -1,6 +1,5 @@
 #import <MixedAnswer/MixedAnswer.h>
-
-#import "examples/multi_platform/MixedLibWithHeaderMap/MixedAnswer-Swift.h"
+#import <MixedAnswer/MixedAnswer-Swift.h>
 
 @implementation MixedAnswerObjc
 


### PR DESCRIPTION
This follows up #2352 by adding header map support to `experimental_mixed_language_library`. It adds a new parameter: `enable_header_map` which if `True` will generate a headermap for the mixed language `objc_library`. This header map will be included by the `swift_library` and `objc_library` to enable `#import <>` semantics.

Closes #2371 