### PR TITLE
Remove comments relating to Tulsi

### DIFF
--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -566,8 +566,7 @@ def _bundle_post_process_and_sign(
             content = "This is dummy file because tree artifacts are enabled",
         )
     else:
-        # This output, while an intermediate artifact not exposed through the AppleBundleInfo
-        # provider, is used by Tulsi for custom processing logic. (b/120221708)
+        # This output, is an intermediate artifact used for post processing, signing, etc.
         unprocessed_archive = intermediates.file(
             actions = actions,
             target_name = rule_label.name,

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -164,9 +164,7 @@ ios_ui_test = rule_factory.create_apple_test_rule(
     doc = """iOS UI Test rule.
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 The `provisioning_profile` attribute needs to be set to run the test on a real device.
 
@@ -240,9 +238,7 @@ ios_internal_unit_test_bundle = _ios_internal_unit_test_bundle
 
 ios_unit_test = rule_factory.create_apple_test_rule(
     doc = """Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 `ios_unit_test` targets can work in two modes: as app or library
 tests. If the `test_host` attribute is set to an `ios_application` target, the

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -174,9 +174,7 @@ macos_internal_ui_test_bundle = _macos_internal_ui_test_bundle
 
 macos_ui_test = rule_factory.create_apple_test_rule(
     doc = """Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: macOS UI tests are not currently supported in the default test runner.""",
     implementation = _macos_ui_test_impl,
@@ -255,9 +253,7 @@ macos_internal_unit_test_bundle = _macos_internal_unit_test_bundle
 
 macos_unit_test = rule_factory.create_apple_test_rule(
     doc = """Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 `macos_unit_test` targets can work in two modes: as app or library tests. If the
 `test_host` attribute is set to an `macos_application` target, the tests will

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -165,9 +165,7 @@ tvos_internal_ui_test_bundle = _tvos_internal_ui_test_bundle
 tvos_ui_test = rule_factory.create_apple_test_rule(
     doc = """
 Builds and bundles a tvOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: tvOS UI tests are not currently supported in the default test runner.
 
@@ -238,9 +236,7 @@ tvos_internal_unit_test_bundle = _tvos_internal_unit_test_bundle
 tvos_unit_test = rule_factory.create_apple_test_rule(
     doc = """
 Builds and bundles a tvOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: tvOS unit tests are not currently supported in the default test runner.
 

--- a/apple/internal/testing/visionos_rules.bzl
+++ b/apple/internal/testing/visionos_rules.bzl
@@ -159,9 +159,7 @@ visionos_internal_ui_test_bundle = _visionos_internal_ui_test_bundle
 visionos_ui_test = rule_factory.create_apple_test_rule(
     doc = """
 Builds and bundles a visionOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: visionOS UI tests are not currently supported in the default test runner.
 
@@ -234,9 +232,7 @@ visionos_internal_unit_test_bundle = _visionos_internal_unit_test_bundle
 visionos_unit_test = rule_factory.create_apple_test_rule(
     doc = """
 Builds and bundles a visionOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: visionOS unit tests are not currently supported in the default test runner.
 

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -571,9 +571,7 @@ ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">de
 iOS UI Test rule.
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 The `provisioning_profile` attribute needs to be set to run the test on a real device.
 
@@ -615,9 +613,7 @@ ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-de
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 `ios_unit_test` targets can work in two modes: as app or library
 tests. If the `test_host` attribute is set to an `ios_application` target, the

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -623,9 +623,7 @@ macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-de
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: macOS UI tests are not currently supported in the default test runner.
 
@@ -660,9 +658,7 @@ macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_t
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 `macos_unit_test` targets can work in two modes: as app or library tests. If the
 `test_host` attribute is set to an `macos_application` target, the tests will

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -332,9 +332,7 @@ tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps"
 </pre>
 
 Builds and bundles a tvOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: tvOS UI tests are not currently supported in the default test runner.
 
@@ -373,9 +371,7 @@ tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test
 </pre>
 
 Builds and bundles a tvOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: tvOS unit tests are not currently supported in the default test runner.
 

--- a/doc/rules-visionos.md
+++ b/doc/rules-visionos.md
@@ -280,9 +280,7 @@ visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_u
 </pre>
 
 Builds and bundles a visionOS UI `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: visionOS UI tests are not currently supported in the default test runner.
 
@@ -321,9 +319,7 @@ visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#vision
 </pre>
 
 Builds and bundles a visionOS Unit `.xctest` test bundle. Runs the tests using the
-provided test runner when invoked with `bazel test`. When using Tulsi to run
-tests built with this target, `runner` will not be used since Xcode is the test
-runner in that case.
+provided test runner when invoked with `bazel test`.
 
 Note: visionOS unit tests are not currently supported in the default test runner.
 


### PR DESCRIPTION
Tulsi is deprecated and we confusingly called it out in several docstrings and comments. This change removes all references to Tulsi in the codebase.