### PR TITLE
Change `_DEFAULT_TEST_RUNNER` to use `str(Label())`

### DIFF
--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -53,7 +53,7 @@ ios_sticker_pack_extension = _ios_sticker_pack_extension
 ios_imessage_extension = _ios_imessage_extension
 ios_static_framework = _ios_static_framework
 
-_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:ios_default_runner"
+_DEFAULT_TEST_RUNNER = str(Label("//apple/testing/default_runner:ios_default_runner"))
 
 def ios_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", None) or _DEFAULT_TEST_RUNNER

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -242,7 +242,7 @@ def macos_dynamic_framework(name, **kwargs):
         **bundling_args
     )
 
-_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:macos_default_runner"
+_DEFAULT_TEST_RUNNER = str(Label("//apple/testing/default_runner:macos_default_runner"))
 
 def macos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -45,7 +45,7 @@ tvos_extension = _tvos_extension
 tvos_framework = _tvos_framework
 tvos_static_framework = _tvos_static_framework
 
-_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:tvos_default_runner"
+_DEFAULT_TEST_RUNNER = str(Label("//apple/testing/default_runner:tvos_default_runner"))
 
 def tvos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)

--- a/apple/visionos.bzl
+++ b/apple/visionos.bzl
@@ -44,7 +44,7 @@ visionos_dynamic_framework = _visionos_dynamic_framework
 visionos_framework = _visionos_framework
 visionos_static_framework = _visionos_static_framework
 
-_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:visionos_default_runner"
+_DEFAULT_TEST_RUNNER = str(Label("//apple/testing/default_runner:visionos_default_runner"))
 
 def visionos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -45,7 +45,7 @@ watchos_framework = _watchos_framework
 watchos_extension = _watchos_extension
 watchos_static_framework = _watchos_static_framework
 
-_DEFAULT_TEST_RUNNER = "@build_bazel_rules_apple//apple/testing/default_runner:watchos_default_runner"
+_DEFAULT_TEST_RUNNER = str(Label("//apple/testing/default_runner:watchos_default_runner"))
 
 def watchos_unit_test(name, **kwargs):
     runner = kwargs.pop("runner", _DEFAULT_TEST_RUNNER)


### PR DESCRIPTION
Before this change, users would have to use `repo_name = “build_bazel_rules_apple”` when using rules_apple with Bzlmod.