### PR TITLE
Add Label() to archive_contents_test marco

### DIFF
--- a/test/starlark_tests/rules/common_verification_tests.bzl
+++ b/test/starlark_tests/rules/common_verification_tests.bzl
@@ -221,7 +221,7 @@ def archive_contents_test(
             "TEXT_FILE_NOT_CONTAINS": text_file_not_contains,
         },
         target_under_test = target_under_test,
-        verifier_script = "//test/starlark_tests:verifier_scripts/archive_contents_test.sh",
+        verifier_script = Label("//test/starlark_tests:verifier_scripts/archive_contents_test.sh"),
         **kwargs
     )
 


### PR DESCRIPTION
Since this macro is not specific to any test or target under test in rule_apple, Label() helps resolve the script form externally defined targets and tests.

There are many more uses of the `apple_verification_test` rule, but they are specific internally and I chose not to add across the board.