### PR TITLE
Fix issues with experimental_mixed_language_library header map

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -282,13 +282,14 @@ target only contains Objective-C files.""")
     # `enable_modules` set to `True` in `objc_library`. This enables it via copts.
     # See: https://github.com/bazelbuild/bazel/issues/20703
     if enable_modules:
-        objc_copts.append("-fmodules")
+        # buildifier: disable=list-append (select does not support list append)
+        objc_copts += ["-fmodules"]
 
     objc_deps = [":" + swift_library_name]
 
     # Add Obj-C includes to Swift header search paths
     repository_name = native.repository_name()
-    includes = kwargs.pop("includes", [])
+    includes = [] + kwargs.pop("includes", [])
     for x in includes:
         include = x if repository_name == "@" else "external/" + repository_name.lstrip("@") + "/" + x
         swift_copts += [
@@ -303,6 +304,7 @@ target only contains Objective-C files.""")
             module_name = module_name,
             hdrs = hdrs,
             deps = [":" + swift_library_name],
+            testonly = testonly,
         )
         includes += header_map_ctx.includes
         objc_copts += header_map_ctx.copts

--- a/apple/internal/header_map_support.bzl
+++ b/apple/internal/header_map_support.bzl
@@ -20,7 +20,8 @@ def _create_header_map_context(
         name,
         module_name,
         hdrs,
-        deps):
+        deps,
+        testonly = False):
     """
     Creates header_map(s) for the target with the given name.
 
@@ -31,6 +32,7 @@ def _create_header_map_context(
             under module_name and flattened.
         deps: The direct dependencies to include in the header map, any headers in the deps will be rooted
             under this `module_name` and flattened.
+        testonly: Whether or not this is a header map being used for a test only target.
 
     Returns a struct (or `None` if no headers) with the following attributes:
         copts: The compiler options to use when compiling a C family library with header maps.
@@ -52,6 +54,7 @@ def _create_header_map_context(
         module_name = module_name,
         hdrs = [public_hdrs_filegroup],
         deps = deps,
+        testonly = testonly,
     )
 
     copts = [


### PR DESCRIPTION
Fixes some issues I ran into while integrating on a more real project than the examples:

- `includes` is a frozen list after `kwargs.pop`, use `[] + kwargs.pop` to allow mutation within the macro.
- `objc_copts` and `append` do not work when `objc_copts` is a `select`. Use `+=` to add a default list of copts to any list or `select`
- Add `testonly` support to `header_map_support`