### PR TITLE
Support Linux with `dossier_codesigning_reader.py`

### DIFF
--- a/tools/dossier_codesigningtool/dossier_codesigning_reader_test.py
+++ b/tools/dossier_codesigningtool/dossier_codesigning_reader_test.py
@@ -92,6 +92,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
         dossier_directory_path='/tmp/dossier/',
         codesign_path='/usr/bin/fake_codesign',
         signing_keychain=_ADDITIONAL_SIGNING_KEYCHAIN,
+        certificates_directory_path='/tmp/certs/',
         override_codesign_identity='-',
         allowed_entitlements=None)
 
@@ -157,6 +158,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
         dossier_directory_path='/tmp/dossier/',
         codesign_path='/usr/bin/fake_codesign',
         signing_keychain=_ADDITIONAL_SIGNING_KEYCHAIN,
+        certificates_directory_path='/tmp/certs/',
         override_codesign_identity='-',
         allowed_entitlements=None)
     self.assertEqual(mock_codesign.call_count, 1)
@@ -183,6 +185,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
         dossier_directory_path='/tmp/dossier/',
         codesign_path='/usr/bin/fake_codesign',
         signing_keychain=_ADDITIONAL_SIGNING_KEYCHAIN,
+        certificates_directory_path='/tmp/certs/',
         override_codesign_identity='-',
         allowed_entitlements=['test-an-entitlement'])
 
@@ -258,6 +261,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
           manifest=fake_manifest,
           dossier_directory_path='/tmp/dossier/',
           signing_keychain=_ADDITIONAL_SIGNING_KEYCHAIN,
+          certificates_directory_path='/tmp/certs/',
           codesign_path='/usr/bin/fake_codesign',
           allowed_entitlements=None)
 
@@ -272,6 +276,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
         codesign_path='/usr/bin/fake_codesign',
         allowed_entitlements=None,
         signing_keychain=_ADDITIONAL_SIGNING_KEYCHAIN,
+        certificates_directory_path='/tmp/certs/',
         codesign_identity='-',
         executor=executor)
     dossier_codesigning_reader._wait_signing_futures(futures)
@@ -282,6 +287,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
         '/usr/bin/fake_codesign',
         None,
         _ADDITIONAL_SIGNING_KEYCHAIN,
+        '/tmp/certs/',
         '-',
         executor,
     )
@@ -446,6 +452,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
           tmp_fake_codesign.name,
           None,
           _ADDITIONAL_SIGNING_KEYCHAIN,
+          None,
       )
 
   @mock.patch.object(dossier_codesigning_reader, '_package_ipa')
@@ -495,6 +502,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
           tmp_fake_codesign.name,
           None,
           _ADDITIONAL_SIGNING_KEYCHAIN,
+          None,
       )
       mock_package.assert_called_once()
 
@@ -543,6 +551,7 @@ class DossierCodesigningReaderTest(unittest.TestCase):
           tmp_fake_codesign.name,
           None,
           _ADDITIONAL_SIGNING_KEYCHAIN,
+          None,
       )
       mock_package.assert_called_once()
 


### PR DESCRIPTION
On Linux there is no keychain or the `security` command. To codesign on Linux you’ll have to use something like https://gregoryszorc.com/docs/apple-codesign/0.17.0/apple_codesign_rcodesign.html, with a wrapper that translates `codesign` arguments to `rcodesign` arguments.

Using that method requires using `.cer` files instead of identity strings (which are part of the subject of a certificate). The change made here assumes you are using that method, which has worked for us in our internal project.