### PR TITLE
Add `collect_code_coverage` attribute to tests

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -40,6 +40,12 @@ load(
 # Returns the common set of rule attributes to support Apple test rules.
 # TODO(b/246990309): Move _COMMON_TEST_ATTRS to rule attrs in a follow up CL.
 _COMMON_TEST_ATTRS = {
+    "collect_code_coverage": attr.bool(
+        doc = """
+Whether to collect code coverage for this test if `--collect_code_coverage=yes`.
+""",
+        default = True,
+    ),
     "data": attr.label_list(
         allow_files = True,
         default = [],

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -327,14 +327,16 @@ def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):
             if test_host_dossier:
                 direct_runfiles.append(test_host_dossier)
 
-    if ctx.file.test_coverage_manifest:
-        direct_runfiles.append(ctx.file.test_coverage_manifest)
-
     test_host_artifact = test_bundle_target[AppleTestInfo].test_host
     if test_host_artifact:
         direct_runfiles.append(test_host_artifact)
 
-    if ctx.configuration.coverage_enabled:
+    test_coverage_manifest = None
+    if ctx.configuration.coverage_enabled and ctx.attr.collect_code_coverage:
+        test_coverage_manifest = ctx.file.test_coverage_manifest
+        if test_coverage_manifest:
+            direct_runfiles.append(test_coverage_manifest)
+
         apple_coverage_support_files = ctx.attr._apple_coverage_support.files
         covered_binaries = test_bundle_target[_CoverageFilesInfo].covered_binaries
 
@@ -358,7 +360,7 @@ def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):
         substitutions = _get_template_substitutions(
             test_bundle = test_bundle,
             test_bundle_dossier = test_bundle_dossier,
-            test_coverage_manifest = ctx.file.test_coverage_manifest,
+            test_coverage_manifest = test_coverage_manifest,
             test_env_inherit = ctx.attr.env_inherit,
             test_environment = test_environment,
             test_filter = ctx.attr.test_filter,

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -288,7 +288,7 @@ if [[ "$test_exit_code" -ne 0 ]]; then
   exit "$test_exit_code"
 fi
 
-if [[ "${COVERAGE:-}" -ne 1 ]]; then
+if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
   exit 0
 fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -635,7 +635,7 @@ then
   exit 1
 fi
 
-if [[ "${COVERAGE:-}" -ne 1 ]]; then
+if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
   exit 0
 fi

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -566,9 +566,9 @@ Outputs:
 ## ios_ui_test
 
 <pre>
-ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-env_inherit">env_inherit</a>, <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-            <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>, <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>,
-            <a href="#ios_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-env_inherit">env_inherit</a>,
+            <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>,
+            <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>, <a href="#ios_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 iOS UI Test rule.
@@ -594,6 +594,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="ios_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="ios_ui_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="ios_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="ios_ui_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="ios_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
@@ -611,9 +612,9 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
-ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-env_inherit">env_inherit</a>, <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-              <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>, <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>,
-              <a href="#ios_unit_test-test_host">test_host</a>, <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-env_inherit">env_inherit</a>,
+              <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>,
+              <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>, <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS Unit `.xctest` test bundle. Runs the tests using the
@@ -645,6 +646,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="ios_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="ios_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="ios_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="ios_unit_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="ios_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="ios_unit_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="ios_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -617,9 +617,9 @@ i.e. `--features=-swift.no_generated_header`).
 ## macos_ui_test
 
 <pre>
-macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-env_inherit">env_inherit</a>, <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-              <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>, <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>,
-              <a href="#macos_ui_test-test_host">test_host</a>, <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-env_inherit">env_inherit</a>,
+              <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>,
+              <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>, <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles an iOS UI `.xctest` test bundle. Runs the tests using the
@@ -636,6 +636,7 @@ Note: macOS UI tests are not currently supported in the default test runner.
 | <a id="macos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="macos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="macos_ui_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="macos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="macos_ui_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="macos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
@@ -653,9 +654,9 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
-macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-env_inherit">env_inherit</a>, <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-                <a href="#macos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>, <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>,
-                <a href="#macos_unit_test-test_host">test_host</a>, <a href="#macos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-env_inherit">env_inherit</a>,
+                <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>,
+                <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>, <a href="#macos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a macOS unit `.xctest` test bundle. Runs the tests using the
@@ -678,6 +679,7 @@ find more information about testing for Apple platforms
 | <a id="macos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="macos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="macos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="macos_unit_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="macos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="macos_unit_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="macos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -326,9 +326,9 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
-tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-env_inherit">env_inherit</a>, <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-             <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>, <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>,
-             <a href="#tvos_ui_test-test_host">test_host</a>, <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-env_inherit">env_inherit</a>,
+             <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>,
+             <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>, <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a tvOS UI `.xctest` test bundle. Runs the tests using the
@@ -349,6 +349,7 @@ the attributes inherited by all test rules, please check the
 | <a id="tvos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="tvos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="tvos_ui_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="tvos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="tvos_ui_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="tvos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
@@ -366,9 +367,9 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
-tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-env_inherit">env_inherit</a>, <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-               <a href="#tvos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>, <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>,
-               <a href="#tvos_unit_test-test_host">test_host</a>, <a href="#tvos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-env_inherit">env_inherit</a>,
+               <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>,
+               <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>, <a href="#tvos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a tvOS Unit `.xctest` test bundle. Runs the tests using the
@@ -397,6 +398,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="tvos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="tvos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="tvos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="tvos_unit_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="tvos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="tvos_unit_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="tvos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |

--- a/doc/rules-visionos.md
+++ b/doc/rules-visionos.md
@@ -274,9 +274,9 @@ i.e. `--features=-swift.no_generated_header`).
 ## visionos_ui_test
 
 <pre>
-visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_ui_test-deps">deps</a>, <a href="#visionos_ui_test-data">data</a>, <a href="#visionos_ui_test-bundle_name">bundle_name</a>, <a href="#visionos_ui_test-env">env</a>, <a href="#visionos_ui_test-env_inherit">env_inherit</a>, <a href="#visionos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-                 <a href="#visionos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_ui_test-platform_type">platform_type</a>, <a href="#visionos_ui_test-runner">runner</a>, <a href="#visionos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_ui_test-test_filter">test_filter</a>,
-                 <a href="#visionos_ui_test-test_host">test_host</a>, <a href="#visionos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_ui_test-deps">deps</a>, <a href="#visionos_ui_test-data">data</a>, <a href="#visionos_ui_test-bundle_name">bundle_name</a>, <a href="#visionos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#visionos_ui_test-env">env</a>, <a href="#visionos_ui_test-env_inherit">env_inherit</a>,
+                 <a href="#visionos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#visionos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_ui_test-platform_type">platform_type</a>, <a href="#visionos_ui_test-runner">runner</a>,
+                 <a href="#visionos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_ui_test-test_filter">test_filter</a>, <a href="#visionos_ui_test-test_host">test_host</a>, <a href="#visionos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a visionOS UI `.xctest` test bundle. Runs the tests using the
@@ -297,6 +297,7 @@ the attributes inherited by all test rules, please check the
 | <a id="visionos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="visionos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="visionos_ui_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="visionos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="visionos_ui_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="visionos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
@@ -314,9 +315,9 @@ the attributes inherited by all test rules, please check the
 ## visionos_unit_test
 
 <pre>
-visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#visionos_unit_test-deps">deps</a>, <a href="#visionos_unit_test-data">data</a>, <a href="#visionos_unit_test-bundle_name">bundle_name</a>, <a href="#visionos_unit_test-env">env</a>, <a href="#visionos_unit_test-env_inherit">env_inherit</a>, <a href="#visionos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-                   <a href="#visionos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_unit_test-platform_type">platform_type</a>, <a href="#visionos_unit_test-runner">runner</a>, <a href="#visionos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_unit_test-test_filter">test_filter</a>,
-                   <a href="#visionos_unit_test-test_host">test_host</a>, <a href="#visionos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#visionos_unit_test-deps">deps</a>, <a href="#visionos_unit_test-data">data</a>, <a href="#visionos_unit_test-bundle_name">bundle_name</a>, <a href="#visionos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#visionos_unit_test-env">env</a>, <a href="#visionos_unit_test-env_inherit">env_inherit</a>,
+                   <a href="#visionos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#visionos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_unit_test-platform_type">platform_type</a>, <a href="#visionos_unit_test-runner">runner</a>,
+                   <a href="#visionos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_unit_test-test_filter">test_filter</a>, <a href="#visionos_unit_test-test_host">test_host</a>, <a href="#visionos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 Builds and bundles a visionOS Unit `.xctest` test bundle. Runs the tests using the
@@ -345,6 +346,7 @@ of the attributes inherited by all test rules, please check the
 | <a id="visionos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="visionos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="visionos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="visionos_unit_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="visionos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="visionos_unit_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="visionos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -292,9 +292,9 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
-watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-env_inherit">env_inherit</a>, <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-                <a href="#watchos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>, <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>,
-                <a href="#watchos_ui_test-test_host">test_host</a>, <a href="#watchos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-env_inherit">env_inherit</a>,
+                <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#watchos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>,
+                <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>, <a href="#watchos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 watchOS UI Test rule.
@@ -308,6 +308,7 @@ watchOS UI Test rule.
 | <a id="watchos_ui_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="watchos_ui_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_ui_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="watchos_ui_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="watchos_ui_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="watchos_ui_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="watchos_ui_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |
@@ -325,9 +326,9 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
-watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-env_inherit">env_inherit</a>, <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>,
-                  <a href="#watchos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>, <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>,
-                  <a href="#watchos_unit_test-test_host">test_host</a>, <a href="#watchos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
+watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-env_inherit">env_inherit</a>,
+                  <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#watchos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>,
+                  <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>, <a href="#watchos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
 </pre>
 
 watchOS Unit Test rule.
@@ -341,6 +342,7 @@ watchOS Unit Test rule.
 | <a id="watchos_unit_test-deps"></a>deps |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="watchos_unit_test-data"></a>data |  Files to be made available to the test during its execution.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="watchos_unit_test-bundle_name"></a>bundle_name |  The desired name of the bundle (without the extension). If this attribute is not set, then the name of the target will be used instead.   | String | optional |  `""`  |
+| <a id="watchos_unit_test-collect_code_coverage"></a>collect_code_coverage |  Whether to collect code coverage for this test if `--collect_code_coverage=yes`.   | Boolean | optional |  `True`  |
 | <a id="watchos_unit_test-env"></a>env |  Dictionary of environment variables that should be set during the test execution. The values of the dictionary are subject to "Make" variable expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 | <a id="watchos_unit_test-env_inherit"></a>env_inherit |  List of environment variables to inherit from the external environment.   | List of strings | optional |  `[]`  |
 | <a id="watchos_unit_test-minimum_deployment_os_version"></a>minimum_deployment_os_version |  A required string indicating the minimum deployment OS version supported by the target, represented as a dotted version number (for example, "9.0"). This is different from `minimum_os_version`, which is effective at compile time. Ensure version specific APIs are guarded with `available` clauses.   | String | optional |  `""`  |


### PR DESCRIPTION
Code coverage is only collected when `True` (the default). This allows individual targets to opt out of code coverage collection, which can be useful in some cases, like UI tests.