### PR TITLE
Drop bazel 6.x support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,9 +14,6 @@ x_defaults:
     - "examples/..."
     test_flags:
     - --test_tag_filters=-skipci
-  bazel_6: &bazel_6
-    test_flags:
-    - --test_tag_filters=-skipci,-skip_bazel6_ci
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.
@@ -25,12 +22,6 @@ tasks:
     name: "Current LTS"
     bazel: latest
     <<: *common
-
-  macos_6_lts:
-    name: "6.x LTS"
-    bazel: 6.x
-    <<: *common
-    <<: *bazel_6
 
   macos_last_green:
     name: "Last Green Bazel"

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,12 +21,6 @@ build --nocheck_visibility
 # dependencies cause us to use a newer version
 build --check_direct_dependencies=off
 
-# This is needed for Bazel 6 compatibility.
-# It's enabled (and can't be disabled) in Bazel 7.
-# TODO: Remove this once we drop Bazel 6 support.
-# See also: https://github.com/bazelbuild/bazel/issues/14327
-build --experimental_enable_aspect_hints
-
 # Disable the worker, which has sandboxing disabled by default, which can hide
 # issues with non-hermetic bugs.
 build --spawn_strategy=sandboxed,local

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -133,9 +133,8 @@ def _apple_resource_aspect_impl(target, ctx):
     hint_action = None
     default_action = None
 
-    # TODO: remove usage of `getattr` and use `aspect_ctx.rule.attr.aspect_hints` directly when we drop Bazel 6.
     aspect_hint = None
-    for hint in getattr(ctx.rule.attr, "aspect_hints", []):
+    for hint in ctx.rule.attr.aspect_hints:
         if AppleResourceHintInfo in hint:
             if aspect_hint:
                 fail(("Conflicting AppleResourceHintInfo from aspect hints " +

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -148,23 +148,6 @@ def _common_linking_api_attrs(*, deps_cfg):
         ),
     })
 
-def _j2objc_binary_linking_attrs():
-    """Returns a dictionary of required attributes for J2ObjC processing code in native linking.
-    """
-    return {
-        # xcrunwrapper is no longer used by rules_apple, but the underlying implementation of
-        # apple_common.link_multi_arch_binary and j2objc_dead_code_pruner require this attribute.
-        # See CompilationSupport.java:
-        # - `registerJ2ObjcDeadCodeRemovalActions()`
-        # - `registerLinkActions()` --> `registerBinaryStripAction()`
-        # TODO(b/117932394): Remove this once Bazel 6 support is dropped.
-        "_xcrunwrapper": attr.label(
-            cfg = "exec",
-            executable = True,
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-        ),
-    }
-
 def _static_library_linking_attrs(*, deps_cfg):
     """Returns dictionary of required attributes for apple_common.link_multi_arch_static_library.
 
@@ -218,7 +201,6 @@ def _binary_linking_attrs(
     return dicts.add(
         extra_attrs,
         _common_linking_api_attrs(deps_cfg = deps_cfg),
-        _j2objc_binary_linking_attrs(),
         {
             "codesign_inputs": attr.label_list(
                 doc = """

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -134,7 +134,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/generated_dynamic_xcframework_with_headers.framework/generated_dynamic_xcframework_with_headers (offset 24)",
         ],
-        tags = [name, "skip_bazel6_ci"],
+        tags = [name],
     )
 
     # Verify the correct XCFramework library was bundled and sliced for the required architecture.


### PR DESCRIPTION
With 8.x out imminently, the number of permutations to support bazel
changes and legacy linking behavior in bazel 6.x is getting too costly.
