### PR TITLE
Remove internal uses of @build_bazel_rules_apple

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,6 +23,16 @@ tasks:
     bazel: latest
     <<: *common
 
+  macos_7.x_workspace:
+    name: "7.x WORKSPACE support"
+    bazel: latest
+    <<: *common
+    build_flags:
+      - --enable_bzlmod=false
+    test_flags:
+      - --test_tag_filters=-skipci
+      - --enable_bzlmod=false
+
   macos_last_green:
     name: "Last Green Bazel"
     # FIXME: Use last_green once we cherry-pick in changes needed by

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,16 +23,6 @@ tasks:
     bazel: latest
     <<: *common
 
-  macos_7.x_workspace:
-    name: "7.x WORKSPACE support"
-    bazel: latest
-    <<: *common
-    build_flags:
-      - --enable_bzlmod=false
-    test_flags:
-      - --test_tag_filters=-skipci
-      - --enable_bzlmod=false
-
   macos_last_green:
     name: "Last Green Bazel"
     # FIXME: Use last_green once we cherry-pick in changes needed by

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,6 @@ module(
     version = "0",
     bazel_compatibility = [">=7.0.0"],
     compatibility_level = 1,
-    repo_name = "build_bazel_rules_apple",
 )
 
 bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")

--- a/apple/apple.bzl
+++ b/apple/apple.bzl
@@ -15,35 +15,35 @@
 """# Rules that apply to all Apple platforms."""
 
 load(
-    "@build_bazel_rules_apple//apple:apple_static_library.bzl",
+    "//apple:apple_static_library.bzl",
     _apple_static_library = "apple_static_library",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_framework_import.bzl",
+    "//apple/internal:apple_framework_import.bzl",
     _apple_dynamic_framework_import = "apple_dynamic_framework_import",
     _apple_static_framework_import = "apple_static_framework_import",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_universal_binary.bzl",
+    "//apple/internal:apple_universal_binary.bzl",
     _apple_universal_binary = "apple_universal_binary",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_xcframework_import.bzl",
+    "//apple/internal:apple_xcframework_import.bzl",
     _apple_dynamic_xcframework_import = "apple_dynamic_xcframework_import",
     _apple_static_xcframework_import = "apple_static_xcframework_import",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental_mixed_language_library.bzl",
+    "//apple/internal:experimental_mixed_language_library.bzl",
     _experimental_mixed_language_library = "experimental_mixed_language_library",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:local_provisioning_profiles.bzl",
+    "//apple/internal:local_provisioning_profiles.bzl",
     _local_provisioning_profile = "local_provisioning_profile",
     _provisioning_profile_repository = "provisioning_profile_repository",
     _provisioning_profile_repository_extension = "provisioning_profile_repository_extension",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:xcframework_rules.bzl",
+    "//apple/internal:xcframework_rules.bzl",
     _apple_static_xcframework = "apple_static_xcframework",
     _apple_xcframework = "apple_xcframework",
 )

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -15,19 +15,19 @@
 """Starlark implementation of `apple_binary` to transition from native Bazel."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 

--- a/apple/apple_static_library.bzl
+++ b/apple/apple_static_library.bzl
@@ -15,27 +15,27 @@
 """apple_static_library Starlark implementation"""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "ApplePlatformInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebinaryinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 

--- a/apple/aspects.bzl
+++ b/apple/aspects.bzl
@@ -15,7 +15,7 @@
 """Aspects that apply to all Apple platforms."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     _framework_provider_aspect = "framework_provider_aspect",
 )
 

--- a/apple/capabilities.bzl
+++ b/apple/capabilities.bzl
@@ -15,7 +15,7 @@
 """Rules related to Apple capabilities."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:capabilities_rules.bzl",
+    "//apple/internal:capabilities_rules.bzl",
     _apple_base_bundle_id = "apple_base_bundle_id",
     _apple_capability_set = "apple_capability_set",
 )

--- a/apple/docc.bzl
+++ b/apple/docc.bzl
@@ -15,7 +15,7 @@
 """Defines rules for building Apple DocC targets."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:docc.bzl",
+    "//apple/internal:docc.bzl",
     _docc_archive = "docc_archive",
 )
 

--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -27,7 +27,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/header_map.bzl
+++ b/apple/header_map.bzl
@@ -17,7 +17,7 @@ Rules for creating header maps.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:header_map.bzl",
+    "//apple/internal:header_map.bzl",
     _header_map = "header_map",
 )
 

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -32,50 +32,50 @@ load(
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleFrameworkImportInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
-    "group_files_by_directory",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
-    "AppleXPlatToolsToolchainInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
-    "cc_toolchain_info_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
-    "is_experimental_tree_artifact_enabled",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
-    "framework_import_support",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
-    "rule_attrs",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
-    "SwiftUsageInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
-    "AppleFrameworkImportBundleInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
-    "bundle_paths",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftToolchainInfo",
     "swift_clang_module_aspect",
     "swift_common",
+)
+load(
+    "//apple:providers.bzl",
+    "AppleFrameworkImportInfo",
+)
+load(
+    "//apple:utils.bzl",
+    "group_files_by_directory",
+)
+load(
+    "//apple/internal:apple_toolchains.bzl",
+    "AppleXPlatToolsToolchainInfo",
+)
+load(
+    "//apple/internal:cc_toolchain_info_support.bzl",
+    "cc_toolchain_info_support",
+)
+load(
+    "//apple/internal:experimental.bzl",
+    "is_experimental_tree_artifact_enabled",
+)
+load(
+    "//apple/internal:framework_import_support.bzl",
+    "framework_import_support",
+)
+load(
+    "//apple/internal:rule_attrs.bzl",
+    "rule_attrs",
+)
+load(
+    "//apple/internal/aspects:swift_usage_aspect.bzl",
+    "SwiftUsageInfo",
+)
+load(
+    "//apple/internal/providers:framework_import_bundle_info.bzl",
+    "AppleFrameworkImportBundleInfo",
+)
+load(
+    "//apple/internal/utils:bundle_paths.bzl",
+    "bundle_paths",
 )
 
 def _swiftmodule_for_cpu(swiftmodule_files, cpu):

--- a/apple/internal/apple_toolchains.bzl
+++ b/apple/internal/apple_toolchains.bzl
@@ -120,12 +120,12 @@ def _shared_attrs():
     """Private attributes on every rule to provide access to bundling tools and other file deps."""
     return {
         "_mac_toolchain": attr.label(
-            default = Label("@build_bazel_rules_apple//apple/internal:mac_tools_toolchain"),
+            default = Label("//apple/internal:mac_tools_toolchain"),
             providers = [[AppleMacToolsToolchainInfo]],
             cfg = "exec",
         ),
         "_xplat_toolchain": attr.label(
-            default = Label("@build_bazel_rules_apple//apple/internal:xplat_tools_toolchain"),
+            default = Label("//apple/internal:xplat_tools_toolchain"),
             providers = [[AppleXPlatToolsToolchainInfo]],
             cfg = "exec",
         ),

--- a/apple/internal/apple_universal_binary.bzl
+++ b/apple/internal/apple_universal_binary.bzl
@@ -15,23 +15,23 @@
 """Implementation for apple universal binary rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebinaryinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -18,35 +18,35 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftToolchainInfo", "swift_clang_module_aspect", "swift_common")
+load("//apple:providers.bzl", "AppleFrameworkImportInfo")
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
+    "//apple/internal:cc_toolchain_info_support.bzl",
     "cc_toolchain_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
+load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
+    "//apple/internal/providers:framework_import_bundle_info.bzl",
     "AppleFrameworkImportBundleInfo",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftToolchainInfo", "swift_clang_module_aspect", "swift_common")
-load("//apple:providers.bzl", "AppleFrameworkImportInfo")
-load("//apple/internal:intermediates.bzl", "intermediates")
-load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 
 # Currently, XCFramework bundles can contain Apple frameworks or libraries.
 # This defines an _enum_ to identify an imported XCFramework bundle type.

--- a/apple/internal/aspects/framework_provider_aspect.bzl
+++ b/apple/internal/aspects/framework_provider_aspect.bzl
@@ -15,12 +15,12 @@
 """Implementation of the aspect that propagates framework providers."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleFrameworkImportInfo",
     "apple_provider",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:embeddable_info.bzl",
+    "//apple/internal/providers:embeddable_info.bzl",
     "AppleEmbeddableInfo",
     "embeddable_info",
 )

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -27,53 +27,53 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:providers.bzl",
     "AppleDsymBundleInfo",
     "AppleFrameworkBundleInfo",
     "AppleResourceInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appledsymbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect_hint.bzl",
+    "//apple/internal/aspects:resource_aspect_hint.bzl",
     "AppleResourceHintInfo",
     "apple_resource_hint_action",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
+    "//apple/internal/providers:apple_debug_info.bzl",
     "AppleDebugInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:framework_import_bundle_info.bzl",
+    "//apple/internal/providers:framework_import_bundle_info.bzl",
     "AppleFrameworkImportBundleInfo",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 def _platform_prerequisites_for_aspect(target, aspect_ctx):

--- a/apple/internal/aspects/resource_aspect_hint.bzl
+++ b/apple/internal/aspects/resource_aspect_hint.bzl
@@ -98,7 +98,7 @@ and processed like objc_library.
 cc_library(
     name = "somelib",
     data = ["mydata.txt"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:use_resources"],
+    aspect_hints = ["//apple:use_resources"],
 )
 ```
 
@@ -112,7 +112,7 @@ an objc_library by adding an aspect hint to `use_runfiles` instead of resources.
 objc_library(
     name = "somelib",
     data = ["mydata.txt"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:use_runfiles"],
+    aspect_hints = ["//apple:use_runfiles"],
 )
 ```
 
@@ -128,7 +128,7 @@ with a build file
 cc_library(
     name = "somelib",
     data = ["myFile1.txt", "some_folder/myFile2.txt"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:use_runfiles"],
+    aspect_hints = ["//apple:use_runfiles"],
 )
 ```
 then the resources will be in
@@ -150,7 +150,7 @@ any aspect hint applied.
 objc_library(
     name = "somelib",
     data = ["mydata.txt"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:suppress_resources"],
+    aspect_hints = ["//apple:suppress_resources"],
 )
 ```
 """,

--- a/apple/internal/bundling_support.bzl
+++ b/apple/internal/bundling_support.bzl
@@ -15,7 +15,7 @@
 """Low-level bundling name helpers."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBaseBundleIdInfo",
     "AppleSharedCapabilityInfo",
 )

--- a/apple/internal/capabilities_rules.bzl
+++ b/apple/internal/capabilities_rules.bzl
@@ -15,15 +15,15 @@
 """Rules related to Apple capabilities."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBaseBundleIdInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebasebundleidinfo",
     "new_applesharedcapabilityinfo",
 )

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -27,15 +27,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -177,7 +177,7 @@ NOTE: At this time Swift is the only supported language for this rule.
 Example:
 
 ```starlark
-load("//apple:docc.bzl", "docc_archive")
+load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
 
 docc_archive(
     name = "Lib.doccarchive",

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -23,16 +23,16 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "DocCBundleInfo",
     "DocCSymbolGraphsInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebinaryinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:docc_archive_aspect.bzl",
+    "//apple/internal/aspects:docc_archive_aspect.bzl",
     "docc_bundle_info_aspect",
     "docc_symbol_graphs_aspect",
 )
@@ -177,7 +177,7 @@ NOTE: At this time Swift is the only supported language for this rule.
 Example:
 
 ```starlark
-load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
+load("//apple:docc.bzl", "docc_archive")
 
 docc_archive(
     name = "Lib.doccarchive",

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -19,23 +19,23 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:common.bzl",
+    "//apple:common.bzl",
     "entitlements_validation_mode",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -25,19 +25,19 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 

--- a/apple/internal/experimental.bzl
+++ b/apple/internal/experimental.bzl
@@ -15,7 +15,7 @@
 """Temporary file to centralize configuration of the experimental bundling logic."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -16,8 +16,9 @@
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "ApplePlatformInfo",
     "IosAppClipBundleInfo",
@@ -28,61 +29,61 @@ load(
     "WatchosApplicationBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleframeworkbundleinfo",
     "new_iosappclipbundleinfo",
     "new_iosapplicationbundleinfo",
@@ -93,59 +94,58 @@ load(
     "new_iosstaticframeworkbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:run_support.bzl",
+    "//apple/internal:run_support.bzl",
     "run_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:stub_support.bzl",
+    "//apple/internal:stub_support.bzl",
     "stub_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
 def _ios_application_impl(ctx):
     """Implementation of ios_application."""

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -16,11 +16,11 @@
 
 load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_toolchain_info_support.bzl",
+    "//apple/internal:cc_toolchain_info_support.bzl",
     "cc_toolchain_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -63,7 +63,7 @@ You only need this in the case you want to setup fallback profiles, otherwise
 it can be ommitted when using bzlmod.
 
 ```bzl
-provisioning_profile_repository = use_extension("//apple:apple.bzl", "provisioning_profile_repository_extension")
+provisioning_profile_repository = use_extension("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
 provisioning_profile_repository.setup(
     fallback_profiles = "//path/to/some:filegroup", # Profiles to use if one isn't found locally
 )

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -1,7 +1,7 @@
 """# Rules for using locally installed provisioning profiles"""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleProvisioningProfileInfo",
 )
 
@@ -63,7 +63,7 @@ You only need this in the case you want to setup fallback profiles, otherwise
 it can be ommitted when using bzlmod.
 
 ```bzl
-provisioning_profile_repository = use_extension("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
+provisioning_profile_repository = use_extension("//apple:apple.bzl", "provisioning_profile_repository_extension")
 provisioning_profile_repository.setup(
     fallback_profiles = "//path/to/some:filegroup", # Profiles to use if one isn't found locally
 )
@@ -186,7 +186,7 @@ local_provisioning_profile = rule(
         ),
         "_finder": attr.label(
             cfg = "exec",
-            default = "@build_bazel_rules_apple//tools/local_provisioning_profile_finder",
+            default = "//tools/local_provisioning_profile_finder",
             executable = True,
         ),
     },

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -19,49 +19,49 @@ load(
     "dicts",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBinaryInfoplistInfo",
     "AppleBundleVersionInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 
@@ -186,7 +186,7 @@ macos_binary_infoplist = rule(
             ),
             "_environment_plist": attr.label(
                 allow_single_file = True,
-                default = "@build_bazel_rules_apple//apple/internal:environment_plist_macos",
+                default = "//apple/internal:environment_plist_macos",
             ),
             "version": attr.label(providers = [[AppleBundleVersionInfo]]),
         },

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -16,7 +16,11 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:providers.bzl",
     "AppleBinaryInfoplistInfo",
     "AppleBundleInfo",
     "AppleBundleVersionInfo",
@@ -27,61 +31,61 @@ load(
     "MacosXPCServiceBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebinaryinfo",
     "new_appleframeworkbundleinfo",
     "new_macosapplicationbundleinfo",
@@ -93,57 +97,53 @@ load(
     "new_macosxpcservicebundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:run_support.bzl",
+    "//apple/internal:run_support.bzl",
     "run_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 def _macos_application_impl(ctx):
@@ -2306,7 +2306,7 @@ that this target depends on.
             "_runner_template": attr.label(
                 cfg = "exec",
                 allow_single_file = True,
-                default = Label("@build_bazel_rules_apple//apple/internal/templates:macos_template"),
+                default = Label("//apple/internal/templates:macos_template"),
             ),
             "include_symbols_in_bundle": attr.bool(
                 default = False,

--- a/apple/internal/outputs.bzl
+++ b/apple/internal/outputs.bzl
@@ -23,11 +23,11 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 

--- a/apple/internal/partials.bzl
+++ b/apple/internal/partials.bzl
@@ -15,103 +15,103 @@
 """Proxy file for referencing processor partials."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:app_assets_validation.bzl",
+    "//apple/internal/partials:app_assets_validation.bzl",
     _app_assets_validation_partial = "app_assets_validation_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:app_intents_metadata_bundle.bzl",
+    "//apple/internal/partials:app_intents_metadata_bundle.bzl",
     _app_intents_metadata_bundle_partial = "app_intents_metadata_bundle_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:apple_bundle_info.bzl",
+    "//apple/internal/partials:apple_bundle_info.bzl",
     _apple_bundle_info_partial = "apple_bundle_info_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:apple_symbols_file.bzl",
+    "//apple/internal/partials:apple_symbols_file.bzl",
     _apple_symbols_file_partial = "apple_symbols_file_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:binary.bzl",
+    "//apple/internal/partials:binary.bzl",
     _binary_partial = "binary_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:cc_info_dylibs.bzl",
+    "//apple/internal/partials:cc_info_dylibs.bzl",
     _cc_info_dylibs_partial = "cc_info_dylibs_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:clang_rt_dylibs.bzl",
+    "//apple/internal/partials:clang_rt_dylibs.bzl",
     _clang_rt_dylibs_partial = "clang_rt_dylibs_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:codesigning_dossier.bzl",
+    "//apple/internal/partials:codesigning_dossier.bzl",
     _codesigning_dossier_partial = "codesigning_dossier_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:debug_symbols.bzl",
+    "//apple/internal/partials:debug_symbols.bzl",
     _debug_symbols_partial = "debug_symbols_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:embedded_bundles.bzl",
+    "//apple/internal/partials:embedded_bundles.bzl",
     _embedded_bundles_partial = "embedded_bundles_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:extension_safe_validation.bzl",
+    "//apple/internal/partials:extension_safe_validation.bzl",
     _extension_safe_validation_partial = "extension_safe_validation_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:framework_header_modulemap.bzl",
+    "//apple/internal/partials:framework_header_modulemap.bzl",
     _framework_header_modulemap_partial = "framework_header_modulemap_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:framework_headers.bzl",
+    "//apple/internal/partials:framework_headers.bzl",
     _framework_headers_partial = "framework_headers_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:framework_import.bzl",
+    "//apple/internal/partials:framework_import.bzl",
     _framework_import_partial = "framework_import_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:framework_provider.bzl",
+    "//apple/internal/partials:framework_provider.bzl",
     _framework_provider_partial = "framework_provider_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:macos_additional_contents.bzl",
+    "//apple/internal/partials:macos_additional_contents.bzl",
     _macos_additional_contents_partial = "macos_additional_contents_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:main_thread_checker_dylibs.bzl",
+    "//apple/internal/partials:main_thread_checker_dylibs.bzl",
     _main_thread_checker_dylibs_partial = "main_thread_checker_dylibs_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:messages_stub.bzl",
+    "//apple/internal/partials:messages_stub.bzl",
     _messages_stub_partial = "messages_stub_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:provisioning_profile.bzl",
+    "//apple/internal/partials:provisioning_profile.bzl",
     _provisioning_profile_partial = "provisioning_profile_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:resources.bzl",
+    "//apple/internal/partials:resources.bzl",
     _resources_partial = "resources_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:settings_bundle.bzl",
+    "//apple/internal/partials:settings_bundle.bzl",
     _settings_bundle_partial = "settings_bundle_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:swift_dylibs.bzl",
+    "//apple/internal/partials:swift_dylibs.bzl",
     _swift_dylibs_partial = "swift_dylibs_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:swift_dynamic_framework.bzl",
+    "//apple/internal/partials:swift_dynamic_framework.bzl",
     _swift_dynamic_framework_partial = "swift_dynamic_framework_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:swift_framework.bzl",
+    "//apple/internal/partials:swift_framework.bzl",
     _swift_framework_partial = "swift_framework_partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials:watchos_stub.bzl",
+    "//apple/internal/partials:watchos_stub.bzl",
     _watchos_stub_partial = "watchos_stub_partial",
 )
 

--- a/apple/internal/partials/app_assets_validation.bzl
+++ b/apple/internal/partials/app_assets_validation.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundling_support",
 )
 

--- a/apple/internal/partials/app_intents_metadata_bundle.bzl
+++ b/apple/internal/partials/app_intents_metadata_bundle.bzl
@@ -15,17 +15,17 @@
 """Partial implementation for processing AppIntents metadata bundle."""
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load(
-    "@build_bazel_rules_apple//apple/internal/providers:app_intents_info.bzl",
-    "AppIntentsInfo",
-)
-load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:app_intents.bzl",
-    "generate_app_intents_metadata_bundle",
-)
 load("//apple/internal:intermediates.bzl", "intermediates")
 load("//apple/internal:linking_support.bzl", "linking_support")
 load("//apple/internal:processor.bzl", "processor")
+load(
+    "//apple/internal/providers:app_intents_info.bzl",
+    "AppIntentsInfo",
+)
+load(
+    "//apple/internal/resource_actions:app_intents.bzl",
+    "generate_app_intents_metadata_bundle",
+)
 
 def _app_intents_metadata_bundle_partial_impl(
         *,

--- a/apple/internal/partials/apple_bundle_info.bzl
+++ b/apple/internal/partials/apple_bundle_info.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebundleinfo",
 )
 

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -24,15 +24,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleFrameworkImportInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/binary.bzl
+++ b/apple/internal/partials/binary.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/cc_info_dylibs.bzl
+++ b/apple/internal/partials/cc_info_dylibs.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -23,15 +23,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 

--- a/apple/internal/partials/codesigning_dossier.bzl
+++ b/apple/internal/partials/codesigning_dossier.bzl
@@ -27,27 +27,27 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applecodesigningdossierinfo",
 )
 

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -28,28 +28,28 @@ load(
 )
 load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleVersionInfo",
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appledsymbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
+    "//apple/internal/providers:apple_debug_info.bzl",
     "AppleDebugInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/partials/embedded_bundles.bzl
+++ b/apple/internal/partials/embedded_bundles.bzl
@@ -19,15 +19,15 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:embeddable_info.bzl",
+    "//apple/internal/providers:embeddable_info.bzl",
     "AppleEmbeddableInfo",
 )
 

--- a/apple/internal/partials/framework_header_modulemap.bzl
+++ b/apple/internal/partials/framework_header_modulemap.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/framework_headers.bzl
+++ b/apple/internal/partials/framework_headers.bzl
@@ -19,7 +19,7 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -27,23 +27,23 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleFrameworkImportInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/internal/partials/framework_provider.bzl
+++ b/apple/internal/partials/framework_provider.bzl
@@ -23,7 +23,7 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
 

--- a/apple/internal/partials/macos_additional_contents.bzl
+++ b/apple/internal/partials/macos_additional_contents.bzl
@@ -23,16 +23,16 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBinaryInfo",
     "AppleBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/internal/partials/main_thread_checker_dylibs.bzl
+++ b/apple/internal/partials/main_thread_checker_dylibs.bzl
@@ -23,15 +23,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
 )
 

--- a/apple/internal/partials/messages_stub.bzl
+++ b/apple/internal/partials/messages_stub.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/provisioning_profile.bzl
+++ b/apple/internal/partials/provisioning_profile.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/resources.bzl
+++ b/apple/internal/partials/resources.bzl
@@ -29,36 +29,36 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleResourceInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials/support:resources_support.bzl",
+    "//apple/internal/partials/support:resources_support.bzl",
     "PROVIDER_TO_FIELD_ACTION",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/internal/partials/settings_bundle.bzl
+++ b/apple/internal/partials/settings_bundle.bzl
@@ -19,19 +19,19 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleResourceInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/internal/partials/support/resources_support.bzl
+++ b/apple/internal/partials/support/resources_support.bzl
@@ -36,23 +36,23 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
+    "//apple:utils.bzl",
     "group_files_by_directory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -27,15 +27,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/partials/swift_dynamic_framework.bzl
+++ b/apple/internal/partials/swift_dynamic_framework.bzl
@@ -23,11 +23,11 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/partials/swift_framework.bzl
+++ b/apple/internal/partials/swift_framework.bzl
@@ -23,11 +23,11 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_info_support.bzl",
+    "//apple/internal:swift_info_support.bzl",
     "swift_info_support",
 )
 

--- a/apple/internal/partials/watchos_stub.bzl
+++ b/apple/internal/partials/watchos_stub.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -76,27 +76,27 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:defines.bzl",
+    "//apple/internal/utils:defines.bzl",
     "defines",
 )
 

--- a/apple/internal/resource_actions.bzl
+++ b/apple/internal/resource_actions.bzl
@@ -15,47 +15,47 @@
 """Proxy file for referencing resource processing actions."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:actool.bzl",
+    "//apple/internal/resource_actions:actool.bzl",
     _compile_asset_catalog = "compile_asset_catalog",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:datamodel.bzl",
+    "//apple/internal/resource_actions:datamodel.bzl",
     _compile_datamodels = "compile_datamodels",
     _compile_mappingmodel = "compile_mappingmodel",
     _generate_datamodels = "generate_datamodels",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:ibtool.bzl",
+    "//apple/internal/resource_actions:ibtool.bzl",
     _compile_storyboard = "compile_storyboard",
     _compile_xib = "compile_xib",
     _link_storyboards = "link_storyboards",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:intent.bzl",
+    "//apple/internal/resource_actions:intent.bzl",
     _generate_intent_classes_sources = "generate_intent_classes_sources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:metals.bzl",
+    "//apple/internal/resource_actions:metals.bzl",
     _compile_metals = "compile_metals",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:mlmodel.bzl",
+    "//apple/internal/resource_actions:mlmodel.bzl",
     _compile_mlmodel = "compile_mlmodel",
     _generate_mlmodel_sources = "generate_mlmodel_sources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:plist.bzl",
+    "//apple/internal/resource_actions:plist.bzl",
     _compile_plist = "compile_plist",
     _merge_resource_infoplists = "merge_resource_infoplists",
     _merge_root_infoplists = "merge_root_infoplists",
     _plisttool_action = "plisttool_action",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:png.bzl",
+    "//apple/internal/resource_actions:png.bzl",
     _copy_png = "copy_png",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_actions:texture_atlas.bzl",
+    "//apple/internal/resource_actions:texture_atlas.bzl",
     _compile_texture_atlas = "compile_texture_atlas",
 )
 

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -31,19 +31,19 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
+    "//apple:utils.bzl",
     "group_files_by_directory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
 

--- a/apple/internal/resource_actions/datamodel.bzl
+++ b/apple/internal/resource_actions/datamodel.bzl
@@ -19,7 +19,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
 

--- a/apple/internal/resource_actions/ibtool.bzl
+++ b/apple/internal/resource_actions/ibtool.bzl
@@ -27,7 +27,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
 

--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -23,7 +23,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
 

--- a/apple/internal/resource_actions/mlmodel.bzl
+++ b/apple/internal/resource_actions/mlmodel.bzl
@@ -19,7 +19,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:xctoolrunner.bzl",
+    "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
 

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -27,15 +27,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleVersionInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 

--- a/apple/internal/resource_rules/apple_bundle_import.bzl
+++ b/apple/internal/resource_rules/apple_bundle_import.bzl
@@ -19,11 +19,11 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleresourcebundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -27,28 +27,28 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
+    "//apple:utils.bzl",
     "group_files_by_directory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -27,29 +27,29 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -23,21 +23,21 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resource_actions.bzl",
+    "//apple/internal:resource_actions.bzl",
     "resource_actions",
 )
 

--- a/apple/internal/resource_rules/apple_metal_library.bzl
+++ b/apple/internal/resource_rules/apple_metal_library.bzl
@@ -27,20 +27,20 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleXPlatToolsToolchainInfo",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 

--- a/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
@@ -23,46 +23,46 @@ load(
     "partial",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
     "AppleResourceInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_product_type.bzl",
+    "apple_product_type",
+)
+load(
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleresourcebundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
-)
-load(
-    "//apple/internal:apple_product_type.bzl",
-    "apple_product_type",
 )
 
 def _apple_precompiled_resource_bundle_impl(ctx):
@@ -326,11 +326,11 @@ bundle root in the same structure passed to this argument, so `["res/foo.png"]` 
             ),
             "_environment_plist": attr.label(
                 allow_single_file = True,
-                default = "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
+                default = "//apple/internal:environment_plist_ios",
             ),
             "_fallback_infoplist": attr.label(
                 allow_single_file = True,
-                default = "@build_bazel_rules_apple//apple/internal/resource_rules:Info.plist",
+                default = "//apple/internal/resource_rules:Info.plist",
             ),
         },
         rule_attrs.common_tool_attrs(),

--- a/apple/internal/resource_rules/apple_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_resource_bundle.bzl
@@ -15,7 +15,7 @@
 """Implementation of apple_resource_bundle rule."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleresourcebundleinfo",
 )
 

--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -76,19 +76,19 @@ load(
     "types",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleresourceinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/partials/support:resources_support.bzl",
+    "//apple/internal/partials/support:resources_support.bzl",
     "PROVIDER_TO_FIELD_ACTION",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:bundle_paths.bzl",
+    "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
 

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -23,11 +23,15 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:common.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:common.bzl",
     "entitlements_validation_mode",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBaseBundleIdInfo",
     "AppleBundleVersionInfo",
     "ApplePlatformInfo",
@@ -35,36 +39,32 @@ load(
     "AppleSharedCapabilityInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:app_intents_aspect.bzl",
+    "//apple/internal/aspects:app_intents_aspect.bzl",
     "app_intents_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "//apple/internal/aspects:swift_usage_aspect.bzl",
     "swift_usage_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_info_aspect",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 def _common_attrs():
@@ -121,7 +121,7 @@ def _cc_toolchain_forwarder_attrs(*, deps_cfg):
             cfg = deps_cfg,
             providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
             default =
-                "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+                "//apple:default_cc_toolchain_forwarder",
         ),
     }
 
@@ -144,7 +144,7 @@ def _common_linking_api_attrs(*, deps_cfg):
             cfg = deps_cfg,
             providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
             default =
-                "@build_bazel_rules_apple//apple:default_cc_toolchain_forwarder",
+                "//apple:default_cc_toolchain_forwarder",
         ),
     })
 
@@ -327,7 +327,7 @@ binaries/libraries will be created combining all architectures specified by
         platform_attrs = dicts.add(platform_attrs, {
             "_environment_plist": attr.label(
                 allow_single_file = True,
-                default = "@build_bazel_rules_apple//apple/internal:environment_plist_{}".format(
+                default = "//apple/internal:environment_plist_{}".format(
                     platform_type,
                 ),
             ),
@@ -687,7 +687,7 @@ def _simulator_runner_template_attr():
             cfg = "exec",
             allow_single_file = True,
             default = Label(
-                "@build_bazel_rules_apple//apple/internal/templates:apple_simulator_template",
+                "//apple/internal/templates:apple_simulator_template",
             ),
         ),
     }
@@ -699,7 +699,7 @@ def _device_runner_template_attr():
             cfg = "exec",
             allow_single_file = True,
             default = Label(
-                "@build_bazel_rules_apple//apple/internal/templates:apple_device_template",
+                "//apple/internal/templates:apple_device_template",
             ),
         ),
     }
@@ -720,7 +720,7 @@ This value takes precedence (and is preferred) over locales defined using `--def
 _TEST_HOST_ASPECTS = [framework_provider_aspect]
 
 # Returns the default root Info.plist required to support a test bundle rule.
-_test_bundle_infoplist = "@build_bazel_rules_apple//apple/testing:DefaultTestBundlePlist"
+_test_bundle_infoplist = "//apple/testing:DefaultTestBundlePlist"
 
 rule_attrs = struct(
     app_icon_attrs = _app_icon_attrs,

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -20,20 +20,20 @@ load(
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleTestRunnerInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "coverage_files_aspect",
 )
 

--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -22,11 +22,11 @@ parameters that affect both the attributes and the implementation logic of the r
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundle_package_type.bzl",
+    "//apple/internal:bundle_package_type.bzl",
     "bundle_package_type",
 )
 

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -15,7 +15,7 @@
 """Common definitions used to make runnable Apple bundling rules."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -23,7 +23,7 @@ load(
     "lipo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 

--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -16,12 +16,12 @@
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
-    "intermediates",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
+)
+load(
+    "//apple/internal:intermediates.bzl",
+    "intermediates",
 )
 
 def _verify_found_module_name(*, bundle_name, found_module_name):

--- a/apple/internal/swift_support.bzl
+++ b/apple/internal/swift_support.bzl
@@ -15,7 +15,7 @@
 """Support functions for working with Swift."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -19,83 +19,83 @@ load(
     "types",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleTestInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleextraoutputsinfo",
     "new_appletestinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 # Default test bundle ID for tests that don't have a test host or were not given

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -19,7 +19,7 @@ load(
     "dicts",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleCodesigningDossierInfo",
     "AppleDsymBundleInfo",

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -15,12 +15,12 @@
 """Rules for writing build tests for libraries that target Apple platforms."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "AppleBinaryInfo",
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of iOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "IosApplicationBundleInfo",
     "IosExtensionBundleInfo",
@@ -23,43 +23,43 @@ load(
     "IosImessageApplicationBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_iosxctestbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_bundle_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "apple_test_rule_support",
 )
 

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -15,49 +15,49 @@
 """Implementation of macOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "MacosApplicationBundleInfo",
     "MacosFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_macosxctestbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_bundle_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "apple_test_rule_support",
 )
 

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -15,50 +15,50 @@
 """Implementation of tvOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "TvosApplicationBundleInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_tvosxctestbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_bundle_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "apple_test_rule_support",
 )
 

--- a/apple/internal/testing/visionos_rules.bzl
+++ b/apple/internal/testing/visionos_rules.bzl
@@ -15,50 +15,50 @@
 """Implementation of visionOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "VisionosApplicationBundleInfo",
     "VisionosExtensionBundleInfo",
     "VisionosFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_visionosxctestbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_bundle_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "apple_test_rule_support",
 )
 

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -15,49 +15,49 @@
 """Implementation of watchOS test rules."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "WatchosApplicationBundleInfo",
     "WatchosFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_watchosxctestbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_bundle_support.bzl",
+    "//apple/internal/testing:apple_test_bundle_support.bzl",
     "apple_test_bundle_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_rule_support.bzl",
+    "//apple/internal/testing:apple_test_rule_support.bzl",
     "apple_test_rule_support",
 )
 

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -38,7 +38,7 @@ load(
     "CPU_TO_DEFAULT_PLATFORM_NAME",
 )
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -16,68 +16,72 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "ApplePlatformInfo",
     "TvosExtensionBundleInfo",
     "TvosFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleframeworkbundleinfo",
     "new_tvosapplicationbundleinfo",
     "new_tvosextensionbundleinfo",
@@ -85,57 +89,53 @@ load(
     "new_tvosstaticframeworkbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:run_support.bzl",
+    "//apple/internal:run_support.bzl",
     "run_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 def _tvos_application_impl(ctx):

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -16,61 +16,65 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "AppleBundleInfo",
     "ApplePlatformInfo",
     "VisionosExtensionBundleInfo",
@@ -82,57 +86,53 @@ load(
     "new_visionosstaticframeworkbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:run_support.bzl",
+    "//apple/internal:run_support.bzl",
     "run_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 visibility([

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -20,7 +20,11 @@ load(
 )
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+load(
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "ApplePlatformInfo",
     "WatchosExtensionBundleInfo",
@@ -28,117 +32,113 @@ load(
     "WatchosStaticFrameworkBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:bundling_support.bzl",
+    "//apple/internal:bundling_support.bzl",
     "bundle_id_suffix_default",
     "bundling_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:codesigning_support.bzl",
+    "//apple/internal:codesigning_support.bzl",
     "codesigning_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:entitlements_support.bzl",
+    "//apple/internal:entitlements_support.bzl",
     "entitlements_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:framework_import_support.bzl",
+    "//apple/internal:framework_import_support.bzl",
     "libraries_to_link_for_dynamic_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_appleframeworkbundleinfo",
     "new_watchosapplicationbundleinfo",
     "new_watchosextensionbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:stub_support.bzl",
+    "//apple/internal:stub_support.bzl",
     "stub_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:framework_provider_aspect.bzl",
+    "//apple/internal/aspects:framework_provider_aspect.bzl",
     "framework_provider_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
+    "//apple/internal/aspects:swift_dynamic_framework_aspect.bzl",
     "SwiftDynamicFrameworkInfo",
     "swift_dynamic_framework_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:clang_rt_dylibs.bzl",
+    "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:main_thread_checker_dylibs.bzl",
+    "//apple/internal/utils:main_thread_checker_dylibs.bzl",
     "main_thread_checker_dylibs",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 
 def _watchos_framework_impl(ctx):

--- a/apple/internal/xcarchive.bzl
+++ b/apple/internal/xcarchive.bzl
@@ -3,16 +3,16 @@ Rule for packaging a bundle into a .xcarchive.
 """
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebinaryinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/providers:apple_debug_info.bzl",
+    "//apple/internal/providers:apple_debug_info.bzl",
     "AppleDebugInfo",
 )
 
@@ -84,7 +84,7 @@ The label to a target to re-package into a .xcarchive. For example, an
             """,
         ),
         "_make_xcarchive": attr.label(
-            default = Label("@build_bazel_rules_apple//tools/xcarchivetool:make_xcarchive"),
+            default = Label("//tools/xcarchivetool:make_xcarchive"),
             executable = True,
             cfg = "exec",
             doc = """\

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -20,98 +20,98 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleVersionInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",
+    "//apple/internal:apple_product_type.bzl",
     "apple_product_type",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleMacToolsToolchainInfo",
     "AppleXPlatToolsToolchainInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:cc_info_support.bzl",
+    "//apple/internal:cc_info_support.bzl",
     "cc_info_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:experimental.bzl",
+    "//apple/internal:experimental.bzl",
     "is_experimental_tree_artifact_enabled",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:features_support.bzl",
+    "//apple/internal:features_support.bzl",
     "features_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",
+    "//apple/internal:intermediates.bzl",
     "intermediates",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:linking_support.bzl",
+    "//apple/internal:linking_support.bzl",
     "linking_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:outputs.bzl",
+    "//apple/internal:outputs.bzl",
     "outputs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:partials.bzl",
+    "//apple/internal:partials.bzl",
     "partials",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:platform_support.bzl",
+    "//apple/internal:platform_support.bzl",
     "platform_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:processor.bzl",
+    "//apple/internal:processor.bzl",
     "processor",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebundleinfo",
     "new_applestaticxcframeworkbundleinfo",
     "new_applexcframeworkbundleinfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_attrs.bzl",
+    "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_factory.bzl",
+    "//apple/internal:rule_factory.bzl",
     "rule_factory",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:rule_support.bzl",
+    "//apple/internal:rule_support.bzl",
     "rule_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:swift_support.bzl",
+    "//apple/internal:swift_support.bzl",
     "swift_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:transition_support.bzl",
+    "//apple/internal:transition_support.bzl",
     "transition_support",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:resource_aspect.bzl",
+    "//apple/internal/aspects:resource_aspect.bzl",
     "apple_resource_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/aspects:swift_usage_aspect.bzl",
+    "//apple/internal/aspects:swift_usage_aspect.bzl",
     "swift_usage_aspect",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/utils:files.bzl",
+    "//apple/internal/utils:files.bzl",
     "files",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
 def _group_link_outputs_by_library_identifier(
         *,
@@ -799,8 +799,8 @@ apple_xcframework = rule_factory.create_apple_rule(
         {
             "_environment_plist_files": attr.label_list(
                 default = [
-                    "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
-                    "@build_bazel_rules_apple//apple/internal:environment_plist_tvos",
+                    "//apple/internal:environment_plist_ios",
+                    "//apple/internal:environment_plist_tvos",
                 ],
             ),
             "bundle_id": attr.string(
@@ -1155,7 +1155,7 @@ the target will be used instead.
             ),
             "_environment_plist_ios": attr.label(
                 allow_single_file = True,
-                default = "@build_bazel_rules_apple//apple/internal:environment_plist_ios",
+                default = "//apple/internal:environment_plist_ios",
             ),
             "avoid_deps": attr.label_list(
                 aspects = [apple_resource_aspect],

--- a/apple/ios.bzl
+++ b/apple/ios.bzl
@@ -15,7 +15,7 @@
 """Bazel rules for creating iOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
+    "//apple/internal:ios_rules.bzl",
     _ios_app_clip = "ios_app_clip",
     _ios_application = "ios_application",
     _ios_dynamic_framework = "ios_dynamic_framework",
@@ -27,15 +27,15 @@ load(
     _ios_sticker_pack_extension = "ios_sticker_pack_extension",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "//apple/internal/testing:build_test_rules.bzl",
     "apple_build_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
+    "//apple/internal/testing:ios_rules.bzl",
     _ios_internal_ui_test_bundle = "ios_internal_ui_test_bundle",
     _ios_internal_unit_test_bundle = "ios_internal_unit_test_bundle",
     _ios_ui_test = "ios_ui_test",

--- a/apple/ios.doc.bzl
+++ b/apple/ios.doc.bzl
@@ -18,7 +18,7 @@
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal:ios_rules.bzl",
+    "//apple/internal:ios_rules.bzl",
     _ios_app_clip = "ios_app_clip",
     _ios_application = "ios_application",
     _ios_dynamic_framework = "ios_dynamic_framework",
@@ -30,16 +30,16 @@ load(
     _ios_sticker_pack_extension = "ios_sticker_pack_extension",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:ios_rules.bzl",
+    "//apple/internal/testing:ios_rules.bzl",
     _ios_ui_test = "ios_ui_test",
     _ios_unit_test = "ios_unit_test",
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "//apple/testing/default_runner:ios_test_runner.bzl",
     _ios_test_runner = "ios_test_runner",
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    "//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     _ios_xctestrun_runner = "ios_xctestrun_runner",
 )
 load(

--- a/apple/macos.bzl
+++ b/apple/macos.bzl
@@ -15,12 +15,12 @@
 """Bazel rules for creating macOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:macos_binary_support.bzl",
+    "//apple/internal:macos_binary_support.bzl",
     "macos_binary_infoplist",
     "macos_command_line_launchdplist",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:macos_rules.bzl",
+    "//apple/internal:macos_rules.bzl",
     _macos_application = "macos_application",
     _macos_bundle = "macos_bundle",
     _macos_command_line_application = "macos_command_line_application",
@@ -35,15 +35,15 @@ load(
     _macos_xpc_service = "macos_xpc_service",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "//apple/internal/testing:build_test_rules.bzl",
     "apple_build_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
+    "//apple/internal/testing:macos_rules.bzl",
     _macos_internal_ui_test_bundle = "macos_internal_ui_test_bundle",
     _macos_internal_unit_test_bundle = "macos_internal_unit_test_bundle",
     _macos_ui_test = "macos_ui_test",

--- a/apple/macos.doc.bzl
+++ b/apple/macos.doc.bzl
@@ -15,7 +15,7 @@
 """# Bazel rules for creating macOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:macos_rules.bzl",
+    "//apple/internal:macos_rules.bzl",
     _macos_application = "macos_application",
     _macos_bundle = "macos_bundle",
     _macos_command_line_application = "macos_command_line_application",
@@ -34,7 +34,7 @@ load(
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:macos_rules.bzl",
+    "//apple/internal/testing:macos_rules.bzl",
     _macos_ui_test = "macos_ui_test",
     _macos_unit_test = "macos_unit_test",
 )

--- a/apple/providers.bzl
+++ b/apple/providers.bzl
@@ -30,7 +30,7 @@ boundary with well-defined public APIs for broader usage.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     _AppleBaseBundleIdInfo = "AppleBaseBundleIdInfo",
     _AppleBinaryInfo = "AppleBinaryInfo",
     _AppleBundleInfo = "AppleBundleInfo",

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -14,43 +14,43 @@
 
 """# Rules related to Apple resources and resource bundles."""
 
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@build_bazel_rules_apple//apple/internal:resources.bzl",
+    "//apple/internal:resources.bzl",
     _resources_common = "resources",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_bundle_import.bzl",
+    "//apple/internal/resource_rules:apple_bundle_import.bzl",
     _apple_bundle_import = "apple_bundle_import",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_data_model.bzl",
+    "//apple/internal/resource_rules:apple_core_data_model.bzl",
     _apple_core_data_model = "apple_core_data_model",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_core_ml_library.bzl",
+    "//apple/internal/resource_rules:apple_core_ml_library.bzl",
     _apple_core_ml_library = "apple_core_ml_library",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_intent_library.bzl",
+    "//apple/internal/resource_rules:apple_intent_library.bzl",
     _apple_intent_library = "apple_intent_library",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_metal_library.bzl",
+    "//apple/internal/resource_rules:apple_metal_library.bzl",
     _apple_metal_library = "apple_metal_library",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_precompiled_resource_bundle.bzl",
+    "//apple/internal/resource_rules:apple_precompiled_resource_bundle.bzl",
     _apple_precompiled_resource_bundle = "apple_precompiled_resource_bundle",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_resource_bundle.bzl",
+    "//apple/internal/resource_rules:apple_resource_bundle.bzl",
     _apple_resource_bundle = "apple_resource_bundle",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/resource_rules:apple_resource_group.bzl",
+    "//apple/internal/resource_rules:apple_resource_group.bzl",
     _apple_resource_group = "apple_resource_group",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 apple_bundle_import = _apple_bundle_import
 apple_intent_library = _apple_intent_library

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -15,7 +15,7 @@
 """iOS test runner rule."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
@@ -109,7 +109,7 @@ into the XCTest invocation.
         ),
         "_test_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.template.sh",
+                "//apple/testing/default_runner:ios_test_runner.template.sh",
             ),
             allow_single_file = True,
         ),
@@ -126,7 +126,7 @@ dependency is the test runner binary.
         ),
         "_simulator_creator": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator",
+                "//apple/testing/default_runner:simulator_creator",
             ),
             executable = True,
             cfg = "exec",

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -4,7 +4,7 @@ simulators. This rule currently doesn't support UI tests or running on device.
 """
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
@@ -164,14 +164,14 @@ Toggle simulator reuse. The default behavior is to reuse an existing device of t
         ),
         "_simulator_creator": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:simulator_creator",
+                "//apple/testing/default_runner:simulator_creator",
             ),
             executable = True,
             cfg = "exec",
         ),
         "_test_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.template.sh",
+                "//apple/testing/default_runner:ios_xctestrun_runner.template.sh",
             ),
             allow_single_file = True,
         ),
@@ -183,13 +183,13 @@ Toggle simulator reuse. The default behavior is to reuse an existing device of t
         ),
         "_xctestrun_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.template.xctestrun",
+                "//apple/testing/default_runner:ios_xctestrun_runner.template.xctestrun",
             ),
             allow_single_file = True,
         ),
         "_xctrunner_entitlements_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:xctrunner_entitlements.template.plist",
+                "//apple/testing/default_runner:xctrunner_entitlements.template.plist",
             ),
             allow_single_file = True,
         ),
@@ -206,13 +206,13 @@ You can use this rule directly if you need to override 'device_type' or
 'os_version', otherwise you can use the predefined runners:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+"//apple/testing/default_runner:ios_xctestrun_ordered_runner"
 ```
 
 or:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+"//apple/testing/default_runner:ios_xctestrun_random_runner"
 ```
 
 Depending on if you want random test ordering or not. Set these as the `runner`
@@ -222,7 +222,7 @@ attribute on your `ios_unit_test` target:
 ios_unit_test(
     name = "Tests",
     minimum_os_version = "15.5",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    runner = "//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":TestsLib"],
 )
 ```

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -206,13 +206,13 @@ You can use this rule directly if you need to override 'device_type' or
 'os_version', otherwise you can use the predefined runners:
 
 ```
-"//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
 ```
 
 or:
 
 ```
-"//apple/testing/default_runner:ios_xctestrun_random_runner"
+"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
 ```
 
 Depending on if you want random test ordering or not. Set these as the `runner`
@@ -222,7 +222,7 @@ attribute on your `ios_unit_test` target:
 ios_unit_test(
     name = "Tests",
     minimum_os_version = "15.5",
-    runner = "//apple/testing/default_runner:ios_xctestrun_random_runner",
+    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":TestsLib"],
 )
 ```

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -19,7 +19,7 @@ load(
     "xcode_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "apple_provider",
 )
 
@@ -107,7 +107,7 @@ macos_test_runner = rule(
     _macos_test_runner_impl,
     attrs = {
         "_test_template": attr.label(
-            default = Label("@build_bazel_rules_apple//apple/testing/default_runner:macos_test_runner.template.sh"),
+            default = Label("//apple/testing/default_runner:macos_test_runner.template.sh"),
             allow_single_file = True,
         ),
         "_xcode_config": attr.label(
@@ -117,7 +117,7 @@ macos_test_runner = rule(
             ),
         ),
         "_xctestrun_template": attr.label(
-            default = Label("@build_bazel_rules_apple//apple/testing/default_runner:macos_test_runner.template.xctestrun"),
+            default = Label("//apple/testing/default_runner:macos_test_runner.template.xctestrun"),
             allow_single_file = True,
         ),
     },

--- a/apple/testing/default_runner/tvos_test_runner.bzl
+++ b/apple/testing/default_runner/tvos_test_runner.bzl
@@ -15,7 +15,7 @@
 """tvOS test runner rule."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
@@ -98,7 +98,7 @@ By default, it is the latest supported version of the device type.'
         ),
         "_test_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:tvos_test_runner.template.sh",
+                "//apple/testing/default_runner:tvos_test_runner.template.sh",
             ),
             allow_single_file = True,
         ),

--- a/apple/testing/default_runner/visionos_test_runner.bzl
+++ b/apple/testing/default_runner/visionos_test_runner.bzl
@@ -15,7 +15,7 @@
 """visionOS test runner rule."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
@@ -98,7 +98,7 @@ By default, it is the latest supported version of the device type.'
         ),
         "_test_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:visionos_test_runner.template.sh",
+                "//apple/testing/default_runner:visionos_test_runner.template.sh",
             ),
             allow_single_file = True,
         ),

--- a/apple/testing/default_runner/watchos_test_runner.bzl
+++ b/apple/testing/default_runner/watchos_test_runner.bzl
@@ -15,7 +15,7 @@
 """watchOS test runner rule."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
     "apple_provider",
 )
@@ -98,7 +98,7 @@ By default, it is the latest supported version of the device type.'
         ),
         "_test_template": attr.label(
             default = Label(
-                "@build_bazel_rules_apple//apple/testing/default_runner:watchos_test_runner.template.sh",
+                "//apple/testing/default_runner:watchos_test_runner.template.sh",
             ),
             allow_single_file = True,
         ),

--- a/apple/tvos.bzl
+++ b/apple/tvos.bzl
@@ -15,7 +15,7 @@
 """Bazel rules for creating tvOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:tvos_rules.bzl",
+    "//apple/internal:tvos_rules.bzl",
     _tvos_application = "tvos_application",
     _tvos_dynamic_framework = "tvos_dynamic_framework",
     _tvos_extension = "tvos_extension",
@@ -23,15 +23,15 @@ load(
     _tvos_static_framework = "tvos_static_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "//apple/internal/testing:build_test_rules.bzl",
     "apple_build_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:tvos_rules.bzl",
+    "//apple/internal/testing:tvos_rules.bzl",
     _tvos_internal_ui_test_bundle = "tvos_internal_ui_test_bundle",
     _tvos_internal_unit_test_bundle = "tvos_internal_unit_test_bundle",
     _tvos_ui_test = "tvos_ui_test",

--- a/apple/tvos.doc.bzl
+++ b/apple/tvos.doc.bzl
@@ -4,7 +4,7 @@
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal:tvos_rules.bzl",
+    "//apple/internal:tvos_rules.bzl",
     _tvos_application = "tvos_application",
     _tvos_dynamic_framework = "tvos_dynamic_framework",
     _tvos_extension = "tvos_extension",
@@ -12,7 +12,7 @@ load(
     _tvos_static_framework = "tvos_static_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:tvos_rules.bzl",
+    "//apple/internal/testing:tvos_rules.bzl",
     _tvos_ui_test = "tvos_ui_test",
     _tvos_unit_test = "tvos_unit_test",
 )

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -19,12 +19,12 @@ load(
     "dicts",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_toolchains.bzl",
+    "//apple/internal:apple_toolchains.bzl",
     "AppleXPlatToolsToolchainInfo",
     "apple_toolchain_utils",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "//apple/internal:providers.bzl",
     "new_applebundleversioninfo",
 )
 

--- a/apple/visionos.bzl
+++ b/apple/visionos.bzl
@@ -15,22 +15,22 @@
 """Bazel rules for creating visionOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:visionos_rules.bzl",
+    "//apple/internal:visionos_rules.bzl",
     _visionos_application = "visionos_application",
     _visionos_dynamic_framework = "visionos_dynamic_framework",
     _visionos_framework = "visionos_framework",
     _visionos_static_framework = "visionos_static_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "//apple/internal/testing:build_test_rules.bzl",
     "apple_build_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:visionos_rules.bzl",
+    "//apple/internal/testing:visionos_rules.bzl",
     _visionos_internal_ui_test_bundle = "visionos_internal_ui_test_bundle",
     _visionos_internal_unit_test_bundle = "visionos_internal_unit_test_bundle",
     _visionos_ui_test = "visionos_ui_test",

--- a/apple/visionos.doc.bzl
+++ b/apple/visionos.doc.bzl
@@ -1,11 +1,11 @@
 """# Bazel rules for creating visionOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple:visionos.bzl",
+    "//apple:visionos.bzl",
     _visionos_build_test = "visionos_build_test",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:visionos_rules.bzl",
+    "//apple/internal:visionos_rules.bzl",
     _visionos_application = "visionos_application",
     _visionos_dynamic_framework = "visionos_dynamic_framework",
     _visionos_framework = "visionos_framework",
@@ -16,7 +16,7 @@ load(
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:visionos_rules.bzl",
+    "//apple/internal/testing:visionos_rules.bzl",
     _visionos_ui_test = "visionos_ui_test",
     _visionos_unit_test = "visionos_unit_test",
 )

--- a/apple/watchos.bzl
+++ b/apple/watchos.bzl
@@ -15,7 +15,7 @@
 """Bazel rules for creating watchOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:watchos_rules.bzl",
+    "//apple/internal:watchos_rules.bzl",
     _watchos_application = "watchos_application",
     _watchos_dynamic_framework = "watchos_dynamic_framework",
     _watchos_extension = "watchos_extension",
@@ -23,15 +23,15 @@ load(
     _watchos_static_framework = "watchos_static_framework",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:apple_test_assembler.bzl",
+    "//apple/internal/testing:apple_test_assembler.bzl",
     "apple_test_assembler",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:build_test_rules.bzl",
+    "//apple/internal/testing:build_test_rules.bzl",
     "apple_build_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:watchos_rules.bzl",
+    "//apple/internal/testing:watchos_rules.bzl",
     _watchos_internal_ui_test_bundle = "watchos_internal_ui_test_bundle",
     _watchos_internal_unit_test_bundle = "watchos_internal_unit_test_bundle",
     _watchos_ui_test = "watchos_ui_test",

--- a/apple/watchos.doc.bzl
+++ b/apple/watchos.doc.bzl
@@ -1,11 +1,11 @@
 """# Bazel rules for creating watchOS applications and bundles."""
 
 load(
-    "@build_bazel_rules_apple//apple:watchos.bzl",
+    "//apple:watchos.bzl",
     _watchos_build_test = "watchos_build_test",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:watchos_rules.bzl",
+    "//apple/internal:watchos_rules.bzl",
     _watchos_application = "watchos_application",
     _watchos_dynamic_framework = "watchos_dynamic_framework",
     _watchos_extension = "watchos_extension",
@@ -17,7 +17,7 @@ load(
 # so that stardoc documents the rule attributes, not an opaque
 # **kwargs argument.
 load(
-    "@build_bazel_rules_apple//apple/internal/testing:watchos_rules.bzl",
+    "//apple/internal/testing:watchos_rules.bzl",
     _watchos_ui_test = "watchos_ui_test",
     _watchos_unit_test = "watchos_unit_test",
 )

--- a/apple/xcarchive.bzl
+++ b/apple/xcarchive.bzl
@@ -17,7 +17,7 @@ Rules for creating Xcode archives.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:xcarchive.bzl",
+    "//apple/internal:xcarchive.bzl",
     _xcarchive = "xcarchive",
 )
 

--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -85,7 +85,7 @@ build_test(
 ios_ui_test(
     name = "HelloWorldSwiftUITests",
     minimum_os_version = "15.0",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    runner = "//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     test_host = ":HelloWorldSwift",
     deps = [":UITests"],
 )

--- a/examples/ios/Squarer/BUILD
+++ b/examples/ios/Squarer/BUILD
@@ -28,7 +28,7 @@ ios_unit_test(
     name = "SquarerTestsOrdered",
     env = {"TEST_ENV_VAR": "test_value"},
     minimum_os_version = "11.0",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    runner = "//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     deps = [":SquarerTestsLib"],
 )
 
@@ -36,6 +36,6 @@ ios_unit_test(
     name = "SquarerTestsRandom",
     env = {"TEST_ENV_VAR": "test_value"},
     minimum_os_version = "11.0",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    runner = "//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":SquarerTestsLib"],
 )

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -69,7 +69,7 @@ function create_new_workspace() {
   mkdir -p "${new_workspace_dir}"
   cd "${new_workspace_dir}"
 
-  rules_apple_path=$(resolve_external_repository build_bazel_rules_apple)
+  rules_apple_path=$(resolve_external_repository rules_apple)
 
   touch MODULE.bazel
   cat > MODULE.bazel <<EOF
@@ -140,5 +140,5 @@ if [[ -z "$XCODE_QUERY" ]]; then
   printf "of Xcode.\n" >> "$TEST_log"
 fi
 
-source "$(rlocation build_bazel_rules_apple/test/apple_shell_testutils.sh)"
-source "$(rlocation build_bazel_rules_apple/test/${test_script})"
+source "$(rlocation rules_apple/test/apple_shell_testutils.sh)"
+source "$(rlocation rules_apple/test/${test_script})"

--- a/test/ios_application_test.sh
+++ b/test/ios_application_test.sh
@@ -242,7 +242,7 @@ function verify_debugger_entitlements_with_params() {
 
   create_common_files
 
-  cp $(rlocation build_bazel_rules_apple/test/testdata/provisioning/integration_testing_ios.mobileprovision) \
+  cp $(rlocation rules_apple/test/testdata/provisioning/integration_testing_ios.mobileprovision) \
     app/profile.mobileprovision
   if [[ "${INCLUDE_DEBUGGER}" == "n" ]]; then
     sed -i'.original' -e '/get-task-allow/,+1 d' app/profile.mobileprovision

--- a/test/ios_extension_test.sh
+++ b/test/ios_extension_test.sh
@@ -200,10 +200,10 @@ EOF
 
   mkdir -p app/fmwk.framework
   if [[ $framework_type == dynamic ]]; then
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
+    cp $(rlocation rules_apple/test/testdata/binaries/empty_dylib_lipobin.dylib) \
         app/fmwk.framework/fmwk
   else
-    cp $(rlocation build_bazel_rules_apple/test/testdata/binaries/libdummy_lib.a) \
+    cp $(rlocation rules_apple/test/testdata/binaries/libdummy_lib.a) \
         app/fmwk.framework/fmwk
   fi
 

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -15,7 +15,7 @@
 """apple_dynamic_xcframework_import Starlark tests."""
 
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -15,7 +15,7 @@
 """apple_static_xcframework_import Starlark tests."""
 
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1299,7 +1299,7 @@ cc_library(
 cc_library(
     name = "cc_library_with_resource_a",
     srcs = ["main.cc"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:use_resources"],
+    aspect_hints = ["//apple:use_resources"],
     data = [
         # because of aspect-hint, this file should be placed in /Resources/nested.txt
         "//test/starlark_tests/resources:cc_lib_resources/resource_a.txt",
@@ -1310,7 +1310,7 @@ cc_library(
 cc_library(
     name = "cc_library_with_suppressed_resources",
     srcs = ["main.cc"],
-    aspect_hints = ["@build_bazel_rules_apple//apple:suppress_resources"],
+    aspect_hints = ["//apple:suppress_resources"],
     data = [
         # because of aspect-hint, this file should not be included in the application
         "//test/starlark_tests/resources:cc_lib_resources/suppressed_resource.txt",

--- a/test/starlark_tests/rules/analysis_failure_message_test.bzl
+++ b/test/starlark_tests/rules/analysis_failure_message_test.bzl
@@ -22,7 +22,7 @@ load(
     "asserts",
 )
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 

--- a/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
+++ b/test/starlark_tests/rules/analysis_output_group_info_files_test.bzl
@@ -15,11 +15,11 @@
 """Starlark test rule for OutputGroupInfo output group files."""
 
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
+    "//test/starlark_tests/rules:analysis_provider_test.bzl",
     "make_provider_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "//test/starlark_tests/rules:assertions.bzl",
     "assertions",
 )
 

--- a/test/starlark_tests/rules/analysis_target_actions_test.bzl
+++ b/test/starlark_tests/rules/analysis_target_actions_test.bzl
@@ -20,7 +20,7 @@ load(
     "unittest",
 )
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 

--- a/test/starlark_tests/rules/analysis_target_outputs_test.bzl
+++ b/test/starlark_tests/rules/analysis_target_outputs_test.bzl
@@ -19,11 +19,11 @@ load(
     "analysistest",
 )
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "//test/starlark_tests/rules:assertions.bzl",
     "assertions",
 )
 

--- a/test/starlark_tests/rules/apple_codesigning_dossier_info_provider_test.bzl
+++ b/test/starlark_tests/rules/apple_codesigning_dossier_info_provider_test.bzl
@@ -24,11 +24,11 @@ load(
     "asserts",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleCodesigningDossierInfo",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
+    "//test/starlark_tests/rules:analysis_provider_test.bzl",
     "make_provider_test_rule",
 )
 

--- a/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
+++ b/test/starlark_tests/rules/apple_dsym_bundle_info_test.bzl
@@ -15,15 +15,15 @@
 """Starlark test rules for debug symbols."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleDsymBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:analysis_provider_test.bzl",
+    "//test/starlark_tests/rules:analysis_provider_test.bzl",
     "make_provider_test_rule",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:assertions.bzl",
+    "//test/starlark_tests/rules:assertions.bzl",
     "assertions",
 )
 

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -27,16 +27,16 @@ load(
     "paths",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBinaryInfo",
     "AppleBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//apple/build_settings:build_settings.bzl",
+    "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
+    "//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
     "apple_product_type",
 )  # buildifier: disable=bzl-visibility
 
@@ -369,10 +369,10 @@ into a bash array.
         ),
         "_runner_script": attr.label(
             allow_single_file = True,
-            default = "@build_bazel_rules_apple//test/starlark_tests:verifier_scripts/apple_verification_test_runner.sh.template",
+            default = "//test/starlark_tests:verifier_scripts/apple_verification_test_runner.sh.template",
         ),
         "_test_deps": attr.label(
-            default = "@build_bazel_rules_apple//test:apple_verification_test_deps",
+            default = "//test:apple_verification_test_deps",
         ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",

--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -15,7 +15,7 @@
 """Macros for common verification test tests."""
 
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:apple_verification_test.bzl",
+    "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_test",
 )
 
@@ -221,7 +221,7 @@ def archive_contents_test(
             "TEXT_FILE_NOT_CONTAINS": text_file_not_contains,
         },
         target_under_test = target_under_test,
-        verifier_script = "@build_bazel_rules_apple//test/starlark_tests:verifier_scripts/archive_contents_test.sh",
+        verifier_script = "//test/starlark_tests:verifier_scripts/archive_contents_test.sh",
         **kwargs
     )
 
@@ -316,7 +316,7 @@ def binary_contents_test(
             "PLIST_TEST_VALUES": _dict_to_space_separated_string_array(embedded_plist_test_values),
         },
         target_under_test = target_under_test,
-        verifier_script = "@build_bazel_rules_apple//test/starlark_tests:verifier_scripts/binary_contents_test.sh",
+        verifier_script = "//test/starlark_tests:verifier_scripts/binary_contents_test.sh",
         **kwargs
     )
 
@@ -350,7 +350,7 @@ def apple_symbols_file_test(
         },
         target_under_test = target_under_test,
         apple_generate_dsym = True,
-        verifier_script = "@build_bazel_rules_apple//test/starlark_tests:verifier_scripts/apple_symbols_file_verifier.sh",
+        verifier_script = "//test/starlark_tests:verifier_scripts/apple_symbols_file_verifier.sh",
         tags = tags,
     )
 
@@ -378,6 +378,6 @@ def entry_point_test(
             "ENTRY_POINT": [entry_point],
         },
         target_under_test = target_under_test,
-        verifier_script = "@build_bazel_rules_apple//test/starlark_tests:verifier_scripts/entry_point_verifier.sh",
+        verifier_script = "//test/starlark_tests:verifier_scripts/entry_point_verifier.sh",
         tags = tags,
     )

--- a/test/starlark_tests/rules/dummy_apple_resource_info.bzl
+++ b/test/starlark_tests/rules/dummy_apple_resource_info.bzl
@@ -19,7 +19,7 @@ that may change at any time. Please do not depend on this rule.
 """
 
 load(
-    "@build_bazel_rules_apple//apple/internal:providers.bzl",  # buildifier: disable=bzl-visibility
+    "//apple/internal:providers.bzl",  # buildifier: disable=bzl-visibility
     "new_appleresourceinfo",
 )
 

--- a/test/starlark_tests/rules/entitlements_contents_test.bzl
+++ b/test/starlark_tests/rules/entitlements_contents_test.bzl
@@ -24,7 +24,7 @@ rule.
 """
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
 )
 load(

--- a/test/starlark_tests/rules/generate_framework.bzl
+++ b/test/starlark_tests/rules/generate_framework.bzl
@@ -16,11 +16,11 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:generation_support.bzl",
+    "//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
 _SDK_TO_OS = {
     "iphonesimulator": "ios",
@@ -201,14 +201,14 @@ Minimum version of the OS corresponding to the SDK that this binary will support
         "src": attr.label(
             allow_single_file = True,
             default = Label(
-                "@build_bazel_rules_apple//test/starlark_tests/resources/frameworks:SharedClass.m",
+                "//test/starlark_tests/resources/frameworks:SharedClass.m",
             ),
             doc = "Source file for the generated framework.",
         ),
         "hdrs": attr.label(
             allow_files = True,
             default = Label(
-                "@build_bazel_rules_apple//test/starlark_tests/resources/frameworks:SharedClass.h",
+                "//test/starlark_tests/resources/frameworks:SharedClass.h",
             ),
             doc = "Header files for the generated framework.",
         ),

--- a/test/starlark_tests/rules/generate_framework_dsym.bzl
+++ b/test/starlark_tests/rules/generate_framework_dsym.bzl
@@ -21,7 +21,7 @@ load(
     "apple_support",
 )
 load(
-    "@build_bazel_rules_apple//apple:utils.bzl",
+    "//apple:utils.bzl",
     "group_files_by_directory",
 )
 

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -17,11 +17,11 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:generation_support.bzl",
+    "//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
 _PLATFORM_TO_SDK = {
     "ios": "iphoneos",

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -17,7 +17,7 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
-    "@build_bazel_rules_apple//apple/internal:intermediates.bzl",  # buildifier: disable=bzl-visibility
+    "//apple/internal:intermediates.bzl",  # buildifier: disable=bzl-visibility
     "intermediates",
 )
 

--- a/test/starlark_tests/rules/infoplist_contents_test.bzl
+++ b/test/starlark_tests/rules/infoplist_contents_test.bzl
@@ -22,16 +22,16 @@ that may change at any time. Please do not depend on this rule.
 """
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBinaryInfo",
     "AppleBundleInfo",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:apple_verification_test.bzl",
+    "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_transition",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:output_group_test_support.bzl",
+    "//test/starlark_tests/rules:output_group_test_support.bzl",
     "output_group_test_support",
 )
 

--- a/test/starlark_tests/rules/output_group_zip_contents_test.bzl
+++ b/test/starlark_tests/rules/output_group_zip_contents_test.bzl
@@ -15,11 +15,11 @@
 """Starlark test rule to validate the zip file referenced from an output group."""
 
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:apple_verification_test.bzl",
+    "//test/starlark_tests/rules:apple_verification_test.bzl",
     "apple_verification_transition",
 )
 load(
-    "@build_bazel_rules_apple//test/starlark_tests/rules:output_group_test_support.bzl",
+    "//test/starlark_tests/rules:output_group_test_support.bzl",
     "output_group_test_support",
 )
 

--- a/test/starlark_tests/rules/output_text_match_test.bzl
+++ b/test/starlark_tests/rules/output_text_match_test.bzl
@@ -119,7 +119,7 @@ are expected to **not** be found somewhere in that file.
             doc = "The target whose outputs are to be verified.",
         ),
         "_test_deps": attr.label(
-            default = "@build_bazel_rules_apple//test:apple_verification_test_deps",
+            default = "//test:apple_verification_test_deps",
         ),
     },
     implementation = _output_text_match_test_impl,

--- a/test/starlark_tests/rules/product_type_test.bzl
+++ b/test/starlark_tests/rules/product_type_test.bzl
@@ -20,7 +20,7 @@ load(
     "unittest",
 )
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "AppleBundleInfo",
 )
 

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1549,8 +1549,8 @@ public struct SwiftLib {
 
 apple_metal_library(
     name = "SampleMetal",
-    srcs = ["@build_bazel_rules_apple//test/testdata/resources:metal_srcs"],
-    hdrs = ["@build_bazel_rules_apple//test/testdata/resources:metal_hdrs"],
+    srcs = ["//test/testdata/resources:metal_srcs"],
+    hdrs = ["//test/testdata/resources:metal_hdrs"],
     tags = common.fixture_tags,
 )
 

--- a/test/starlark_tests/watchos_extension_tests.bzl
+++ b/test/starlark_tests/watchos_extension_tests.bzl
@@ -15,7 +15,7 @@
 """watchos_extension Starlark tests."""
 
 load(
-    "@build_bazel_rules_apple//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
+    "//apple/internal:apple_product_type.bzl",  # buildifier: disable=bzl-visibility
     "apple_product_type",
 )  # buildifier: disable=bzl-visibility
 load(

--- a/test/test_rules.bzl
+++ b/test/test_rules.bzl
@@ -107,7 +107,7 @@ def apple_shell_test(
             "//test:apple_shell_testutils.sh",
             "//test/testdata/provisioning:integration_testing_profiles",
             "//test:unittest.bash",
-            "@build_bazel_rules_apple//:BUILD",
+            "//:BUILD",
         ] + (data or []),
         deps = [
             "@bazel_tools//tools/bash/runfiles",

--- a/test/testdata/rules/dummy_test_runner.bzl
+++ b/test/testdata/rules/dummy_test_runner.bzl
@@ -15,7 +15,7 @@
 """Dummy test runner rule. Does not actually run tests."""
 
 load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
+    "//apple:providers.bzl",
     "apple_provider",
 )
 
@@ -39,7 +39,7 @@ dummy_test_runner = rule(
     _dummy_test_runner_impl,
     attrs = {
         "_test_template": attr.label(
-            default = Label("@build_bazel_rules_apple//test/testdata/rules:dummy_test_runner.template"),
+            default = Label("//test/testdata/rules:dummy_test_runner.template"),
             allow_single_file = True,
         ),
     },


### PR DESCRIPTION
This is just nice to do, but also works around https://github.com/bazelbuild/bazel/pull/24582 for now