### PR TITLE
Add `destination_timeout` attribute to `ios_xctestrun_runner`

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -20,6 +20,7 @@ def _get_template_substitutions(
         command_line_args,
         xctestrun_template,
         attachment_lifetime,
+        destination_timeout,
         reuse_simulator,
         xctrunner_entitlements_template):
     substitutions = {
@@ -34,6 +35,7 @@ def _get_template_substitutions(
         "xctestrun_template": xctestrun_template,
         "attachment_lifetime": attachment_lifetime,
         "reuse_simulator": reuse_simulator,
+        "destination_timeout": destination_timeout,
         "xctrunner_entitlements_template": xctrunner_entitlements_template,
     }
 
@@ -71,6 +73,7 @@ def _ios_xctestrun_runner_impl(ctx):
             command_line_args = " ".join(ctx.attr.command_line_args) if ctx.attr.command_line_args else "",
             xctestrun_template = ctx.file._xctestrun_template.short_path,
             attachment_lifetime = ctx.attr.attachment_lifetime,
+            destination_timeout = "" if ctx.attr.destination_timeout == 0 else str(ctx.attr.destination_timeout),
             reuse_simulator = "true" if ctx.attr.reuse_simulator else "false",
             xctrunner_entitlements_template = ctx.file._xctrunner_entitlements_template.short_path,
         ),
@@ -149,6 +152,9 @@ Attachment lifetime to set in the xctestrun file when running the test bundle - 
 or `"deleteOnSuccess"`. This affects presence of attachments in the XCResult output. This does not force using
 `xcodebuild` or an XCTestRun file but the value will be used in that case.
 """,
+        ),
+        "destination_timeout": attr.int(
+            doc = "Use the specified timeout when searching for a destination device. The default is 30 seconds.",
         ),
         "reuse_simulator": attr.bool(
             default = True,

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -23,6 +23,7 @@ simulator_name=""
 device_id=""
 command_line_args=(%(command_line_args)s)
 attachment_lifetime="%(attachment_lifetime)s"
+destination_timeout="%(destination_timeout)s"
 while [[ $# -gt 0 ]]; do
   arg="$1"
   case $arg in
@@ -473,6 +474,10 @@ if [[ "$should_use_xcodebuild" == true ]]; then
   args=(
     -xctestrun "$xctestrun_file" \
   )
+
+  if [[ -n "$destination_timeout" ]]; then
+    args+=(-destination-timeout "$destination_timeout")
+  fi
 
   if [[ "$build_for_device" == true ]]; then
     args+=(-destination "platform=iOS,id=$device_id")

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -661,7 +661,8 @@ of the attributes inherited by all test rules, please check the
 
 <pre>
 ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-attachment_lifetime">attachment_lifetime</a>, <a href="#ios_xctestrun_runner-command_line_args">command_line_args</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>,
-                     <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>, <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
+                     <a href="#ios_xctestrun_runner-destination_timeout">destination_timeout</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>,
+                     <a href="#ios_xctestrun_runner-xcodebuild_args">xcodebuild_args</a>)
 </pre>
 
 This rule creates a test runner for iOS tests that uses xctestrun files to run
@@ -710,6 +711,7 @@ in Xcode.
 | <a id="ios_xctestrun_runner-attachment_lifetime"></a>attachment_lifetime |  Attachment lifetime to set in the xctestrun file when running the test bundle - `"keepNever"` (default), `"keepAlways"` or `"deleteOnSuccess"`. This affects presence of attachments in the XCResult output. This does not force using `xcodebuild` or an XCTestRun file but the value will be used in that case.   | String | optional |  `"keepNever"`  |
 | <a id="ios_xctestrun_runner-command_line_args"></a>command_line_args |  CommandLineArguments to pass to xctestrun file when running the test bundle. This means it will always use `xcodebuild test-without-building` to run the test bundle.   | List of strings | optional |  `[]`  |
 | <a id="ios_xctestrun_runner-create_xcresult_bundle"></a>create_xcresult_bundle |  Force the test runner to always create an XCResult bundle. This means it will always use `xcodebuild test-without-building` to run the test bundle.   | Boolean | optional |  `False`  |
+| <a id="ios_xctestrun_runner-destination_timeout"></a>destination_timeout |  Use the specified timeout when searching for a destination device. The default is 30 seconds.   | Integer | optional |  `0`  |
 | <a id="ios_xctestrun_runner-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of `xcrun simctl list devicetypes`. E.g., iPhone X, iPad Air. By default, it reads from --ios_simulator_device or falls back to some device.   | String | optional |  `""`  |
 | <a id="ios_xctestrun_runner-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5. By default, it reads --ios_simulator_version and then falls back to the latest supported version.   | String | optional |  `""`  |
 | <a id="ios_xctestrun_runner-random"></a>random |  Whether to run the tests in random order to identify unintended state dependencies.   | Boolean | optional |  `False`  |


### PR DESCRIPTION
Adds the ability to override the default `xctest -destination-timeout` value (30 seconds) in the `ios_xctestrun_runner` rule. If using the rule is not possible, the same can be done with `--test_arg="--command_line_arg=-destination-timeout=VALUE"`.