### PR TITLE
Use devicectl to install and launch *_application targets on a physical device

### DIFF
--- a/apple/build_settings/build_settings.bzl
+++ b/apple/build_settings/build_settings.bzl
@@ -38,6 +38,14 @@ Enables Bazel's tree artifacts for Apple bundle rules (instead of archives).
 """,
         default = False,
     ),
+    "ios_device": struct(
+        doc = """
+The identifier, ECID, serial number, UDID, user-provided name, or DNS name
+of the device for running an iOS application.
+You can get a list of devices by running 'xcrun devicectl list devices`.
+""",
+        default = "",
+    ),
 }
 
 _BUILD_SETTING_LABELS = {

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -479,7 +479,7 @@ def _ios_application_impl(ctx):
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
             runner_template = ctx.file._device_runner_template,
-            device = ctx.fragments.objc.ios_simulator_device,
+            device = apple_xplat_toolchain_info.build_settings.ios_device,
         )
     else:
         run_support.register_simulator_executable(
@@ -797,7 +797,7 @@ def _ios_app_clip_impl(ctx):
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
             runner_template = ctx.file._device_runner_template,
-            device = ctx.fragments.objc.ios_simulator_device,
+            device = apple_xplat_toolchain_info.build_settings.ios_device,
         )
     else:
         run_support.register_simulator_executable(

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -468,20 +468,33 @@ def _ios_application_impl(ctx):
         label_name = label.name,
     )
 
-    # TODO(b/254511920): Consider creating a custom build config for iOS simulator device/version.
-    run_support.register_simulator_executable(
-        actions = actions,
-        bundle_extension = bundle_extension,
-        bundle_name = bundle_name,
-        label_name = label.name,
-        output = executable,
-        platform_prerequisites = platform_prerequisites,
-        predeclared_outputs = predeclared_outputs,
-        rule_descriptor = rule_descriptor,
-        runner_template = ctx.file._runner_template,
-        simulator_device = ctx.fragments.objc.ios_simulator_device,
-        simulator_version = ctx.fragments.objc.ios_simulator_version,
-    )
+    if platform_prerequisites.platform.is_device:
+        run_support.register_device_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._device_runner_template,
+            device = ctx.fragments.objc.ios_simulator_device,
+        )
+    else:
+        run_support.register_simulator_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._simulator_runner_template,
+            simulator_device = ctx.fragments.objc.ios_simulator_device,
+            simulator_version = ctx.fragments.objc.ios_simulator_version,
+        )
 
     archive = outputs.archive(
         actions = actions,
@@ -773,20 +786,33 @@ def _ios_app_clip_impl(ctx):
         label_name = label.name,
     )
 
-    # TODO(b/254511920): Consider creating a custom build config for iOS simulator device/version.
-    run_support.register_simulator_executable(
-        actions = actions,
-        bundle_extension = bundle_extension,
-        bundle_name = bundle_name,
-        label_name = label.name,
-        output = executable,
-        platform_prerequisites = platform_prerequisites,
-        predeclared_outputs = predeclared_outputs,
-        rule_descriptor = rule_descriptor,
-        runner_template = ctx.file._runner_template,
-        simulator_device = ctx.fragments.objc.ios_simulator_device,
-        simulator_version = ctx.fragments.objc.ios_simulator_version,
-    )
+    if platform_prerequisites.platform.is_device:
+        run_support.register_device_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._device_runner_template,
+            device = ctx.fragments.objc.ios_simulator_device,
+        )
+    else:
+        run_support.register_simulator_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._simulator_runner_template,
+            simulator_device = ctx.fragments.objc.ios_simulator_device,
+            simulator_version = ctx.fragments.objc.ios_simulator_version,
+        )
 
     archive = outputs.archive(
         actions = actions,
@@ -2544,6 +2570,7 @@ ios_application = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
             is_mandatory = True,
         ),
+        rule_attrs.device_runner_template_attr(),
         rule_attrs.infoplist_attrs(),
         rule_attrs.ipa_post_processor_attrs(),
         rule_attrs.launch_images_attrs(),
@@ -2656,6 +2683,7 @@ ios_app_clip = rule_factory.create_apple_rule(
             allowed_families = rule_attrs.defaults.allowed_families.ios,
             is_mandatory = True,
         ),
+        rule_attrs.device_runner_template_attr(),
         rule_attrs.infoplist_attrs(),
         rule_attrs.ipa_post_processor_attrs(),
         rule_attrs.locales_to_include_attrs(),

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -719,11 +719,23 @@ bundle in a directory named `Settings.bundle`.
 def _simulator_runner_template_attr():
     """Returns the attribute required to `bazel run` a *_application target with an Apple sim."""
     return {
-        "_runner_template": attr.label(
+        "_simulator_runner_template": attr.label(
             cfg = "exec",
             allow_single_file = True,
             default = Label(
                 "@build_bazel_rules_apple//apple/internal/templates:apple_simulator_template",
+            ),
+        ),
+    }
+
+def _device_runner_template_attr():
+    """Returns the attribute required to `bazel run` a *_application target with on a physical device."""
+    return {
+        "_device_runner_template": attr.label(
+            cfg = "exec",
+            allow_single_file = True,
+            default = Label(
+                "@build_bazel_rules_apple//apple/internal/templates:apple_device_template",
             ),
         ),
     }
@@ -757,6 +769,7 @@ rule_attrs = struct(
     common_tool_attrs = _common_tool_attrs,
     custom_transition_allowlist_attr = _custom_transition_allowlist_attr,
     device_family_attrs = _device_family_attrs,
+    device_runner_template_attr = _device_runner_template_attr,
     extensionkit_attrs = _extensionkit_attrs,
     infoplist_attrs = _infoplist_attrs,
     ipa_post_processor_attrs = _ipa_post_processor_attrs,

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -729,7 +729,7 @@ def _simulator_runner_template_attr():
     }
 
 def _device_runner_template_attr():
-    """Returns the attribute required to `bazel run` a *_application target with on a physical device."""
+    """Returns the attribute required to `bazel run` a *_application target on a physical device."""
     return {
         "_device_runner_template": attr.label(
             cfg = "exec",

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -158,7 +158,7 @@ def _register_macos_executable(
 
 # Define the loadable module that lists the exported symbols in this file.
 run_support = struct(
-    register_simulator_executable = _register_simulator_executable,
     register_device_executable = _register_device_executable,
     register_macos_executable = _register_macos_executable,
+    register_simulator_executable = _register_simulator_executable,
 )

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -76,6 +76,59 @@ def _register_simulator_executable(
         },
     )
 
+def _register_device_executable(
+        *,
+        actions,
+        bundle_extension,
+        bundle_name,
+        label_name,
+        output,
+        platform_prerequisites,
+        predeclared_outputs,
+        rule_descriptor,
+        runner_template,
+        device = None):
+    """Registers an action that runs the bundled app on a physical device.
+
+    Args:
+      actions: The actions provider from ctx.actions.
+      bundle_extension: Extension for the Apple bundle inside the archive.
+      bundle_name: The name of the output bundle.
+      label_name: The name of the target.
+      output: The `File` representing where the executable should be generated.
+      platform_prerequisites: Struct containing information on the platform being targeted.
+      predeclared_outputs: Outputs declared by the owning context. Typically from `ctx.outputs`
+      rule_descriptor: The rule descriptor for the given rule.
+      runner_template: The simulator runner template as a `File`.
+      device: The identifier of the device ( <uuid|ecid|serial_number|udid|name|dns_name> ).
+    """
+
+    device = str(device or "")
+    minimum_os = str(platform_prerequisites.minimum_os)
+    platform_type = str(platform_prerequisites.platform_type)
+    archive = outputs.archive(
+        actions = actions,
+        bundle_name = bundle_name,
+        bundle_extension = bundle_extension,
+        label_name = label_name,
+        platform_prerequisites = platform_prerequisites,
+        predeclared_outputs = predeclared_outputs,
+        rule_descriptor = rule_descriptor,
+    )
+
+    actions.expand_template(
+        output = output,
+        is_executable = True,
+        template = runner_template,
+        substitutions = {
+            "%app_name%": bundle_name,
+            "%ipa_file%": archive.short_path,
+            "%minimum_os%": minimum_os,
+            "%platform_type%": platform_type,
+            "%device%": device,
+        },
+    )
+
 def _register_macos_executable(
         *,
         actions,
@@ -106,5 +159,6 @@ def _register_macos_executable(
 # Define the loadable module that lists the exported symbols in this file.
 run_support = struct(
     register_simulator_executable = _register_simulator_executable,
+    register_device_executable = _register_device_executable,
     register_macos_executable = _register_macos_executable,
 )

--- a/apple/internal/templates/BUILD
+++ b/apple/internal/templates/BUILD
@@ -19,6 +19,15 @@ filegroup(
 )
 
 filegroup(
+    name = "apple_device_template",
+    srcs = ["apple_device.template.py"],
+    # Used by the rule implementations, so it needs to be public; but
+    # should be considered an implementation detail of the rules and
+    # not used by other things.
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "macos_template",
     srcs = ["macos.template.sh"],
     # Used by the rule implementations, so it needs to be public; but

--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -173,13 +173,12 @@ class Device(collections.abc.Mapping):
       return self.is_apple_vision
     else:
       raise ValueError(
-          f"Apple platform type not supported for simulator: {platform_type}."
+          f"Apple platform type not supported for running on device: {platform_type}."
       )
 
 
 def os_version_number_to_int(version: str) -> int:
   """Converts a OS version number string to an integer.
-å
   Args:
     minimum_os: A string in the form '12.2' or '13.2.3'.
 
@@ -201,7 +200,9 @@ def discover_best_compatible_device(
     devicectl_path: str,
     minimum_os: str,
 ) -> Optional[Device]:
-  """Discovers the best compatible device.
+  """Discovers the most suitable compatible device by prioritizing booted devices
+  over shutdown ones, paired devices over unpaired ones, and iPhones over iPads
+  and also maintains the original order from devicectl list devices.
 
   Args:
     platform_type: The Apple platform type for the given *_application() target.
@@ -373,7 +374,7 @@ def run_app(
     application_output_path: str,
     app_name: str,
 ) -> None:
-  """Installs and runs an app in the specified simulator.
+  """Installs and runs an app on the specified device.
 
   Args:
     device_identifier: The identifier of the device.
@@ -431,7 +432,7 @@ def main(
     application_output_path: Path to the output of an *_application().
     minimum_os: The minimum OS version required by the *_application() target.
     platform_type: The Apple platform type for the given *_application() target.
-    device: The identifier of the device ( <uuid|ecid|serial_number|udid|name|dns_name> ).
+    device: The identifier of the device (<uuid|ecid|serial_number|udid|name|dns_name>).
   """
   xcode_select_result = subprocess.run(
       ["xcode-select", "-p"],

--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Invoked by `bazel run` to launch *_application targets on a physical device."""
+
+# This script works in one of two modes.
+#
+# If no device identifier is provided:
+#
+# 1. Discovers a compatible device with the minimum_os of the
+#    *_application target. If not found, fail.
+# 2. Installs and launches the application
+# 3. Displays the application's output on the console
+#
+# If a device identifier is provided:
+#
+# 1. Installs and launches the application on a device corresponding to `device_identifier`.
+# 2. Displays the application's output on the console
+
+import collections.abc
+import contextlib
+import json
+import logging
+import os
+import os.path
+import pathlib
+import platform
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Dict, Optional
+import zipfile
+
+
+# Custom type for methods yielding an Apple simulator UDID.
+AppleSimulatorUDID = collections.abc.Generator[str, None, None]
+
+
+logging.basicConfig(
+    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+if platform.system() != "Darwin":
+  raise Exception(
+      "Cannot run Apple platform application targets on a non-mac machine."
+  )
+
+
+class Device(collections.abc.Mapping):
+  """Wraps the `device` dictionary from `devicectl list devices -j`.
+
+  Provides an ordering so
+  booted devices > shutdown devices,
+  paired devices > unpaired devices,
+  iPhones > iPads.
+  In addition, maintains the original order from `devicectl list devices`
+  as `list_index` to ensure newer device types are sorted after older device types
+  """
+
+  def __init__(self, device, list_index):
+    self.device = device
+    self.list_index = list_index
+
+  @property
+  def device_properties(self):
+    return self["deviceProperties"]
+
+  @property
+  def hardware_properties(self):
+    return self["hardwareProperties"]
+
+  @property
+  def name(self):
+    return self.device_properties["name"]
+
+  @property
+  def identifier(self):
+    return self["identifier"]
+
+  @property
+  def udid(self):
+    return self.hardware_properties["udid"]
+
+  @property
+  def device_type(self):
+    return self.hardware_properties["deviceType"]
+
+  @property
+  def os_version_number(self):
+    return self.device_properties["osVersionNumber"]
+
+  @property
+  def is_apple_tv(self) -> bool:
+    return self.device_type.lower() == "appletv"
+
+  @property
+  def is_apple_watch(self) -> bool:
+    return self.device_type.lower() == "applewatch"
+
+  @property
+  def is_apple_vision(self) -> bool:
+    return self.device_type.lower() == "applevision"
+
+  @property
+  def is_iphone(self) -> bool:
+    return self.device_type.lower() == "iphone"
+
+  @property
+  def is_ipad(self) -> bool:
+    return self.device_type.lower() == "ipad"
+
+  @property
+  def is_shutdown(self):
+    return not self.is_booted
+
+  @property
+  def is_booted(self):
+    return self.device_properties["bootState"] == "Booted"
+
+  @property
+  def is_paired(self):
+    return self.device_properties["pairingState"] == "paired"
+
+  def __getitem__(self, name):
+    return self.device[name]
+
+  def __iter__(self):
+    return iter(self.device)
+
+  def __len__(self):
+    return len(self.device)
+
+  def __repr__(self):
+    return self.name + "(" + self.udid + ")"
+
+  def __lt__(self, other):
+    if self.is_shutdown and other.is_booted:
+      return True
+    elif self.is_booted and other.is_shutdown:
+      return False
+    elif not self.is_paired and other.is_paired:
+      return True
+    elif self.is_paired and not other.is_paired:
+      return False
+    elif self.is_ipad and other.is_iphone:
+      return True
+    elif self.is_iphone and other.is_ipad:
+      return False
+    return self.list_index < other.list_index
+
+  def supports_platform_type(self, platform_type: str) -> bool:
+    """Returns boolean to indicate if device supports given Apple platform type."""
+    if platform_type == "ios":
+      return self.is_iphone or self.is_ipad
+    elif platform_type == "tvos":
+      return self.is_apple_tv
+    elif platform_type == "watchos":
+      return self.is_apple_watch
+    elif platform_type == "visionos":
+      return self.is_apple_vision
+    else:
+      raise ValueError(
+          f"Apple platform type not supported for simulator: {platform_type}."
+      )
+
+
+def os_version_number_to_int(version: str) -> int:
+  """Converts a OS version number string to an integer.
+å
+  Args:
+    minimum_os: A string in the form '12.2' or '13.2.3'.
+
+  Returns:
+    An integer in the form 0xAABBCC, where AA is the major version, BB is
+    the minor version, and CC is the micro version.
+  """
+  # Pad the version to major.minor.micro.
+  version_components = (version.split(".") + ["0"] * 3)[:3]
+  result = 0
+  for component in version_components:
+    result = (result << 8) | int(component)
+  return result
+
+
+def discover_best_compatible_device(
+    *,
+    platform_type: str,
+    devicectl_path: str,
+    minimum_os: str,
+) -> Optional[Device]:
+  """Discovers the best compatible device.
+
+  Args:
+    platform_type: The Apple platform type for the given *_application() target.
+    devicectl_path: The path to the `devicectl` binary.
+    minimum_os: The minimum OS version required by the *_application() target.
+
+  Returns:
+    A tuple (device_type, device) containing the DeviceType and Device
+    of the best compatible simulator (might be None if no match was found).
+
+  Raises:
+    subprocess.SubprocessError: if `devicectl list devices` fails or times out.
+  """
+  json_fp = tempfile.NamedTemporaryFile(delete=False)
+  subprocess.run(
+      [devicectl_path, "list", "devices", "--json-output", json_fp.name],
+      capture_output=True,
+      check=True,
+  )
+  with open(json_fp.name, 'r') as json_file:
+    devicectl_data = json.load(json_file)
+  json_fp.close()
+  os.unlink(json_fp.name)
+  compatible_devices = []
+  minimum_version_int = os_version_number_to_int(minimum_os)
+  # Remember the index of each device type to preserve that ordering when
+  # sorting device types.
+  for list_index, device_data in enumerate(devicectl_data["result"]["devices"]):
+    device = Device(device_data, list_index)
+    if not device.supports_platform_type(platform_type):
+      continue
+    version_int = os_version_number_to_int(device.os_version_number)
+    if version_int < minimum_version_int:
+      continue
+    compatible_devices.append(device)
+  compatible_devices.sort()
+  logger.debug(
+      "Found %d compatible devices.", len(compatible_devices)
+  )
+  return  compatible_devices[-1] if compatible_devices else None
+
+
+def register_dsyms(dsyms_dir: str):
+  """Adds all dSYMs in `dsyms_dir` to the symbolscache.
+
+  Args:
+    dsyms_dir: Path to directory potentially containing dSYMs
+  """
+  symbolscache_command = [
+      "/usr/bin/symbolscache",
+      "delete",
+      "--tag",
+      "Bazel",
+      "compact",
+      "add",
+      "--tag",
+      "Bazel",
+  ] + [
+      a
+      for a in pathlib.Path(dsyms_dir).glob(
+          "**/*.dSYM/Contents/Resources/DWARF/*"
+      )
+  ]
+  logger.debug("Running command: %s", symbolscache_command)
+  result = subprocess.run(
+      symbolscache_command,
+      capture_output=True,
+      check=True,
+      encoding="utf-8",
+      text=True,
+  )
+  logger.debug("symbolscache output: %s", result.stdout)
+
+
+@contextlib.contextmanager
+def extracted_app(
+    application_output_path: str, app_name: str
+) -> AppleSimulatorUDID:
+  """Extracts Foo.app from *_application() output and makes it writable.
+
+  Args:
+    application_output_path: Path to the output of an `*_application()`. If the
+      path is a directory, copies it to a temporary directory and makes the
+      contents writable, as `simctl install` fails to install an `.app` that is
+      read-only. If the path is an .ipa archive, unzips it to a temporary
+      directory.
+    app_name: The name of the application (e.g. "Foo" for "Foo.app").
+
+  Yields:
+    Path to Foo.app in temporary directory (re-used if already present).
+  """
+  if os.path.isdir(application_output_path):
+    # Re-use the same path for each run and rsync to it (reducing
+    # copies). Ensure the result is writable, or `simctl install` will
+    # fail with `Unhandled error domain NSPOSIXErrorDomain, code 13`.
+    dst_dir = os.path.join(tempfile.gettempdir(), "bazel_temp_" + app_name)
+    os.makedirs(dst_dir, exist_ok=True)
+    rsync_command = [
+        "/usr/bin/rsync",
+        "--archive",
+        "--delete",
+        "--checksum",
+        "--chmod=u+w",
+        "--verbose",
+        # The output path might itself be a symlink; resolve to the
+        # real path so rsync doesn't just copy the symlink.
+        os.path.realpath(application_output_path),
+        dst_dir,
+    ]
+    logger.debug(
+        "Found app directory: %s, running command: %s",
+        application_output_path,
+        rsync_command,
+    )
+    result = subprocess.run(
+        rsync_command,
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+        text=True,
+    )
+    logger.debug("rsync output: %s", result.stdout)
+    yield os.path.join(dst_dir, app_name + ".app")
+  else:
+    # Create a new temporary directory for each run, deleting it
+    # afterwards (there's no efficient way to "sync" an unzip, so this
+    # can't re-use the output directory).
+    with tempfile.TemporaryDirectory(prefix="bazel_temp") as temp_dir:
+      logger.debug(
+          "Unzipping IPA from %s to %s", application_output_path, temp_dir
+      )
+      with zipfile.ZipFile(application_output_path) as ipa_zipfile:
+        ipa_zipfile.extractall(temp_dir)
+        yield os.path.join(temp_dir, "Payload", app_name + ".app")
+
+
+def bundle_id(bundle_path: str) -> str:
+  """Returns the bundle ID given a bundle directory path."""
+  info_plist_path = os.path.join(bundle_path, "Info.plist")
+  with open(info_plist_path, mode="rb") as plist_file:
+    plist = plistlib.load(plist_file)
+    return plist["CFBundleIdentifier"]
+
+
+def devicectl_launch_environ() -> Dict[str, str]:
+  """Calculates an environment dictionary for running `devicectl device process launch`."""
+  # Pass environment variables prefixed with "IOS_" to the device, replace
+  # the prefix with "DEVICECTL_CHILD_". bazel adds "IOS_" to the env vars which
+  # will be passed to the app as prefix to differentiate from other env vars. We
+  # replace the prefix "IOS_" with "DEVICECTL_CHILD_" here, because "devicectl" only
+  # pass the env vars prefixed with "DEVICECTL_CHILD_" to the app.
+  result = {}
+  for k, v in os.environ.items():
+    if not k.startswith("IOS_"):
+      continue
+    new_key = k.replace("IOS_", "DEVICECTL_CHILD_", 1)
+    result[new_key] = v
+  if "IDE_DISABLED_OS_ACTIVITY_DT_MODE" not in os.environ:
+    # Ensure os_log() mirrors writes to stderr. (lldb and Xcode set this
+    # environment variable as well.)
+    result["DEVICECTL_CHILD_OS_ACTIVITY_DT_MODE"] = "enable"
+  return result
+
+
+def run_app(
+    *,
+    device_identifier: str,
+    devicectl_path: str,
+    application_output_path: str,
+    app_name: str,
+) -> None:
+  """Installs and runs an app in the specified simulator.
+
+  Args:
+    device_identifier: The identifier of the device.
+    devicectl_path: The path to the `devicectl` binary.
+    application_output_path: Path to the output of an `*_application()`.
+    app_name: The name of the application (e.g. "Foo" for "Foo.app").
+  """
+  root_dir = os.path.dirname(application_output_path)
+  register_dsyms(root_dir)
+  with extracted_app(application_output_path, app_name) as app_path:
+    logger.debug("Installing app %s to device %s", app_path, device_identifier)
+    subprocess.run(
+        [
+          devicectl_path,
+          "device",
+          "install",
+          "app",
+          "--device",
+          device_identifier,
+          app_path
+        ],
+        check=True
+    )
+    app_bundle_id = bundle_id(app_path)
+    logger.info(
+        "Launching app %s on %s", app_bundle_id, device_identifier
+    )
+    args = [
+        devicectl_path,
+        "device",
+        "process",
+        "launch",
+        "--console",  # Attaches the application to the console and waits for it to exit.
+        "--device",
+        device_identifier,
+        app_bundle_id,
+    ]
+    # Append optional launch arguments.
+    args.extend(sys.argv[1:])
+    subprocess.run(args, env=devicectl_launch_environ(), check=False)
+
+
+def main(
+    *,
+    app_name: str,
+    application_output_path: str,
+    minimum_os: str,
+    platform_type: str,
+    device_identifier: str,
+):
+  """Main entry point to `bazel run` for *_application() targets.
+
+  Args:
+    app_name: The name of the application (e.g. "Foo" for "Foo.app").
+    application_output_path: Path to the output of an *_application().
+    minimum_os: The minimum OS version required by the *_application() target.
+    platform_type: The Apple platform type for the given *_application() target.
+    device: The identifier of the device ( <uuid|ecid|serial_number|udid|name|dns_name> ).
+  """
+  xcode_select_result = subprocess.run(
+      ["xcode-select", "-p"],
+      encoding="utf-8",
+      check=True,
+      stdout=subprocess.PIPE,
+  )
+  developer_path = xcode_select_result.stdout.rstrip()
+  devicectl_path = os.path.join(developer_path, "usr", "bin", "devicectl")
+
+  if not device_identifier:
+    device = discover_best_compatible_device(
+      platform_type=platform_type,
+      devicectl_path=devicectl_path,
+      minimum_os=minimum_os,
+    )
+    if not device:
+      raise Exception(
+          f"No compatible device found for platform type {platform_type}"
+          f"with minimum OS {minimum_os}."
+      )
+    device_identifier = device.identifier
+
+  run_app(
+      device_identifier=device_identifier,
+      devicectl_path=devicectl_path,
+      application_output_path=application_output_path,
+      app_name=app_name,
+  )
+
+
+if __name__ == "__main__":
+  try:
+    # Template values filled in by rules_apple/apple/internal/run_support.bzl.
+    main(
+        app_name="%app_name%",
+        application_output_path="%ipa_file%",
+        minimum_os="%minimum_os%",
+        platform_type="%platform_type%",
+        device_identifier="%device%",
+    )
+  except subprocess.CalledProcessError as e:
+    logger.error("%s exited with error code %d", e.cmd, e.returncode)
+  except KeyboardInterrupt:
+    pass

--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -39,17 +39,11 @@ import os.path
 import pathlib
 import platform
 import plistlib
-import shutil
 import subprocess
 import sys
 import tempfile
-import time
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 import zipfile
-
-
-# Custom type for methods yielding an Apple simulator UDID.
-AppleSimulatorUDID = collections.abc.Generator[str, None, None]
 
 
 logging.basicConfig(
@@ -81,31 +75,31 @@ class Device(collections.abc.Mapping):
     self.list_index = list_index
 
   @property
-  def device_properties(self):
+  def device_properties(self) -> Dict[str, Any]:
     return self["deviceProperties"]
 
   @property
-  def hardware_properties(self):
+  def hardware_properties(self) -> Dict[str, Any]:
     return self["hardwareProperties"]
 
   @property
-  def name(self):
+  def name(self) -> str:
     return self.device_properties["name"]
 
   @property
-  def identifier(self):
+  def identifier(self) -> str:
     return self["identifier"]
 
   @property
-  def udid(self):
+  def udid(self) -> str:
     return self.hardware_properties["udid"]
 
   @property
-  def device_type(self):
+  def device_type(self) -> str:
     return self.hardware_properties["deviceType"]
 
   @property
-  def os_version_number(self):
+  def os_version_number(self) -> str:
     return self.device_properties["osVersionNumber"]
 
   @property
@@ -285,7 +279,7 @@ def register_dsyms(dsyms_dir: str):
 @contextlib.contextmanager
 def extracted_app(
     application_output_path: str, app_name: str
-) -> AppleSimulatorUDID:
+) -> collections.abc.Generator[str, None, None]:
   """Extracts Foo.app from *_application() output and makes it writable.
 
   Args:
@@ -467,9 +461,8 @@ def main(
       )
     else:
       logger.info(
-        "Found device %s with UUID %s and identifier %s",
+        "Found device %s with identifier %s",
         device.name,
-        device.udid,
         device.identifier,
       )
     device_identifier = device.identifier

--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -390,7 +390,7 @@ def run_app(
   root_dir = os.path.dirname(application_output_path)
   register_dsyms(root_dir)
   with extracted_app(application_output_path, app_name) as app_path:
-    logger.debug("Installing app %s to device %s", app_path, device_identifier)
+    logger.info("Installing app %s to device %s", app_path, device_identifier)
     subprocess.run(
         [
           devicectl_path,
@@ -449,6 +449,11 @@ def main(
   devicectl_path = os.path.join(developer_path, "usr", "bin", "devicectl")
 
   if not device_identifier:
+    logger.info(
+        f"Searching for a compatible device for platform type %s with minimum OS %s",
+        platform_type,
+        minimum_os,
+    )
     device = discover_best_compatible_device(
       platform_type=platform_type,
       devicectl_path=devicectl_path,
@@ -456,10 +461,20 @@ def main(
     )
     if not device:
       raise Exception(
-          f"No compatible device found for platform type {platform_type}"
-          f"with minimum OS {minimum_os}."
+          f"No compatible device found for platform type % with minimum OS %s",
+          platform_type,
+          minimum_os,
+      )
+    else:
+      logger.info(
+        "Found device %s with UUID %s and identifier %s",
+        device.name,
+        device.udid,
+        device.identifier,
       )
     device_identifier = device.identifier
+  else:
+    logger.info("Using device %s", device_identifier)
 
   run_app(
       device_identifier=device_identifier,

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -411,18 +411,30 @@ def _tvos_application_impl(ctx):
         label_name = label.name,
     )
 
-    # TODO(b/254511920): Consider creating a custom build config for tvOS simulator device/version.
-    run_support.register_simulator_executable(
-        actions = actions,
-        bundle_extension = bundle_extension,
-        bundle_name = bundle_name,
-        label_name = label.name,
-        output = executable,
-        platform_prerequisites = platform_prerequisites,
-        predeclared_outputs = predeclared_outputs,
-        rule_descriptor = rule_descriptor,
-        runner_template = ctx.file._runner_template,
-    )
+    if platform_prerequisites.platform.is_device:
+        run_support.register_device_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._device_runner_template,
+        )
+    else:
+        run_support.register_simulator_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._simulator_runner_template,
+        )
 
     archive = outputs.archive(
         actions = actions,
@@ -1477,6 +1489,7 @@ tvos_application = rule_factory.create_apple_rule(
         rule_attrs.device_family_attrs(
             allowed_families = rule_attrs.defaults.allowed_families.tvos,
         ),
+        rule_attrs.device_runner_template_attr(),
         rule_attrs.infoplist_attrs(),
         rule_attrs.ipa_post_processor_attrs(),
         rule_attrs.locales_to_include_attrs(),

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -408,17 +408,31 @@ Resolved Xcode is version {xcode_version}.
         actions = actions,
         label_name = label.name,
     )
-    run_support.register_simulator_executable(
-        actions = actions,
-        bundle_extension = bundle_extension,
-        bundle_name = bundle_name,
-        label_name = label.name,
-        output = executable,
-        platform_prerequisites = platform_prerequisites,
-        predeclared_outputs = predeclared_outputs,
-        rule_descriptor = rule_descriptor,
-        runner_template = ctx.file._runner_template,
-    )
+
+    if platform_prerequisites.platform.is_device:
+        run_support.register_device_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._device_runner_template,
+        )
+    else:
+        run_support.register_simulator_executable(
+            actions = actions,
+            bundle_extension = bundle_extension,
+            bundle_name = bundle_name,
+            label_name = label.name,
+            output = executable,
+            platform_prerequisites = platform_prerequisites,
+            predeclared_outputs = predeclared_outputs,
+            rule_descriptor = rule_descriptor,
+            runner_template = ctx.file._simulator_runner_template,
+        )
 
     archive = outputs.archive(
         actions = actions,
@@ -1472,6 +1486,7 @@ visionos_application = rule_factory.create_apple_rule(
         rule_attrs.device_family_attrs(
             allowed_families = rule_attrs.defaults.allowed_families.visionos,
         ),
+        rule_attrs.device_runner_template_attr(),
         rule_attrs.infoplist_attrs(),
         rule_attrs.ipa_post_processor_attrs(),
         rule_attrs.locales_to_include_attrs(),

--- a/doc/tutorials/ios-app.md
+++ b/doc/tutorials/ios-app.md
@@ -398,7 +398,8 @@ bazel run //:iOSApp --ios_multi_cpus=arm64
 ```
 
 The runner will find any available physical device with an OS version higher than `minimum_os_version`.
-If you want to specify a particular device, you can specify it like this `--@build_bazel_rules_apple//apple/build_settings:ios_device=<uuid|ecid|serial_number|udid|name|dns_name>`.
+To specify a particular device, use this flag: `--@build_bazel_rules_apple//apple/build_settings:ios_device=<uuid|ecid|serial_number|udid|name|dns_name>`.
+Alternatively, add this flag alias to your `.bazelrc` file: `common --flag_alias=ios_device=@rules_apple//apple/build_settings:ios_device`. Then you can use it like this: `bazel run //:iOSApp --ios_device=<uuid|ecid|serial_number|udid|name|dns_namee>`.
 To see a list of available devices, use `xcrun devicectl list devices`.
 
 Another way to install the app on the device is to launch Xcode and use the

--- a/doc/tutorials/ios-app.md
+++ b/doc/tutorials/ios-app.md
@@ -391,8 +391,18 @@ rules.
 
 ### Install the app on a device
 
-The easiest way to install the app on the device is to launch Xcode and use the
-`Windows > Devices` command. Select your plugged-in device from the list on the
+You can install the app on a physical device using the bazel run command, just as you would for a simulator:
+
+```bash
+bazel run //:iOSApp --ios_multi_cpus=arm64
+```
+
+The runner will find any available physical device with an OS version higher than `minimum_os_version`.
+If you want to specify a particular device, you can specify it like this `--@build_bazel_rules_apple//apple/build_settings:ios_device=<uuid|ecid|serial_number|udid|name|dns_name>`.
+To see a list of available devices, use `xcrun devicectl list devices`.
+
+Another way to install the app on the device is to launch Xcode and use the
+`Window > Devices and Simulators` command. Select your plugged-in device from the list on the
 left, then add the app by clicking the **Add** (plus sign) button under
 "Installed Apps" and selecting the `.ipa` file that you built.
 

--- a/doc/tutorials/ios-app.md
+++ b/doc/tutorials/ios-app.md
@@ -391,7 +391,7 @@ rules.
 
 ### Install the app on a device
 
-You can install the app on a physical device using the bazel run command, just as you would for a simulator:
+You can install the app on a physical device using a bazel run command when targeting a specific device architecture:
 
 ```bash
 bazel run //:iOSApp --ios_multi_cpus=arm64


### PR DESCRIPTION
In Xcode 15, Apple introduced a new command-line tool that allows management of physical devices. This makes it possible to install and launch *_application targets on a physical device without third-party solutions.

With these changes, you can now use `bazel run //:iOSApp --ios_multi_cpus=arm64`.

Previously, this command would attempt to launch the application on a simulator and fail due to an invalid architecture.

Bazel currently lacks a specific flag for specifying device identifiers suitable for this purpose. I created a [PR to Bazel](https://github.com/bazelbuild/bazel/pull/23599) introducing an `--ios_device` flag. However, it's unlikely to be accepted since it's a platform-specific flag.  If it is accepted, we can utilize it in the future.

For the current implementation, I added astring_flagthat allows passing a device identifier. It can be used like this:--@build_bazel_rules_apple//apple/build_settings:ios_device=<uuid|ecid|serial_number|udid|name|dns_name&gt; .

Note: `//doc:check_apple` failing on master