### PR TITLE
Make the `hmaptool` support response file

### DIFF
--- a/tools/hmaptool/BinaryHeaderMapTool.swift
+++ b/tools/hmaptool/BinaryHeaderMapTool.swift
@@ -25,6 +25,23 @@ struct BinaryHeaderMapTool {
             var arguments = arguments
             var output: URL?
 
+            // If the first argument starts with @, treat it as a response file.
+            // Since this is an internal tool, it's safe to just check the first argument.
+            if let arg = arguments.first, arg.hasPrefix("@") {
+                // Remove @ prefix to get file path
+                let filePath = String(arg.dropFirst())
+
+                guard FileManager.default.fileExists(atPath: filePath) else {
+                    fatalError("The response file doesn't exist: \(filePath)")
+                }
+
+                guard let fileContents = try? String(contentsOfFile: filePath, encoding: .utf8) else {
+                    fatalError("The response file cannot be read: \(filePath)")
+                }
+
+                arguments = fileContents.components(separatedBy: .newlines)
+            }
+
             if let outputIndex = arguments.firstIndex(of: "--output") {
                 guard outputIndex + 1 < arguments.count else {
                     fatalError("Missing output path after --output")


### PR DESCRIPTION
Currently if we have a long list of header files for `header_map` rule
```
header_map(
  name = "HeaderMap",
  hdrs = [<A long list of header files],
)
```
we will see the following build error:
```
tools_hmaptool_BinaryHeaderMapTool/BinaryHeaderMapTool.swift:45: Fatal error: Missing output path
```

This is because Bazel will use response file for a long list of parameters ([here](https://github.com/bazelbuild/rules_apple/blob/1c9fc9cf136986f89f47d764a11b5b29e516eb8a/apple/internal/header_map.bzl#L47)). This PR makes `hmaptool` to support the response file and avoid the build error. 
