### PR TITLE
fix broken URL for platforms repo version 0.0.9

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -131,7 +131,7 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
             http_archive,
             name = "platforms",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.7.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
                 "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
             ],
             sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",


### PR DESCRIPTION
Was noticing these warnings lately, since this URL update wasn't quite complete:
```
WARNING: Download from https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.7.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found
```
