### PR TITLE
Fix private header support in `experimental_mixed_language_library`

### DIFF
--- a/apple/internal/experimental_mixed_language_library.bzl
+++ b/apple/internal/experimental_mixed_language_library.bzl
@@ -312,11 +312,13 @@ target only contains Objective-C files.""")
         swift_copts += header_map_ctx.swift_copts
 
     # Generate module map for the underlying Obj-C module
+    # This is the modulemap used exclusively by the swift_library
+    # as such we export all the headers including the private ones so they can be found in the Swift module.
     objc_module_map_name = name + ".internal.objc"
     textual_hdrs = kwargs.get("textual_hdrs", [])
     _module_map(
         name = objc_module_map_name,
-        hdrs = hdrs,
+        hdrs = hdrs + private_hdrs,
         module_name = module_name,
         textual_hdrs = textual_hdrs,
         testonly = testonly,

--- a/examples/multi_platform/MixedLib/BUILD
+++ b/examples/multi_platform/MixedLib/BUILD
@@ -10,6 +10,7 @@ experimental_mixed_language_library(
     srcs = [
         "MixedAnswer.m",
         "MixedAnswer.swift",
+        "MixedAnswerPrivate.h",  # private header support
     ],
     hdrs = ["MixedAnswer.h"],
     enable_modules = True,

--- a/examples/multi_platform/MixedLib/MixedAnswer.swift
+++ b/examples/multi_platform/MixedLib/MixedAnswer.swift
@@ -8,6 +8,11 @@ public class MixedAnswerSwift: NSObject {
         "\(MixedAnswerObjc.mixedAnswerObjc() ?? "invalid")_swiftMixedAnswer"
     }
 
+    public
+    static func swiftMixedAnswerPrivate() -> String {
+        "\(MixedAnswerPrivateObjc.mixedAnswerPrivateObjc() ?? "invalid")_swiftPrivateMixedAnswer"
+    }
+
     @objc
     public
     static func swiftToObjcMixedAnswer() -> String {

--- a/examples/multi_platform/MixedLib/MixedAnswerPrivate.h
+++ b/examples/multi_platform/MixedLib/MixedAnswerPrivate.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface MixedAnswerPrivateObjc : NSObject
+
++ (NSString *)mixedAnswerPrivateObjc;
+
+@end


### PR DESCRIPTION
I was running into an issue where an `experimental_mixed_language_library` declared a private header via `srcs`. A type from this header was used in the Swift module part of the mixed library leading to not found errors.

This adds the private headers to the module map we create for the `swift_library` allowing it to find the types in the those headers. Note that because this is not the "umbrella" modulemap, the private headers do not end up being exposed publicly to dependencies of this mixed library and are only available within the mixed library as intended.