### PR TITLE
Allow users to nest `.app` bundles when using tree artifacts

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -172,7 +172,7 @@ class Bundler(object):
       self._copy_file(src, dest, executable, bundle_root)
 
   def _add_zip_contents(self, src, dest, bundle_root):
-    """Adds the contents of another ZIP file to the bundle.
+    """Adds the contents of another ZIP file/App to the bundle.
 
     Args:
       src: The path to the file or directory that should be added.
@@ -182,19 +182,30 @@ class Bundler(object):
       bundle_root: The bundle root directory into which the files should be
           added.
     """
-    with zipfile.ZipFile(src, 'r') as src_zip:
-      for src_zipinfo in src_zip.infolist():
-        # Normalize the destination path to remove any extraneous internal
-        # slashes or "." segments, but retain the final slash for directory
-        # entries.
-        file_dest = os.path.normpath(os.path.join(dest, src_zipinfo.filename))
-        if src_zipinfo.filename.endswith('/'):
-          continue
+    # Some bundle_zip entries may be bundled apps which are nested
+    # into the current bundle.
+    _, ext = os.path.splitext(src)
+    if ext == ".app":
+        # If so, we can just copy those into the expected location
+        # without any additional processing
+        app_name = os.path.basename(src)
+        shutil.copytree(src, os.path.join(bundle_root, dest, app_name))
+    else:
+        with zipfile.ZipFile(src, "r") as src_zip:
+            for src_zipinfo in src_zip.infolist():
+                # Normalize the destination path to remove any extraneous internal
+                # slashes or "." segments, but retain the final slash for directory
+                # entries.
+                file_dest = os.path.normpath(
+                    os.path.join(dest, src_zipinfo.filename)
+                )
+                if src_zipinfo.filename.endswith("/"):
+                    continue
 
-        # Check for Unix --x--x--x permissions.
-        executable = src_zipinfo.external_attr >> 16 & 0o111 != 0
-        data = src_zip.read(src_zipinfo)
-        self._write_entry(file_dest, data, executable, bundle_root)
+                # Check for Unix --x--x--x permissions.
+                executable = src_zipinfo.external_attr >> 16 & 0o111 != 0
+                data = src_zip.read(src_zipinfo)
+                self._write_entry(file_dest, data, executable, bundle_root)
 
   def _copy_file(self, src, dest, executable, bundle_root):
     """Copies a file into the bundle.


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_apple/issues/2447

Please see the above issue for more detail, but the gist of it is that users cannot have `macos_application` targets as input to the `additional_contents` when the tree artifact option is enabled, as the target is treated as a zip file anyway.

Build that shows the failing test: https://buildkite.com/bazel/rules-apple-darwin/builds/9082#_ or [log](https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/018eec4b-6b6a-45f3-adcd-6aada295af2d/test/macos_application_test.default/test_attempts/attempt_1.log) here in case the buildkite link dies somehow.