### PR TITLE
Fix `bundle_id` calculation in `apple_precompiled_resource_bundle`

### DIFF
--- a/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
@@ -92,7 +92,7 @@ def _apple_precompiled_resource_bundle_impl(ctx):
     )
 
     bundle_name = "{}.bundle".format(ctx.attr.bundle_name or label.name)
-    bundle_id = ctx.attr.bundle_id or "com.bazel.apple_precompiled_resource_bundle_".format(ctx.attr.bundle_name or label.name)
+    bundle_id = ctx.attr.bundle_id or "com.bazel.apple_precompiled_resource_bundle_{}".format(ctx.attr.bundle_name or label.name)
 
     apple_resource_infos = []
     process_args = {


### PR DESCRIPTION
The default value would always be the same, which lead to bundle loading issues.