### PR TITLE
Dont override destination-timeout in xctestrun runner

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -468,7 +468,6 @@ if [[ "$should_use_xcodebuild" == true ]]; then
   fi
 
   args=(
-    -destination-timeout 15 \
     -xctestrun "$xctestrun_file" \
   )
 


### PR DESCRIPTION
The default value for this is `30`. We probably shouldn't override this by default. I will follow up this PR by allowing the `-destination-timeout` to be set via the `ios_xctestrun_runner` rule **and** via the `--test_env`

```
man xcodebuild

-destination-timeout timeout
  Use the specified timeout when searching for a destination device. The default is 30 seconds.

```