### PR TITLE
Update DocC for rules_swift 2.1.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(
     name = "rules_swift",
-    version = "2.0.0",
+    version = "2.1.0",
     max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -122,8 +122,8 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
         _maybe(
             http_archive,
             name = "build_bazel_rules_swift",
-            sha256 = "32eeb4ef33c708d9c9a4ee0fa8475322ef149dabc81884ddc3b50eb2efff7843",
-            url = "https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz",
+            sha256 = "8e0c72aa2be5ae44da44521c46e0700df184953e8dbc5d5423222b8cb141c64f",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/2.1.0/rules_swift.2.1.0.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 

--- a/doc/rules-docc.md
+++ b/doc/rules-docc.md
@@ -7,9 +7,10 @@ Defines rules for building Apple DocC targets.
 ## docc_archive
 
 <pre>
-docc_archive(<a href="#docc_archive-name">name</a>, <a href="#docc_archive-default_code_listing_language">default_code_listing_language</a>, <a href="#docc_archive-dep">dep</a>, <a href="#docc_archive-diagnostic_level">diagnostic_level</a>, <a href="#docc_archive-enable_inherited_docs">enable_inherited_docs</a>,
-             <a href="#docc_archive-fallback_bundle_identifier">fallback_bundle_identifier</a>, <a href="#docc_archive-fallback_bundle_version">fallback_bundle_version</a>, <a href="#docc_archive-fallback_display_name">fallback_display_name</a>,
-             <a href="#docc_archive-hosting_base_path">hosting_base_path</a>, <a href="#docc_archive-kinds">kinds</a>, <a href="#docc_archive-transform_for_static_hosting">transform_for_static_hosting</a>)
+docc_archive(<a href="#docc_archive-name">name</a>, <a href="#docc_archive-default_code_listing_language">default_code_listing_language</a>, <a href="#docc_archive-dep">dep</a>, <a href="#docc_archive-diagnostic_level">diagnostic_level</a>,
+             <a href="#docc_archive-emit_extension_block_symbols">emit_extension_block_symbols</a>, <a href="#docc_archive-enable_inherited_docs">enable_inherited_docs</a>, <a href="#docc_archive-fallback_bundle_identifier">fallback_bundle_identifier</a>,
+             <a href="#docc_archive-fallback_bundle_version">fallback_bundle_version</a>, <a href="#docc_archive-fallback_display_name">fallback_display_name</a>, <a href="#docc_archive-hosting_base_path">hosting_base_path</a>, <a href="#docc_archive-kinds">kinds</a>,
+             <a href="#docc_archive-minimum_access_level">minimum_access_level</a>, <a href="#docc_archive-transform_for_static_hosting">transform_for_static_hosting</a>)
 </pre>
 
 Builds a .doccarchive for the given dependency.
@@ -19,7 +20,7 @@ NOTE: At this time Swift is the only supported language for this rule.
 
 Example:
 
-```python
+```starlark
 load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
 
 docc_archive(
@@ -40,12 +41,14 @@ docc_archive(
 | <a id="docc_archive-default_code_listing_language"></a>default_code_listing_language |  A fallback default language for code listings if no value is provided in the documentation bundle's Info.plist file.   | String | optional |  `""`  |
 | <a id="docc_archive-dep"></a>dep |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="docc_archive-diagnostic_level"></a>diagnostic_level |  Filters diagnostics above this level from output This filter level is inclusive. If a level of `information` is specified, diagnostics with a severity up to and including `information` will be printed. Must be one of "error", "warning", "information", or "hint"   | String | optional |  `""`  |
+| <a id="docc_archive-emit_extension_block_symbols"></a>emit_extension_block_symbols |  Defines if the symbol graph information for `extension` blocks should be emitted in addition to the default symbol graph information.<br><br>This value must be either `"0"` or `"1"`.When the value is `"1"`, the symbol graph information for `extension` blocks will be emitted in addition to the default symbol graph information. The default value is `"0"`.   | String | optional |  `"0"`  |
 | <a id="docc_archive-enable_inherited_docs"></a>enable_inherited_docs |  Inherit documentation for inherited symbols.   | Boolean | optional |  `False`  |
 | <a id="docc_archive-fallback_bundle_identifier"></a>fallback_bundle_identifier |  A fallback bundle identifier if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_bundle_version"></a>fallback_bundle_version |  A fallback bundle version if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-fallback_display_name"></a>fallback_display_name |  A fallback display name if no value is provided in the documentation bundle's Info.plist file.   | String | required |  |
 | <a id="docc_archive-hosting_base_path"></a>hosting_base_path |  The base path your documentation website will be hosted at. For example, to deploy your site to 'example.com/my_name/my_project/documentation' instead of 'example.com/documentation', pass '/my_name/my_project' as the base path.   | String | optional |  `""`  |
 | <a id="docc_archive-kinds"></a>kinds |  The kinds of entities to filter generated documentation for.   | List of strings | optional |  `[]`  |
+| <a id="docc_archive-minimum_access_level"></a>minimum_access_level |  " The minimum access level of the declarations that should be emitted in the symbol graphs. This value must be either `fileprivate`, `internal`, `private`, or `public`. The default value is `public`.   | String | optional |  `"public"`  |
 | <a id="docc_archive-transform_for_static_hosting"></a>transform_for_static_hosting |  -   | Boolean | optional |  `True`  |
 
 

--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -96,8 +96,10 @@ docc_archive(
     default_code_listing_language = "en",
     dep = ":HelloWorldSwift",
     diagnostic_level = "information",
+    emit_extension_block_symbols = "1",
     enable_inherited_docs = True,
     fallback_bundle_identifier = "com.example.hello-world-swift",
     fallback_bundle_version = "1.0.0",
     fallback_display_name = "HelloWorldSwift",
+    minimum_access_level = "internal",
 )

--- a/examples/ios/HelloWorldSwift/Sources/BazelApp.swift
+++ b/examples/ios/HelloWorldSwift/Sources/BazelApp.swift
@@ -15,20 +15,61 @@
 import SwiftUI
 
 @main
-struct BazelApp: App {
-  var body: some Scene {
+public struct BazelApp: App {
+  public init() { }
+
+  public var body: some Scene {
     WindowGroup {
       Text("Hello World")
         .accessibility(identifier: "HELLO_WORLD")
     }
   }
 
-  /// A foo API to test DooC documentation generation.
+  /// A public API to test DooC documentation generation.
   ///
-  /// Example referencing ``AppDelegate``:
+  /// Example referencing ``BazelApp``:
   ///
   /// ```swift
-  /// let appDelegate = AppDelegate()
+  /// let app = BazelApp()
   /// ```
   public func foo() { }
+
+  /// An internal API to test `minimum_access_level` DooC option.
+  internal func internalFoo() { }
+}
+
+// MARK: - View Extension
+
+extension View {
+
+  /// A public API extension on ``View`` to test DooC documentation generation.
+  public func viewFoo() { }
+
+  /// An internal API extension on ``View`` to test `minimum_access_level` DooC option.
+  internal func internalViewFoo() { }
+}
+
+// MARK: - Custom type
+
+/// My Struct
+///
+/// Example referencing ``MyStruct``:
+///
+/// ```swift
+///
+/// let foo = MyStruct()
+/// ```
+public struct MyStruct {
+  public init() { }
+
+  /// My Struct's foo API to test DooC documentation generation.
+  /// - Parameters:
+  ///  - bar: A bar parameter.
+  public func foo(bar: Int) { }
+
+  /// An internal foo API to test DooC documentation generation with `minimum_access_level` set to `internal`.
+  ///
+  /// - Parameters:
+  /// - bar: A bar parameter.
+  internal func internalFoo(bar: Int) { }
 }

--- a/test/starlark_tests/docc_tests.bzl
+++ b/test/starlark_tests/docc_tests.bzl
@@ -102,7 +102,8 @@ def docc_test_suite(name):
         text_file_not_contains = [],
         text_test_file = "$BUNDLE_ROOT/index.html",
         text_test_values = [
-            "<script src=\"/custom/base/path/js/",
+            "<script defer=\"defer\" src=\"/custom/base/path/js/",
+            "<link href=\"/custom/base/path/css/",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4875,7 +4875,7 @@ swift_library(
     name = "basic_framework_lib_with_docc_bundle",
     srcs = ["//test/starlark_tests/resources:BasicFramework.swift"],
     data = ["//test/starlark_tests/resources:basic_docc_bundle_files"],
-    module_name = "BasicFramework",
+    module_name = "BasicFrameworkWithDocCBundle",
     tags = common.fixture_tags,
     visibility = ["//visibility:public"],
 )
@@ -4901,7 +4901,7 @@ docc_archive(
 ios_dynamic_framework(
     name = "basic_framework_with_docc_bundle",
     bundle_id = "com.google.example.framework",
-    bundle_name = "BasicFramework",
+    bundle_name = "BasicFrameworkWithDocCBundle",
     families = [
         "iphone",
         "ipad",


### PR DESCRIPTION
Updates the DocC rules to support rules_swift 2.x which introduced breaking changes to how Swift symbol graphs are collected.

This PR updates to use the new aspect to extract the symbol graphs. The public API remains unchanged.

Fixes #2445