### PR TITLE
Fix allow space in bundle_name for ipa_post_processor

### DIFF
--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -91,6 +91,12 @@ def ios_application_test_suite(name):
         expected_outputs = ["app_minimal.app"],
         tags = [name],
     )
+    analysis_target_tree_artifacts_outputs_test(
+        name = "{}_tree_artifact_outputs_with_space_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal_with_space_and_post_processor",
+        expected_outputs = ["app_minimal_with_space_and_post_processor_archive-root/Payload/app minimal.app"],
+        tags = [name],
+    )
 
     analysis_target_tree_artifacts_outputs_test(
         name = "{}_duplicate_bundle_target1_test".format(name),

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -83,6 +83,23 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_minimal_with_space_and_post_processor",
+    bundle_id = "com.google.example",
+    bundle_name = "app minimal",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 xcarchive(
     name = "app_minimal.xcarchive",
     bundle = ":app_minimal",

--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -276,7 +276,7 @@ class Bundler(object):
     # Configure the TREE_ARTIFACT_OUTPUT environment variable to the path of the
     # bundle, but keep the work_dir for compatibility with the bundletool post
     # processing.
-    exit_code = os.system('TREE_ARTIFACT_OUTPUT=%s %s "%s"' %
+    exit_code = os.system('TREE_ARTIFACT_OUTPUT="%s" %s "%s"' %
                           (bundle_root, post_processor, work_dir))
     if exit_code:
       raise PostProcessorError(exit_code)


### PR DESCRIPTION
`bundle_root` can contain spaces if the `bundle_name` of the target has spaces, it should be quoted to prevent issues