### PR TITLE
Fix iOS + SwiftUI example project UIWindow issue

### DIFF
--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -71,7 +71,6 @@ ios_application(
         "ipad",
     ],
     infoplists = [":Info.plist"],
-    launch_storyboard = "//examples/resources:Launch.storyboard",
     minimum_os_version = "15.0",
     deps = [":Sources"],
 )

--- a/examples/ios/HelloWorldSwift/Info.plist
+++ b/examples/ios/HelloWorldSwift/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Related Issue/PR

#2416 cc @keith 

## Modification

Update example's Info.plist file.

> Open the newly created file and paste in it the contents found in this [example Info.plist file](https://github.com/bazelbuild/rules_apple/blob/master/examples/ios/HelloWorldSwift/Info.plist).

The [tutorial](https://github.com/bazelbuild/rules_apple/blob/master/doc/tutorials/ios-app.md) guide us to use the Info.plist file here.

But it lacks some information and will make the ipa binary to launch as compatible mode of legacy iOS app.

## Description

Before the PR:
![Old Behavior](https://github.com/bazelbuild/rules_apple/assets/43724855/d811d90c-1bee-4134-ba93-082ffb66bd9a)

After the PR:
![New Behavior](https://github.com/bazelbuild/rules_apple/assets/43724855/e9d20d09-26c1-4a56-9f35-1efec7e3fc42)

## Test

You can verify the behavior by running the [tutorial](https://github.com/bazelbuild/rules_apple/blob/master/doc/tutorials/ios-app.md).

Or

Once we delete the extra `launch_storyboard = "//examples/resources:Launch.storyboard"` in `HelloWorldSwift`. We can also reproduce it by running the following commands

```shell
cd ${PROJECT_ROOT}/examples/ios/HelloWorldSwift
# If you are running a stable bazel, you can `rm ${PROJECT_ROOT}/.bazelversion` to workaround the error
bazel run //examples/ios/HelloWorldSwift:HelloWorldSwift 
```
