### PR TITLE
Fix build errors in test/starlark_tests/targets_under_test/macos

### DIFF
--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -1314,8 +1314,8 @@ macos_application(
     minimum_os_version = common.min_os_macos.baseline,
     tags = common.fixture_tags,
     deps = [
+        ":macOSImportedDynamicFrameworkWithDebugInfo",
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/starlark_tests/targets_under_test/apple:macOSImportedDynamicFrameworkWithDebugInfo",
     ],
 )
 
@@ -2026,8 +2026,8 @@ macos_application(
     minimum_os_version = common.min_os_macos.baseline,
     tags = common.fixture_tags,
     deps = [
+        ":macOSImportedDynamicFrameworkWithBitcode",
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/starlark_tests/targets_under_test/apple:macOSImportedDynamicFrameworkWithBitcode",
     ],
 )
 
@@ -2041,9 +2041,9 @@ macos_application(
     minimum_os_version = common.min_os_macos.baseline,
     tags = common.fixture_tags,
     deps = [
+        ":macOSImportedDynamicFrameworkWithDebugInfo",
+        ":macOSImportedDynamicFrameworkWithDsym",
         "//test/starlark_tests/resources:objc_main_lib",
-        "//test/starlark_tests/targets_under_test/apple:macOSImportedDynamicFrameworkWithDebugInfo",
-        "//test/starlark_tests/targets_under_test/apple:macOSImportedDynamicFrameworkWithDsym",
     ],
 )
 


### PR DESCRIPTION
* The `.../apple:macOSImported...` targets should be `:macOSImported...`
* Without this change, the following command fails

```
bazel build test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_fmwk_with_dsym --macos_cpu=x86_64
```