### PR TITLE
Add the `apple.no_legacy_swiftinterface` feature to disable the automatic library evolution transition on framework rules.

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -320,6 +320,7 @@ def _resolved_environment_arch_for_arch(*, arch, environment, platform_type):
 
 def _command_line_options_for_xcframework_platform(
         *,
+        attr,
         minimum_os_version,
         platform_attr,
         platform_type,
@@ -328,6 +329,7 @@ def _command_line_options_for_xcframework_platform(
     """Generates a dictionary of command line options keyed by 1:2+ transition for this platform.
 
     Args:
+        attr: The attributes passed to the transition function.
         minimum_os_version: A string representing the minimum OS version specified for this
             platform, represented as a dotted version number (for example, `"9.0"`).
         platform_attr: The attribute for the apple platform specifying in dictionary form which
@@ -361,7 +363,10 @@ def _command_line_options_for_xcframework_platform(
                     environment = target_environment,
                     platform_type = platform_type,
                 ): _command_line_options(
-                    emit_swiftinterface = True,
+                    emit_swiftinterface = _should_emit_swiftinterface(
+                        attr,
+                        is_xcframework = True,
+                    ),
                     environment_arch = resolved_environment_arch,
                     minimum_os_version = minimum_os_version,
                     platform_type = platform_type,
@@ -372,11 +377,33 @@ def _command_line_options_for_xcframework_platform(
 
     return output_dictionary
 
+def _should_emit_swiftinterface(attr, is_xcframework = False):
+    """Determines if a .swiftinterface file should be generated for Swift dependencies.
+
+    This is temporary while we migrate users of the framework rules to enable
+    library evolution on specific targets instead of having it automatically
+    applied to the entire dependency subgraph.
+    """
+
+    # TODO(b/239957001): Delete all this when everyone is migrated to the new
+    # `library_evolution` attribute on `swift_library`.
+    features = getattr(attr, "features", [])
+
+    # Post cl/558262406, features could be a SelectorList
+    # TODO: @aranguyen b/297016619
+    if type(features) == "list" and "apple.no_legacy_swiftinterface" in features:
+        return False
+
+    # iOS and tvOS static frameworks require underlying swift_library targets generate a Swift
+    # interface file. These rules define a private attribute called `_emitswiftinterface` that
+    # let's this transition flip rules_swift config down the build graph.
+    return is_xcframework or hasattr(attr, "_emitswiftinterface")
+
 def _apple_rule_base_transition_impl(settings, attr):
     """Rule transition for Apple rules using Bazel CPUs and a valid Apple split transition."""
     platform_type = attr.platform_type
     return _command_line_options(
-        emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
+        emit_swiftinterface = _should_emit_swiftinterface(attr),
         environment_arch = _environment_archs(platform_type, settings)[0],
         minimum_os_version = attr.minimum_os_version,
         platform_type = platform_type,
@@ -447,7 +474,7 @@ def _apple_platforms_rule_base_transition_impl(settings, attr):
         environment_arch = _environment_archs(platform_type, settings)[0]
     return _command_line_options(
         apple_platforms = settings["//command_line_option:apple_platforms"],
-        emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
+        emit_swiftinterface = _should_emit_swiftinterface(attr),
         environment_arch = environment_arch,
         minimum_os_version = minimum_os_version,
         platform_type = platform_type,
@@ -470,7 +497,7 @@ def _apple_platforms_rule_bundle_output_base_transition_impl(settings, attr):
         environment_arch = _environment_archs(platform_type, settings)[0]
     return _command_line_options(
         apple_platforms = settings["//command_line_option:apple_platforms"],
-        emit_swiftinterface = hasattr(attr, "_emitswiftinterface"),
+        emit_swiftinterface = _should_emit_swiftinterface(attr),
         environment_arch = environment_arch,
         force_bundle_outputs = True,
         minimum_os_version = minimum_os_version,
@@ -550,7 +577,7 @@ def _apple_platform_split_transition_impl(settings, attr):
     # iOS and tvOS static frameworks require underlying swift_library targets generate a Swift
     # interface file. These rules define a private attribute called `_emitswiftinterface` that
     # let's this transition flip rules_swift config down the build graph.
-    emit_swiftinterface = hasattr(attr, "_emitswiftinterface")
+    emit_swiftinterface = _should_emit_swiftinterface(attr)
 
     if settings["//command_line_option:incompatible_enable_apple_toolchain_resolution"]:
         platforms = (
@@ -665,6 +692,7 @@ def _xcframework_transition_impl(settings, attr):
             target_environments.append("simulator")
 
         command_line_options = _command_line_options_for_xcframework_platform(
+            attr = attr,
             minimum_os_version = attr.minimum_os_versions.get(platform_type),
             platform_attr = getattr(attr, platform_type),
             platform_type = platform_type,

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1244,7 +1244,8 @@ swift_library(
 swift_library(
     name = "Swift3PFmwkWithGenHeader",
     srcs = ["DummyFmwk.swift"],
-    features = ["swift.enable_library_evolution"],
+    # Uncomment when rule no longer enforces library evolution
+    # features = ["swift.enable_library_evolution"],
     generates_header = True,
     module_name = "Swift3PFmwkWithGenHeader",
     tags = common.fixture_tags,


### PR DESCRIPTION
Followup on #2104. 
