### PR TITLE
Add resource collection for `cc_*` rules

### DIFF
--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -139,7 +139,7 @@ def _apple_resource_aspect_impl(target, ctx):
         if ctx.rule.attr.srcs or ctx.rule.attr.non_arc_srcs or ctx.rule.attr.deps:
             owner = str(ctx.label)
 
-    elif ctx.rule.kind == "objc_import":
+    elif ctx.rule.kind in ["cc_import", "objc_import"]:
         collect_args["res_attrs"] = ["data"]
 
     elif ctx.rule.kind == "swift_library":
@@ -164,6 +164,14 @@ def _apple_resource_aspect_impl(target, ctx):
         collect_structured_args["res_attrs"] = ["structured_resources"]
         process_args["bundle_id"] = ctx.rule.attr.bundle_id or None
         bundle_name = "{}.bundle".format(ctx.rule.attr.bundle_name or ctx.label.name)
+
+    elif ctx.rule.kind == "cc_library":
+        collect_args["res_attrs"] = ["data"]
+
+        # Only set cc_library targets as owners if they have srcs or deps. This
+        # treats cc_library targets without sources as resource aggregators.
+        if ctx.rule.attr.srcs or ctx.rule.attr.deps:
+            owner = str(ctx.label)
 
     # Collect all resource files related to this target.
     if collect_infoplists_args:

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -992,6 +992,17 @@ Found "com.bazel.app.example" which does not match previously defined "com.altba
         tags = [name],
     )
 
+    # Test app with cc_library `data` attribute includes the data files in the final binary.
+    archive_contents_test(
+        name = "{}_contains_cc_library_data".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_cc_library_data",
+        contains = [
+            "$BUNDLE_ROOT/basic.bundle",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -397,6 +397,54 @@ def macos_application_test_suite(name):
         tags = [name],
     )
 
+    # Test app with cc_library dependency that defines `data` attribute.
+    archive_contents_test(
+        name = "{}_contains_cc_library_data".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_cc_library_data",
+        contains = [
+            "$CONTENT_ROOT/MacOS/app_with_cc_library_data",
+            "$CONTENT_ROOT/Resources/basic.bundle",
+        ],
+        tags = [name],
+    )
+
+    # Test app with cc_library dependency that defines structured resources.
+    archive_contents_test(
+        name = "{}_contains_cc_library_structured_resources".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_cc_library_structured_resources",
+        contains = [
+            "$CONTENT_ROOT/MacOS/app_with_cc_library_structured_resources",
+            "$CONTENT_ROOT/Resources/Resources/some.file",
+        ],
+        tags = [name],
+    )
+
+    # Test app with cc_import dependency that defines `data` attribute.
+    archive_contents_test(
+        name = "{}_contains_cc_import_data".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_cc_import_data",
+        contains = [
+            "$CONTENT_ROOT/MacOS/app_with_cc_import_data",
+            "$CONTENT_ROOT/Resources/basic.bundle",
+        ],
+        tags = [name],
+    )
+
+    # Test app with cc_import dependency that defines structured resources.
+    archive_contents_test(
+        name = "{}_contains_cc_import_structured_resources".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_cc_import_structured_resources",
+        contains = [
+            "$CONTENT_ROOT/MacOS/app_with_cc_import_structured_resources",
+            "$CONTENT_ROOT/Resources/Resources/some.file",
+        ],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1117,3 +1117,56 @@ swift_library(
     linkopts = ["-Wl,-framework,AppIntents"],
     tags = common.fixture_tags,
 )
+
+# --------------------------------------------------------------------------------
+# C/C++ rules with data
+
+cc_library(
+    name = "cc_lib_with_data",
+    srcs = ["main.cc"],
+    data = [
+        "//test/testdata/resources:basic_bundle",
+    ],
+    tags = common.fixture_tags,
+)
+
+cc_library(
+    name = "cc_lib_with_structured_resources",
+    srcs = ["main.cc"],
+    data = [
+        ":structured_resources_in_resources",
+    ],
+    tags = common.fixture_tags,
+)
+
+cc_library(
+    name = "cc_lib_with_cc_import_with_data",
+    srcs = ["main.cc"],
+    deps = [
+        ":cc_import_with_data",
+    ],
+)
+
+cc_library(
+    name = "cc_lib_with_cc_import_with_structured_resources",
+    srcs = ["main.cc"],
+    deps = [
+        ":cc_import_with_structured_resources",
+    ],
+)
+
+cc_import(
+    name = "cc_import_with_data",
+    data = [
+        "//test/testdata/resources:basic_bundle",
+    ],
+    tags = common.fixture_tags,
+)
+
+cc_import(
+    name = "cc_import_with_structured_resources",
+    data = [
+        ":structured_resources_in_resources",
+    ],
+    tags = common.fixture_tags,
+)

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4957,3 +4957,19 @@ ios_extension(
         "//test/starlark_tests/resources:objc_main_lib",
     ],
 )
+
+# ---------------------------------------------------------------------------------------
+# Targets to test resource processing with C/C++ rules.
+
+ios_application(
+    name = "app_with_cc_library_data",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    deps = [
+        "//test/starlark_tests/resources:cc_lib_with_data",
+    ],
+)

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2907,3 +2907,58 @@ macos_unit_test(
         "//test/starlark_tests/resources:objc_test_lib",
     ],
 )
+
+# ---------------------------------------------------------------------------------------
+# Targets to test resource processing with C/C++ rules.
+
+macos_application(
+    name = "app_with_cc_library_data",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:cc_lib_with_data",
+    ],
+)
+
+macos_application(
+    name = "app_with_cc_import_data",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:cc_lib_with_cc_import_with_data",
+    ],
+)
+
+macos_application(
+    name = "app_with_cc_library_structured_resources",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:cc_lib_with_structured_resources",
+    ],
+)
+
+macos_application(
+    name = "app_with_cc_import_structured_resources",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:cc_lib_with_cc_import_with_structured_resources",
+    ],
+)


### PR DESCRIPTION
Adds support for `data` attributes of `cc_library` and `cc_import` rules. These attributes were previously being ignored during bundling. 