### PR TITLE
*_build_test: Don't allow targets to be empty.

### DIFF
--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -106,6 +106,7 @@ number (for example, `"9.0"`).
 """,
             ),
             "targets": attr.label_list(
+                allow_empty = False,
                 cfg = transition_support.apple_platform_split_transition,
                 doc = "The targets to check for successful build.",
             ),


### PR DESCRIPTION
Cherry-pick: https://github.com/bazelbuild/rules_apple/commit/897df583606a42234d959aac9c8ac8189e8be01a