### PR TITLE
Update docs and bzl_library usage for Bazel 8

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -43,5 +43,8 @@ tasks:
     platform: ubuntu2004
     test_targets:
     - "doc/..."
+    test_flags:
+    # TODO: Remove this once stardoc is updated to 0.7.1+ (https://github.com/bazelbuild/stardoc/pull/238)
+    - --noincompatible_disallow_empty_glob
 
 buildifier: 6.4.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ module(
 bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.0.2")
 bazel_dep(
     name = "rules_swift",
     version = "2.1.1",
@@ -20,6 +21,12 @@ bazel_dep(
     version = "0.6.2",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "21.7",
+    dev_dependency = True,
+    repo_name = "com_google_protobuf",
 )
 
 non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
@@ -33,3 +40,20 @@ use_repo(provisioning_profile_repository, "local_provisioning_profiles")
 
 apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
+
+# TODO: Remove override when a protobuf release is available that supports
+# Bazel 8
+archive_override(
+    module_name = "protobuf",
+    integrity = "sha256-+dloYVexGlGsxKLTARuU4KXZ5ORo/BWPR6obFk73d+Q=",
+    strip_prefix = "protobuf-b93b8e5f64ed922d101759380d7c6a2bbe474e26",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/b93b8e5f64ed922d101759380d7c6a2bbe474e26.zip"],
+)
+
+# TODO: Remove override when a protobuf release that marks `stardoc` as a
+# dev_dependency is available, until then it's upgrading our stardoc version
+# so override it here.
+single_version_override(
+    module_name = "stardoc",
+    version = "0.6.2",
+)

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -43,6 +43,7 @@ bzl_library(
         "//apple/internal:experimental_mixed_language_library",
         "//apple/internal:local_provisioning_profiles",
         "//apple/internal:xcframework_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -121,6 +122,7 @@ bzl_library(
         "//apple/internal/testing:apple_test_assembler",
         "//apple/internal/testing:build_test_rules",
         "//apple/internal/testing:ios_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -144,6 +146,7 @@ bzl_library(
         "//apple/internal/testing:apple_test_assembler",
         "//apple/internal/testing:build_test_rules",
         "//apple/internal/testing:macos_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -178,6 +181,7 @@ bzl_library(
         "//apple/internal/resource_rules:apple_precompiled_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -189,6 +193,7 @@ bzl_library(
         "//apple/internal/testing:apple_test_assembler",
         "//apple/internal/testing:build_test_rules",
         "//apple/internal/testing:tvos_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -221,6 +226,7 @@ bzl_library(
         "//apple/internal/testing:apple_test_assembler",
         "//apple/internal/testing:build_test_rules",
         "//apple/internal/testing:visionos_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 
@@ -238,6 +244,7 @@ bzl_library(
         "//apple/internal/testing:apple_test_assembler",
         "//apple/internal/testing:build_test_rules",
         "//apple/internal/testing:watchos_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
 


### PR DESCRIPTION
This should fix the `last_green` Bazel doc tests