### PR TITLE
Update docc rule to support deps and data

### DIFF
--- a/apple/internal/aspects/docc_archive_aspect.bzl
+++ b/apple/internal/aspects/docc_archive_aspect.bzl
@@ -79,7 +79,7 @@ def _docc_bundle_info_aspect_impl(target, ctx):
         first_docc_bundle = _first_docc_bundle(target, ctx)
         if first_docc_bundle:
             return [DocCBundleInfo(bundle = first_docc_bundle)]
-    elif hasattr(ctx.rule.attr, "deps"):
+    if hasattr(ctx.rule.attr, "deps"):
         # If this target has "deps", try to find a DocCBundleInfo provider in its deps.
         for dep in ctx.rule.attr.deps:
             if DocCBundleInfo in dep:

--- a/test/starlark_tests/docc_tests.bzl
+++ b/test/starlark_tests/docc_tests.bzl
@@ -69,6 +69,27 @@ def docc_test_suite(name):
         tags = [name],
     )
 
+    # Verify doccarchive bundle is created for an ObjC library which defines data and has a dependency on a Swift lib.
+    archive_contents_test(
+        name = "{}_contains_doccarchive_when_objc_library_with_swift_dep".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_objc_lib_with_data_and_docc_bundle_dependency.doccarchive",
+        contains = [
+            "$BUNDLE_ROOT/index.html",
+            "$BUNDLE_ROOT/documentation/basiclib/readme/index.html",
+        ],
+        text_file_not_contains = [],
+        text_test_file = "$BUNDLE_ROOT/metadata.json",
+        text_test_values = [
+            "\"bundleDisplayName\":\"BasicLib\"",
+            "\"bundleIdentifier\":\"com.google.example.objc.lib\"",
+            "\"major\":0",
+            "\"minor\":1",
+            "\"patch\":0",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4880,6 +4880,24 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 
+objc_library(
+    name = "basic_objc_lib_with_data_and_docc_bundle_dependency",
+    srcs = [
+        "//test/starlark_tests/resources:shared.h",
+        "//test/starlark_tests/resources:shared.m",
+    ],
+    data = ["//test/starlark_tests/resources:additional.txt"],
+    deps = [":basic_framework_lib_with_docc_bundle"],
+)
+
+docc_archive(
+    name = "basic_objc_lib_with_data_and_docc_bundle_dependency.doccarchive",
+    dep = ":basic_objc_lib_with_data_and_docc_bundle_dependency",
+    fallback_bundle_identifier = "com.google.example.objc.lib",
+    fallback_bundle_version = "1.0",
+    fallback_display_name = "BasicLib",
+)
+
 ios_dynamic_framework(
     name = "basic_framework_with_docc_bundle",
     bundle_id = "com.google.example.framework",


### PR DESCRIPTION
Updates the `.docc` aspect to allow both `deps` and `data` attributes as providers for the `.docc` bundle information. Previously, if the rule defined `data` but had no DocC bundle we'd lose out on any docc bundle information from the deps.