### PR TITLE
Fix wrong os in xcframework frameworks infoplist

### DIFF
--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -61,6 +61,7 @@ def _environment_plist_impl(ctx):
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = False,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+        environment = getattr(ctx.fragments.apple.single_arch_platform, "get_target_environment", None),
     )
     environment_plist_tool = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo].environment_plist_tool
     platform = platform_prerequisites.platform

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -78,6 +78,9 @@ def _apple_core_data_model_impl(ctx):
         uses_swift = True,
         xcode_version_config =
             ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+        environment = getattr(
+            ctx.fragments.apple.single_arch_platform, "get_target_environment", None
+        ),
     )
 
     datamodel_groups = group_files_by_directory(

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -100,6 +100,7 @@ def _apple_core_ml_library_impl(ctx):
         platform_type_string = str(ctx.fragments.apple.single_arch_platform.platform_type),
         uses_swift = uses_swift,
         xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+        environment = getattr(ctx.fragments.apple.single_arch_platform, "get_target_environment", None),
     )
 
     apple_mac_toolchain_info = ctx.attr._mac_toolchain[AppleMacToolsToolchainInfo]

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -561,6 +561,7 @@ def _apple_xcframework_impl(ctx):
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+            environment = link_output.environment,
         )
 
         overridden_predeclared_outputs = struct(
@@ -1040,6 +1041,7 @@ def _apple_static_xcframework_impl(ctx):
             platform_type_string = link_output.platform,
             uses_swift = link_output.uses_swift,
             xcode_version_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+            environment = link_output.environment,
         )
         resource_deps = _unioned_attrs(
             attr_names = ["deps"],

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -361,6 +361,30 @@ def apple_xcframework_test_suite(name):
         tags = [name],
     )
 
+    # Tests checks respect to platfrom name with ios build for iphonesimulator. 
+    archive_contents_test(
+        name = "{}_multiple_infoplist_test_platform_name_iphonesimulator".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_multiple_infoplists",
+        plist_test_file = "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework_multiple_infoplists.framework/Info.plist",
+        plist_test_values = {
+            "DTPlatformName": "iphonesimulator",
+        },
+        tags = [name],
+    )
+
+    # Tests checks respect to platfrom name with ios build for iphoneos. 
+    archive_contents_test(
+        name = "{}_multiple_infoplist_test_platform_name_iphoneos".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_dynamic_xcframework_multiple_infoplists",
+        plist_test_file = "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework_multiple_infoplists.framework/Info.plist",
+        plist_test_values = {
+            "DTPlatformName": "iphoneos",
+        },
+        tags = [name],
+    )
+
     # Tests that resource bundles and files assigned through "data" are respected.
     archive_contents_test(
         name = "{}_dbg_resources_data_test".format(name),


### PR DESCRIPTION

This PR aims to fix an issue where the Info.plist contains an incorrect value in the xcframework multiplatform bundle.

```
apple_xcframework(
    ...
    ios = {
        "simulator": ["x86_64"],
        "device": ["arm64"],
    },
    ..
)
```
In this configuration, the Info.plist for x86_64 will contain the 'iphoneos' value for DTPlatformName, but it is supposed to be iphonesimulator.

Related to #2524   