### PR TITLE
Add a new series of boundary checks to keep users informed of how to resolve issues with 3P static library SDK rules (such as apple_static_xcframework) caused by making avoid_deps too all-encompassing.

### DIFF
--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -68,15 +68,16 @@ def _swift_include_info(
         The module found from `transitive_modules` that has the necessary swift interfaces.
     """
     swift_module = None
+    transitive_modules_list = transitive_modules.to_list()
 
-    for module in transitive_modules.to_list():
+    for module in transitive_modules_list:
         if not module.swift or sets.contains(avoid_modules, module.name):
             continue
 
         if swift_module or (found_module_name and module.name != found_module_name):
             fail(
                 """\
-error: Swift third party frameworks expect a single swift_library dependency with no transitive \
+Error: Swift third party frameworks expect a single swift_library dependency with no transitive \
 swift_library dependencies.\
 """,
             )
@@ -84,12 +85,43 @@ swift_library dependencies.\
         if not all([module.name, module.swift.swiftdoc]) or not (module.swift.swiftmodule or module.swift.swiftinterface):
             fail(
                 """\
-error: Could not find all required artifacts and information to build a Swift framework. \
+Error: Could not find all required artifacts and information to build a Swift framework. \
 Please file an issue with a reproducible error case.\
 """,
             )
 
         swift_module = module
+
+    if not swift_module:
+        if not transitive_modules_list:
+            fail("""\
+Internal Error: Swift third party frameworks require a Swift module to be defined from a \
+"swift_library", but could not find any Swift modules from deps. Please file an issue on the Apple \
+BUILD rules with a reproducible error case.
+""")
+
+        avoid_modules_list = sets.to_list(avoid_modules) if avoid_modules else None
+        if avoid_modules_list:
+            fail("""\
+Error: Could not find a Swift module to build a Swift framework. This could be because "avoid_deps"\
+ is too broadly defined.
+
+Found these Swift modules within "avoid_deps": {avoid_modules_list}
+
+Found these Swift modules within "deps": {transitive_modules_list}
+""".format(
+                avoid_modules_list = ", ".join(sorted(avoid_modules_list)),
+                transitive_modules_list = ", ".join(sorted([
+                    module.name
+                    for module in transitive_modules_list
+                ])),
+            ))
+
+        fail("""\
+Internal Error: Could not find any Swift modules from deps, even though information for transitive \
+modules from a Swift library dependency was found in deps. Please file an issue on the Apple BUILD \
+rules with a reproducible error case.
+""")
 
     return swift_module
 

--- a/test/starlark_tests/apple_static_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_tests.bzl
@@ -15,6 +15,10 @@
 """xcframework Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
@@ -275,6 +279,13 @@ def apple_static_xcframework_test_suite(name):
             "$BUNDLE_ROOT/ios-arm64_arm64e/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/Info.plist",
             "$BUNDLE_ROOT/ios-arm64_arm64e/ios_static_xcframework_with_resources.framework/resource_bundle.bundle/custom_apple_resource_info.out",
         ],
+        tags = [name],
+    )
+
+    analysis_failure_message_test(
+        name = "{}_overreaching_avoid_deps_swift_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:ios_swift_static_xcframework_with_broad_avoid_deps",
+        expected_error = "Error: Could not find a Swift module to build a Swift framework. This could be because \"avoid_deps\" is too broadly defined.",
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1181,6 +1181,31 @@ apple_static_xcframework(
     deps = [":fmwk_lib"],
 )
 
+apple_static_xcframework(
+    name = "ios_swift_static_xcframework_with_broad_avoid_deps",
+    avoid_deps = [":swift_lib_for_static_xcfmwk"],
+    # TODO(b/239957001): Remove this when the rule no longer forces library
+    # evolution.
+    features = ["apple.no_legacy_swiftinterface"],
+    ios = {
+        "simulator": [
+            "arm64",
+            "x86_64",
+        ],
+        "device": [
+            "arm64",
+        ],
+    },
+    minimum_os_versions = {
+        "ios": common.min_os_ios.baseline,
+    },
+    public_hdrs = [
+        "//test/starlark_tests/resources:shared.h",
+    ],
+    tags = common.fixture_tags,
+    deps = [":swift_lib_for_static_xcfmwk"],
+)
+
 genrule(
     name = "dummy_fmwk_objc_hdr",
     outs = ["DummyFmwk.h"],

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1169,7 +1169,6 @@ apple_static_xcframework(
         ],
         "device": [
             "arm64",
-            "x86_64",
         ],
     },
     minimum_os_versions = {


### PR DESCRIPTION
Cherry-picks:

- https://github.com/bazelbuild/rules_apple/commit/f03ec363cfbccfbb20420777b7296136e88cf212
- https://github.com/bazelbuild/rules_apple/commit/137a8ed1cb4306a2a40fd10b3db8509f741d58c
