### PR TITLE
Fix `mixed_language_library`

### DIFF
--- a/apple/internal/aspects/framework_provider_aspect.bzl
+++ b/apple/internal/aspects/framework_provider_aspect.bzl
@@ -36,9 +36,6 @@ _FRAMEWORK_PROVIDERS_ASPECT_ATTRS = [
     "implementation_deps",
     "private_deps",
     "runtime_deps",
-    # rules_swift `mixed_language_target`
-    "clang_target",
-    "swift_target",
 ]
 
 def _framework_provider_aspect_impl(target, ctx):


### PR DESCRIPTION
Regressed with 942c213f7e32797ca4f010de4e9d7b99e45c84e8.