### PR TITLE
Update swift_intent_library to check for srcs and data from kwargs

### DIFF
--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -202,6 +202,7 @@ def swift_intent_library(
         swift_version = None,
         testonly = False,
         **kwargs):
+    # buildifier: disable=function-docstring-args
     """
 This macro supports the integration of Intents `.intentdefinition` files into Apple rules.
 

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -219,6 +219,13 @@ Args:
     testonly: Set to True to enforce that this library is only used from test code.
 """
     intent_name = "{}.Intent".format(name)
+
+    # Since we are accepting swift_library attrs, combine kwargs src and data
+    kwargs_src = kwargs.pop("srcs", [])
+    kwargs_data = kwargs.pop("data", [])
+    srcs = [intent_name] + kwargs_src
+    data = [src] + kwargs_data
+    
     _apple_intent_library(
         name = intent_name,
         src = src,
@@ -231,8 +238,8 @@ Args:
     )
     swift_library(
         name = name,
-        srcs = [intent_name],
-        data = [src],
+        srcs = srcs,
+        data = data,
         testonly = testonly,
         **kwargs
     )

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -226,7 +226,7 @@ Args:
     kwargs_data = kwargs.pop("data", [])
     srcs = [intent_name] + kwargs_src
     data = [src] + kwargs_data
-    
+
     _apple_intent_library(
         name = intent_name,
         src = src,


### PR DESCRIPTION
As per the docs 

```
It takes a single `.intentdefinition` file and creates a target that can be added as a dependency from `objc_library` or
`swift_library` targets.
It accepts the regular `swift_library` attributes too.
```

However, if `swift_intent_library` is passed srcs and data params, it errors out with 

```sh
Error in swift_library: rule(...) got multiple values for parameter 'srcs'
```