### PR TITLE
Remove explicit repo name loading local bzl files

### DIFF
--- a/apple/cc_toolchain_forwarder.bzl
+++ b/apple/cc_toolchain_forwarder.bzl
@@ -16,8 +16,8 @@
 A rule for handling the cc_toolchains and their constraints for a potential "fat" Mach-O binary.
 """
 
-load("@build_bazel_rules_apple//apple/internal:providers.bzl", "new_appleplatforminfo")
-load("@build_bazel_rules_apple//apple:providers.bzl", "ApplePlatformInfo")
+load("//apple/internal:providers.bzl", "new_appleplatforminfo")
+load("//apple:providers.bzl", "ApplePlatformInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _target_os_from_rule_ctx(ctx):

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -32,13 +32,13 @@ load(
     "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
-load("@build_bazel_rules_apple//apple/internal:intermediates.bzl", "intermediates")
-load("@build_bazel_rules_apple//apple/internal:rule_attrs.bzl", "rule_attrs")
+load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("//apple:providers.bzl", "AppleFrameworkImportInfo")
 load(
     "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
     "AppleFrameworkImportBundleInfo",

--- a/apple/internal/aspects/app_intents_aspect.bzl
+++ b/apple/internal/aspects/app_intents_aspect.bzl
@@ -22,9 +22,9 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
-load("@build_bazel_rules_apple//apple/internal:cc_info_support.bzl", "cc_info_support")
+load("//apple/internal:cc_info_support.bzl", "cc_info_support")
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:app_intents_info.bzl",
+    "//apple/internal/providers:app_intents_info.bzl",
     "AppIntentsInfo",
 )
 load(

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -14,11 +14,11 @@
 
 """Support methods for Apple framework import rules."""
 
-load("@build_bazel_rules_apple//apple/internal/utils:files.bzl", "files")
-load("@build_bazel_rules_apple//apple/internal:providers.bzl", "new_appleframeworkimportinfo")
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
-load("@build_bazel_rules_apple//apple/internal/utils:defines.bzl", "defines")
-load("@build_bazel_rules_apple//apple:utils.bzl", "group_files_by_directory")
+load("//apple/internal/utils:files.bzl", "files")
+load("//apple/internal:providers.bzl", "new_appleframeworkimportinfo")
+load("//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("//apple/internal/utils:defines.bzl", "defines")
+load("//apple:utils.bzl", "group_files_by_directory")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -63,7 +63,7 @@ provisioning_profile_repository.setup(
 ### In your `WORKSPACE` file:
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository")
+load("//apple:apple.bzl", "provisioning_profile_repository")
 
 provisioning_profile_repository(
     name = "local_provisioning_profiles",
@@ -74,7 +74,7 @@ provisioning_profile_repository(
 ### In your `BUILD` files (see `local_provisioning_profile` for more examples):
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+load("//apple:apple.bzl", "local_provisioning_profile")
 
 local_provisioning_profile(
     name = "app_debug_profile",
@@ -199,7 +199,7 @@ same profile name.
 ## Example
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+load("//apple:apple.bzl", "local_provisioning_profile")
 
 local_provisioning_profile(
     name = "app_debug_profile",

--- a/apple/internal/partials/app_intents_metadata_bundle.bzl
+++ b/apple/internal/partials/app_intents_metadata_bundle.bzl
@@ -14,9 +14,9 @@
 
 """Partial implementation for processing AppIntents metadata bundle."""
 
-load("@build_bazel_rules_apple//apple/internal:intermediates.bzl", "intermediates")
-load("@build_bazel_rules_apple//apple/internal:linking_support.bzl", "linking_support")
-load("@build_bazel_rules_apple//apple/internal:processor.bzl", "processor")
+load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:linking_support.bzl", "linking_support")
+load("//apple/internal:processor.bzl", "processor")
 load(
     "@build_bazel_rules_apple//apple/internal/providers:app_intents_info.bzl",
     "AppIntentsInfo",

--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -15,7 +15,7 @@
 """AppIntents intents related actions."""
 
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
-load("@build_bazel_rules_apple//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:intermediates.bzl", "intermediates")
 
 def generate_app_intents_metadata_bundle(
         *,

--- a/apple/internal/xcarchive.bzl
+++ b/apple/internal/xcarchive.bzl
@@ -101,7 +101,7 @@ metadata for the .xcarchive.
 Example:
 
 ````starlark
-load("@build_bazel_rules_apple//apple:xcarchive.bzl", "xcarchive")
+load("//apple:xcarchive.bzl", "xcarchive")
 
 ios_application(
     name = "App",

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -335,7 +335,7 @@ same profile name.
 ## Example
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+load("//apple:apple.bzl", "local_provisioning_profile")
 
 local_provisioning_profile(
     name = "app_debug_profile",
@@ -442,7 +442,7 @@ provisioning_profile_repository.setup(
 ### In your `WORKSPACE` file:
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository")
+load("//apple:apple.bzl", "provisioning_profile_repository")
 
 provisioning_profile_repository(
     name = "local_provisioning_profiles",
@@ -453,7 +453,7 @@ provisioning_profile_repository(
 ### In your `BUILD` files (see `local_provisioning_profile` for more examples):
 
 ```starlark
-load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+load("//apple:apple.bzl", "local_provisioning_profile")
 
 local_provisioning_profile(
     name = "app_debug_profile",

--- a/doc/rules-xcarchive.md
+++ b/doc/rules-xcarchive.md
@@ -18,7 +18,7 @@ metadata for the .xcarchive.
 Example:
 
 ````starlark
-load("@build_bazel_rules_apple//apple:xcarchive.bzl", "xcarchive")
+load("//apple:xcarchive.bzl", "xcarchive")
 
 ios_application(
     name = "App",


### PR DESCRIPTION
Removes explicit repo names in load commands in favor of relative names.