### PR TITLE
Always pass '--enable-on-demand-resources YES' to actool

### DIFF
--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -284,6 +284,8 @@ def compile_asset_catalog(
         "--minimum-deployment-target",
         platform_prerequisites.minimum_os,
         "--compress-pngs",
+        "--enable-on-demand-resources",
+        "YES",
     ]
 
     args.extend(_actool_args_for_special_file_types(


### PR DESCRIPTION
This needs to be set to be able to support ODR in rules_apple. Xcode also always passes it. See [Apple docs](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/On_Demand_Resources_Guide/).