### PR TITLE
Remove unprocessed archive output

### DIFF
--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -698,7 +698,6 @@ def _post_process_and_sign_archive_action(
             "%should_compress%": "1" if should_compress else "",
             "%should_verify%": "1",  # always verify the crc
             "%signing_command_lines%": signing_command_lines,
-            "%unprocessed_archive_path%": input_archive.path,
             "%work_dir%": output_archive_root_path,
         },
     )

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -566,59 +566,6 @@ def _bundle_post_process_and_sign(
             content = "This is dummy file because tree artifacts are enabled",
         )
     else:
-        # This output, while an intermediate artifact not exposed through the AppleBundleInfo
-        # provider, is used by Tulsi for custom processing logic. (b/120221708)
-        unprocessed_archive = intermediates.file(
-            actions = actions,
-            target_name = rule_label.name,
-            output_discriminator = output_discriminator,
-            file_name = "unprocessed_archive.zip",
-        )
-        _bundle_partial_outputs_files(
-            actions = actions,
-            apple_mac_toolchain_info = apple_mac_toolchain_info,
-            apple_xplat_toolchain_info = apple_xplat_toolchain_info,
-            bundle_extension = bundle_extension,
-            bundle_name = bundle_name,
-            ipa_post_processor = ipa_post_processor,
-            label_name = rule_label.name,
-            locales_to_include = locales_to_include,
-            output_discriminator = output_discriminator,
-            output_file = unprocessed_archive,
-            partial_outputs = partial_outputs,
-            platform_prerequisites = platform_prerequisites,
-            provisioning_profile = provisioning_profile,
-            rule_descriptor = rule_descriptor,
-        )
-
-        archive_codesigning_path = archive_paths[_LOCATION_ENUM.bundle]
-        frameworks_path = archive_paths[_LOCATION_ENUM.framework]
-
-        output_archive_root_path = outputs.root_path_from_archive(archive = output_archive)
-
-        # TODO(b/149874635): Don't pass frameworks_path unless the rule has it (ios_application).
-        codesigning_support.post_process_and_sign_archive_action(
-            actions = actions,
-            archive_codesigning_path = archive_codesigning_path,
-            codesign_inputs = codesign_inputs,
-            codesigningtool = apple_mac_toolchain_info.codesigningtool,
-            codesignopts = codesignopts,
-            entitlements = entitlements,
-            features = features,
-            frameworks_path = frameworks_path,
-            input_archive = unprocessed_archive,
-            ipa_post_processor = ipa_post_processor,
-            label_name = rule_label.name,
-            output_archive = output_archive,
-            output_archive_root_path = output_archive_root_path,
-            output_discriminator = output_discriminator,
-            platform_prerequisites = platform_prerequisites,
-            process_and_sign_template = process_and_sign_template,
-            provisioning_profile = provisioning_profile,
-            rule_descriptor = rule_descriptor,
-            signed_frameworks = transitive_signed_frameworks,
-        )
-
         has_different_embedding_archive = outputs.has_different_embedding_archive(
             platform_prerequisites = platform_prerequisites,
             rule_descriptor = rule_descriptor,

--- a/tools/bundletool/process_and_sign.sh.template
+++ b/tools/bundletool/process_and_sign.sh.template
@@ -17,9 +17,7 @@ readonly POST_PROCESSOR=%ipa_post_processor%
 readonly SHOULD_COMPRESS=%should_compress%
 # Indicates whether the final archive should be verified by unzipping (1) or not (0).
 readonly SHOULD_VERIFY=%should_verify%
-# The path to archive with the unprocessed and unsigned bundle.
-readonly UNPROCESSED_ARCHIVE_PATH=%unprocessed_archive_path%
-# The absolute path to the directory where the unprocessed archive will be
+# The absolute path to the directory where the archive will be
 # extracted for post-processing and signing.
 readonly WORK_DIR=%work_dir%
 
@@ -29,9 +27,6 @@ if [[ -d "$WORK_DIR" ]]; then
   rm -rf "$WORK_DIR"
 fi
 mkdir -p "$WORK_DIR"
-
-# Expand the unprocessed archive into the temporary directory.
-unzip -qq -d "$WORK_DIR" "$UNPROCESSED_ARCHIVE_PATH"
 
 # Execute the archive post-processor, if it was provided.
 if [[ -n "$POST_PROCESSOR" ]]; then


### PR DESCRIPTION
This output, as the comment says, is intended for Tulsi which is now deprecated. As part of #2641 we are removing this output to save on disk space utilization.