### PR TITLE
Stop using rule(output_to_genfiles = True)

### DIFF
--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -78,7 +78,6 @@ dtrace_compile = rule(
             doc = "dtrace(.d) source files to be compiled.",
         ),
     }),
-    output_to_genfiles = True,
     fragments = ["apple"],
     doc = """
 Compiles

--- a/apple/internal/header_map.bzl
+++ b/apple/internal/header_map.bzl
@@ -96,7 +96,6 @@ def _header_map_impl(ctx):
 
 header_map = rule(
     implementation = _header_map_impl,
-    output_to_genfiles = True,
     attrs = {
         "module_name": attr.string(
             mandatory = False,

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -173,7 +173,6 @@ into mlmodelc files.
             ),
         },
     ),
-    output_to_genfiles = True,
     fragments = ["apple"],
     doc = """
 This rule takes a single mlmodel file or mlpackage bundle and creates a target that can be added

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -146,7 +146,6 @@ Label to a single `.intentdefinition` files from which to generate sources files
             ),
         },
     ),
-    output_to_genfiles = True,
     fragments = ["apple"],
     doc = """
 This rule supports the integration of Intents `.intentdefinition` files into Apple rules.


### PR DESCRIPTION
Ever since bazel-bin/ and bazel-genfiles/ got merged, this option doesn't do anything anymore.