### PR TITLE
Add `exec_data` attribute to tests

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -51,6 +51,16 @@ Dictionary of environment variables that should be set during the test execution
 the dictionary are subject to "Make" variable expansion.
 """,
     ),
+    "exec_data": attr.label_list(
+        allow_files = True,
+        cfg = "exec",
+        default = [],
+        doc = """
+Files to be made available to the test during its execution, on the machine
+running the test. The most common use case for this are executables run as
+part of UI tests.
+""",
+    ),
     "runner": attr.label(
         doc = """
 The runner target that will provide the logic on how to run the tests. Needs to provide the

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -365,6 +365,9 @@ def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):
     for data_dep in ctx.attr.data:
         transitive_runfiles.append(data_dep.files)
         transitive_runfile_objects.append(data_dep.default_runfiles)
+    for data_dep in ctx.attr.exec_data:
+        transitive_runfiles.append(data_dep.files)
+        transitive_runfile_objects.append(data_dep.default_runfiles)
 
     return [
         # Repropagate the AppleBundleInfo and AppleTestInfo providers from the test bundle so that

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -566,8 +566,8 @@ Outputs:
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>,
-            <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>,
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-exec_data">exec_data</a>, <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+            <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>,
             <a href="#ios_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
@@ -595,6 +595,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="ios_ui_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="ios_ui_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="ios_ui_test-platform_type"></a>platform_type |  -   | String | optional |  `"ios"`  |
@@ -610,9 +611,9 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>,
-              <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>,
-              <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-exec_data">exec_data</a>, <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+              <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>,
+              <a href="#ios_unit_test-test_host">test_host</a>, <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -645,6 +646,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="ios_unit_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="ios_unit_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="ios_unit_test-platform_type"></a>platform_type |  -   | String | optional |  `"ios"`  |

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -617,9 +617,9 @@ i.e. `--features=-swift.no_generated_header`).
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>,
-              <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>,
-              <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-exec_data">exec_data</a>, <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+              <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>,
+              <a href="#macos_ui_test-test_host">test_host</a>, <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -637,6 +637,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="macos_ui_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="macos_ui_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="macos_ui_test-platform_type"></a>platform_type |  -   | String | optional |  `"macos"`  |
@@ -652,7 +653,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-exec_data">exec_data</a>, <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                 <a href="#macos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>,
                 <a href="#macos_unit_test-test_host">test_host</a>, <a href="#macos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -678,6 +679,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="macos_unit_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="macos_unit_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="macos_unit_test-platform_type"></a>platform_type |  -   | String | optional |  `"macos"`  |

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -326,9 +326,9 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>,
-             <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>,
-             <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-exec_data">exec_data</a>, <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+             <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>,
+             <a href="#tvos_ui_test-test_host">test_host</a>, <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a tvOS UI `.xctest` test bundle. Runs the tests using the
@@ -350,6 +350,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="tvos_ui_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="tvos_ui_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="tvos_ui_test-platform_type"></a>platform_type |  -   | String | optional |  `"tvos"`  |
@@ -365,7 +366,7 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-exec_data">exec_data</a>, <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                <a href="#tvos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>,
                <a href="#tvos_unit_test-test_host">test_host</a>, <a href="#tvos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -397,6 +398,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="tvos_unit_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="tvos_unit_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="tvos_unit_test-platform_type"></a>platform_type |  -   | String | optional |  `"tvos"`  |

--- a/doc/rules-visionos.md
+++ b/doc/rules-visionos.md
@@ -274,7 +274,7 @@ i.e. `--features=-swift.no_generated_header`).
 ## visionos_ui_test
 
 <pre>
-visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_ui_test-deps">deps</a>, <a href="#visionos_ui_test-data">data</a>, <a href="#visionos_ui_test-bundle_name">bundle_name</a>, <a href="#visionos_ui_test-env">env</a>, <a href="#visionos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_ui_test-deps">deps</a>, <a href="#visionos_ui_test-data">data</a>, <a href="#visionos_ui_test-bundle_name">bundle_name</a>, <a href="#visionos_ui_test-env">env</a>, <a href="#visionos_ui_test-exec_data">exec_data</a>, <a href="#visionos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                  <a href="#visionos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_ui_test-platform_type">platform_type</a>, <a href="#visionos_ui_test-runner">runner</a>, <a href="#visionos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_ui_test-test_filter">test_filter</a>,
                  <a href="#visionos_ui_test-test_host">test_host</a>, <a href="#visionos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -298,6 +298,7 @@ the attributes inherited by all test rules, please check the
 | <a id="visionos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="visionos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="visionos_ui_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="visionos_ui_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="visionos_ui_test-platform_type"></a>platform_type |  -   | String | optional |  `"visionos"`  |
@@ -313,7 +314,7 @@ the attributes inherited by all test rules, please check the
 ## visionos_unit_test
 
 <pre>
-visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#visionos_unit_test-deps">deps</a>, <a href="#visionos_unit_test-data">data</a>, <a href="#visionos_unit_test-bundle_name">bundle_name</a>, <a href="#visionos_unit_test-env">env</a>, <a href="#visionos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#visionos_unit_test-deps">deps</a>, <a href="#visionos_unit_test-data">data</a>, <a href="#visionos_unit_test-bundle_name">bundle_name</a>, <a href="#visionos_unit_test-env">env</a>, <a href="#visionos_unit_test-exec_data">exec_data</a>, <a href="#visionos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                    <a href="#visionos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_unit_test-platform_type">platform_type</a>, <a href="#visionos_unit_test-runner">runner</a>, <a href="#visionos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_unit_test-test_filter">test_filter</a>,
                    <a href="#visionos_unit_test-test_host">test_host</a>, <a href="#visionos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -345,6 +346,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="visionos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="visionos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="visionos_unit_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="visionos_unit_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="visionos_unit_test-platform_type"></a>platform_type |  -   | String | optional |  `"visionos"`  |

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -292,7 +292,7 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-exec_data">exec_data</a>, <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                 <a href="#watchos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>,
                 <a href="#watchos_ui_test-test_host">test_host</a>, <a href="#watchos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -309,6 +309,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="watchos_ui_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="watchos_ui_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="watchos_ui_test-platform_type"></a>platform_type |  -   | String | optional |  `"watchos"`  |
@@ -324,7 +325,7 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-exec_data">exec_data</a>, <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
                   <a href="#watchos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>,
                   <a href="#watchos_unit_test-test_host">test_host</a>, <a href="#watchos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
@@ -341,6 +342,7 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="watchos_unit_test-exec_data"></a>exec_data |  Files to be made available to the test during its execution, on the machine running the test. The most common use case for this are executables run as part of UI tests.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
 | <a id="watchos_unit_test-minimum_os_version"></a>minimum_os_version |  A required string indicating the minimum OS version supported by the target, represented as a dotted version number (for example, "9.0").   | String | required |  |
 | <a id="watchos_unit_test-platform_type"></a>platform_type |  -   | String | optional |  `"watchos"`  |


### PR DESCRIPTION
This differs from `data` in that it uses the `exec` config for the files. This is useful for running host-based tools in UI tests.

We could add `data` to the test runners for the same effect, but then we would need different test runners per test, which isn’t ideal.