### PR TITLE
Add j2objc fragment to all rules

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -135,7 +135,7 @@ def _create_apple_rule(
         cfg = cfg,
         doc = doc,
         executable = is_executable,
-        fragments = ["apple", "cpp", "objc"],
+        fragments = ["apple", "cpp", "objc", "j2objc"],
         toolchains = toolchains,
         **extra_args
     )


### PR DESCRIPTION
This is required since some linking logic moved to starlark

Fixes https://github.com/bazelbuild/rules_apple/issues/2400
