### PR TITLE
Infer tvOS/watchOS archs from the CPU parameters, similarly to iOS

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -163,6 +163,11 @@ def _cpu_string(*, environment_arch, platform_type, settings = {}):
         tvos_cpus = settings["//command_line_option:tvos_cpus"]
         if tvos_cpus:
             return "tvos_{}".format(tvos_cpus[0])
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith("tvos_"):
+            return cpu_value
+        if cpu_value == "darwin_arm64":
+            return "tvos_sim_arm64"
         return "tvos_x86_64"
     if platform_type == "watchos":
         if environment_arch:
@@ -170,6 +175,11 @@ def _cpu_string(*, environment_arch, platform_type, settings = {}):
         watchos_cpus = settings["//command_line_option:watchos_cpus"]
         if watchos_cpus:
             return "watchos_{}".format(watchos_cpus[0])
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith("watchos_"):
+            return cpu_value
+        if cpu_value == "darwin_arm64":
+            return "watchos_arm64"
         return "watchos_x86_64"
 
     fail("ERROR: Unknown platform type: {}".format(platform_type))


### PR DESCRIPTION
iOS currently has some special logic in `transition_support.bzl` that defaults the architecture to the value of `//command_line_option:cpu` if the value is iOS related (or a arm64 mac), but the same was not being done for other platforms. This was causing some confusion on our team as although on one end the regular iOS builds were being automatically resolved to arm64 simulator builds, on the other end everything else was resolving to x86_64 despite no changes in the environment.

This PR adds this same special logic to tvOS/watchOS for make them consistent with iOS. So in my case, building tvOS from a arm64 mac would now result in a tvOS arm64 simulator build.

It's unclear to me if the iOS case was done just to support some legacy use-case (meaning we should probably not do this for the other platforms), so if that's the case, let me know how to best solve this!