### PR TITLE
Fix provider type checking for AppleDynamicFrameworkProvider migration

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -1656,7 +1656,9 @@ def _ios_dynamic_framework_impl(ctx):
 
     additional_providers = []
     for provider in providers:
-        if type(provider) == "AppleDynamicFramework":
+        # HACK: this should be updated so we do not need to dynamically check the provider instance.
+        # See: https://github.com/bazelbuild/bazel/issues/22095
+        if hasattr(provider, "framework_files"):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # ios_dynamic_framework usable as a dependency in swift_library

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -3273,7 +3273,9 @@ def _macos_dynamic_framework_impl(ctx):
 
     additional_providers = []
     for provider in providers:
-        if type(provider) == "AppleDynamicFramework":
+        # HACK: this should be updated so we do not need to dynamically check the provider instance.
+        # See: https://github.com/bazelbuild/bazel/issues/22095
+        if hasattr(provider, "framework_files"):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # macos_dynamic_framework usable as a dependency in swift_library

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -715,7 +715,9 @@ def _tvos_dynamic_framework_impl(ctx):
     providers = processor_result.providers
     additional_providers = []
     for provider in providers:
-        if type(provider) == "AppleDynamicFramework":
+        # HACK: this should be updated so we do not need to dynamically check the provider instance.
+        # See: https://github.com/bazelbuild/bazel/issues/22095
+        if hasattr(provider, "framework_files"):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # tvos_dynamic_framework usable as a dependency in swift_library

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -712,7 +712,9 @@ def _visionos_dynamic_framework_impl(ctx):
     providers = processor_result.providers
     additional_providers = []
     for provider in providers:
-        if type(provider) == "AppleDynamicFramework":
+        # HACK: this should be updated so we do not need to dynamically check the provider instance.
+        # See: https://github.com/bazelbuild/bazel/issues/22095
+        if hasattr(provider, "framework_files"):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # visionos_dynamic_framework usable as a dependency in swift_library

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -666,7 +666,9 @@ def _watchos_dynamic_framework_impl(ctx):
     providers = processor_result.providers
     additional_providers = []
     for provider in providers:
-        if type(provider) == "AppleDynamicFramework":
+        # HACK: this should be updated so we do not need to dynamically check the provider instance.
+        # See: https://github.com/bazelbuild/bazel/issues/22095
+        if hasattr(provider, "framework_files"):
             # Make the ObjC provider using the framework_files depset found
             # in the AppleDynamicFramework provider. This is to make the
             # watchos_dynamic_framework usable as a dependency in swift_library
@@ -1851,7 +1853,7 @@ This attribute is deprecated, please use `extensions` instead.
                 doc = """
 In case of single-target watchOS app, a list of watchOS application extensions to include in the final watch app bundle.
 
-In case of an extension-based watchOS app, a list with a single element, 
+In case of an extension-based watchOS app, a list with a single element,
 the watchOS 2 `watchos_extension` that is required to be bundled within a watchOS 2 app.
 """,
             ),


### PR DESCRIPTION
With the move of `AppleDynamicFramework` provider to Starlark doing something like `type(provider)` will always return `"struct"`. This is behavior we shouldn't have and is now broken in latest Bazel versions.

This PR updates to use `hasattr` to approximate the type as long as it has the fields we need.

More info: https://github.com/bazelbuild/bazel/issues/22095