### PR TITLE
Update `ios_xctestrun_runner.device_type` default

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -53,7 +53,7 @@ def _ios_xctestrun_runner_impl(ctx):
                      ctx.attr._xcode_config[apple_common.XcodeProperties].default_ios_sdk_version)
 
     # TODO: Ideally we would be smarter about picking a device, but we don't know what the current version of Xcode supports
-    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or "iPhone 12"
+    device_type = ctx.attr.device_type or ctx.fragments.objc.ios_simulator_device or "iPhone 15"
 
     if not os_version:
         fail("error: os_version must be set on ios_xctestrun_runner, or passed with --ios_simulator_version")


### PR DESCRIPTION
Use the `iPhone 15` as the default iOS simulator device for `ios_xctestrun_runner` since Apple [requires Xcode 15 or newer be used to submit iOS apps these days](https://developer.apple.com/ios/submit/):
>All iOS and iPadOS apps uploaded to App Store Connect must be built with a minimum of Xcode 15 and the iOS 17 SDK.

This can still be overridden by `--ios_simulator_device` or `ios_xctestrun_runner.device_type`.