### PR TITLE
Re-add fixed releaser

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: brentleyjones
+  email: github@brentleyjones.com


### PR DESCRIPTION
Turns out because were on bazelbuild org a fork of the registry isnt possible and so the fixed releaser must be set to tell the bot where the fork lives.