### PR TITLE
Increase `ios_coverage_test` size to `large`

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -196,7 +196,7 @@ apple_multi_shell_test(
 
 apple_shell_test(
     name = "ios_coverage_test",
-    size = "medium",
+    size = "large",
     src = "ios_coverage_test.sh",
 )
 


### PR DESCRIPTION
This will increase the timeout as well as this test some times is timing out after >300 seconds.