### PR TITLE
Add `manual` tag to test bundle rule

### DIFF
--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -105,11 +105,17 @@ def _assemble(name, bundle_rule, test_rule, runner = None, runners = None, **kwa
     # `bundle_name` is either provided or the default is `name`.
     bundle_name = bundle_attrs.pop("bundle_name", name)
 
+    # `//...` shouldn't try to build the bundle rule directly.
+    bundle_tags = bundle_attrs.pop("tags", [])
+    if "manual" not in bundle_tags:
+        bundle_tags = bundle_tags + ["manual"]
+
     # Ideally this target should be private, but the outputs should not be private, so we're
     # explicitly using the same visibility as the test (or None if none was set).
     bundle_rule(
         name = test_bundle_name,
         bundle_name = bundle_name,
+        tags = bundle_tags,
         test_bundle_output = "{}.zip".format(bundle_name),
         testonly = True,
         **bundle_attrs


### PR DESCRIPTION
Fixes an issue related to toolchain selection when doing `//...` multi-platform builds.