### PR TITLE
Upgrade to Xcode 15.4 from 15.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos_arm64
-    xcode_version: "15.2"
+    xcode_version: "15.4"
     build_targets:
     - "tools/..."
     - "test/..."


### PR DESCRIPTION
Fixes the following warning:

```
Your selected Xcode version 15.2 was not available on the machine. Bazel CI automatically picked a fallback version: 15.4. Available versions are: 15.4.
```