### PR TITLE
Skip `ios_test_runner_ui_test` which is failing in CI

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -248,6 +248,7 @@ apple_shell_test(
     args = [
         "--ios_multi_cpus=sim_arm64,x86_64",
     ],
+    tags = common.skip_ci_tags,
 )
 
 apple_shell_test(


### PR DESCRIPTION
This test is failing in CI but passing locally, disabling for now until we can fix and re-enable.