### PR TITLE
fix(docs): update Xcode Version Selection example

### DIFF
--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -506,7 +506,7 @@ bazelrc_lines=()
 
 if [[ $OSTYPE == darwin* ]]; then
   xcode_path=$(xcode-select -p)
-  xcode_version=$(xcodebuild -version | tail -1 | cut -d " " -f3)
+  xcode_version=$(/usr/bin/xcodebuild -version 2>/dev/null | head -1 | cut -d " " -f2)
   xcode_build_number=$(/usr/bin/xcodebuild -version 2>/dev/null | tail -1 | cut -d " " -f3)
 
   bazelrc_lines+=("startup --host_jvm_args=-Xdock:name=$xcode_path")


### PR DESCRIPTION
Before this change, the `xcode_version` variable was evaluated to the same value as the `xcode_build_number` variable.

This change instead assigns the XCode version to the `xcode_version` variable.