### PR TITLE
Add a few more `exec_compatible_with`

### DIFF
--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -93,6 +93,9 @@ dtrace_compile = rule(
             doc = "dtrace(.d) source files to be compiled.",
         ),
     }),
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
     fragments = ["apple"],
     doc = """
 Compiles

--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -135,6 +135,9 @@ def _create_apple_rule(
         ),
         cfg = cfg,
         doc = doc,
+        exec_compatible_with = [
+            "@platforms//os:macos",
+        ],
         executable = is_executable,
         fragments = ["apple", "cpp", "objc", "j2objc"],
         toolchains = toolchains,

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -120,6 +120,9 @@ number (for example, `"9.0"`).
             ),
         },
         doc = doc,
+        exec_compatible_with = [
+            "@platforms//os:macos",
+        ],
         implementation = _apple_build_test_rule_impl,
         test = True,
         cfg = transition_support.apple_rule_transition,


### PR DESCRIPTION
Makes working with `ios_application`, `ios_build_test`, etc on multi-platform builds easier.