### PR TITLE
WIP: make llvm-cov export err output non-blocking, if the exit code was still 0

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -310,11 +310,14 @@ xcrun llvm-cov \
   2> "$error_file" \
   || llvm_cov_status=$?
 
+if [[ -s "$error_file" ]]; then
+  cat "$error_file" >&2
+fi
+
 # Error ourselves if lcov outputs warnings, such as if we misconfigure
 # something and the file path of one of the covered files doesn't exist
-if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
+if [[ "$llvm_cov_status" -ne 0 ]]; then
   echo "error: while exporting coverage report" >&2
-  cat "$error_file" >&2
   exit 1
 fi
 
@@ -328,9 +331,13 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json" \
     2> "$error_file" \
     || llvm_cov_json_export_status=$?
-  if [[ -s "$error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
-    echo "error: while exporting json coverage report" >&2
+
+  if [[ -s "$error_file" ]]; then
     cat "$error_file" >&2
+  fi
+
+  if [[ "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
     exit 1
   fi
 fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -625,11 +625,14 @@ xcrun llvm-cov \
   2> "$error_file" \
   || llvm_cov_status=$?
 
+if [[ -s "$error_file" ]]; then
+  cat "$error_file" >&2
+fi
+
 # Error ourselves if lcov outputs warnings, such as if we misconfigure
 # something and the file path of one of the covered files doesn't exist
-if [[ -s "$error_file" || "$llvm_cov_status" -ne 0 ]]; then
+if [[ "$llvm_cov_status" -ne 0 ]]; then
   echo "error: while exporting coverage report" >&2
-  cat "$error_file" >&2
   exit 1
 fi
 
@@ -643,9 +646,13 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json" \
     2> "$error_file" \
     || llvm_cov_json_export_status=$?
-  if [[ -s "$error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
-    echo "error: while exporting json coverage report" >&2
+
+  if [[ -s "$error_file" ]]; then
     cat "$error_file" >&2
+  fi
+
+  if [[ "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
     exit 1
   fi
 fi

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -174,11 +174,14 @@ xcrun llvm-cov \
   2> "$export_error_file" \
   || llvm_cov_export_status=$?
 
+if [[ -s "$export_error_file" ]]; then
+  cat "$export_error_file" >&2
+fi
+
 # Error ourselves if lcov outputs warnings, such as if we misconfigure
 # something and the file path of one of the covered files doesn't exist
-if [[ -s "$export_error_file" || "$llvm_cov_export_status" -ne 0 ]]; then
+if [[ "$llvm_cov_export_status" -ne 0 ]]; then
   echo "error: while exporting coverage report" >&2
-  cat "$export_error_file" >&2
   exit 1
 fi
 
@@ -193,9 +196,13 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     > "$TEST_UNDECLARED_OUTPUTS_DIR/coverage.json"
     2> "$export_error_file" \
     || llvm_cov_json_export_status=$?
-  if [[ -s "$export_error_file" || "$llvm_cov_json_export_status" -ne 0 ]]; then
-    echo "error: while exporting json coverage report" >&2
+
+  if [[ -s "$export_error_file" ]]; then
     cat "$export_error_file" >&2
+  fi
+
+  if [[ "$llvm_cov_json_export_status" -ne 0 ]]; then
+    echo "error: while exporting json coverage report" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
We may want more customization here (since this could obscure real
issues), or better ordering of the error log
and the stderr output from llvm-cov.

Context: https://bazelbuild.slack.com/archives/CD3QY5C2X/p1734100078982459
