### PR TITLE
Revert "Embed frameworks in `ios_message_extension` (#1706)"

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -2246,16 +2246,6 @@ def _ios_imessage_extension_impl(ctx):
             rule_label = label,
             targets_to_validate = ctx.attr.frameworks,
         ),
-        partials.framework_import_partial(
-            actions = actions,
-            apple_mac_toolchain_info = apple_mac_toolchain_info,
-            features = features,
-            label_name = label.name,
-            platform_prerequisites = platform_prerequisites,
-            provisioning_profile = provisioning_profile,
-            rule_descriptor = rule_descriptor,
-            targets = ctx.attr.deps + ctx.attr.frameworks,
-        ),
         partials.resources_partial(
             actions = actions,
             apple_mac_toolchain_info = apple_mac_toolchain_info,


### PR DESCRIPTION
This reverts commit 75afaa289ea8217b550202ff696f091effd4f694.

I tried uploading an app we're moving to Bazel to ASC today and got this back from altool:

```
[ContentDelivery.Uploader.6000035C02C0] Asset validation failed (90685) CFBundleIdentifier Collision. There is more than one bundle with the CFBundleIdentifier value 'io.sentry.Sentry' under the iOS application 'Dropbox.app'. (ID: 70764510-61df-4d35-a5ae-c58c46bcd2ec)
[ContentDelivery.Uploader.6000035C02C0] Asset validation failed (90205) Invalid Bundle. The bundle at 'Dropbox.app/PlugIns/DropboxMessageExtension.appex' contains disallowed nested bundles. Refer to https://developer.apple.com/go/?id=framework-imessage for a workaround. (ID: 7dcc5f1e-43d3-4eee-965f-74af1e0a8ed8)
[ContentDelivery.Uploader.6000035C02C0] Asset validation failed (90206) Invalid Bundle. The bundle at 'Dropbox.app/PlugIns/DropboxMessageExtension.appex' contains disallowed file 'Frameworks'. (ID: 731b294a-ceb5-40fa-b1b6-8dcd76124934)
Error uploading '/var/folders/yk/2ntskjpj28l6pt3w5q_693mw0000gn/T/a672ce89-fff4-4f35-87d9-1bc5b4b9c39e.ipa'.
```

It appears as though iMessage extensions cannot have embedded frameworks, and this change has made it so that one of our framework deps is getting pulled in and bundled.
