### PR TITLE
Fix DWARF binary not copied for AppleDsymBundleInfo

### DIFF
--- a/test/starlark_tests/xcarchive_tests.bzl
+++ b/test/starlark_tests/xcarchive_tests.bzl
@@ -53,6 +53,8 @@ def xcarchive_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal.xcarchive",
         contains = [
             "$BUNDLE_ROOT/dSYMs/app_minimal.app.dSYM",
+            "$BUNDLE_ROOT/dSYMs/app_minimal.app.dSYM/Contents/Resources/DWARF/app_minimal",
+            "$BUNDLE_ROOT/dSYMs/app_minimal.app.dSYM/Contents/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Products/Applications/app_minimal.app",
         ],
@@ -76,6 +78,8 @@ def xcarchive_test_suite(name):
         contains = [
             "$BUNDLE_ROOT/dSYMs/app_with_ext_space_in_path.app.dSYM",
             "$BUNDLE_ROOT/dSYMs/ext with space.appex.dSYM",
+            "$BUNDLE_ROOT/dSYMs/ext with space.appex.dSYM/Contents/Resources/DWARF/ext with space",
+            "$BUNDLE_ROOT/dSYMs/ext with space.appex.dSYM/Contents/Info.plist",
             "$BUNDLE_ROOT/Info.plist",
             "$BUNDLE_ROOT/Products/Applications/app_with_ext_space_in_path.app",
         ],


### PR DESCRIPTION
From what I can tell the `AppleDebugInfo` provider correctly gives us the binary paths, the only difference is that `AppleDsymBundleInfo` seems to add a `/dSYMS/` directory path:

```
AppleDsymBundleInfo: bazel-out/<sha>/bin/Code/Apps/CashAppWidgets/WidgetExtension/dSYMs/WidgetExtension_dsyms/Widget Extension.appex.dSYM
AppleDebugInfo:      bazel-out/<sha>/bin/Code/Apps/CashAppWidgets/WidgetExtension/WidgetExtension_dsyms/Widget Extension.appex.dSYM
```

It looks like thats intentional given: https://github.com/bazelbuild/rules_apple/blob/afd97b7f9e0530b6848ed45844febe8de21bdcb7/apple/internal/partials/debug_symbols.bzl#L330-L332

But then the rule copies it without the `/dSYMS`: https://github.com/bazelbuild/rules_apple/blob/afd97b7f9e0530b6848ed45844febe8de21bdcb7/apple/internal/partials/debug_symbols.bzl#L132-L137

---

Before:

```
bazel-bin/Code/Apps/CashApp/Cash.xcarchive/dSYMS
├── Cash.app.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
├── Siri UI.appex.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
├── Siri.appex.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
└── Widget Extension.appex.dSYM
    └── Contents
        ├── Info.plist
        └── Resources
            └── DWARF
```

After:

```
bazel-bin/Code/Apps/CashApp/Cash.xcarchive/dSYMS
├── Cash.app.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
│               └── Cash
├── Siri UI.appex.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
│               └── Siri UI
├── Siri.appex.dSYM
│   └── Contents
│       ├── Info.plist
│       └── Resources
│           └── DWARF
│               └── Siri
└── Widget Extension.appex.dSYM
    └── Contents
        ├── Info.plist
        └── Resources
            └── DWARF
                └── Widget Extension
```