### PR TITLE
Exclude swiftinterfaces contained within dSYMs from a framework's `swift_interface_imports`

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -187,7 +187,7 @@ def _classify_file_imports(config_vars, import_files):
         if file_extension == "swiftmodule":
             swift_module_imports.append(file)
             continue
-        if file_extension == "swiftinterface":
+        if file_extension == "swiftinterface" and ".framework.dSYM/" not in file.short_path:
             swift_interface_imports.append(file)
             continue
         if file_extension in ["swiftdoc", "swiftsourceinfo"]:


### PR DESCRIPTION
context: https://bazelbuild.slack.com/archives/C04DFUBQGSU/p1737737997785549

it was reported today that some xcframeworks with bundled dSYMs have unusual structures, including embedded swiftinterfaces in those dSYMs. These would [normally be excluded by dsymutil](https://reviews.llvm.org/D75196), but to make it easier for folks, let's also batch these dSYM-nested-swiftinterfaces under `dsym_imports` instead of `swift_interface_imports` to avoid this analysis error:

```
ERROR: /Users/sky/Developer/bazel_apple/rules_apple/examples/ios/HelloWorldSwift/BUILD:9:33: in apple_dynamic_xcframework_import rule //examples/ios/HelloWorldSwift:ZendeskSDKMessaging:
Traceback (most recent call last):
        File "/Users/sky/Developer/bazel_apple/rules_apple/apple/internal/apple_xcframework_import.bzl", line 508, column 51, in _apple_dynamic_xcframework_import_impl
                xcframework_library = _get_xcframework_library(
        File "/Users/sky/Developer/bazel_apple/rules_apple/apple/internal/apple_xcframework_import.bzl", line 161, column 66, in _get_xcframework_library
                xcframework_library = _get_xcframework_library_from_paths(
        File "/Users/sky/Developer/bazel_apple/rules_apple/apple/internal/apple_xcframework_import.bzl", line 221, column 98, in _get_xcframework_library_from_paths
                swift_module_interfaces = framework_import_support.get_swift_module_files_with_target_triplet(
        File "/Users/sky/Developer/bazel_apple/rules_apple/apple/internal/framework_import_support.bzl", line 379, column 47, in _get_swift_module_files_with_target_triplet
                files_by_module = group_files_by_directory(
        File "/Users/sky/Developer/bazel_apple/rules_apple/apple/utils.bzl", line 117, column 13, in group_files_by_directory
                fail("Expected only files inside directories named with the extensions " +
Error in fail: Expected only files inside directories named with the extensions ["swiftmodule"], but found: [
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDK.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKConversationKit.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKCoreUtilities.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKGuideKit.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKLogger.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKStorage.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/aarch64/ZendeskSDKUIComponents.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDK.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKConversationKit.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKCoreUtilities.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKGuideKit.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKLogger.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKStorage.swiftinterface,
  examples/ios/HelloWorldSwift/ZendeskSDKMessaging.xcframework/ios-arm64_x86_64-simulator/dSYMs/ZendeskSDKMessaging.framework.dSYM/Contents/Resources/Swift/x86_64/ZendeskSDKUIComponents.swiftinterface
] swift_module_files
```
