### PR TITLE
Add `apple.codesign_frameworks_without_provisioning_profile` feature

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -326,7 +326,8 @@ def _should_sign_bundles(*, provisioning_profile, rule_descriptor, features):
           rule_support.codesigning_exceptions.sign_with_provisioning_profile):
         # If the rule doesn't have a provisioning profile, do not sign the binary or its
         # frameworks.
-        if not provisioning_profile:
+        if (not provisioning_profile and
+            "apple.codesign_frameworks_without_provisioning_profile" not in features):
             should_sign_bundles = False
     elif codesigning_exceptions == rule_support.codesigning_exceptions.skip_signing:
         should_sign_bundles = False
@@ -825,5 +826,6 @@ codesigning_support = struct(
     embedded_codesigning_dossier = _embedded_codesigning_dossier,
     generate_codesigning_dossier_action = _generate_codesigning_dossier_action,
     post_process_and_sign_archive_action = _post_process_and_sign_archive_action,
+    should_sign_bundles = _should_sign_bundles,
     sign_binary_action = _sign_binary_action,
 )

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -908,10 +908,12 @@ def _ios_framework_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
     signed_frameworks = []
-    if provisioning_profile:
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -1504,10 +1506,12 @@ def _ios_dynamic_framework_impl(ctx):
     )
 
     signed_frameworks = []
-    if getattr(ctx.file, "provisioning_profile", None):
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = ctx.file.provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
 
     extra_linkopts = [
         "-dynamiclib",

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -2796,10 +2796,12 @@ def _macos_framework_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
     signed_frameworks = []
-    if provisioning_profile:
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -3083,10 +3085,12 @@ def _macos_dynamic_framework_impl(ctx):
     )
 
     signed_frameworks = []
-    if getattr(ctx.file, "provisioning_profile", None):
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = ctx.file.provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
 
     extra_linkopts = [
         "-dynamiclib",

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -541,10 +541,12 @@ def _tvos_dynamic_framework_impl(ctx):
     )
 
     signed_frameworks = []
-    if getattr(ctx.file, "provisioning_profile", None):
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = ctx.file.provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
 
     link_result = linking_support.register_binary_linking_action(
         ctx,
@@ -816,10 +818,12 @@ def _tvos_framework_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
     signed_frameworks = []
-    if provisioning_profile:
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -545,10 +545,12 @@ def _visionos_dynamic_framework_impl(ctx):
     )
 
     signed_frameworks = []
-    if getattr(ctx.file, "provisioning_profile", None):
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = ctx.file.provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
 
     link_result = linking_support.register_binary_linking_action(
         ctx,
@@ -821,10 +823,12 @@ def _visionos_framework_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
     signed_frameworks = []
-    if provisioning_profile:
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -190,10 +190,12 @@ def _watchos_framework_impl(ctx):
     provisioning_profile = ctx.file.provisioning_profile
     resource_deps = ctx.attr.deps + ctx.attr.resources
     signed_frameworks = []
-    if provisioning_profile:
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
     top_level_infoplists = resources.collect(
         attr = ctx.attr,
         res_attrs = ["infoplists"],
@@ -474,10 +476,12 @@ def _watchos_dynamic_framework_impl(ctx):
     )
 
     signed_frameworks = []
-    if getattr(ctx.file, "provisioning_profile", None):
-        signed_frameworks = [
-            bundle_name + rule_descriptor.bundle_extension,
-        ]
+    if codesigning_support.should_sign_bundles(
+        provisioning_profile = ctx.file.provisioning_profile,
+        rule_descriptor = rule_descriptor,
+        features = features,
+    ):
+        signed_frameworks = [bundle_name + bundle_extension]
 
     extra_linkopts = [
         "-dynamiclib",


### PR DESCRIPTION
This feature causes `*_{dynamic_,}framework` targets to codesign themselves even when they don’t have a provisioning profile set. This allows moving and caching some of the codesigning time into the framework targets, which can be a big win if your incremental builds don’t touch a lot of the frameworks.