### PR TITLE
fix: remove strings from provides

### DIFF
--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -671,7 +671,7 @@ def _settings_bundle_attrs():
     return {
         "settings_bundle": attr.label(
             aspects = [apple_resource_aspect],
-            providers = [["objc"], [AppleResourceBundleInfo], [apple_common.Objc]],
+            providers = [[AppleResourceBundleInfo], [apple_common.Objc]],
             doc = """
 A resource bundle (e.g. `apple_bundle_import`) target that contains the files that make up the
 application's settings bundle. These files will be copied into the root of the final application


### PR DESCRIPTION
This is cherrypick of: https://github.com/bazelbuild/rules_apple/commit/a5d8a280180c607c4e65de398c2f8e94c1a0522f
PiperOrigin-RevId: 742698261

Strings used to refer to legacy struct providers, which were removed from Bazel.

Legacy struct providers have been deprecated by Bazel. Replacing them with modern providers, will make it possible to simplify and remove legacy handling from Blaze.

The change is a no-op.

More information: https://github.com/bazelbuild/bazel/issues/25836