### PR TITLE
Enable --experimental_enable_aspect_hints like we do in rules_swift

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,12 @@ build --nocheck_visibility
 # dependencies cause us to use a newer version
 build --check_direct_dependencies=off
 
+# This is needed for Bazel 6 compatibility.
+# It's enabled (and can't be disabled) in Bazel 7.
+# TODO: Remove this once we drop Bazel 6 support.
+# See also: https://github.com/bazelbuild/bazel/issues/14327
+build --experimental_enable_aspect_hints
+
 # Disable the worker, which has sandboxing disabled by default, which can hide
 # issues with non-hermetic bugs.
 build --spawn_strategy=sandboxed,local


### PR DESCRIPTION
This was recently enabled in rules_swift (with https://github.com/bazelbuild/rules_swift/pull/1191) and it seems to be required in the next `rules_swift` bump. I saw the failure initially when testing a rules_swift bump in #2418 which was [failing](https://buildkite.com/bazel/rules-apple-darwin/builds/9191#018fdd69-abfb-451a-a454-4b0771e26b77) with the following error only in the Bazel 6.x configuration as expected (since it's enabled by default on Bazel 7):
```
Error: No attribute 'aspect_hints' in attr. Make sure you declared a rule attribute with this name.
```