### PR TITLE
Don't set an install path for macOS QuickLook plugins

### DIFF
--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -1018,14 +1018,11 @@ def _macos_quick_look_plugin_impl(ctx):
         validation_mode = ctx.attr.entitlements_validation,
     )
 
-    extra_linkopts = [
-        "-dynamiclib",
-    ]
     link_result = linking_support.register_binary_linking_action(
         ctx,
         entitlements = entitlements.linking,
         exported_symbols_lists = ctx.files.exported_symbols_lists,
-        extra_linkopts = extra_linkopts,
+        extra_linkopts = ["-bundle"],
         platform_prerequisites = platform_prerequisites,
         rule_descriptor = rule_descriptor,
         stamp = ctx.attr.stamp,

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -1020,8 +1020,6 @@ def _macos_quick_look_plugin_impl(ctx):
 
     extra_linkopts = [
         "-dynamiclib",
-        "-install_name",
-        "\"/Library/Frameworks/{0}.qlgenerator/{0}\"".format(ctx.attr.bundle_name),
     ]
     link_result = linking_support.register_binary_linking_action(
         ctx,

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -368,7 +368,7 @@ _RULE_TYPE_DESCRIPTORS = {
             allowed_device_families = ["mac"],
             bundle_extension = ".qlgenerator",
             bundle_locations = _DEFAULT_MACOS_BUNDLE_LOCATIONS,
-            bundle_package_type = bundle_package_type.extension_or_xpc,
+            bundle_package_type = bundle_package_type.bundle,
             product_type = apple_product_type.quicklook_plugin,
             requires_signing_for_device = False,
         ),

--- a/test/macos_quick_look_plugin_test.sh
+++ b/test/macos_quick_look_plugin_test.sh
@@ -47,7 +47,6 @@ EOF
 {
   CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
   CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "XPC!";
   CFBundleShortVersionString = "1.0";
   CFBundleVersion = "1.0";
 }
@@ -81,7 +80,6 @@ function test_missing_version_fails() {
 {
   CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
   CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "XPC!";
   CFBundleShortVersionString = "1.0";
 }
 EOF
@@ -102,7 +100,6 @@ function test_missing_short_version_fails() {
 {
   CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
   CFBundleName = "\${PRODUCT_NAME}";
-  CFBundlePackageType = "XPC!";
   CFBundleVersion = "1.0";
 }
 EOF

--- a/test/starlark_tests/macos_quick_look_plugin_tests.bzl
+++ b/test/starlark_tests/macos_quick_look_plugin_tests.bzl
@@ -59,7 +59,7 @@ def macos_quick_look_plugin_test_suite(name):
             "CFBundleExecutable": "ql_plugin",
             "CFBundleIdentifier": "com.google.example",
             "CFBundleName": "ql_plugin",
-            "CFBundlePackageType": "XPC!",
+            "CFBundlePackageType": "BNDL",
             "CFBundleSupportedPlatforms:0": "MacOSX",
             "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
             "DTPlatformBuild": "*",
@@ -80,6 +80,15 @@ def macos_quick_look_plugin_test_suite(name):
         build_type = "device",
         binary_test_file = "$CONTENT_ROOT/MacOS/ql_plugin",
         macho_load_commands_not_contain = ["cmd LC_RPATH"],
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
+        tags = [name],
+    )
+
+    archive_contents_test(
+        name = "{}_missing_id_dylib_header_value_test".format(name),
+        build_type = "device",
+        binary_test_file = "$CONTENT_ROOT/MacOS/ql_plugin",
+        macho_load_commands_not_contain = ["cmd LC_ID_DYLIB"],
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ql_plugin",
         tags = [name],
     )


### PR DESCRIPTION
Removes the linker option that sets the `install_name` of QuickLook plugins to `/Library/Frameworks/<bundle_name>.qlgenerator`, and passes `-bundle` rather than `-dynamiclib`. 

QuickLook plugins can be located in multiple locations on disk (e.g. `/Library/QuickLook`, `~/Library/QuickLook`, in an app bundle, etc) and they're usually built as bundles rather than linked to directly (they get loaded manually by `quicklookd`), so an install path isn't necessary. 

Also, as currently implemented this only works if you explicitly set `bundle_name`, and adds a garbage value otherwise (`/Library/Frameworks/.qlgenerator/`).