### PR TITLE
Add support for the --hosting-base-path argument to docc_archive

### DIFF
--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -229,7 +229,7 @@ Must be one of "error", "warning", "information", or "hint"
                 mandatory = True,
             ),
             "hosting_base_path": attr.string(
-                doc = "The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path..",
+                doc = "The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.",
                 mandatory = False,
             ),
             "kinds": attr.string_list(

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -48,6 +48,7 @@ def _docc_archive_impl(ctx):
     fallback_bundle_identifier = ctx.attr.fallback_bundle_identifier
     fallback_bundle_version = ctx.attr.fallback_bundle_version
     fallback_display_name = ctx.attr.fallback_display_name
+    hosting_base_path = ctx.attr.hosting_base_path
     kinds = ctx.attr.kinds
     platform = ctx.fragments.apple.single_arch_platform
     transform_for_static_hosting = ctx.attr.transform_for_static_hosting
@@ -91,6 +92,8 @@ def _docc_archive_impl(ctx):
         arguments.add_all("--kind", kinds)
     if transform_for_static_hosting:
         arguments.add("--transform-for-static-hosting")
+    if hosting_base_path:
+        arguments.add("--hosting-base-path", hosting_base_path)
 
     # Add symbol graphs
     if symbol_graphs_info:
@@ -224,6 +227,10 @@ Must be one of "error", "warning", "information", or "hint"
             "fallback_display_name": attr.string(
                 doc = "A fallback display name if no value is provided in the documentation bundle's Info.plist file.",
                 mandatory = True,
+            ),
+            "hosting_base_path": attr.string(
+                doc = "The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path..",
+                mandatory = False,
             ),
             "kinds": attr.string_list(
                 doc = "The kinds of entities to filter generated documentation for.",

--- a/doc/rules-docc.md
+++ b/doc/rules-docc.md
@@ -8,8 +8,8 @@ Defines rules for building Apple DocC targets.
 
 <pre>
 docc_archive(<a href="#docc_archive-name">name</a>, <a href="#docc_archive-default_code_listing_language">default_code_listing_language</a>, <a href="#docc_archive-dep">dep</a>, <a href="#docc_archive-diagnostic_level">diagnostic_level</a>, <a href="#docc_archive-enable_inherited_docs">enable_inherited_docs</a>,
-             <a href="#docc_archive-fallback_bundle_identifier">fallback_bundle_identifier</a>, <a href="#docc_archive-fallback_bundle_version">fallback_bundle_version</a>, <a href="#docc_archive-fallback_display_name">fallback_display_name</a>, <a href="#docc_archive-kinds">kinds</a>,
-             <a href="#docc_archive-transform_for_static_hosting">transform_for_static_hosting</a>)
+             <a href="#docc_archive-fallback_bundle_identifier">fallback_bundle_identifier</a>, <a href="#docc_archive-fallback_bundle_version">fallback_bundle_version</a>, <a href="#docc_archive-fallback_display_name">fallback_display_name</a>,
+             <a href="#docc_archive-hosting_base_path">hosting_base_path</a>, <a href="#docc_archive-kinds">kinds</a>, <a href="#docc_archive-transform_for_static_hosting">transform_for_static_hosting</a>)
 </pre>
 
 Builds a .doccarchive for the given dependency.
@@ -44,6 +44,7 @@ docc_archive(
 | <a id="docc_archive-fallback_bundle_identifier"></a>fallback_bundle_identifier |  A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_bundle_version"></a>fallback_bundle_version |  A fallback bundle version if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_display_name"></a>fallback_display_name |  A fallback display name if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
+| <a id="docc_archive-hosting_base_path"></a>hosting_base_path |  The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path..   | String | optional |  `""`  |
 | <a id="docc_archive-kinds"></a>kinds |  The kinds of entities to filter generated documentation for.   | List of strings | optional |  `[]`  |
 | <a id="docc_archive-transform_for_static_hosting"></a>transform_for_static_hosting |  -   | Boolean | optional |  `True`  |
 

--- a/doc/rules-docc.md
+++ b/doc/rules-docc.md
@@ -44,7 +44,7 @@ docc_archive(
 | <a id="docc_archive-fallback_bundle_identifier"></a>fallback_bundle_identifier |  A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_bundle_version"></a>fallback_bundle_version |  A fallback bundle version if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_display_name"></a>fallback_display_name |  A fallback display name if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
-| <a id="docc_archive-hosting_base_path"></a>hosting_base_path |  The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path..   | String | optional |  `""`  |
+| <a id="docc_archive-hosting_base_path"></a>hosting_base_path |  The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.   | String | optional |  `""`  |
 | <a id="docc_archive-kinds"></a>kinds |  The kinds of entities to filter generated documentation for.   | List of strings | optional |  `[]`  |
 | <a id="docc_archive-transform_for_static_hosting"></a>transform_for_static_hosting |  -   | Boolean | optional |  `True`  |
 

--- a/test/starlark_tests/docc_tests.bzl
+++ b/test/starlark_tests/docc_tests.bzl
@@ -90,6 +90,23 @@ def docc_test_suite(name):
         tags = [name],
     )
 
+    # Verify hosting_base_path support.
+    archive_contents_test(
+        name = "{}_contains_doccarchive_with_docc_bundle_when_ios_framework_with_hosting_base_path".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_docc_bundle_custom_base_path.doccarchive",
+        contains = [
+            "$BUNDLE_ROOT/index.html",
+            "$BUNDLE_ROOT/documentation/basicframework/readme/index.html",
+        ],
+        text_file_not_contains = [],
+        text_test_file = "$BUNDLE_ROOT/index.html",
+        text_test_values = [
+            "<script src=\"/custom/base/path/js/",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4924,6 +4924,15 @@ docc_archive(
     fallback_display_name = "BasicFramework",
 )
 
+docc_archive(
+    name = "basic_framework_with_docc_bundle_custom_base_path.doccarchive",
+    dep = ":basic_framework_with_docc_bundle",
+    fallback_bundle_identifier = "com.google.example.framework",
+    fallback_bundle_version = "1.0",
+    fallback_display_name = "BasicFramework",
+    hosting_base_path = "custom/base/path",
+)
+
 # ---------------------------------------------------------------------------------------
 # Target for extension resource bundling.
 


### PR DESCRIPTION
Update `docc_archive` to support providing a value for the `--hosting-base-path` argument for `docc convert`.

From `docc convert --help`:

```
OVERVIEW: Converts documentation from a source bundle.

USAGE: docc convert [<options>] <source-bundle-path>

ARGUMENTS:
  <source-bundle-path>    Path to a documentation bundle directory.
        The '.docc' bundle docc will build.

OPTIONS:
   [extra output omitted]

  --hosting-base-path <hosting-base-path>
                          The base path your documentation website will be hosted at.
        For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.
  -h, --help              Show help information.
```