### PR TITLE
Add back `ImportedDynamicFrameworkProcessor` `execution_requirements`

### DIFF
--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -199,6 +199,7 @@ def _framework_import_partial_impl(
             apple_fragment = platform_prerequisites.apple_fragment,
             arguments = [args],
             executable = imported_dynamic_framework_processor,
+            execution_requirements = execution_requirements,
             inputs = input_files,
             mnemonic = "ImportedDynamicFrameworkProcessor",
             outputs = [framework_zip],


### PR DESCRIPTION
Accidently removed in 8cbbef1db4e4eb1b21e6a72e01d190139f868156.