### PR TITLE
Update key to better match what xcode outputs

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>BazelTests</key>
+  <key>BAZEL_TEST_PRODUCT_MODULE_NAME</key>
   <dict>
     <key>ProductModuleName</key>
     <string>BAZEL_TEST_PRODUCT_MODULE_NAME</string>


### PR DESCRIPTION
The key used in the ios_xctestrun_runner.template.xctestrun file is hard coded to `BazelTests`. By updating it to `BAZEL_TEST_PRODUCT_MODULE_NAME` the output will better match what xcode outputs. This also updates the format of any generated xcresult bundle files.