### PR TITLE
Fix apple_xcframework framework plist generated for invalid platform

### DIFF
--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -72,7 +72,8 @@ def _platform_prerequisites(
         objc_fragment,
         platform_type_string,
         uses_swift,
-        xcode_version_config):
+        xcode_version_config, 
+        environment = None):
     """Returns a struct containing information on the platform being targeted.
 
     Args:
@@ -93,7 +94,14 @@ def _platform_prerequisites(
       A struct representing the collected platform information.
     """
     platform_type_attr = getattr(apple_common.platform_type, platform_type_string)
-    platform = apple_fragment.multi_arch_platform(platform_type_attr)
+    
+    if platform_type_attr == apple_common.platform_type.ios and environment:
+        if environment == "simulator":
+            platform = apple_common.platform.ios_simulator
+        elif environment == "device":
+            platform = apple_common.platform.ios_device
+    else:
+        platform = apple_fragment.multi_arch_platform(platform_type_attr)
 
     if explicit_minimum_os:
         minimum_os = explicit_minimum_os

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -561,6 +561,7 @@ def _apple_xcframework_impl(ctx):
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+            environment = link_output.environment,
         )
 
         overridden_predeclared_outputs = struct(
@@ -1040,6 +1041,7 @@ def _apple_static_xcframework_impl(ctx):
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+            environment = link_output.environment,
         )
         resource_deps = _unioned_attrs(
             attr_names = ["deps"],


### PR DESCRIPTION
Fixing issue #2524: using apple_xcframework to generate a xcframework for ios (arm64 + arm64 simulator), Info.plist for frameworks is always generated same for simulator and device with same values in CFBundleSupportedPlatforms, DTPlatformName and DTSDKName.