### PR TITLE
Fix broken builds with Bazel < 6.4.0

### DIFF
--- a/apple/internal/partials/app_assets_validation.bzl
+++ b/apple/internal/partials/app_assets_validation.bzl
@@ -27,6 +27,8 @@ load(
     "partial",
 )
 
+_supports_visionos = hasattr(apple_common.platform_type, "visionos")
+
 def _app_assets_validation_partial_impl(
         *,
         app_icons,
@@ -72,7 +74,8 @@ def _app_assets_validation_partial_impl(
                 extension = "brandassets",
                 files = app_icons,
             )
-        elif platform_prerequisites.platform_type == apple_common.platform_type.visionos:
+        elif (_supports_visionos and
+              platform_prerequisites.platform_type == apple_common.platform_type.visionos):
             message = ("visionOS apps must use visionOS app icon layers grouped in " +
                        ".solidimagestack bundles, not traditional App Icon Sets")
             bundling_support.ensure_single_xcassets_type(

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -43,6 +43,8 @@ load(
     "paths",
 )
 
+_supports_visionos = hasattr(apple_common.platform_type, "visionos")
+
 def _actool_args_for_special_file_types(
         *,
         asset_files,
@@ -107,7 +109,8 @@ def _actool_args_for_special_file_types(
     elif platform_prerequisites.platform_type == apple_common.platform_type.tvos:
         appicon_extension = "brandassets"
         icon_files = [f for f in asset_files if ".brandassets/" in f.path]
-    elif platform_prerequisites.platform_type == apple_common.platform_type.visionos:
+    elif (_supports_visionos and
+          platform_prerequisites.platform_type == apple_common.platform_type.visionos):
         appicon_extension = "solidimagestack"
         icon_files = [f for f in asset_files if ".solidimagestack/" in f.path]
     else:


### PR DESCRIPTION
Which doesn't have `visionos` in the platform type API.