### PR TITLE
Disable builtin CC toolchain for BCR tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,3 +4,5 @@ tasks:
     platform: macos
     test_targets:
       - '@rules_apple//examples/macos/CommandLine:ExamplesBuildTest'
+    build_flags:
+    - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -4,5 +4,5 @@ tasks:
     platform: macos
     test_targets:
       - '@rules_apple//examples/macos/CommandLine:ExamplesBuildTest'
-    build_flags:
+    test_flags:
     - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"


### PR DESCRIPTION
BCR tests run outside our repo so toolchain ordering is wrong
