### PR TITLE
Fix ios_extension with resources

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1150,6 +1150,7 @@ def _ios_extension_impl(ctx):
         attr = ctx.attr,
         res_attrs = [
             "app_icons",
+            "resources",
             "strings",
         ],
     )

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -259,6 +259,17 @@ def ios_extension_test_suite(name):
         tags = [name],
     )
 
+    # Test ext with resources bundles them at the top level
+    archive_contents_test(
+        name = "{}_contains_resources_test".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_with_resources",
+        contains = [
+            "$BUNDLE_ROOT/additional.txt",
+        ],
+        tags = [name],
+    )
+
     # Test dSYM binaries and linkmaps from framework embedded via 'data' are propagated correctly
     # at the top-level ios_extension rule, and present through the 'dsysms' and 'linkmaps' output
     # groups.

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4905,3 +4905,28 @@ docc_archive(
     fallback_bundle_version = "1.0",
     fallback_display_name = "BasicFramework",
 )
+
+# ---------------------------------------------------------------------------------------
+# Target for extension resource bundling.
+
+ios_extension(
+    name = "ext_with_resources",
+    bundle_id = "com.google.example.ext_with_resources",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    resources = [
+        "//test/starlark_tests/resources:additional.txt",
+    ],
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)


### PR DESCRIPTION
Fixes issue where an `ios_extension` with resources wouldn't include them in the final bundle.

This came up when trying to include a `PrivacyInfo.xcprivacy` at the top-level of an extension's `appex`.