### PR TITLE
Update to rules_swift 2.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(
     name = "rules_swift",
-    version = "1.18.0",
+    version = "2.0.0",
     max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -519,6 +519,7 @@ def _swift_info_from_module_interface(
         swiftinterface_file = swiftinterface_file,
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
+        target_name = ctx.label.name,
     )
 
     return swift_common.create_swift_info(

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -122,8 +122,8 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
         _maybe(
             http_archive,
             name = "build_bazel_rules_swift",
-            sha256 = "bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2",
-            url = "https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz",
+            sha256 = "32eeb4ef33c708d9c9a4ee0fa8475322ef149dabc81884ddc3b50eb2efff7843",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -77,7 +77,7 @@ module(name = "build_bazel_rules_apple_integration_tests", version = "0")
 
 # Specify oldest possible bzlmod versions and let rules_apple versions take precedence
 bazel_dep(name = "apple_support", version = "0.11.0", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_swift", version = "1.2.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "1.2.0", repo_name = "build_bazel_rules_swift", max_compatibility_level = 2)
 bazel_dep(name = "rules_apple", version = "0", repo_name = "build_bazel_rules_apple")
 
 xcode_configure = use_extension("@bazel_tools//tools/osx:xcode_configure.bzl", "xcode_configure_extension")


### PR DESCRIPTION
Updates the **rules_swift** dependency to 2.0.0. This unblocks the new rules/aspects in other planned PRs

## Tasks

- [x] Wait for a final 2.0.0 release

## Follow up tasks

- Merge https://github.com/bazelbuild/rules_apple/pull/2418
- Merge https://github.com/bazelbuild/rules_apple/pull/2487