### PR TITLE
Replace usages of to_json() with json.encode(..)

### DIFF
--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -168,7 +168,7 @@ def _extract_signing_info(
         )
         actions.write(
             output = control_file,
-            content = struct(**control).to_json(),
+            content = json.encode(struct(**control)),
         )
 
         apple_support.run(
@@ -305,7 +305,7 @@ def _process_entitlements(
     )
     actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
 
     resource_actions.plisttool_action(
@@ -344,7 +344,7 @@ def _process_entitlements(
         )
         actions.write(
             output = simulator_control_file,
-            content = simulator_control.to_json(),
+            content = json.encode(simulator_control),
         )
 
         resource_actions.plisttool_action(

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -228,7 +228,7 @@ def _generate_dsym_info_plist(
     )
     actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
 
     resource_actions.plisttool_action(

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -397,7 +397,7 @@ def _bundle_partial_outputs_files(
     )
     actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
 
     bundletool_inputs = input_files + [control_file] + extra_input_files

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -169,7 +169,7 @@ def merge_resource_infoplists(
     )
     actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
 
     plisttool_action(
@@ -379,7 +379,7 @@ def merge_root_infoplists(
     )
     actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
 
     plisttool_action(

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -129,7 +129,7 @@ def _apple_bundle_version_impl(ctx):
     )
     ctx.actions.write(
         output = control_file,
-        content = control.to_json(),
+        content = json.encode(control),
     )
     inputs.append(control_file)
 


### PR DESCRIPTION
struct.to_json() is deprecated and is being removed.

This replaces usages of it with the builtin json module.