### PR TITLE
Remove analysis error in `local_provisioning_profiles.bzl`

### DIFF
--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -141,8 +141,6 @@ def _local_provisioning_profile(ctx):
         args.add_all("--local_profiles", ctx.files._local_srcs)
     if ctx.files._fallback_srcs:
         args.add_all("--fallback_profiles", ctx.files._fallback_srcs)
-    if not ctx.files._local_srcs and not ctx.files._fallback_srcs:
-        fail("Either local or fallback provisioning profiles must exist")
 
     ctx.actions.run(
         executable = ctx.executable._finder,


### PR DESCRIPTION
This can result in build failures that normally wouldn’t fail. At execution we get an error if profiles aren’t found, which is good enough.