### PR TITLE
Update ios_ui_test section to have test_host to be required

### DIFF
--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -598,7 +598,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-runner"></a>runner |  The runner target that will provide the logic on how to run the tests. Needs to provide the AppleTestRunnerInfo provider.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="ios_ui_test-test_coverage_manifest"></a>test_coverage_manifest |  A file that will be used in lcov export calls to limit the scope of files instrumented with coverage.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="ios_ui_test-test_filter"></a>test_filter |  Test filter string that will be passed into the test runner to select which tests will run.   | String | optional |  `""`  |
-| <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="ios_ui_test-test_host"></a>test_host |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  `None`  |
 | <a id="ios_ui_test-test_host_is_bundle_loader"></a>test_host_is_bundle_loader |  Whether the 'test_host' should be used as the -bundle_loader to allow testing the symbols from the test host app   | Boolean | optional |  `True`  |
 
 


### PR DESCRIPTION
`ios_ui_test` needs a test_host as part of a required parameter. The docs mention it as optional however it is a required param

https://github.com/bazel-ios/rules_ios/blob/master/rules/test.bzl#L273