### PR TITLE
Use sha before platform_type starlarkification for last_green

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,7 +15,10 @@ x_defaults:
     test_flags:
     - --test_tag_filters=-skipci
   common_last_green: &common_last_green
-    bazel: last_green
+    # TODO: switch back to last_green once the breakage from
+    # https://github.com/bazelbuild/bazel/commit/8e783b065c66c005db26d85e9ec6e8e28c42b2f2
+    # is fixed.
+    bazel: fbdae6f28afda0131213dbb42cc80ee3515f7f8c
     test_flags:
       - --test_tag_filters=-skipci
 


### PR DESCRIPTION
`last_green` is currently crashing on [our CI](https://buildkite.com/bazel/rules-apple-darwin/builds/9175#018fc229-2846-4765-95a6-daed4dd73ad4) due to https://github.com/bazelbuild/bazel/commit/8e783b065c66c005db26d85e9ec6e8e28c42b2f2:
```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfiguredTargetKey{label=//apple/internal:environment_plist_tvos, config=BuildConfigurationKey[19631119a756c56b7ba908af962bcae20ec090a98f145c6a975d1a8a9107e15a]}' (requested by nodes 'ConfiguredTargetKey{label=//test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_with_generated_header, config=BuildConfigurationKey[19631119a756c56b7ba908af962bcae20ec090a98f145c6a975d1a8a9107e15a]}')
	at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:557)
	at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:426)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException: IllegalArgumentException thrown during Starlark evaluation (//apple/internal:environment_plist_tvos)
	at <starlark>.multi_arch_platform(<builtin>:0)
	at <starlark>._platform_prerequisites(/Users/buildkite/builds/bk-macstudio-10/bazel/rules-apple-darwin/apple/internal/platform_support.bzl:96)
	at <starlark>._environment_plist_impl(/Users/buildkite/builds/bk-macstudio-10/bazel/rules-apple-darwin/apple/internal/environment_plist.bzl:52)
Caused by: java.lang.IllegalArgumentException: Expected post-split-transition platform type ios to match input ios
	at com.google.devtools.build.lib.rules.apple.AppleConfiguration.getMultiArchitectures(AppleConfiguration.java:280)
	at com.google.devtools.build.lib.rules.apple.AppleConfiguration.getMultiArchPlatform(AppleConfiguration.java:326)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
```