### PR TITLE
Relax rsync path for permissions workaround in macOS 15.4+

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -39,6 +39,7 @@ import os.path
 import pathlib
 import platform
 import plistlib
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -300,8 +301,15 @@ def extracted_app(
     # fail with `Unhandled error domain NSPOSIXErrorDomain, code 13`.
     dst_dir = os.path.join(tempfile.gettempdir(), "bazel_temp_" + app_name)
     os.makedirs(dst_dir, exist_ok=True)
+
+    # NOTE: use `which` to find the path to `rsync`.
+    # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+    # This allows users to workaround the issue by overriding the system `rsync` with a working version.
+    # Remove this once we no longer support macOS versions with broken `rsync`.
+    rsync_path = shutil.which("rsync")
+
     rsync_command = [
-        "/usr/bin/rsync",
+        rsync_path,
         "--archive",
         "--delete",
         "--checksum",

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -132,7 +132,7 @@ class DeviceType(collections.abc.Mapping):
 
   def is_apple_watch(self) -> bool:
     return self.has_product_family_or_identifier("Apple Watch")
-  
+
   def is_apple_vision(self) -> bool:
     return self.has_product_family_or_identifier("Apple Vision")
 
@@ -537,8 +537,15 @@ def extracted_app(
     # fail with `Unhandled error domain NSPOSIXErrorDomain, code 13`.
     dst_dir = os.path.join(tempfile.gettempdir(), "bazel_temp_" + app_name)
     os.makedirs(dst_dir, exist_ok=True)
+
+    # NOTE: use `which` to find the path to `rsync`.
+    # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+    # This allows users to workaround the issue by overriding the system `rsync` with a working version.
+    # Remove this once we no longer support macOS versions with broken `rsync`.
+    rsync_path = shutil.which("rsync")
+
     rsync_command = [
-        "/usr/bin/rsync",
+        rsync_path,
         "--archive",
         "--delete",
         "--checksum",


### PR DESCRIPTION
This fixes `rsync` permission issues in macOS 15.4+ if users instead use a working `rsync` binary (e.g. one from Homebrew).