### PR TITLE
Allow .xcprivacy files in infoplists attribute of ios_application

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2529,7 +2529,7 @@ ios_application = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
             is_mandatory = True,
         ),
-        rule_attrs.infoplist_attrs(),
+        rule_attrs.infoplist_attrs(extra_allow_files = [".xcprivacy"]),
         rule_attrs.ipa_post_processor_attrs(),
         rule_attrs.launch_images_attrs(),
         rule_attrs.platform_attrs(

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -528,13 +528,14 @@ The base bundle ID rule to dictate the form that a given bundle rule's bundle ID
 
     return signing_attrs
 
-def _infoplist_attrs(*, default_infoplist = None):
+def _infoplist_attrs(*, default_infoplist = None, extra_allow_files = []):
     """Returns the attributes required to support a root Info.plist for the given target.
 
     Args:
         default_infoplist: A string representing a label to a default Info.plist. Optional. If not
             set or if set to None, the `infoplists` attribute will be considered mandatory for the
             user to set.
+        extra_allow_files: Extra extension to allow, such as .xcprivacy.
     """
     attr_args = {}
     if default_infoplist:
@@ -544,7 +545,7 @@ def _infoplist_attrs(*, default_infoplist = None):
     return {
         "infoplists": attr.label_list(
             allow_empty = False,
-            allow_files = [".plist"],
+            allow_files = [".plist"] + extra_allow_files,
             doc = """
 A list of .plist files that will be merged to form the Info.plist for this target. At least one file
 must be specified. Please see


### PR DESCRIPTION
When submitting an app for TestFlight review, we got a new warning regarding missing API declarations (`ITMS-91053: Missing API declaration`). The easiest way to fulfill this requirement is to use Xcode to create a so-called "App Privacy" file, which is actually a small `.plist` file.

I'm not sure whether this should also apply to macOS and watchOS bundles, but I'm pretty sure the answer is yes, so it might be a good idea to allow `.xcprivacy` files on any `infoplists` attribute.