### PR TITLE
Remove visionos_x86_64 support

### DIFF
--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -1650,7 +1650,7 @@ dependency of other Bazel targets. For that use case, use the corresponding
 Unlike other visionos bundles, the fat binary in an `visionos_static_framework` may
 simultaneously contain simulator and device architectures (that is, you can
 build a single framework artifact that works for all architectures by specifying
-`--visionos_cpus=x86_64,arm64` when you build).
+`--visionos_cpus=sim_arm64,arm64` when you build).
 
 `visionos_static_framework` supports Swift, but there are some constraints:
 

--- a/doc/rules-visionos.md
+++ b/doc/rules-visionos.md
@@ -212,7 +212,7 @@ dependency of other Bazel targets. For that use case, use the corresponding
 Unlike other visionos bundles, the fat binary in an `visionos_static_framework` may
 simultaneously contain simulator and device architectures (that is, you can
 build a single framework artifact that works for all architectures by specifying
-`--visionos_cpus=x86_64,arm64` when you build).
+`--visionos_cpus=sim_arm64,arm64` when you build).
 
 `visionos_static_framework` supports Swift, but there are some constraints:
 

--- a/platform_mappings_visionos
+++ b/platform_mappings_visionos
@@ -47,10 +47,6 @@ platforms:
     --apple_platform_type=tvos
     --cpu=tvos_arm64
 
-  @build_bazel_apple_support//platforms:visionos_x86_64
-    --apple_platform_type=visionos
-    --cpu=visionos_x86_64
-
   @build_bazel_apple_support//platforms:visionos_sim_arm64
     --apple_platform_type=visionos
     --cpu=visionos_sim_arm64
@@ -127,10 +123,6 @@ flags:
   --cpu=tvos_arm64
   --apple_platform_type=tvos
     @build_bazel_apple_support//platforms:tvos_arm64
-
-  --cpu=visionos_x86_64
-  --apple_platform_type=visionos
-    @build_bazel_apple_support//platforms:visionos_x86_64
 
   --cpu=visionos_sim_arm64
   --apple_platform_type=visionos

--- a/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
+++ b/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
@@ -64,7 +64,7 @@ analysis_output_group_info_files_test = make_provider_test_rule(
         "//command_line_option:macos_cpus": "arm64,x86_64",
         "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
         "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
-        "//command_line_option:visionos_cpus": "sim_arm64,x86_64",
+        "//command_line_option:visionos_cpus": "sim_arm64",
         "//command_line_option:watchos_cpus": "arm64,x86_64",
     },
 )

--- a/test/starlark_tests/rules/apple_codesigning_dossier_info_provider_test.bzl
+++ b/test/starlark_tests/rules/apple_codesigning_dossier_info_provider_test.bzl
@@ -70,7 +70,7 @@ apple_codesigning_dossier_info_provider_test = make_provider_test_rule(
         "//command_line_option:macos_cpus": "arm64,x86_64",
         "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
         "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
-        "//command_line_option:visionos_cpus": "sim_arm64,x86_64",
+        "//command_line_option:visionos_cpus": "sim_arm64",
         "//command_line_option:watchos_cpus": "arm64,x86_64",
     },
 )

--- a/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
+++ b/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
@@ -69,7 +69,7 @@ created for them as transitive dependencies of the given providers.
         "//command_line_option:macos_cpus": "arm64,x86_64",
         "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
         "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
-        "//command_line_option:visionos_cpus": "sim_arm64,x86_64",
+        "//command_line_option:visionos_cpus": "sim_arm64",
         "//command_line_option:watchos_cpus": "arm64,x86_64",
     },
 )

--- a/test/starlark_tests/rules/linkmap_test.bzl
+++ b/test/starlark_tests/rules/linkmap_test.bzl
@@ -89,7 +89,7 @@ provided.
         "//command_line_option:macos_cpus": "arm64,x86_64",
         "//command_line_option:ios_multi_cpus": "sim_arm64,x86_64",
         "//command_line_option:tvos_cpus": "sim_arm64,x86_64",
-        "//command_line_option:visionos_cpus": "sim_arm64,x86_64",
+        "//command_line_option:visionos_cpus": "sim_arm64",
         "//command_line_option:watchos_cpus": "arm64,x86_64",
     },
     fragments = ["apple"],


### PR DESCRIPTION
Since Apple released this without intel support, I think it's a good
time to remove it
