### PR TITLE
Use buildifier 6.4.0 for improved load sorting

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -44,4 +44,4 @@ tasks:
     - "doc/..."
     <<: *common_last_green
 
-buildifier: 6.3.2
+buildifier: 6.4.0

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -24,18 +24,13 @@ load(
     _apple_static_framework_import = "apple_static_framework_import",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
-    _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
-    _apple_static_xcframework_import = "apple_static_xcframework_import",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:apple_universal_binary.bzl",
     _apple_universal_binary = "apple_universal_binary",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:xcframework_rules.bzl",
-    _apple_static_xcframework = "apple_static_xcframework",
-    _apple_xcframework = "apple_xcframework",
+    "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
+    _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
+    _apple_static_xcframework_import = "apple_static_xcframework_import",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:experimental_mixed_language_library.bzl",
@@ -46,6 +41,11 @@ load(
     _local_provisioning_profile = "local_provisioning_profile",
     _provisioning_profile_repository = "provisioning_profile_repository",
     _provisioning_profile_repository_extension = "provisioning_profile_repository_extension",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:xcframework_rules.bzl",
+    _apple_static_xcframework = "apple_static_xcframework",
+    _apple_xcframework = "apple_xcframework",
 )
 
 apple_dynamic_framework_import = _apple_dynamic_framework_import

--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -15,6 +15,10 @@
 """apple_static_library Starlark implementation"""
 
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "ApplePlatformInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
     "linking_support",
 )
@@ -33,10 +37,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
     "transition_support",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "ApplePlatformInfo",
 )
 
 def _apple_static_library_impl(ctx):

--- a/apple/cc_toolchain_forwarder.bzl
+++ b/apple/cc_toolchain_forwarder.bzl
@@ -16,9 +16,9 @@
 A rule for handling the cc_toolchains and their constraints for a potential "fat" Mach-O binary.
 """
 
-load("//apple/internal:providers.bzl", "new_appleplatforminfo")
-load("//apple:providers.bzl", "ApplePlatformInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("//apple:providers.bzl", "ApplePlatformInfo")
+load("//apple/internal:providers.bzl", "new_appleplatforminfo")
 
 def _target_os_from_rule_ctx(ctx):
     """Returns a `String` representing the selected Apple OS."""

--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -15,20 +15,20 @@
 """# Bazel rules for working with dtrace."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
-    "bundle_paths",
-)
-load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "bundle_paths",
 )
 
 def _dtrace_compile_impl(ctx):

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -30,13 +30,14 @@ load(
     "@bazel_skylib//lib:sets.bzl",
     "sets",
 )
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkImportInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
-    "AppleFrameworkImportBundleInfo",
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -47,24 +48,28 @@ load(
     "cc_toolchain_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
-    "bundle_paths",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
-    "SwiftUsageInfo",
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "framework_import_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
-    "group_files_by_directory",
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "SwiftUsageInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
+    "AppleFrameworkImportBundleInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "bundle_paths",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
@@ -72,11 +77,6 @@ load(
     "swift_clang_module_aspect",
     "swift_common",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "framework_import_support",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _swiftmodule_for_cpu(swiftmodule_files, cpu):
     """Select the cpu specific swiftmodule."""

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -15,20 +15,20 @@
 """Implementation for apple universal binary rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
-    "rule_attrs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
-    "rule_factory",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",
     "new_applebinaryinfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "rule_attrs",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "rule_factory",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:transition_support.bzl",

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -14,6 +14,9 @@
 
 """Implementation of XCFramework import rules."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -32,21 +35,18 @@ load(
     "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
-load("//apple/internal:intermediates.bzl", "intermediates")
-load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
-load("//apple:providers.bzl", "AppleFrameworkImportInfo")
 load(
     "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
     "AppleFrameworkImportBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftToolchainInfo", "swift_clang_module_aspect", "swift_common")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 
 # Currently, XCFramework bundles can contain Apple frameworks or libraries.
 # This defines an _enum_ to identify an imported XCFramework bundle type.

--- a/apple/internal/aspects/app_intents_aspect.bzl
+++ b/apple/internal/aspects/app_intents_aspect.bzl
@@ -22,11 +22,6 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
-load("//apple/internal:cc_info_support.bzl", "cc_info_support")
-load(
-    "//apple/internal/providers:app_intents_info.bzl",
-    "AppIntentsInfo",
-)
 load(
     "@build_bazel_rules_swift//swift:module_name.bzl",
     "derive_swift_module_name",
@@ -34,6 +29,11 @@ load(
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
+)
+load("//apple/internal:cc_info_support.bzl", "cc_info_support")
+load(
+    "//apple/internal/providers:app_intents_info.bzl",
+    "AppIntentsInfo",
 )
 
 def _app_intents_aspect_impl(target, ctx):

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -15,12 +15,22 @@
 """Implementation of the resource propagation aspect."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
-    "AppleDebugInfo",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDsymBundleInfo",
+    "AppleFrameworkBundleInfo",
+    "AppleResourceInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -49,10 +59,8 @@ load(
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleDsymBundleInfo",
-    "AppleFrameworkBundleInfo",
-    "AppleResourceInfo",
+    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
+    "AppleDebugInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
@@ -61,14 +69,6 @@ load(
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _platform_prerequisites_for_aspect(target, aspect_ctx):

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -15,12 +15,16 @@
 """Actions related to codesigning."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
-    "defines",
+    "@bazel_skylib//lib:shell.bzl",
+    "shell",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
@@ -31,12 +35,8 @@ load(
     "rule_support",
 )
 load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@bazel_skylib//lib:shell.bzl",
-    "shell",
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
 )
 
 # The adhoc signature used as an identity, partially documented at https://developer.apple.com/documentation/security/seccodesignatureflags/1397793-adhoc

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -15,12 +15,12 @@
 """Defines rules for building Apple DocC targets."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -19,8 +19,8 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
-    "defines",
+    "@build_bazel_rules_apple//apple:common.bzl",
+    "entitlements_validation_mode",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -35,8 +35,8 @@ load(
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple:common.bzl",
-    "entitlements_validation_mode",
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
 )
 
 def _tool_validation_mode(*, is_device, rules_mode):

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -17,8 +17,8 @@ A rule for generating the environment plist
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
-    "features_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
@@ -29,16 +29,16 @@ load(
     "AppleMacToolsToolchainInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
     "rule_attrs",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
 )
 
 def _environment_plist_impl(ctx):

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -14,17 +14,17 @@
 
 """Support methods for Apple framework import rules."""
 
-load("//apple/internal/utils:files.bzl", "files")
-load("//apple/internal:providers.bzl", "new_appleframeworkimportinfo")
-load("//apple:providers.bzl", "AppleFrameworkImportInfo")
-load("//apple/internal/utils:defines.bzl", "defines")
-load("//apple:utils.bzl", "group_files_by_directory")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
     "swift_common",
 )
-load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//apple:providers.bzl", "AppleFrameworkImportInfo")
+load("//apple:utils.bzl", "group_files_by_directory")
+load("//apple/internal:providers.bzl", "new_appleframeworkimportinfo")
+load("//apple/internal/utils:defines.bzl", "defines")
+load("//apple/internal/utils:files.bzl", "files")
 
 # TODO: Remove once we drop bazel 7.x
 _OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -14,21 +14,18 @@
 
 """Implementation of iOS rules."""
 
+load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
-    "framework_provider_aspect",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
-    "apple_resource_aspect",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
-    "clang_rt_dylibs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
-    "main_thread_checker_dylibs",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "ApplePlatformInfo",
+    "IosAppClipBundleInfo",
+    "IosExtensionBundleInfo",
+    "IosFrameworkBundleInfo",
+    "IosImessageExtensionBundleInfo",
+    "IosStickerPackExtensionBundleInfo",
+    "WatchosApplicationBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -45,12 +42,12 @@ load(
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
-    "codesigning_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
     "cc_info_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "codesigning_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
@@ -59,6 +56,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:features_support.bzl",
     "features_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "libraries_to_link_for_dynamic_framework",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -124,28 +125,27 @@ load(
     "transition_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "framework_provider_aspect",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "apple_resource_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "libraries_to_link_for_dynamic_framework",
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "ApplePlatformInfo",
-    "IosAppClipBundleInfo",
-    "IosExtensionBundleInfo",
-    "IosFrameworkBundleInfo",
-    "IosImessageExtensionBundleInfo",
-    "IosStickerPackExtensionBundleInfo",
-    "WatchosApplicationBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "main_thread_checker_dylibs",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@bazel_skylib//lib:collections.bzl", "collections")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 # TODO: Remove once we drop bazel 7.x
 _OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -16,12 +16,12 @@
 
 load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
-    "entitlements_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
     "cc_toolchain_info_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "entitlements_support",
 )
 
 # TODO: Remove once we drop bazel 7.x

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -15,6 +15,15 @@
 """Internal helper definitions used by macOS command line rules."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfoplistInfo",
+    "AppleBundleVersionInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -28,12 +37,12 @@ load(
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
-    "intermediates",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:features_support.bzl",
     "features_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -54,15 +63,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
     "rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfoplistInfo",
-    "AppleBundleVersionInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
 )
 
 def _macos_binary_infoplist_impl(ctx):

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -14,6 +14,18 @@
 
 """Implementation of macOS rules."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfoplistInfo",
+    "AppleBundleInfo",
+    "AppleBundleVersionInfo",
+    "ApplePlatformInfo",
+    "MacosExtensionBundleInfo",
+    "MacosFrameworkBundleInfo",
+    "MacosStaticFrameworkBundleInfo",
+    "MacosXPCServiceBundleInfo",
+)
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
@@ -29,6 +41,10 @@ load(
     "bundling_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "cc_info_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
@@ -39,6 +55,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:features_support.bzl",
     "features_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "libraries_to_link_for_dynamic_framework",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -109,6 +129,11 @@ load(
     "apple_resource_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "SwiftDynamicFrameworkInfo",
+    "swift_dynamic_framework_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -117,34 +142,9 @@ load(
     "main_thread_checker_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
-    "cc_info_support",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
-    "SwiftDynamicFrameworkInfo",
-    "swift_dynamic_framework_aspect",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "libraries_to_link_for_dynamic_framework",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfoplistInfo",
-    "AppleBundleInfo",
-    "AppleBundleVersionInfo",
-    "ApplePlatformInfo",
-    "MacosExtensionBundleInfo",
-    "MacosFrameworkBundleInfo",
-    "MacosStaticFrameworkBundleInfo",
-    "MacosXPCServiceBundleInfo",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 # TODO: Remove once we drop bazel 7.x
 _OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -19,16 +19,16 @@ registered to generate these files.
 """
 
 load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _archive(

--- a/apple/internal/partials.bzl
+++ b/apple/internal/partials.bzl
@@ -35,12 +35,12 @@ load(
     _binary_partial = "binary_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:clang_rt_dylibs.bzl",
-    _clang_rt_dylibs_partial = "clang_rt_dylibs_partial",
+    "@build_bazel_rules_apple//apple/internal/partials:cc_info_dylibs.bzl",
+    _cc_info_dylibs_partial = "cc_info_dylibs_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:main_thread_checker_dylibs.bzl",
-    _main_thread_checker_dylibs_partial = "main_thread_checker_dylibs_partial",
+    "@build_bazel_rules_apple//apple/internal/partials:clang_rt_dylibs.bzl",
+    _clang_rt_dylibs_partial = "clang_rt_dylibs_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:codesigning_dossier.bzl",
@@ -53,10 +53,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/partials:embedded_bundles.bzl",
     _embedded_bundles_partial = "embedded_bundles_partial",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/partials:cc_info_dylibs.bzl",
-    _cc_info_dylibs_partial = "cc_info_dylibs_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:extension_safe_validation.bzl",
@@ -81,6 +77,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/partials:macos_additional_contents.bzl",
     _macos_additional_contents_partial = "macos_additional_contents_partial",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/partials:main_thread_checker_dylibs.bzl",
+    _main_thread_checker_dylibs_partial = "main_thread_checker_dylibs_partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/partials:messages_stub.bzl",

--- a/apple/internal/partials/app_assets_validation.bzl
+++ b/apple/internal/partials/app_assets_validation.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for app assets validation."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
     "bundling_support",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 _supports_visionos = hasattr(apple_common.platform_type, "visionos")

--- a/apple/internal/partials/app_intents_metadata_bundle.bzl
+++ b/apple/internal/partials/app_intents_metadata_bundle.bzl
@@ -14,9 +14,7 @@
 
 """Partial implementation for processing AppIntents metadata bundle."""
 
-load("//apple/internal:intermediates.bzl", "intermediates")
-load("//apple/internal:linking_support.bzl", "linking_support")
-load("//apple/internal:processor.bzl", "processor")
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load(
     "@build_bazel_rules_apple//apple/internal/providers:app_intents_info.bzl",
     "AppIntentsInfo",
@@ -25,7 +23,9 @@ load(
     "@build_bazel_rules_apple//apple/internal/resource_actions:app_intents.bzl",
     "generate_app_intents_metadata_bundle",
 )
-load("@bazel_skylib//lib:partial.bzl", "partial")
+load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:linking_support.bzl", "linking_support")
+load("//apple/internal:processor.bzl", "processor")
 
 def _app_intents_metadata_bundle_partial_impl(
         *,

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for the AppleBundleInfo provider."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",
     "new_applebundleinfo",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _apple_bundle_info_partial_impl(

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -15,6 +15,11 @@
 """Partial implementation for Apple .symbols file processing."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load("@bazel_skylib//lib:shell.bzl", "shell")
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -30,11 +35,6 @@ load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
 )
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load("@bazel_skylib//lib:shell.bzl", "shell")
 
 _AppleSymbolsFileInfo = provider(
     doc = "Private provider to propagate the transitive .symbols `File`s.",

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for binary processing for bundles."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _binary_partial_impl(

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -15,6 +15,14 @@
 """Partial implementation for Clang runtime libraries processing."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -25,14 +33,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _clang_rt_dylibs_partial_impl(

--- a/apple/internal/partials/codesigning_dossier.bzl
+++ b/apple/internal/partials/codesigning_dossier.bzl
@@ -15,8 +15,16 @@
 """Partial implementation for codesigning dossier file generation."""
 
 load(
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
@@ -37,14 +45,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -14,10 +14,23 @@
 
 """Partial implementation for debug symbol file processing."""
 
-load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
+load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
 load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
+)
+load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleVersionInfo",
+    "AppleDsymBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
@@ -38,19 +51,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
     "defines",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleVersionInfo",
-    "AppleDsymBundleInfo",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _declare_linkmap(

--- a/apple/internal/partials/embedded_bundles.bzl
+++ b/apple/internal/partials/embedded_bundles.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for processing embeddadable bundles."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/providers:embeddable_info.bzl",

--- a/apple/internal/partials/framework_header_modulemap.bzl
+++ b/apple/internal/partials/framework_header_modulemap.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for bundling header and modulemaps for external-facing frameworks."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _get_link_declarations(dylibs = [], frameworks = []):

--- a/apple/internal/partials/framework_headers.bzl
+++ b/apple/internal/partials/framework_headers.bzl
@@ -15,12 +15,12 @@
 """Partial implementation for embedding provisioning profiles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
-    "processor",
-)
-load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "processor",
 )
 
 def _framework_headers_partial_impl(*, hdrs):

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -15,6 +15,14 @@
 """Partial implementation for framework import file processing."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -27,24 +35,16 @@ load(
     "codesigning_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
-    "intermediates",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _framework_import_partial_impl(

--- a/apple/internal/partials/macos_additional_contents.bzl
+++ b/apple/internal/partials/macos_additional_contents.bzl
@@ -15,8 +15,12 @@
 """Partial implementation for processing additional contents for macOS apps."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
-    "processor",
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
 )
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
@@ -24,16 +28,12 @@ load(
     "AppleBundleInfo",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "processor",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _macos_additional_contents_partial_impl(*, additional_contents):

--- a/apple/internal/partials/main_thread_checker_dylibs.bzl
+++ b/apple/internal/partials/main_thread_checker_dylibs.bzl
@@ -15,6 +15,14 @@
 """Partial implementation for Main Thread Checker libraries processing."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
@@ -25,14 +33,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _should_include_main_thread_checker(features):

--- a/apple/internal/partials/messages_stub.bzl
+++ b/apple/internal/partials/messages_stub.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for placing the messages support stub file in the archive."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 _AppleMessagesStubInfo = provider(

--- a/apple/internal/partials/provisioning_profile.bzl
+++ b/apple/internal/partials/provisioning_profile.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for embedding provisioning profiles."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _provisioning_profile_partial_impl(

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -21,12 +21,17 @@ containing resource tuples as described in processor.bzl. Optionally, the struct
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal/partials/support:resources_support.bzl",
-    "resources_support",
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
-    "bundle_paths",
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "AppleResourceInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
@@ -49,17 +54,12 @@ load(
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "AppleResourceInfo",
+    "@build_bazel_rules_apple//apple/internal/partials/support:resources_support.bzl",
+    "resources_support",
 )
 load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
+    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "bundle_paths",
 )
 
 def _merge_root_infoplists(

--- a/apple/internal/partials/settings_bundle.bzl
+++ b/apple/internal/partials/settings_bundle.bzl
@@ -15,6 +15,14 @@
 """Partial implementation for processing the settings bundle for iOS apps."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleResourceInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
 )
@@ -23,16 +31,8 @@ load(
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleResourceInfo",
-)
-load(
     "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _settings_bundle_partial_impl(

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -32,6 +32,14 @@ All methods in this file follow this convention:
 """
 
 load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
@@ -46,14 +54,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
-)
-load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
-    "group_files_by_directory",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _compile_datamodels(

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -15,6 +15,14 @@
 """Partial implementation for Swift dylib processing for bundles."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -29,14 +37,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
     "defines",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 _AppleSwiftDylibsInfo = provider(

--- a/apple/internal/partials/swift_dynamic_framework.bzl
+++ b/apple/internal/partials/swift_dynamic_framework.bzl
@@ -15,20 +15,20 @@
 """Partial implementation for Swift dynamic frameworks."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
-    "intermediates",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
-    "processor",
-)
-load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "processor",
 )
 
 # TODO(b/161370390): Remove ctx from the args when ctx is removed from all partials.

--- a/apple/internal/partials/swift_framework.bzl
+++ b/apple/internal/partials/swift_framework.bzl
@@ -15,20 +15,20 @@
 """Partial implementation for Swift frameworks with third party interfaces."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
-    "processor",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:swift_info_support.bzl",
-    "swift_info_support",
-)
-load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "processor",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:swift_info_support.bzl",
+    "swift_info_support",
 )
 
 def _swift_framework_partial_impl(

--- a/apple/internal/partials/watchos_stub.bzl
+++ b/apple/internal/partials/watchos_stub.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for placing the watchOS stub file in the archive."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:processor.bzl",
     "processor",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 _AppleWatchosStubInfo = provider(

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -64,16 +64,20 @@ rule.
 """
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
     "codesigning_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
-    "bundle_paths",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
-    "defines",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
@@ -88,16 +92,12 @@ load(
     "outputs",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "bundle_paths",
 )
 load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
+    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "defines",
 )
 
 # Location enum that can be used to tag files into their appropriate location

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -15,32 +15,32 @@
 """ACTool related actions."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
-    "intermediates",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
-    xctoolrunner_support = "xctoolrunner",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
-    "apple_product_type",
-)
-load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
-    "group_files_by_directory",
-)
-load(
     "@bazel_skylib//lib:collections.bzl",
     "collections",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "intermediates",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    xctoolrunner_support = "xctoolrunner",
 )
 
 _supports_visionos = hasattr(apple_common.platform_type, "visionos")

--- a/apple/internal/resource_actions/ibtool.bzl
+++ b/apple/internal/resource_actions/ibtool.bzl
@@ -15,20 +15,20 @@
 """IBTool related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
-    xctoolrunner_support = "xctoolrunner",
-)
-load(
     "@bazel_skylib//lib:collections.bzl",
     "collections",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    xctoolrunner_support = "xctoolrunner",
 )
 
 def _ibtool_arguments(min_os, families):

--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -15,16 +15,16 @@
 """Intent definitions related actions."""
 
 load(
+    "@bazel_skylib//lib:versions.bzl",
+    "versions",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
-)
-load(
-    "@bazel_skylib//lib:versions.bzl",
-    "versions",
 )
 
 def generate_intent_classes_sources(

--- a/apple/internal/resource_actions/metals.bzl
+++ b/apple/internal/resource_actions/metals.bzl
@@ -15,12 +15,12 @@
 """Metal related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 
 def _metal_apple_target_triple(platform_prerequisites):

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -15,8 +15,20 @@
 """Plist related actions."""
 
 load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:shell.bzl",
+    "shell",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleVersionInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
@@ -25,18 +37,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleVersionInfo",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@bazel_skylib//lib:shell.bzl",
-    "shell",
 )
 
 def plisttool_action(

--- a/apple/internal/resource_rules/apple_bundle_import.bzl
+++ b/apple/internal/resource_rules/apple_bundle_import.bzl
@@ -15,16 +15,16 @@
 """Implementation of apple_bundle_import rule."""
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",
     "new_appleresourcebundleinfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:resources.bzl",
     "resources",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
 )
 
 def _apple_bundle_import_impl(ctx):

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -15,8 +15,20 @@
 """Implementation of Apple Core Data Model resource rule."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:utils.bzl",
+    "group_files_by_directory",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -28,28 +40,16 @@ load(
     "features_support",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "platform_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
     "rule_attrs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
-    "platform_support",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
-    "group_files_by_directory",
 )
 
 def _apple_core_data_model_impl(ctx):

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -15,6 +15,14 @@
 """Implementation of Apple CoreML library rule."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
@@ -29,12 +37,12 @@ load(
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
-    "resource_actions",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "resource_actions",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
@@ -43,14 +51,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
     "swift_support",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
 )
 
 def _apple_core_ml_library_impl(ctx):

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -15,6 +15,14 @@
 """Implementation of ObjC/Swift Intent library rule."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
@@ -25,20 +33,12 @@ load(
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
-    "resource_actions",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "resource_actions",
 )
 
 def _apple_intent_library_impl(ctx):

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -64,6 +64,18 @@ This file provides methods to easily:
 """
 
 load(
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
+)
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+load(
+    "@bazel_skylib//lib:types.bzl",
+    "types",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
 )
@@ -78,18 +90,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
-)
-load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
-)
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "@bazel_skylib//lib:types.bzl",
-    "types",
 )
 
 _CACHEABLE_PROVIDER_FIELD_TO_ACTION = {

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -15,8 +15,24 @@
 """Common sets of attributes to be shared between the Apple rules."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:common.bzl",
+    "entitlements_validation_mode",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBaseBundleIdInfo",
+    "AppleBundleVersionInfo",
+    "ApplePlatformInfo",
+    "AppleResourceBundleInfo",
+    "AppleSharedCapabilityInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -47,24 +63,8 @@ load(
     "apple_test_info_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:common.bzl",
-    "entitlements_validation_mode",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBaseBundleIdInfo",
-    "AppleBundleVersionInfo",
-    "ApplePlatformInfo",
-    "AppleResourceBundleInfo",
-    "AppleSharedCapabilityInfo",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
 )
 
 def _common_attrs():

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -15,6 +15,16 @@
 """Helpers for defining Apple bundling rules uniformly."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "AppleTestRunnerInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
@@ -26,16 +36,6 @@ load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
     "coverage_files_aspect",
 )
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "AppleTestRunnerInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 # Returns the common set of rule attributes to support Apple test rules.
 # TODO(b/246990309): Move _COMMON_TEST_ATTRS to rule attrs in a follow up CL.

--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -14,6 +14,7 @@
 
 """Support methods for handling artifacts from SwiftInfo providers."""
 
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
     "intermediates",
@@ -22,7 +23,6 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load("@bazel_skylib//lib:sets.bzl", "sets")
 
 def _verify_found_module_name(*, bundle_name, found_module_name):
     """Validate that the module name fits the requirements for Swift frameworks.

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -15,6 +15,15 @@
 """Helper methods for implementing the test bundles."""
 
 load(
+    "@bazel_skylib//lib:types.bzl",
+    "types",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "AppleTestInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -32,12 +41,12 @@ load(
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
-    "features_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "features_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -85,17 +94,8 @@ load(
     "main_thread_checker_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "AppleTestInfo",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
-)
-load(
-    "@bazel_skylib//lib:types.bzl",
-    "types",
 )
 
 # Default test bundle ID for tests that don't have a test host or were not given

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -15,6 +15,10 @@
 """Helper methods for implementing test rules."""
 
 load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleCodesigningDossierInfo",
@@ -22,10 +26,6 @@ load(
     "AppleExtraOutputsInfo",
     "AppleTestInfo",
     "AppleTestRunnerInfo",
-)
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
 )
 
 _CoverageFilesInfo = provider(

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -15,13 +15,13 @@
 """Rules for writing build tests for libraries that target Apple platforms."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
-    "transition_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",
     "AppleBinaryInfo",
     "AppleDsymBundleInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "transition_support",
 )
 
 _PASSING_TEST_SCRIPT = """\

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -15,12 +15,12 @@
 """Implementation of iOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "apple_test_rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "IosApplicationBundleInfo",
+    "IosExtensionBundleInfo",
+    "IosFrameworkBundleInfo",
+    "IosImessageApplicationBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -55,12 +55,12 @@ load(
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "IosApplicationBundleInfo",
-    "IosExtensionBundleInfo",
-    "IosFrameworkBundleInfo",
-    "IosImessageApplicationBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "apple_test_rule_support",
 )
 
 def _ios_ui_test_bundle_impl(ctx):

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -15,12 +15,10 @@
 """Implementation of macOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "apple_test_rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "MacosApplicationBundleInfo",
+    "MacosFrameworkBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -55,10 +53,12 @@ load(
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "MacosApplicationBundleInfo",
-    "MacosFrameworkBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "apple_test_rule_support",
 )
 
 _MACOS_TEST_HOST_PROVIDERS = [[AppleBundleInfo, MacosApplicationBundleInfo]]

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -15,12 +15,11 @@
 """Implementation of tvOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "apple_test_rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "TvosApplicationBundleInfo",
+    "TvosExtensionBundleInfo",
+    "TvosFrameworkBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -55,11 +54,12 @@ load(
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "TvosApplicationBundleInfo",
-    "TvosExtensionBundleInfo",
-    "TvosFrameworkBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "apple_test_rule_support",
 )
 
 _TVOS_TEST_HOST_PROVIDERS = [

--- a/apple/internal/testing/visionos_rules.bzl
+++ b/apple/internal/testing/visionos_rules.bzl
@@ -15,14 +15,6 @@
 """Implementation of visionOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "apple_test_rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
-)
-load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "VisionosApplicationBundleInfo",
@@ -60,6 +52,14 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "apple_test_rule_support",
 )
 
 _VISIONOS_TEST_HOST_PROVIDERS = [

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -15,12 +15,10 @@
 """Implementation of watchOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
-    "apple_test_rule_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_bundle_support",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "WatchosApplicationBundleInfo",
+    "WatchosFrameworkBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -55,10 +53,12 @@ load(
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "WatchosApplicationBundleInfo",
-    "WatchosFrameworkBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "apple_test_bundle_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "apple_test_rule_support",
 )
 
 _WATCHOS_TEST_HOST_PROVIDERS = [[AppleBundleInfo, WatchosApplicationBundleInfo]]

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -14,18 +14,13 @@
 
 """Implementation of tvOS rules."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
-    "SwiftDynamicFrameworkInfo",
-    "swift_dynamic_framework_aspect",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
-    "clang_rt_dylibs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
-    "main_thread_checker_dylibs",
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "ApplePlatformInfo",
+    "TvosExtensionBundleInfo",
+    "TvosFrameworkBundleInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -42,12 +37,12 @@ load(
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
-    "codesigning_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
     "cc_info_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "codesigning_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
@@ -56,6 +51,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:features_support.bzl",
     "features_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "libraries_to_link_for_dynamic_framework",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -114,10 +113,6 @@ load(
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "libraries_to_link_for_dynamic_framework",
-)
-load(
     "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
@@ -126,17 +121,22 @@ load(
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "ApplePlatformInfo",
-    "TvosExtensionBundleInfo",
-    "TvosFrameworkBundleInfo",
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "SwiftDynamicFrameworkInfo",
+    "swift_dynamic_framework_aspect",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "clang_rt_dylibs",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "main_thread_checker_dylibs",
 )
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 # TODO: Remove once we drop bazel 7.x
 _OBJC_PROVIDER_LINKING = hasattr(apple_common.new_objc_provider(), "linkopt")

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -14,6 +14,7 @@
 
 """Implementation of visionOS rules."""
 
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
@@ -133,7 +134,6 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
 visibility([
     "//apple/...",

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -15,6 +15,19 @@
 """Implementation of watchOS rules."""
 
 load(
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
+)
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "ApplePlatformInfo",
+    "WatchosExtensionBundleInfo",
+    "WatchosFrameworkBundleInfo",
+    "WatchosStaticFrameworkBundleInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -29,12 +42,12 @@ load(
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
-    "codesigning_support",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
     "cc_info_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "codesigning_support",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
@@ -43,6 +56,10 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal:features_support.bzl",
     "features_support",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "libraries_to_link_for_dynamic_framework",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
@@ -107,6 +124,11 @@ load(
     "apple_resource_aspect",
 )
 load(
+    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "SwiftDynamicFrameworkInfo",
+    "swift_dynamic_framework_aspect",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -115,30 +137,8 @@ load(
     "main_thread_checker_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "libraries_to_link_for_dynamic_framework",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
-    "ApplePlatformInfo",
-    "WatchosExtensionBundleInfo",
-    "WatchosFrameworkBundleInfo",
-    "WatchosStaticFrameworkBundleInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
-    "SwiftDynamicFrameworkInfo",
-    "swift_dynamic_framework_aspect",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
-)
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
 )
 
 # TODO: Remove once we drop bazel 7.x

--- a/apple/internal/xcarchive.bzl
+++ b/apple/internal/xcarchive.bzl
@@ -8,12 +8,12 @@ load(
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
-    "AppleDebugInfo",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:providers.bzl",
     "new_applebinaryinfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
+    "AppleDebugInfo",
 )
 
 def _xcarchive_impl(ctx):

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -14,9 +14,15 @@
 
 """Implementation of the xcframework rules."""
 
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
+)
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleVersionInfo",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
@@ -105,13 +111,7 @@ load(
     "@build_bazel_rules_apple//apple/internal/utils:files.bzl",
     "files",
 )
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleVersionInfo",
-)
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _group_link_outputs_by_library_identifier(
         *,

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -15,6 +15,18 @@
 """Bazel rules for creating iOS applications and bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
+    _ios_app_clip = "ios_app_clip",
+    _ios_application = "ios_application",
+    _ios_dynamic_framework = "ios_dynamic_framework",
+    _ios_extension = "ios_extension",
+    _ios_framework = "ios_framework",
+    _ios_imessage_application = "ios_imessage_application",
+    _ios_imessage_extension = "ios_imessage_extension",
+    _ios_static_framework = "ios_static_framework",
+    _ios_sticker_pack_extension = "ios_sticker_pack_extension",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
@@ -28,18 +40,6 @@ load(
     _ios_internal_unit_test_bundle = "ios_internal_unit_test_bundle",
     _ios_ui_test = "ios_ui_test",
     _ios_unit_test = "ios_unit_test",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
-    _ios_app_clip = "ios_app_clip",
-    _ios_application = "ios_application",
-    _ios_dynamic_framework = "ios_dynamic_framework",
-    _ios_extension = "ios_extension",
-    _ios_framework = "ios_framework",
-    _ios_imessage_application = "ios_imessage_application",
-    _ios_imessage_extension = "ios_imessage_extension",
-    _ios_static_framework = "ios_static_framework",
-    _ios_sticker_pack_extension = "ios_sticker_pack_extension",
 )
 
 # TODO(b/118104491): Remove these re-exports and move the rule definitions into this file.

--- a/apple/ios.doc.bzl
+++ b/apple/ios.doc.bzl
@@ -30,12 +30,6 @@ load(
     _ios_sticker_pack_extension = "ios_sticker_pack_extension",
 )
 load(
-    ":ios.bzl",
-    _ios_build_test = "ios_build_test",
-    _ios_ui_test_suite = "ios_ui_test_suite",
-    _ios_unit_test_suite = "ios_unit_test_suite",
-)
-load(
     "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
     _ios_ui_test = "ios_ui_test",
     _ios_unit_test = "ios_unit_test",
@@ -47,6 +41,12 @@ load(
 load(
     "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     _ios_xctestrun_runner = "ios_xctestrun_runner",
+)
+load(
+    ":ios.bzl",
+    _ios_build_test = "ios_build_test",
+    _ios_ui_test_suite = "ios_ui_test_suite",
+    _ios_unit_test_suite = "ios_unit_test_suite",
 )
 
 ios_app_clip = _ios_app_clip

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -15,21 +15,6 @@
 """Bazel rules for creating macOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
-    "apple_test_assembler",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
-    "apple_build_test_rule",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
-    _macos_internal_ui_test_bundle = "macos_internal_ui_test_bundle",
-    _macos_internal_unit_test_bundle = "macos_internal_unit_test_bundle",
-    _macos_ui_test = "macos_ui_test",
-    _macos_unit_test = "macos_unit_test",
-)
-load(
     "@build_bazel_rules_apple//apple/internal:macos_binary_support.bzl",
     "macos_binary_infoplist",
     "macos_command_line_launchdplist",
@@ -48,6 +33,21 @@ load(
     _macos_spotlight_importer = "macos_spotlight_importer",
     _macos_static_framework = "macos_static_framework",
     _macos_xpc_service = "macos_xpc_service",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "apple_test_assembler",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "apple_build_test_rule",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
+    _macos_internal_ui_test_bundle = "macos_internal_ui_test_bundle",
+    _macos_internal_unit_test_bundle = "macos_internal_unit_test_bundle",
+    _macos_ui_test = "macos_ui_test",
+    _macos_unit_test = "macos_unit_test",
 )
 
 # TODO(b/118104491): Remove these re-exports and move the rule definitions into this file.

--- a/apple/macos.doc.bzl
+++ b/apple/macos.doc.bzl
@@ -14,14 +14,6 @@
 
 """# Bazel rules for creating macOS applications and bundles."""
 
-# Re-export original rules rather than their wrapper macros
-# so that stardoc documents the rule attributes, not an opaque
-# **kwargs argument.
-load(
-    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
-    _macos_ui_test = "macos_ui_test",
-    _macos_unit_test = "macos_unit_test",
-)
 load(
     "@build_bazel_rules_apple//apple/internal:macos_rules.bzl",
     _macos_application = "macos_application",
@@ -36,6 +28,15 @@ load(
     _macos_spotlight_importer = "macos_spotlight_importer",
     _macos_static_framework = "macos_static_framework",
     _macos_xpc_service = "macos_xpc_service",
+)
+
+# Re-export original rules rather than their wrapper macros
+# so that stardoc documents the rule attributes, not an opaque
+# **kwargs argument.
+load(
+    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
+    _macos_ui_test = "macos_ui_test",
+    _macos_unit_test = "macos_unit_test",
 )
 load(":macos.bzl", _macos_build_test = "macos_build_test")
 

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -15,8 +15,16 @@
 """# Rules related to Apple resources and resource bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    _resources_common = "resources",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/resource_rules:apple_bundle_import.bzl",
     _apple_bundle_import = "apple_bundle_import",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_data_model.bzl",
+    _apple_core_data_model = "apple_core_data_model",
 )
 load(
     "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_ml_library.bzl",
@@ -37,14 +45,6 @@ load(
 load(
     "@build_bazel_rules_apple//apple/internal/resource_rules:apple_resource_group.bzl",
     _apple_resource_group = "apple_resource_group",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_data_model.bzl",
-    _apple_core_data_model = "apple_core_data_model",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
-    _resources_common = "resources",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -15,6 +15,14 @@
 """Bazel rules for creating tvOS applications and bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:tvos_rules.bzl",
+    _tvos_application = "tvos_application",
+    _tvos_dynamic_framework = "tvos_dynamic_framework",
+    _tvos_extension = "tvos_extension",
+    _tvos_framework = "tvos_framework",
+    _tvos_static_framework = "tvos_static_framework",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
@@ -28,14 +36,6 @@ load(
     _tvos_internal_unit_test_bundle = "tvos_internal_unit_test_bundle",
     _tvos_ui_test = "tvos_ui_test",
     _tvos_unit_test = "tvos_unit_test",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:tvos_rules.bzl",
-    _tvos_application = "tvos_application",
-    _tvos_dynamic_framework = "tvos_dynamic_framework",
-    _tvos_extension = "tvos_extension",
-    _tvos_framework = "tvos_framework",
-    _tvos_static_framework = "tvos_static_framework",
 )
 
 # TODO(b/118104491): Remove these re-exports and move the rule definitions into this file.

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -15,8 +15,8 @@
 """# Rules related to Apple bundle versioning."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
-    "new_applebundleversioninfo",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
@@ -24,8 +24,8 @@ load(
     "apple_toolchain_utils",
 )
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "new_applebundleversioninfo",
 )
 
 def _collect_group_names(s):

--- a/apple/visionos.bzl
+++ b/apple/visionos.bzl
@@ -15,6 +15,13 @@
 """Bazel rules for creating visionOS applications and bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:visionos_rules.bzl",
+    _visionos_application = "visionos_application",
+    _visionos_dynamic_framework = "visionos_dynamic_framework",
+    _visionos_framework = "visionos_framework",
+    _visionos_static_framework = "visionos_static_framework",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
@@ -28,13 +35,6 @@ load(
     _visionos_internal_unit_test_bundle = "visionos_internal_unit_test_bundle",
     _visionos_ui_test = "visionos_ui_test",
     _visionos_unit_test = "visionos_unit_test",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:visionos_rules.bzl",
-    _visionos_application = "visionos_application",
-    _visionos_dynamic_framework = "visionos_dynamic_framework",
-    _visionos_framework = "visionos_framework",
-    _visionos_static_framework = "visionos_static_framework",
 )
 
 visibility("public")

--- a/apple/visionos.doc.bzl
+++ b/apple/visionos.doc.bzl
@@ -1,12 +1,8 @@
 """# Bazel rules for creating visionOS applications and bundles."""
 
-# Re-export original rules rather than their wrapper macros
-# so that stardoc documents the rule attributes, not an opaque
-# **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:visionos_rules.bzl",
-    _visionos_ui_test = "visionos_ui_test",
-    _visionos_unit_test = "visionos_unit_test",
+    "@build_bazel_rules_apple//apple:visionos.bzl",
+    _visionos_build_test = "visionos_build_test",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:visionos_rules.bzl",
@@ -15,9 +11,14 @@ load(
     _visionos_framework = "visionos_framework",
     _visionos_static_framework = "visionos_static_framework",
 )
+
+# Re-export original rules rather than their wrapper macros
+# so that stardoc documents the rule attributes, not an opaque
+# **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple:visionos.bzl",
-    _visionos_build_test = "visionos_build_test",
+    "@build_bazel_rules_apple//apple/internal/testing:visionos_rules.bzl",
+    _visionos_ui_test = "visionos_ui_test",
+    _visionos_unit_test = "visionos_unit_test",
 )
 
 visionos_application = _visionos_application

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -15,6 +15,14 @@
 """Bazel rules for creating watchOS applications and bundles."""
 
 load(
+    "@build_bazel_rules_apple//apple/internal:watchos_rules.bzl",
+    _watchos_application = "watchos_application",
+    _watchos_dynamic_framework = "watchos_dynamic_framework",
+    _watchos_extension = "watchos_extension",
+    _watchos_framework = "watchos_framework",
+    _watchos_static_framework = "watchos_static_framework",
+)
+load(
     "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
@@ -28,14 +36,6 @@ load(
     _watchos_internal_unit_test_bundle = "watchos_internal_unit_test_bundle",
     _watchos_ui_test = "watchos_ui_test",
     _watchos_unit_test = "watchos_unit_test",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:watchos_rules.bzl",
-    _watchos_application = "watchos_application",
-    _watchos_dynamic_framework = "watchos_dynamic_framework",
-    _watchos_extension = "watchos_extension",
-    _watchos_framework = "watchos_framework",
-    _watchos_static_framework = "watchos_static_framework",
 )
 
 # TODO(b/118104491): Remove these re-exports and move the rule definitions into this file.

--- a/apple/watchos.doc.bzl
+++ b/apple/watchos.doc.bzl
@@ -1,12 +1,8 @@
 """# Bazel rules for creating watchOS applications and bundles."""
 
-# Re-export original rules rather than their wrapper macros
-# so that stardoc documents the rule attributes, not an opaque
-# **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:watchos_rules.bzl",
-    _watchos_ui_test = "watchos_ui_test",
-    _watchos_unit_test = "watchos_unit_test",
+    "@build_bazel_rules_apple//apple:watchos.bzl",
+    _watchos_build_test = "watchos_build_test",
 )
 load(
     "@build_bazel_rules_apple//apple/internal:watchos_rules.bzl",
@@ -16,9 +12,14 @@ load(
     _watchos_framework = "watchos_framework",
     _watchos_static_framework = "watchos_static_framework",
 )
+
+# Re-export original rules rather than their wrapper macros
+# so that stardoc documents the rule attributes, not an opaque
+# **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple:watchos.bzl",
-    _watchos_build_test = "watchos_build_test",
+    "@build_bazel_rules_apple//apple/internal/testing:watchos_rules.bzl",
+    _watchos_ui_test = "watchos_ui_test",
+    _watchos_unit_test = "watchos_unit_test",
 )
 
 watchos_application = _watchos_application

--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -15,12 +15,12 @@
 """xcframework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def apple_static_xcframework_test_suite(name):

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -15,17 +15,13 @@
 """xcframework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "action_command_line_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
     "analysis_failure_message_with_tree_artifact_outputs_test",
-)
-load(
-    "//test/starlark_tests/rules:action_command_line_test.bzl",
-    "action_command_line_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
@@ -42,6 +38,10 @@ load(
 load(
     "//test/starlark_tests/rules:linkmap_test.bzl",
     "linkmap_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def apple_xcframework_test_suite(name):

--- a/test/starlark_tests/dtrace_compile_tests.bzl
+++ b/test/starlark_tests/dtrace_compile_tests.bzl
@@ -15,12 +15,12 @@
 """`dtrace_compile` Starlark tests."""
 
 load(
-    "//test/starlark_tests/rules:output_text_match_test.bzl",
-    "output_text_match_test",
-)
-load(
     "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
     "analysis_target_outputs_test",
+)
+load(
+    "//test/starlark_tests/rules:output_text_match_test.bzl",
+    "output_text_match_test",
 )
 
 def dtrace_compile_test_suite(name):

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -15,10 +15,6 @@
 """ios_app_clip Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -41,6 +37,10 @@ load(
 load(
     "//test/starlark_tests/rules:linkmap_test.bzl",
     "linkmap_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_app_clip_test_suite(name):

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -15,10 +15,6 @@
 """apple_bundle_version Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -29,6 +25,10 @@ load(
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_application_resources_test_suite(name):

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -15,20 +15,16 @@
 """ios_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(
-    "//test/starlark_tests/rules:apple_verification_test.bzl",
-    "apple_verification_test",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
+    "analysis_output_group_info_files_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
@@ -44,6 +40,14 @@ load(
     "apple_codesigning_dossier_info_provider_test",
 )
 load(
+    "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
+    "apple_dsym_bundle_info_test",
+)
+load(
+    "//test/starlark_tests/rules:apple_verification_test.bzl",
+    "apple_verification_test",
+)
+load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "apple_symbols_file_test",
     "archive_contents_test",
@@ -53,24 +57,20 @@ load(
     "entitlements_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
-    "analysis_output_group_info_files_test",
-)
-load(
-    "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
-    "apple_dsym_bundle_info_test",
-)
-load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    "//test/starlark_tests/rules:linkmap_test.bzl",
+    "linkmap_test",
 )
 load(
     "//test/starlark_tests/rules:output_group_zip_contents_test.bzl",
     "output_group_zip_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:linkmap_test.bzl",
-    "linkmap_test",
+    ":common.bzl",
+    "common",
 )
 
 def ios_application_test_suite(name):

--- a/test/starlark_tests/ios_extension_tests.bzl
+++ b/test/starlark_tests/ios_extension_tests.bzl
@@ -15,10 +15,6 @@
 """ios_extension Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -42,6 +38,10 @@ load(
 load(
     "//test/starlark_tests/rules:linkmap_test.bzl",
     "linkmap_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_extension_test_suite(name):

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -15,10 +15,6 @@
 """ios_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -37,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_framework_test_suite(name):

--- a/test/starlark_tests/ios_imessage_application_tests.bzl
+++ b/test/starlark_tests/ios_imessage_application_tests.bzl
@@ -15,10 +15,6 @@
 """ios_imessage_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -29,6 +25,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_imessage_application_test_suite(name):

--- a/test/starlark_tests/ios_imessage_extension_tests.bzl
+++ b/test/starlark_tests/ios_imessage_extension_tests.bzl
@@ -15,10 +15,6 @@
 """ios_imessage_extension Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -37,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 visibility("private")

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -15,16 +15,16 @@
 """ios_static_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_static_framework_test_suite(name):

--- a/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
+++ b/test/starlark_tests/ios_sticker_pack_extension_tests.bzl
@@ -15,10 +15,6 @@
 """ios_sticker_pack_extension Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -29,6 +25,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_sticker_pack_extension_test_suite(name):

--- a/test/starlark_tests/ios_ui_test_tests.bzl
+++ b/test/starlark_tests/ios_ui_test_tests.bzl
@@ -15,10 +15,6 @@
 """ios_ui_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -41,6 +37,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def ios_ui_test_test_suite(name):

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -15,8 +15,8 @@
 """ios_unit_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "action_command_line_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
@@ -43,8 +43,8 @@ load(
     "infoplist_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:action_command_line_test.bzl",
-    "action_command_line_test",
+    ":common.bzl",
+    "common",
 )
 
 def ios_unit_test_test_suite(name):

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -15,10 +15,6 @@
 """macos_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_with_tree_artifact_outputs_test",
 )
@@ -50,6 +46,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_application_test_suite(name):

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -15,10 +15,6 @@
 """macos_bundle Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -37,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_bundle_test_suite(name):

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -15,10 +15,6 @@
 """macos_command_line_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -41,6 +37,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_command_line_application_test_suite(name):

--- a/test/starlark_tests/macos_dynamic_framework_tests.bzl
+++ b/test/starlark_tests/macos_dynamic_framework_tests.bzl
@@ -15,10 +15,6 @@
 """macos_dynamic_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -29,6 +25,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_dynamic_framework_test_suite(name):

--- a/test/starlark_tests/macos_framework_tests.bzl
+++ b/test/starlark_tests/macos_framework_tests.bzl
@@ -15,16 +15,16 @@
 """macos_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_framework_test_suite(name):

--- a/test/starlark_tests/macos_quick_look_plugin_tests.bzl
+++ b/test/starlark_tests/macos_quick_look_plugin_tests.bzl
@@ -15,10 +15,6 @@
 """macos_quick_look_plugin Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
@@ -29,6 +25,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_quick_look_plugin_test_suite(name):

--- a/test/starlark_tests/macos_static_framework_tests.bzl
+++ b/test/starlark_tests/macos_static_framework_tests.bzl
@@ -15,16 +15,16 @@
 """macos_static_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_static_framework_test_suite(name):

--- a/test/starlark_tests/macos_ui_test_tests.bzl
+++ b/test/starlark_tests/macos_ui_test_tests.bzl
@@ -15,10 +15,6 @@
 """macos_ui_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -41,6 +37,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def macos_ui_test_test_suite(name):

--- a/test/starlark_tests/macos_unit_test_tests.bzl
+++ b/test/starlark_tests/macos_unit_test_tests.bzl
@@ -15,16 +15,16 @@
 """macos_unit_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_runfiles_test.bzl",
+    "analysis_runfiles_test",
 )
 load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
@@ -43,8 +43,8 @@ load(
     "infoplist_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:analysis_runfiles_test.bzl",
-    "analysis_runfiles_test",
+    ":common.bzl",
+    "common",
 )
 
 def macos_unit_test_test_suite(name):

--- a/test/starlark_tests/rules/analysis_failure_message_test.bzl
+++ b/test/starlark_tests/rules/analysis_failure_message_test.bzl
@@ -17,13 +17,13 @@ https://docs.bazel.build/versions/0.27.0/skylark/testing.html#failure-testing
 """
 
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
-    "build_settings_labels",
-)
-load(
     "@bazel_skylib//lib:unittest.bzl",
     "analysistest",
     "asserts",
+)
+load(
+    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "build_settings_labels",
 )
 
 def _analysis_failure_message_test_impl(ctx):

--- a/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
+++ b/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
@@ -15,12 +15,12 @@
 """Starlark test rule for OutputGroupInfo output group files."""
 
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
-    "assertions",
-)
-load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
     "make_provider_test_rule",
+)
+load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "assertions",
 )
 
 visibility("//test/starlark_tests/...")

--- a/test/starlark_tests/rules/analysis_target_actions_test.bzl
+++ b/test/starlark_tests/rules/analysis_target_actions_test.bzl
@@ -15,13 +15,13 @@
 """Starlark analysis test inspecting target under test actions."""
 
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
-    "build_settings_labels",
-)
-load(
     "@bazel_skylib//lib:unittest.bzl",
     "analysistest",
     "unittest",
+)
+load(
+    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "build_settings_labels",
 )
 
 _TARGET_CONTAINS_ACTION_WITH_ARGV_FAIL_MSG = """

--- a/test/starlark_tests/rules/analysis_target_outputs_test.bzl
+++ b/test/starlark_tests/rules/analysis_target_outputs_test.bzl
@@ -15,16 +15,16 @@
 "Starlark test for testing the outputs of analysis phase."
 
 load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+)
+load(
     "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
     "assertions",
-)
-load(
-    "@bazel_skylib//lib:unittest.bzl",
-    "analysistest",
 )
 
 def _analysis_target_outputs_test_impl(ctx):

--- a/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
+++ b/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
@@ -19,12 +19,12 @@ load(
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
-    "assertions",
-)
-load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
     "make_provider_test_rule",
+)
+load(
+    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "assertions",
 )
 
 visibility("//test/starlark_tests/...")

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -19,19 +19,6 @@ that may change at any time. Please do not depend on this rule.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
-    "build_settings_labels",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
-    "apple_product_type",
-)  # buildifier: disable=bzl-visibility
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfo",
-    "AppleBundleInfo",
-)
-load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
@@ -39,6 +26,19 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfo",
+    "AppleBundleInfo",
+)
+load(
+    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "build_settings_labels",
+)
+load(
+    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
+    "apple_product_type",
+)  # buildifier: disable=bzl-visibility
 
 _supports_visionos = hasattr(apple_common.platform_type, "visionos")
 

--- a/test/starlark_tests/rules/assertions.bzl
+++ b/test/starlark_tests/rules/assertions.bzl
@@ -15,17 +15,17 @@
 """Starlark analysis test assertions for tests."""
 
 load(
-    "@bazel_skylib//lib:unittest.bzl",
-    "analysistest",
-    "asserts",
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
 load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
+    "@bazel_skylib//lib:unittest.bzl",
+    "analysistest",
+    "asserts",
 )
 
 visibility("//test/starlark_tests/...")

--- a/test/starlark_tests/rules/entitlements_contents_test.bzl
+++ b/test/starlark_tests/rules/entitlements_contents_test.bzl
@@ -24,12 +24,12 @@ rule.
 """
 
 load(
-    "//test/starlark_tests/rules:apple_verification_test.bzl",
-    "apple_verification_transition",
-)
-load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
+)
+load(
+    "//test/starlark_tests/rules:apple_verification_test.bzl",
+    "apple_verification_transition",
 )
 
 def _entitlements_contents_test_impl(ctx):

--- a/test/starlark_tests/rules/generate_framework.bzl
+++ b/test/starlark_tests/rules/generate_framework.bzl
@@ -14,13 +14,13 @@
 
 """Rules to generate import-ready frameworks for testing."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 _SDK_TO_OS = {
     "iphonesimulator": "ios",

--- a/test/starlark_tests/rules/generate_framework_dsym.bzl
+++ b/test/starlark_tests/rules/generate_framework_dsym.bzl
@@ -14,6 +14,8 @@
 
 """Rules to generate dSYM bundle from given framework for testing."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
@@ -22,8 +24,6 @@ load(
     "@build_bazel_rules_apple//apple:utils.bzl",
     "group_files_by_directory",
 )
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def _dsym_info_plist_content(framework_name):
     return """\

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -14,14 +14,14 @@
 
 """Rules to generate import-ready XCFrameworks for testing."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _PLATFORM_TO_SDK = {
     "ios": "iphoneos",

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -14,12 +14,12 @@
 
 """Apple frameworks and XCFramework generation support methods for testing."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "@build_bazel_rules_apple//apple/internal:intermediates.bzl",  # buildifier: disable=bzl-visibility
     "intermediates",
 )
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 _SDK_TO_VERSION_ARG = {
     "iphonesimulator": "-mios-simulator-version-min",

--- a/test/starlark_tests/rules/infoplist_contents_test.bzl
+++ b/test/starlark_tests/rules/infoplist_contents_test.bzl
@@ -22,17 +22,17 @@ that may change at any time. Please do not depend on this rule.
 """
 
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBinaryInfo",
+    "AppleBundleInfo",
+)
+load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_transition",
 )
 load(
     "@build_bazel_rules_apple//test/starlark_tests/rules:output_group_test_support.bzl",
     "output_group_test_support",
-)
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfo",
-    "AppleBundleInfo",
 )
 
 def _infoplist_contents_test_impl(ctx):

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -15,12 +15,16 @@
 """tvos_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
+    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
@@ -43,12 +47,8 @@ load(
     "linkmap_test",
 )
 load(
-    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
-    "analysis_target_actions_test",
-)
-load(
-    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
-    "analysis_failure_message_test",
+    ":common.bzl",
+    "common",
 )
 
 def tvos_application_test_suite(name):

--- a/test/starlark_tests/tvos_extension_tests.bzl
+++ b/test/starlark_tests/tvos_extension_tests.bzl
@@ -15,10 +15,6 @@
 """tvos_extension Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -37,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def tvos_extension_test_suite(name):

--- a/test/starlark_tests/tvos_framework_tests.bzl
+++ b/test/starlark_tests/tvos_framework_tests.bzl
@@ -15,10 +15,6 @@
 """tvos_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -34,6 +30,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def tvos_framework_test_suite(name):

--- a/test/starlark_tests/tvos_static_framework_tests.bzl
+++ b/test/starlark_tests/tvos_static_framework_tests.bzl
@@ -15,12 +15,12 @@
 """tvos_static_framework Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def tvos_static_framework_test_suite(name):

--- a/test/starlark_tests/tvos_ui_test_tests.bzl
+++ b/test/starlark_tests/tvos_ui_test_tests.bzl
@@ -15,10 +15,6 @@
 """tvos_ui_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -37,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def tvos_ui_test_test_suite(name):

--- a/test/starlark_tests/tvos_unit_test_tests.bzl
+++ b/test/starlark_tests/tvos_unit_test_tests.bzl
@@ -15,10 +15,6 @@
 """tvos_unit_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
 )
@@ -41,6 +37,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def tvos_unit_test_test_suite(name):

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -15,12 +15,12 @@
 """watchos_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
@@ -36,8 +36,8 @@ load(
     "infoplist_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
-    "analysis_target_actions_test",
+    ":common.bzl",
+    "common",
 )
 
 def watchos_application_test_suite(name):

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -19,10 +19,6 @@ load(
     "apple_product_type",
 )  # buildifier: disable=bzl-visibility
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -33,10 +29,6 @@ load(
 load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
-)
-load(
-    "//test/starlark_tests/rules:product_type_test.bzl",
-    "product_type_test",
 )
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
@@ -50,6 +42,14 @@ load(
 load(
     "//test/starlark_tests/rules:linkmap_test.bzl",
     "linkmap_test",
+)
+load(
+    "//test/starlark_tests/rules:product_type_test.bzl",
+    "product_type_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def watchos_extension_test_suite(name):

--- a/test/starlark_tests/watchos_single_target_application_tests.bzl
+++ b/test/starlark_tests/watchos_single_target_application_tests.bzl
@@ -15,12 +15,16 @@
 """watchos_application Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
+)
+load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
+)
+load(
+    "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
+    "apple_dsym_bundle_info_test",
 )
 load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
@@ -35,12 +39,8 @@ load(
     "infoplist_contents_test",
 )
 load(
-    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
-    "analysis_target_actions_test",
-)
-load(
-    "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
-    "apple_dsym_bundle_info_test",
+    ":common.bzl",
+    "common",
 )
 
 def watchos_single_target_application_test_suite(name):

--- a/test/starlark_tests/watchos_single_target_ui_test_tests.bzl
+++ b/test/starlark_tests/watchos_single_target_ui_test_tests.bzl
@@ -15,10 +15,6 @@
 """watchos_ui_test Starlark tests leveraging watchos_single_target_application."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -33,6 +29,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def watchos_single_target_ui_test_test_suite(name):

--- a/test/starlark_tests/watchos_ui_test_tests.bzl
+++ b/test/starlark_tests/watchos_ui_test_tests.bzl
@@ -15,10 +15,6 @@
 """watchos_ui_test Starlark tests leveraging watchos_application."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -33,6 +29,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def watchos_ui_test_test_suite(name):

--- a/test/starlark_tests/watchos_unit_test_tests.bzl
+++ b/test/starlark_tests/watchos_unit_test_tests.bzl
@@ -15,10 +15,6 @@
 """watchos_unit_test Starlark tests."""
 
 load(
-    ":common.bzl",
-    "common",
-)
-load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -33,6 +29,10 @@ load(
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
     "infoplist_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 def watchos_unit_test_test_suite(name):


### PR DESCRIPTION
Followup to/depends on #2499 

Bigger PR than 2499 due to me not including `.bzl` files. I was using a command from my history that just operated on BUILD/MODULE files. Big enough it might make upstream merges a little painful? I'll leave that thought to the maintainers.

**6.3.3:** `out_of_order_load` warning is enabled by default
**6.4.0:** More correct sorting order of load statements

Could bump to 7.1.2 which is latest, but not necessary for auto fixing of load sorting