### PR TITLE
Make `AppleExtensionSafeValidationInfo` a public provider

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -19,6 +19,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
+    "AppleExtensionSafeValidationInfo",
     "ApplePlatformInfo",
     "IosAppClipBundleInfo",
     "IosExtensionBundleInfo",
@@ -2768,7 +2769,11 @@ However, iOS 14 introduced Widget Extensions that use a traditional `main` entry
         ),
         {
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    IosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
@@ -2838,7 +2843,11 @@ to manually dlopen the framework at runtime.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    IosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
@@ -2909,7 +2918,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    IosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))
@@ -3112,7 +3125,11 @@ ios_imessage_extension = rule_factory.create_apple_rule(
         ),
         {
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, IosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    IosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`ios_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_framework))

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -20,6 +20,7 @@ load(
     "AppleBinaryInfoplistInfo",
     "AppleBundleInfo",
     "AppleBundleVersionInfo",
+    "AppleExtensionSafeValidationInfo",
     "ApplePlatformInfo",
     "MacosExtensionBundleInfo",
     "MacosFrameworkBundleInfo",
@@ -2442,7 +2443,11 @@ desired Contents subdirectory.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, MacosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    MacosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`macos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-macos.md#macos_framework))
@@ -3508,7 +3513,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, MacosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    MacosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`macos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-macos.md#macos_framework))
@@ -3571,7 +3580,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, MacosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    MacosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`macos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-macos.md#macos_framework))

--- a/apple/internal/partials/extension_safe_validation.bzl
+++ b/apple/internal/partials/extension_safe_validation.bzl
@@ -18,13 +18,7 @@ load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
-
-_AppleExtensionSafeValidationInfo = provider(
-    doc = "Private provider that propagates whether the target is marked as extension safe or not.",
-    fields = {
-        "is_extension_safe": "Boolean indicating that the target is extension safe or not.",
-    },
-)
+load("//apple:providers.bzl", "AppleExtensionSafeValidationInfo")
 
 def _extension_safe_validation_partial_impl(
         *,
@@ -35,17 +29,24 @@ def _extension_safe_validation_partial_impl(
 
     if is_extension_safe:
         for target in targets_to_validate:
-            if not target[_AppleExtensionSafeValidationInfo].is_extension_safe:
-                # TODO(b/133173778): Revisit the extension_safe attribute, since it's currently
-                # not propagating the -fapplication-extension compilation flags to dependencies.
+            if (AppleExtensionSafeValidationInfo in target and
+                not target[AppleExtensionSafeValidationInfo].is_extension_safe):
+                # TODO(b/133173778): Revisit the extension_safe attribute, since
+                # it's currently not propagating the -fapplication-extension
+                # compilation flags to dependencies.
                 fail((
-                    "The target {current_label} is for an extension but its framework " +
-                    "dependency {target_label} is not marked extension-safe. " +
-                    "Specify 'extension_safe = True' on the framework target."
+                    "The target {current_label} is for an extension but its " +
+                    "framework dependency {target_label} is not marked " +
+                    "extension-safe. Specify 'extension_safe = True' on the " +
+                    "framework target."
                 ).format(current_label = rule_label, target_label = target.label))
 
     return struct(
-        providers = [_AppleExtensionSafeValidationInfo(is_extension_safe = is_extension_safe)],
+        providers = [
+            AppleExtensionSafeValidationInfo(
+                is_extension_safe = is_extension_safe,
+            ),
+        ],
     )
 
 def extension_safe_validation_partial(

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -18,6 +18,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
+    "AppleExtensionSafeValidationInfo",
     "ApplePlatformInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
@@ -1576,7 +1577,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, TvosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    TvosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`tvos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-tvos.md#tvos_framework))
@@ -1625,7 +1630,11 @@ tvos_extension = rule_factory.create_apple_rule(
         ),
         {
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, TvosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    TvosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`tvos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-tvos.md#tvos_framework))
@@ -1687,7 +1696,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, TvosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    TvosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`tvos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-tvos.md#tvos_framework))

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -16,6 +16,10 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleExtensionSafeValidationInfo",
+)
+load(
     "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
@@ -1573,7 +1577,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, VisionosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    VisionosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`visionos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-visionos.md#visionos_framework))
@@ -1621,7 +1629,11 @@ visionos_extension = rule_factory.create_apple_rule(
         ),
         {
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, VisionosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    VisionosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`visionos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-visionos.md#visionos_framework))
@@ -1683,7 +1695,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, VisionosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    VisionosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`visionos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-visionos.md#visionos_framework))

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -22,6 +22,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
+    "AppleExtensionSafeValidationInfo",
     "ApplePlatformInfo",
     "WatchosExtensionBundleInfo",
     "WatchosFrameworkBundleInfo",
@@ -1934,7 +1935,11 @@ A list of watchOS application extensions to include in the final watch extension
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, WatchosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    WatchosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`watchos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-watchos.md#watchos_framework))
@@ -1996,7 +2001,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, WatchosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    WatchosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`watchos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-watchos.md#watchos_framework))
@@ -2059,7 +2068,11 @@ use only extension-safe APIs.
 """,
             ),
             "frameworks": attr.label_list(
-                providers = [[AppleBundleInfo, WatchosFrameworkBundleInfo]],
+                providers = [[
+                    AppleBundleInfo,
+                    AppleExtensionSafeValidationInfo,
+                    WatchosFrameworkBundleInfo,
+                ]],
                 doc = """
 A list of framework targets (see
 [`watchos_framework`](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-watchos.md#watchos_framework))

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -160,6 +160,17 @@ correspond to the output of `xcrun simctl list runtimes`. E.g., 15.5.
     },
 )
 
+AppleExtensionSafeValidationInfo = provider(
+    doc = """
+Provider that propagates whether the target is marked as extension safe or not.
+""",
+    fields = {
+        "is_extension_safe": """
+Boolean indicating that the target is extension safe or not.
+""",
+    },
+)
+
 AppleProvisioningProfileInfo = provider(
     doc = "Provides information about a provisioning profile.",
     fields = {

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -187,6 +187,24 @@ Provides information for an Apple dSYM bundle.
 | <a id="AppleDsymBundleInfo-transitive_dsyms"></a>transitive_dsyms |  `depset` containing `File` references to each of the dSYM bundles that act as transitive dependencies of the given target if any were generated.    |
 
 
+<a id="AppleExtensionSafeValidationInfo"></a>
+
+## AppleExtensionSafeValidationInfo
+
+<pre>
+AppleExtensionSafeValidationInfo(<a href="#AppleExtensionSafeValidationInfo-is_extension_safe">is_extension_safe</a>)
+</pre>
+
+Provider that propagates whether the target is marked as extension safe or not.
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="AppleExtensionSafeValidationInfo-is_extension_safe"></a>is_extension_safe |  Boolean indicating that the target is extension safe or not.    |
+
+
 <a id="AppleExtraOutputsInfo"></a>
 
 ## AppleExtraOutputsInfo


### PR DESCRIPTION
This allows for custom `*_framework` rules to work with rules_apple.