### PR TITLE
Only insert libXCTestBundleInject.dylib for unit tests

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -284,12 +284,25 @@ if [[ -e "$main_thread_checker" ]]; then
     main_thread_checker_dyld_env="$main_thread_checker"
 fi
 
-xctestrun_libraries="__PLATFORMS__/$test_execution_platform/Developer/usr/lib/libXCTestBundleInject.dylib"
-if [[ -n "$sanitizer_dyld_env" ]]; then
-  xctestrun_libraries="${xctestrun_libraries}:${sanitizer_dyld_env}"
+xctestrun_libraries=""
+if [[ "$test_type" != "XCUITEST" ]]; then
+  xctestrun_libraries="__PLATFORMS__/$test_execution_platform/Developer/usr/lib/libXCTestBundleInject.dylib"
 fi
+
+if [[ -n "$sanitizer_dyld_env" ]]; then
+  if [[ -n "$xctestrun_libraries" ]]; then
+    xctestrun_libraries="${xctestrun_libraries}:${sanitizer_dyld_env}"
+  else
+    xctestrun_libraries="${sanitizer_dyld_env}"
+  fi
+fi
+
 if [[ -n "$main_thread_checker_dyld_env" ]]; then
-  xctestrun_libraries="${xctestrun_libraries}:${main_thread_checker_dyld_env}"
+  if [[ -n "$xctestrun_libraries" ]]; then
+    xctestrun_libraries="${xctestrun_libraries}:${main_thread_checker_dyld_env}"
+  else
+    xctestrun_libraries="${main_thread_checker_dyld_env}"
+  fi
 fi
 
 TEST_FILTER="%(test_filter)s"


### PR DESCRIPTION
Fixes #2528.

Stop adding libXCTestBundleInject.dylib for UI tests. Xcode only injects this dylib when running unit tests with host app.

This diff was tested with Xcode 15.2 and Xcode 16 RC1.

```
bazel test //test:ios_xctestrun_runner_ui_test
bazel test //test:ios_xctestrun_runner_unit_test
```