### PR TITLE
Fix dynamic framework lipo issue

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     repo_name = "build_bazel_rules_apple",
 )
 
-bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "1.12.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_swift", version = "1.15.1", repo_name = "build_bazel_rules_swift")

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -114,8 +114,8 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
         _maybe(
             http_archive,
             name = "build_bazel_apple_support",
-            sha256 = "cf4d63f39c7ba9059f70e995bf5fe1019267d3f77379c2028561a5d7645ef67c",
-            url = "https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz",
+            sha256 = "100d12617a84ebc7ee7a10ecf3b3e2fdadaebc167ad93a21f820a6cb60158ead",
+            url = "https://github.com/bazelbuild/apple_support/releases/download/1.12.0/apple_support.1.12.0.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -410,6 +410,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_versioned_xcframework",
         binary_test_file = "$CONTENT_ROOT/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/generated_dynamic_macos_versioned_xcframework",
         binary_test_architecture = "arm64e",
+        binary_not_contains_architectures = ["arm64", "x86_64"],
         macho_load_commands_contain = ["cmd LC_BUILD_VERSION", "platform MACOS"],
         tags = [name],
     )


### PR DESCRIPTION
Previously when a dynamic framework was lipo'd and then bitcode
stripped, the bitcode stripping would replace the lipo'd binary and
you'd end up with a binary that contained more architectures than were
requested.

Fixes https://github.com/bazelbuild/rules_apple/issues/2392
