### PR TITLE
wip: run presubmit CI in github actions

### DIFF
--- a/.github/workflows/BUILD
+++ b/.github/workflows/BUILD
@@ -1,0 +1,8 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+)

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,10 +16,18 @@ jobs:
           - latest
           - last_rc
           - last_green
+        xcode:
+          - 16.2
       fail-fast: false
+    permissions:
+      contents: write
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}
     steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
       - uses: bazel-contrib/setup-bazel@0.14.0
         with:
           bazelisk-cache: true
@@ -27,12 +35,12 @@ jobs:
           repository-cache: true
           bazelrc: |
             test --test_tag_filters=-skipci
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.2'
-      - uses: actions/checkout@v4
-      - run: bazel build //tools/... //test/...
-      - run: bazel test //tools/... //test/... //examples/...
+      - name: Bazel Info
+        run: |
+          bazel version
+          bazel info
+      - run: bazel build tools/... test/...
+      - run: bazel test tools/... test/... examples/...
   doc_tests:
     runs-on: ubuntu-latest
     env:
@@ -41,6 +49,7 @@ jobs:
       # USE_BAZEL_VERSION: last_green
       USE_BAZEL_VERSION: 21a12c72d84e9108142421d9a8526edf8dceb78c
     steps:
+      - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.14.0
         with:
           bazelisk-cache: true
@@ -49,8 +58,11 @@ jobs:
           # TODO: Remove this once stardoc is updated to 0.7.1+ (https://github.com/bazelbuild/stardoc/pull/238)
           bazelrc: |
             test --noincompatible_disallow_empty_glob
-      - uses: actions/checkout@v4
-      - run: bazel test //doc/...
+      - name: Bazel Info
+        run: |
+          bazel version
+          bazel info
+      - run: bazel test doc/...
   buildifier:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -34,7 +34,6 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           bazelrc: |
-            common --sandbox_debug
             test --test_tag_filters=-skipci
       - name: Bazel Info
         run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,0 +1,56 @@
+on:
+  push: ~
+  pull_request: ~
+  workflow_dispatch: ~
+
+# NOTE: To avoid listing the same things for build_flags/test_flags for each
+# of these tasks, they are listed in the .bazelrc instead.
+jobs:
+  macos:
+    runs-on: macos-15
+    strategy:
+      matrix:
+        bazel:
+          - latest
+          - last_rc
+          - last_green
+    env:
+      USE_BAZEL_VERSION: ${{ matrix.bazel }}
+    steps:
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          bazelrc: |
+            test --test_tag_filters=-skipci
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.2'
+      - uses: actions/checkout@v4
+      - run: bazel build //tools/... //test/...
+      - run: bazel test //tools/... //test/... //examples/...
+  doc_tests:
+    runs-on: ubuntu-latest
+    env:
+      # FIXME: Use last_green once we cherry-pick in changes needed by
+      # https://github.com/bazelbuild/bazel/commit/b59004dd17366b09b0758b833f98294fd0e89345
+      # USE_BAZEL_VERSION: last_green
+      USE_BAZEL_VERSION: 21a12c72d84e9108142421d9a8526edf8dceb78c
+    steps:
+      - uses: bazel-contrib/setup-bazel@0.14.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+          # TODO: Remove this once stardoc is updated to 0.7.1+ (https://github.com/bazelbuild/stardoc/pull/238)
+          bazelrc: |
+            test --noincompatible_disallow_empty_glob
+      - uses: actions/checkout@v4
+      - run: bazel test //doc/...
+  buildifier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: buildifier
+        run: bazel run --enable_bzlmod //.github/workflows:buildifier.check

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,7 +1,9 @@
 on:
-  push: ~
-  pull_request: ~
-  workflow_dispatch: ~
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
 
 # NOTE: To avoid listing the same things for build_flags/test_flags for each
 # of these tasks, they are listed in the .bazelrc instead.

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -14,6 +14,7 @@ jobs:
           - latest
           - last_rc
           - last_green
+      fail-fast: false
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}
     steps:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -34,6 +34,7 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           bazelrc: |
+            common --sandbox_debug
             test --test_tag_filters=-skipci
       - name: Bazel Info
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,11 @@ bazel_dep(
     dev_dependency = True,
     repo_name = "com_google_protobuf",
 )
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "7.1.2",
+    dev_dependency = True,
+)
 
 non_module_deps = use_extension("//apple:extensions.bzl", "non_module_deps")
 use_repo(

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1331,19 +1331,11 @@ cc_binary(
     linkshared = True,
 )
 
-# Set up the rpath of the .dylib using install_name_tool. Bazel should probably do this again when packaging
-genrule(
-    name = "ccinfo_dylibs_mylib-shared-with-rpath",
-    srcs = [":ccinfo_dylibs_mylib-shared"],
-    outs = ["libmylib_with_rpath.dylib"],
-    cmd = "install_name_tool -id @rpath/libmylib_with_rpath.dylib $(location :ccinfo_dylibs_mylib-shared) && cp $(location :ccinfo_dylibs_mylib-shared) $@",
-)
-
 # Import our dynamically linked library.
 cc_import(
     name = "ccinfo_dylibs_mylib-import",
     hdrs = ["ccinfo_dylibs/mylib/lib.hpp"],
-    shared_library = ":ccinfo_dylibs_mylib-shared-with-rpath",
+    shared_library = ":ccinfo_dylibs_mylib-shared",
 )
 
 # Wrap our dylib in a cc_library so we can add data[] to it. This is common practice for adding

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1336,11 +1336,7 @@ genrule(
     name = "ccinfo_dylibs_mylib-shared-with-rpath",
     srcs = [":ccinfo_dylibs_mylib-shared"],
     outs = ["libmylib_with_rpath.dylib"],
-    cmd = """
-stat $(location :ccinfo_dylibs_mylib-shared)
-install_name_tool -id @rpath/libmylib_with_rpath.dylib $(location :ccinfo_dylibs_mylib-shared)
-cp $(location :ccinfo_dylibs_mylib-shared) $@
-""",
+    cmd = "install_name_tool -id @rpath/libmylib_with_rpath.dylib $(location :ccinfo_dylibs_mylib-shared) && cp $(location :ccinfo_dylibs_mylib-shared) $@",
 )
 
 # Import our dynamically linked library.

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1336,7 +1336,11 @@ genrule(
     name = "ccinfo_dylibs_mylib-shared-with-rpath",
     srcs = [":ccinfo_dylibs_mylib-shared"],
     outs = ["libmylib_with_rpath.dylib"],
-    cmd = "install_name_tool -id @rpath/libmylib_with_rpath.dylib $(location :ccinfo_dylibs_mylib-shared) && cp $(location :ccinfo_dylibs_mylib-shared) $@",
+    cmd = """
+stat $(location :ccinfo_dylibs_mylib-shared)
+install_name_tool -id @rpath/libmylib_with_rpath.dylib $(location :ccinfo_dylibs_mylib-shared)
+cp $(location :ccinfo_dylibs_mylib-shared) $@
+""",
 )
 
 # Import our dynamically linked library.


### PR DESCRIPTION
experimenting to potentially move off of bazelci, due to various challenges. this is a 1:1 representation of the presubmit.yml as-is, meaning buildifier hasn't been updated from 6.4.0, xcode is still 16.2, and pins for doc_tests are still in place. it is **not** a 1:1 representation in terms of UX or behavior.

updating buildifier and moving the stardoc/doc_tests pins should be done in a separate PR, and potentially xcode 16.3 as well (this would also allow us to more easily test a matrix of xcodes, if desired).
