### PR TITLE
Always link XCTestSwiftSupport into Swift test targets

### DIFF
--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -362,7 +362,7 @@ def _apple_test_bundle_impl(*, ctx, product_type):
         "-bundle",
     ]
 
-    if platform_prerequisites.uses_swift:
+    if any([_is_swift_target(dep) for dep in ctx.attr.deps]):
         extra_linkopts.extend([
             "-Xlinker",
             "-needed-lXCTestSwiftSupport",

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -353,10 +353,22 @@ def _apple_test_bundle_impl(*, ctx, product_type):
         bundle_loader = None
 
     extra_linkopts = [
+        "-Xlinker",
+        "-needed_framework",
+        "-Xlinker",
+        "XCTest",
         "-framework",
         "XCTest",
         "-bundle",
     ]
+
+    if platform_prerequisites.uses_swift:
+        extra_linkopts.extend([
+            "-Xlinker",
+            "-needed-lXCTestSwiftSupport",
+            "-lXCTestSwiftSupport",
+        ])
+
     extra_link_inputs = []
 
     if "apple.swizzle_absolute_xcttestsourcelocation" in features:


### PR DESCRIPTION
Unit tests that only use Swift Testing would not link `XCTestSwiftSupport` which resulted in the tests not actually being run.

Adding `import XCTest` anywhere in the Swift target would work around the issue, but for purely Swift Testing based tests this shouldn't be required.

I copied this set of flags from https://github.com/swiftlang/swift-build/blob/f974e0dc3841d82df08ead210fb900f850b919ac/Sources/SWBUniversalPlatform/Specs/ProductTypes.xcspec#L293