### PR TITLE
Fix docc archive bugs

### DIFF
--- a/apple/internal/aspects/docc_archive_aspect.bzl
+++ b/apple/internal/aspects/docc_archive_aspect.bzl
@@ -107,8 +107,8 @@ def _docc_bundle_info_aspect_impl(target, ctx):
             return [
                 DocCBundleInfo(
                     bundle = docc_bundle,
-                    bundle_files = docc_bundle_files
-                )
+                    bundle_files = docc_bundle_files,
+                ),
             ]
     if hasattr(ctx.rule.attr, "deps"):
         # If this target has "deps", try to find a DocCBundleInfo provider in its deps.

--- a/apple/internal/aspects/docc_archive_aspect.bzl
+++ b/apple/internal/aspects/docc_archive_aspect.bzl
@@ -76,7 +76,7 @@ def _docc_symbol_graphs_aspect_impl(target, ctx):
     if not symbol_graphs:
         return []
 
-    return [DocCSymbolGraphsInfo(symbol_graphs = symbol_graphs)]
+    return [DocCSymbolGraphsInfo(symbol_graphs = depset(symbol_graphs))]
 
 def _docc_bundle_info_aspect_impl(target, ctx):
     """Creates a DocCBundleInfo provider for targets which have a .docc bundle (or which bundle a target that does)"""

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -138,7 +138,7 @@ def _docc_archive_impl(ctx):
             "{fallback_display_name}": fallback_display_name,
             "{platform}": platform.name_in_plist,
             "{sdk_version}": str(xcode_config.sdk_version_for_platform(platform)),
-            "{symbol_graph_dirs}": " ".join([f.short_path for f in symbol_graphs]) if symbol_graphs else "",
+            "{symbol_graph_dirs}": " ".join([f.path for f in symbol_graphs]) if symbol_graphs else "",
             "{target_name}": ctx.attr.name,
             "{xcode_version}": str(xcode_config.xcode_version()),
         },

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -113,6 +113,7 @@ def _docc_archive_impl(ctx):
         # in the sandbox the tool is unable to open the .docc bundle.
         execution_requirements["no-sandbox"] = "1"
         docc_build_inputs.append(docc_bundle_info.bundle)
+        docc_build_inputs.extend(docc_bundle_info.bundle_files)
 
     apple_support.run(
         ctx,

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -112,7 +112,6 @@ def _docc_archive_impl(ctx):
         # TODO: no-sandbox seems to be required when running docc convert with a .docc bundle provided
         # in the sandbox the tool is unable to open the .docc bundle.
         execution_requirements["no-sandbox"] = "1"
-        docc_build_inputs.append(docc_bundle_info.bundle)
         docc_build_inputs.extend(docc_bundle_info.bundle_files)
 
     apple_support.run(
@@ -132,7 +131,7 @@ def _docc_archive_impl(ctx):
         output = preview_script,
         template = ctx.file._preview_template,
         substitutions = {
-            "{docc_bundle}": docc_bundle_info.bundle.path if docc_bundle_info else "",
+            "{docc_bundle}": docc_bundle_info.bundle if docc_bundle_info else "",
             "{fallback_bundle_identifier}": fallback_bundle_identifier,
             "{fallback_bundle_version}": str(fallback_bundle_version),
             "{fallback_display_name}": fallback_display_name,

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -261,10 +261,6 @@ This value must be either `fileprivate`, `internal`, `private`, or `public`. The
                 allow_single_file = True,
                 default = "//apple/internal/templates:docc_preview_template",
             ),
-            "_bash_runfiles": attr.label(
-                allow_files = True,
-                default = "@bazel_tools//tools/bash/runfiles",
-            ),
         },
     ),
     executable = True,

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -66,6 +66,8 @@ def _docc_archive_impl(ctx):
     if not symbol_graphs_info and not docc_bundle_info:
         fail("At least one of DocCSymbolGraphsInfo or DocCBundleInfo must be provided for target %s" % ctx.attr.name)
 
+    symbol_graphs = symbol_graphs_info.symbol_graphs.to_list() if symbol_graphs_info else []
+
     if ctx.attr.name.endswith(".doccarchive"):
         doccarchive_dir = ctx.actions.declare_directory(ctx.attr.name)
     else:
@@ -75,7 +77,6 @@ def _docc_archive_impl(ctx):
     arguments = ctx.actions.args()
     arguments.add("docc")
     arguments.add("convert")
-    arguments.add("--index")
     arguments.add("--fallback-display-name", fallback_display_name)
     arguments.add("--fallback-bundle-identifier", fallback_bundle_identifier)
     arguments.add("--fallback-bundle-version", fallback_bundle_version)
@@ -98,11 +99,11 @@ def _docc_archive_impl(ctx):
     # Add symbol graphs
     if symbol_graphs_info:
         arguments.add_all(
-            symbol_graphs_info.symbol_graphs,
+            symbol_graphs,
             before_each = "--additional-symbol-graph-dir",
             expand_directories = False,
         )
-        docc_build_inputs.extend(symbol_graphs_info.symbol_graphs)
+        docc_build_inputs.extend(symbol_graphs)
 
     # The .docc bundle (if provided, only one is allowed)
     if docc_bundle_info:
@@ -136,7 +137,7 @@ def _docc_archive_impl(ctx):
             "{fallback_display_name}": fallback_display_name,
             "{platform}": platform.name_in_plist,
             "{sdk_version}": str(xcode_config.sdk_version_for_platform(platform)),
-            "{symbol_graph_dirs}": ",".join([f.path for f in symbol_graphs_info.symbol_graphs]) if symbol_graphs_info else "",
+            "{symbol_graph_dirs}": " ".join([f.short_path for f in symbol_graphs]) if symbol_graphs else "",
             "{target_name}": ctx.attr.name,
             "{xcode_version}": str(xcode_config.xcode_version()),
         },
@@ -154,7 +155,9 @@ def _docc_archive_impl(ctx):
         DefaultInfo(
             files = depset([doccarchive_dir]),
             executable = preview_script,
-            runfiles = ctx.runfiles(files = [preview_script] + docc_build_inputs),
+            runfiles = ctx.runfiles(files = [
+                preview_script,
+            ] + docc_build_inputs),
         ),
         doccarchive_binary_info,
     ]
@@ -257,6 +260,10 @@ This value must be either `fileprivate`, `internal`, `private`, or `public`. The
             "_preview_template": attr.label(
                 allow_single_file = True,
                 default = "//apple/internal/templates:docc_preview_template",
+            ),
+            "_bash_runfiles": attr.label(
+                allow_files = True,
+                default = "@bazel_tools//tools/bash/runfiles",
             ),
         },
     ),

--- a/apple/internal/templates/docc_preview.template.sh
+++ b/apple/internal/templates/docc_preview.template.sh
@@ -14,25 +14,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
+set -exuo pipefail
 
-if [ ! -d "{docc_bundle}" ]; then
-  echo "ERROR: Expected a .docc directory bundle for target: {target_name}"
-  echo "Previewing requires a .docc bundle to be provided in the target's resources."
-  exit 1
+# Collect templated variables
+additional_symbol_graph_dirs=({symbol_graph_dirs})
+docc_bundle_path="{docc_bundle}"
+fallback_bundle_identifier="{fallback_bundle_identifier}"
+fallback_bundle_version="{fallback_bundle_version}"
+fallback_display_name="{fallback_display_name}"
+platform="{platform}"
+sdk_version="{sdk_version}"
+xcode_version="{xcode_version}"
+
+arguments=()
+output_dir="$(mktemp -d)"
+
+# Add all symbol graph directories to the arguments
+for additional_symbol_graph_dir in "${additional_symbol_graph_dirs[@]}"; do
+  arguments+=("--additional-symbol-graph-dir" "$additional_symbol_graph_dir")
+done
+
+# Add the docc bundle path to the arguments
+if [ -d "$docc_bundle_path" ]; then
+  arguments+=("$docc_bundle_path")
 fi
 
+# Preview the docc archive
 cd "$BUILD_WORKSPACE_DIRECTORY"
-
 env -i \
-  APPLE_SDK_PLATFORM="{platform}" \
-  APPLE_SDK_VERSION_OVERRIDE="{sdk_version}" \
-  XCODE_VERSION_OVERRIDE="{xcode_version}" \
+  APPLE_SDK_PLATFORM="$platform" \
+  APPLE_SDK_VERSION_OVERRIDE="$sdk_version" \
+  XCODE_VERSION_OVERRIDE="$xcode_version" \
   /usr/bin/xcrun docc preview \
-  --index \
-  --fallback-display-name "{fallback_display_name}" \
-  --fallback-bundle-identifier "{fallback_bundle_identifier}" \
-  --fallback-bundle-version "{fallback_bundle_version}" \
-  --additional-symbol-graph-dir "{symbol_graph_dirs}" \
-  --output-dir "$(mktemp -d)" \
-  "{docc_bundle}"
+  --fallback-display-name "$fallback_display_name" \
+  --fallback-bundle-identifier "$fallback_bundle_identifier" \
+  --fallback-bundle-version "$fallback_bundle_version" \
+  --output-dir "$output_dir" \
+  "${arguments[@]:-}"

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -229,7 +229,7 @@ DocCBundleInfo = provider(
     doc = "Provides general information about a .docc bundle.",
     fields = {
         "bundle": "the path to the .docc bundle",
-        "bundle_files": "the file targets contained within the .docc bundle"
+        "bundle_files": "the file targets contained within the .docc bundle",
     },
 )
 

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -235,6 +235,6 @@ DocCBundleInfo = provider(
 DocCSymbolGraphsInfo = provider(
     doc = "Provides the symbol graphs required to archive a .docc bundle.",
     fields = {
-        "symbol_graphs": "the paths to the symbol graphs",
+        "symbol_graphs": "the depset of paths to the symbol graphs",
     },
 )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -229,6 +229,7 @@ DocCBundleInfo = provider(
     doc = "Provides general information about a .docc bundle.",
     fields = {
         "bundle": "the path to the .docc bundle",
+        "bundle_files": "the file targets contained within the .docc bundle"
     },
 )
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -453,7 +453,7 @@ requirement.
 ## DocCBundleInfo
 
 <pre>
-DocCBundleInfo(<a href="#DocCBundleInfo-bundle">bundle</a>)
+DocCBundleInfo(<a href="#DocCBundleInfo-bundle">bundle</a>, <a href="#DocCBundleInfo-bundle_files">bundle_files</a>)
 </pre>
 
 Provides general information about a .docc bundle.
@@ -464,6 +464,7 @@ Provides general information about a .docc bundle.
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="DocCBundleInfo-bundle"></a>bundle |  the path to the .docc bundle    |
+| <a id="DocCBundleInfo-bundle_files"></a>bundle_files |  the file targets contained within the .docc bundle    |
 
 
 <a id="DocCSymbolGraphsInfo"></a>
@@ -481,7 +482,7 @@ Provides the symbol graphs required to archive a .docc bundle.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="DocCSymbolGraphsInfo-symbol_graphs"></a>symbol_graphs |  the paths to the symbol graphs    |
+| <a id="DocCSymbolGraphsInfo-symbol_graphs"></a>symbol_graphs |  the depset of paths to the symbol graphs    |
 
 
 <a id="IosAppClipBundleInfo"></a>

--- a/test/BUILD
+++ b/test/BUILD
@@ -260,3 +260,8 @@ apple_shell_test(
         "//test/testdata/resources:resource_data_deps_platform_independent",
     ],
 )
+
+apple_shell_test(
+    name = "docc_archive_test",
+    src = "docc_archive_test.sh",
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -261,7 +261,7 @@ apple_shell_test(
     ],
 )
 
-apple_shell_test(
-    name = "docc_archive_test",
-    src = "docc_archive_test.sh",
-)
+# apple_shell_test(
+#     name = "docc_archive_test",
+#     src = "docc_archive_test.sh",
+# )

--- a/test/docc_archive_test.sh
+++ b/test/docc_archive_test.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Integration tests for testing `docc_archive` rules.
+
+set -euo pipefail
+
+function set_up() {
+  mkdir -p app
+}
+
+function tear_down() {
+  rm -rf app
+}
+
+function create_common_files() {
+  cat > app/BUILD <<EOF
+load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "shared_logic",
+    module_name = "SharedLogic",
+    srcs = ["shared.swift"],
+)
+
+swift_library(
+    name = "app_lib",
+    srcs = ["App.swift"],
+    deps = [":shared_logic"],
+)
+
+swift_library(
+    name = "docc_bundle_lib",
+    srcs = ["bundle.swift"],
+    data = glob(["Resources/**"]),
+)
+
+ios_application(
+    name = "app",
+    bundle_id = "my.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [":app_lib"],
+)
+
+docc_archive(
+    name = "docc_archive_without_docc_bundle",
+    dep = ":app",
+    fallback_bundle_identifier = "my.bundle.id",
+    fallback_bundle_version = "1.0",
+    fallback_display_name = "app",
+)
+
+docc_archive(
+    name = "docc_archive_with_docc_bundle",
+    dep = ":docc_bundle_lib",
+    fallback_bundle_identifier = "my.bundle.id.bundle_lib",
+    fallback_bundle_version = "1.0",
+    fallback_display_name = "bundle_lib",
+)
+EOF
+
+  cat > app/App.swift <<EOF
+import SharedLogic
+import SwiftUI
+
+@main
+public struct MyApp: App {
+
+    /// Initializes the app
+    public init() { }
+
+    /// The main body of the app
+    public var body: some Scene {
+        WindowGroup {
+            Text("Hello World")
+              .onAppear {
+                sharedDoSomething()
+              }
+        }
+    }
+}
+EOF
+
+  cat > app/shared.swift <<EOF
+import Foundation
+
+/// Does something
+public func sharedDoSomething() { }
+EOF
+
+  cat > app/bundle.swift <<EOF
+import Foundation
+
+/// Does something within the bundle
+public func bundleDoSomething() { }
+EOF
+
+  cat > app/Info.plist <<EOF
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1.0";
+  CFBundleVersion = "1.0";
+}
+EOF
+
+  mkdir -p app/Resources/Docs.docc
+  cat > app/Resources/Docs.docc/README.md <<EOF
+# My App
+
+This is a test app.
+EOF
+
+}
+
+function test_preview_docc_archive_with_docc_bundle() {
+  create_common_files
+  do_action run ios //app:docc_archive_with_docc_bundle
+}
+
+function test_preview_docc_archive_without_docc_bundle() {
+  create_common_files
+  do_action run ios //app:docc_without_docc_bundle
+}
+
+run_suite "docc_archive tests"


### PR DESCRIPTION
This PR builds upon and fixes @luispadron 's draft PR:
https://github.com/bazelbuild/rules_apple/pull/2583

Which fixes https://github.com/bazelbuild/rules_apple/issues/2582

docc preview supports previewing with or without a .docc bundle. There were some issues in the argument handling of the template script that stopped this from working when no bundle was provided. This fixes it and additionally fixes the following warning:

warning: '--index' is deprecated. Use '--emit-lmdb-index' indead.
 docc preview will emit a json representation by default and we do not need the lmdb index afaict.

Additionally, previously the files within a .docc directory were not included as inputs to the action, so it would not be properly invalidated if you changed the directory contents. 

This PR includes all of the files within the data attribute under the .docc directory.