### PR TITLE
Fix bad docc argument for multiple symbol graphs

### DIFF
--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -97,7 +97,11 @@ def _docc_archive_impl(ctx):
 
     # Add symbol graphs
     if symbol_graphs_info:
-        arguments.add_all("--additional-symbol-graph-dir", symbol_graphs_info.symbol_graphs, expand_directories = False)
+        arguments.add_all(
+            symbol_graphs_info.symbol_graphs,
+            before_each = "--additional-symbol-graph-dir",
+            expand_directories = False,
+        )
         docc_build_inputs.extend(symbol_graphs_info.symbol_graphs)
 
     # The .docc bundle (if provided, only one is allowed)

--- a/test/starlark_tests/docc_tests.bzl
+++ b/test/starlark_tests/docc_tests.bzl
@@ -57,7 +57,6 @@ def docc_test_suite(name):
             "$BUNDLE_ROOT/index.html",
             "$BUNDLE_ROOT/documentation/basicframework/readme/index.html",
         ],
-        text_file_not_contains = [],
         text_test_file = "$BUNDLE_ROOT/metadata.json",
         text_test_values = [
             "\"bundleDisplayName\":\"BasicFramework\"",
@@ -78,7 +77,6 @@ def docc_test_suite(name):
             "$BUNDLE_ROOT/index.html",
             "$BUNDLE_ROOT/documentation/basiclib/readme/index.html",
         ],
-        text_file_not_contains = [],
         text_test_file = "$BUNDLE_ROOT/metadata.json",
         text_test_values = [
             "\"bundleDisplayName\":\"BasicLib\"",
@@ -99,11 +97,22 @@ def docc_test_suite(name):
             "$BUNDLE_ROOT/index.html",
             "$BUNDLE_ROOT/documentation/basicframework/readme/index.html",
         ],
-        text_file_not_contains = [],
         text_test_file = "$BUNDLE_ROOT/index.html",
         text_test_values = [
             "<script defer=\"defer\" src=\"/custom/base/path/js/",
             "<link href=\"/custom/base/path/css/",
+        ],
+        tags = [name],
+    )
+
+    # Verifying multiple symbol graph conversion via transitive dependencies.
+    archive_contents_test(
+        name = "{}_contains_doccarchive_with_transitive_dependencies".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:basic_framework_with_transitive_dependency.doccarchive",
+        contains = [
+            "$BUNDLE_ROOT/index.html",
+            "$BUNDLE_ROOT/documentation/transitivedependencytest/index.html",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -5039,6 +5039,14 @@ docc_archive(
     hosting_base_path = "custom/base/path",
 )
 
+docc_archive(
+    name = "basic_framework_with_transitive_dependency.doccarchive",
+    dep = ":basic_framework_with_transitive_dependency",
+    fallback_bundle_identifier = "com.google.example.framework",
+    fallback_bundle_version = "1.0",
+    fallback_display_name = "BasicFramework",
+)
+
 # ---------------------------------------------------------------------------------------
 # Target for extension resource bundling.
 


### PR DESCRIPTION
When calling `docc convert` with multiple symbol graphs the `--additional-symbol-graph-dir` flag should be added before each symbol graph directory path. This fixes this case by using `before_each` in `Args.add_all`.

Added a test case to verify the fix.