### PR TITLE
Expose a new `AppleDeviceTestRunnerInfo` provider from device-based test runners

### DIFF
--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -144,6 +144,22 @@ target.
     },
 )
 
+AppleDeviceTestRunnerInfo = provider(
+    doc = """
+Provider that device-based runner targets must propagate.
+""",
+    fields = {
+        "device_type": """
+The device type of the iOS simulator to run test. The supported types correspond
+to the output of `xcrun simctl list devicetypes`. E.g., iPhone X, iPad Air.
+""",
+        "os_version": """
+The os version of the iOS simulator to run test. The supported os versions
+correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5.
+""",
+    },
+)
+
 AppleProvisioningProfileInfo = provider(
     doc = "Provides information about a provisioning profile.",
     fields = {

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -16,6 +16,7 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
 
@@ -56,12 +57,16 @@ def _ios_test_runner_impl(ctx):
     )
     return [
         apple_provider.make_apple_test_runner_info(
-            test_runner_template = ctx.outputs.test_runner_template,
             execution_requirements = ctx.attr.execution_requirements,
             execution_environment = _get_execution_environment(
                 xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             ),
             test_environment = ctx.attr.test_environment,
+            test_runner_template = ctx.outputs.test_runner_template,
+        ),
+        AppleDeviceTestRunnerInfo(
+            device_type = device_type,
+            os_version = os_version,
         ),
         DefaultInfo(
             runfiles = ctx.attr._simulator_creator[DefaultInfo].default_runfiles

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -5,6 +5,7 @@ simulators. This rule currently doesn't support UI tests or running on device.
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
 
@@ -81,6 +82,10 @@ def _ios_xctestrun_runner_impl(ctx):
             execution_requirements = {"requires-darwin": ""},
             test_runner_template = ctx.outputs.test_runner_template,
         ),
+        AppleDeviceTestRunnerInfo(
+            device_type = device_type,
+            os_version = os_version,
+        ),
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = [
@@ -141,7 +146,7 @@ will always use `xcodebuild test-without-building` to run the test bundle.
             default = "keepNever",
             doc = """
 Attachment lifetime to set in the xctestrun file when running the test bundle - `"keepNever"` (default), `"keepAlways"`
-or `"deleteOnSuccess"`. This affects presence of attachments in the XCResult output. This does not force using 
+or `"deleteOnSuccess"`. This affects presence of attachments in the XCResult output. This does not force using
 `xcodebuild` or an XCTestRun file but the value will be used in that case.
 """,
         ),

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -16,6 +16,7 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
 
@@ -39,12 +40,15 @@ def _get_execution_environment(*, xcode_config):
 
 def _tvos_test_runner_impl(ctx):
     """Implementation for the tvos_test_runner rule."""
+    device_type = ctx.attr.device_type
+    os_version = ctx.attr.os_version
+
     ctx.actions.expand_template(
         template = ctx.file._test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(
-            device_type = ctx.attr.device_type,
-            os_version = ctx.attr.os_version,
+            device_type = device_type,
+            os_version = os_version,
             testrunner = ctx.executable._testrunner.short_path,
         ),
     )
@@ -55,6 +59,10 @@ def _tvos_test_runner_impl(ctx):
             execution_environment = _get_execution_environment(
                 xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             ),
+        ),
+        AppleDeviceTestRunnerInfo(
+            device_type = device_type,
+            os_version = os_version,
         ),
         DefaultInfo(
             runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,

--- a/apple/testing/default_runner/visionos_test_runner.bzl
+++ b/apple/testing/default_runner/visionos_test_runner.bzl
@@ -16,6 +16,7 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
 
@@ -39,12 +40,15 @@ def _get_execution_environment(*, xcode_config):
 
 def _visionos_test_runner_impl(ctx):
     """Implementation for the visionos_test_runner rule."""
+    device_type = ctx.attr.device_type
+    os_version = ctx.attr.os_version
+
     ctx.actions.expand_template(
         template = ctx.file._test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(
-            device_type = ctx.attr.device_type,
-            os_version = ctx.attr.os_version,
+            device_type = device_type,
+            os_version = os_version,
             testrunner = ctx.executable._testrunner.short_path,
         ),
     )
@@ -55,6 +59,10 @@ def _visionos_test_runner_impl(ctx):
             execution_environment = _get_execution_environment(
                 xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             ),
+        ),
+        AppleDeviceTestRunnerInfo(
+            device_type = device_type,
+            os_version = os_version,
         ),
         DefaultInfo(
             runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,

--- a/apple/testing/default_runner/watchos_test_runner.bzl
+++ b/apple/testing/default_runner/watchos_test_runner.bzl
@@ -16,6 +16,7 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
 
@@ -39,12 +40,15 @@ def _get_execution_environment(*, xcode_config):
 
 def _watchos_test_runner_impl(ctx):
     """Implementation for the watchos_test_runner rule."""
+    device_type = ctx.attr.device_type
+    os_version = ctx.attr.os_version
+
     ctx.actions.expand_template(
         template = ctx.file._test_template,
         output = ctx.outputs.test_runner_template,
         substitutions = _get_template_substitutions(
-            device_type = ctx.attr.device_type,
-            os_version = ctx.attr.os_version,
+            device_type = device_type,
+            os_version = os_version,
             testrunner = ctx.executable._testrunner.short_path,
         ),
     )
@@ -55,6 +59,10 @@ def _watchos_test_runner_impl(ctx):
             execution_environment = _get_execution_environment(
                 xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             ),
+        ),
+        AppleDeviceTestRunnerInfo(
+            device_type = device_type,
+            os_version = os_version,
         ),
         DefaultInfo(
             runfiles = ctx.attr._testrunner[DefaultInfo].default_runfiles,

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -149,6 +149,25 @@ Provides information around the use of a code signing dossier.
 | <a id="AppleCodesigningDossierInfo-dossier"></a>dossier |  A `File` reference to the code signing dossier zip that acts as a direct dependency of the given target if one was generated.    |
 
 
+<a id="AppleDeviceTestRunnerInfo"></a>
+
+## AppleDeviceTestRunnerInfo
+
+<pre>
+AppleDeviceTestRunnerInfo(<a href="#AppleDeviceTestRunnerInfo-device_type">device_type</a>, <a href="#AppleDeviceTestRunnerInfo-os_version">os_version</a>)
+</pre>
+
+Provider that device-based runner targets must propagate.
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="AppleDeviceTestRunnerInfo-device_type"></a>device_type |  The device type of the iOS simulator to run test. The supported types correspond to the output of `xcrun simctl list devicetypes`. E.g., iPhone X, iPad Air.    |
+| <a id="AppleDeviceTestRunnerInfo-os_version"></a>os_version |  The os version of the iOS simulator to run test. The supported os versions correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5.    |
+
+
 <a id="AppleDsymBundleInfo"></a>
 
 ## AppleDsymBundleInfo


### PR DESCRIPTION
This allows downstream rules and aspects to know what device type and OS version was selected.