### PR TITLE
Fix path for XCUIAutomation.framework on Xcode 16.3

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -213,7 +213,6 @@ if [[ -n "$test_host_path" ]]; then
     mkdir -p "$runner_app_frameworks_destination"
     cp -R "$libraries_path/Frameworks/XCTest.framework" "$runner_app_frameworks_destination/XCTest.framework"
     cp -R "$libraries_path/PrivateFrameworks/XCTestCore.framework" "$runner_app_frameworks_destination/XCTestCore.framework"
-    cp -R "$libraries_path/PrivateFrameworks/XCUIAutomation.framework" "$runner_app_frameworks_destination/XCUIAutomation.framework"
     cp -R "$libraries_path/PrivateFrameworks/XCTAutomationSupport.framework" "$runner_app_frameworks_destination/XCTAutomationSupport.framework"
     cp -R "$libraries_path/PrivateFrameworks/XCUnit.framework" "$runner_app_frameworks_destination/XCUnit.framework"
     cp "$developer_path/usr/lib/libXCTestSwiftSupport.dylib" "$runner_app_frameworks_destination/libXCTestSwiftSupport.dylib"
@@ -227,6 +226,16 @@ if [[ -n "$test_host_path" ]]; then
     if [[ -d "$testing_framework_path" ]]; then
       cp -R "$testing_framework_path" "$runner_app_frameworks_destination/Testing.framework"
     fi
+
+    xcuiautomation_path="$libraries_path/Frameworks/XCUIAutomation.framework"
+    # On Xcode 16.3 and later, XCUIAutomation is not private anymore
+    if [[ -d "$xcuiautomation_path" ]]; then
+      cp -R "$xcuiautomation_path" "$runner_app_frameworks_destination/XCUIAutomation.framework"
+    else 
+      xcuiautomation_path="$libraries_path/PrivateFrameworks/XCUIAutomation.framework"
+      cp -R "$xcuiautomation_path" "$runner_app_frameworks_destination/XCUIAutomation.framework"
+    fi
+
     if [[ "$build_for_device" == true ]]; then
       # XCTRunner is multi-archs. When launching XCTRunner on arm64e device, it
       # will be launched as arm64e process by default. If the test bundle is arm64

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -227,14 +227,12 @@ if [[ -n "$test_host_path" ]]; then
       cp -R "$testing_framework_path" "$runner_app_frameworks_destination/Testing.framework"
     fi
 
-    xcuiautomation_path="$libraries_path/Frameworks/XCUIAutomation.framework"
     # On Xcode 16.3 and later, XCUIAutomation is not private anymore
-    if [[ -d "$xcuiautomation_path" ]]; then
-      cp -R "$xcuiautomation_path" "$runner_app_frameworks_destination/XCUIAutomation.framework"
-    else 
-      xcuiautomation_path="$libraries_path/PrivateFrameworks/XCUIAutomation.framework"
-      cp -R "$xcuiautomation_path" "$runner_app_frameworks_destination/XCUIAutomation.framework"
+    xcuiautomation_path="$libraries_path/Frameworks/XCUIAutomation.framework"
+    if [[ ! -d "$xcuiautomation_path" ]]; then
+        xcuiautomation_path="$libraries_path/PrivateFrameworks/XCUIAutomation.framework"
     fi
+    cp -R "$xcuiautomation_path" "$runner_app_frameworks_destination/XCUIAutomation.framework"
 
     if [[ "$build_for_device" == true ]]; then
       # XCTRunner is multi-archs. When launching XCTRunner on arm64e device, it


### PR DESCRIPTION
When running UI tests with Xcode 16.3 selected, I get this error:

```
cp: /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/XCUIAutomation.framework: No such file or directory
```

This is because `XCUIAutomation` is not a private framework anymore -- it's public. This is called out in [Xcode 16.3 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes):

> The XCTest APIs related to UI automation testing have been moved to a new, standalone framework named XCUIAutomation. XCTest re-exports XCUIAutomation so import XCTest continues to import the APIs of both frameworks. You can use XCUIAutomation APIs from XCTest tests and any helper or utility functions they call. (137059728)


I tested this patch locally with both Xcode 16.2 and 16.3.