### PR TITLE
Add `additional_linker_inputs` support for apple_test_assembler.bzl

### DIFF
--- a/apple/internal/testing/apple_test_assembler.bzl
+++ b/apple/internal/testing/apple_test_assembler.bzl
@@ -23,6 +23,7 @@ _BUNDLE_ATTRS = {
     x: None
     for x in [
         "additional_contents",
+        "additional_linker_inputs",
         "deps",
         "base_bundle_id",
         "bundle_id",


### PR DESCRIPTION
This is required when adding custom `linkopts` which depend on a file