### PR TITLE
Add `implementation_deps` to `_FRAMEWORK_PROVIDERS_ASPECT_ATTRS`

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,10 +14,9 @@ x_defaults:
     - "examples/..."
     test_flags:
     - --test_tag_filters=-skipci
-  common_last_green: &common_last_green
-    bazel: last_green
+  bazel_6: &bazel_6
     test_flags:
-      - --test_tag_filters=-skipci
+    - --test_tag_filters=-skipci,-skip_bazel6_ci
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
@@ -31,17 +30,18 @@ tasks:
     name: "6.x LTS"
     bazel: 6.x
     <<: *common
+    <<: *bazel_6
 
   macos_last_green:
     name: "Last Green Bazel"
+    bazel: last_green
     <<: *common
-    <<: *common_last_green
 
   doc_tests:
     name: "Doc tests"
+    bazel: last_green
     platform: ubuntu2004
     test_targets:
     - "doc/..."
-    <<: *common_last_green
 
 buildifier: 6.4.0

--- a/apple/internal/aspects/framework_provider_aspect.bzl
+++ b/apple/internal/aspects/framework_provider_aspect.bzl
@@ -29,7 +29,14 @@ load(
 # these are supported by `objc_library` for frameworks that should be present in the bundle, but not
 # linked against.
 # TODO(b/120205406): Remove `runtime_deps` support to use objc_library/swift_library `data` instead.
-_FRAMEWORK_PROVIDERS_ASPECT_ATTRS = ["deps", "frameworks", "private_deps", "runtime_deps", "data"]
+_FRAMEWORK_PROVIDERS_ASPECT_ATTRS = [
+    "data",
+    "deps",
+    "frameworks",
+    "implementation_deps",
+    "private_deps",
+    "runtime_deps",
+]
 
 def _framework_provider_aspect_impl(target, ctx):
     """Implementation of the framework provider propagation aspect."""

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -282,7 +282,11 @@ def _apple_resource_aspect_impl(target, ctx):
     apple_debug_infos = []
     apple_dsym_bundle_infos = []
     inherited_apple_resource_infos = []
-    provider_deps = ["deps", "private_deps", "implementation_deps"] + collect_args.get("res_attrs", [])
+    provider_deps = [
+        "deps",
+        "implementation_deps",
+        "private_deps",
+    ] + collect_args.get("res_attrs", [])
     for attr in provider_deps:
         if hasattr(ctx.rule.attr, attr):
             targets = getattr(ctx.rule.attr, attr)
@@ -354,7 +358,14 @@ def _apple_resource_aspect_impl(target, ctx):
 
 apple_resource_aspect = aspect(
     implementation = _apple_resource_aspect_impl,
-    attr_aspects = ["data", "deps", "private_deps", "implementation_deps", "resources", "structured_resources"],
+    attr_aspects = [
+        "data",
+        "deps",
+        "implementation_deps",
+        "private_deps",
+        "structured_resources",
+        "resources",
+    ],
     attrs = dicts.add(
         apple_support.action_required_attrs(),
         apple_toolchain_utils.shared_attrs(),

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -118,6 +118,24 @@ def apple_dynamic_xcframework_import_test_suite(name):
         ],
         tags = [name],
     )
+    archive_contents_test(
+        name = "{}_contains_implementation_deps_imported_xcframework_framework_files".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_implementation_deps_imported_xcframework",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Info.plist",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Headers/",
+            "$BUNDLE_ROOT/Frameworks/generated_dynamic_xcframework_with_headers.framework/Modules/",
+        ],
+        binary_test_file = "$BINARY",
+        macho_load_commands_contain = [
+            "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
+        ],
+        tags = [name],
+    )
 
     # Verify the correct XCFramework library was bundled and sliced for the required architecture.
     binary_contents_test(

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -134,7 +134,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
         ],
-        tags = [name],
+        tags = [name, "skip_bazel6_ci"],
     )
 
     # Verify the correct XCFramework library was bundled and sliced for the required architecture.

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -2361,6 +2361,33 @@ int dynamic_xcframework_depending_lib_function() {
     tags = common.fixture_tags,
 )
 
+# Objective-C app with implementation deps imported Objective-C XCFramework.
+ios_application(
+    name = "app_with_implementation_deps_imported_xcframework",
+    bundle_id = "com.google.example",
+    families = [
+        "iphone",
+        "ipad",
+    ],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_xcframework_implemetation_deps_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+objc_library(
+    name = "dynamic_xcframework_implemetation_deps_depending_lib",
+    srcs = [":dynamic_xcframework_depending_lib_file"],
+    implementation_deps = [":ios_imported_dynamic_xcframework"],
+    tags = common.fixture_tags,
+)
+
 # Swift app with imported Objective-C XCFramework.
 ios_application(
     name = "swift_app_with_imported_objc_xcframework",


### PR DESCRIPTION
This allows the various framework rules to work correctly with the new-ish `implementation_deps` attribute of `objc_library`.