### PR TITLE
Fix make var tests in ios_xctestrun_runner_unit_test

### DIFF
--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -448,6 +448,10 @@ ios_unit_test(
     deps = [":make_var_unit_test_lib"],
     minimum_os_version = "${MIN_OS_IOS}",
     runner = ":ios_x86_64_sim_runner",
+    env = {
+        "MY_MAKE_VAR": "\$(MY_MAKE_VAR)",
+    },
+    toolchains = [":my_make_var"],
 )
 
 ios_unit_test(
@@ -457,6 +461,10 @@ ios_unit_test(
     minimum_os_version = "${MIN_OS_IOS}",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
+    env = {
+        "MY_MAKE_VAR": "\$(MY_MAKE_VAR)",
+    },
+    toolchains = [":my_make_var"],
 )
 EOF
 }


### PR DESCRIPTION
`ios_xctestrun_runner_unit_test` is failing with:

```
Test Case '-[MakeVarUnitTest testMakeVar]' started.
/ios/make_var_unit_test.m:12: error: -[MakeVarUnitTest testMakeVar] : (([NSProcessInfo processInfo].environment[@"MY_MAKE_VAR"]) equal to (@"")) failed: ("(null)") is not equal to ("") - should pass
Test Case '-[MakeVarUnitTest testMakeVar]' failed (0.006 seconds).
```
