### PR TITLE
Mark the output bundle's root folder permissions as 0o755 as the user when tree artifact bundling is active, for parity with the output bundle generated by legacy bundling.

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -138,6 +138,8 @@ class Bundler(object):
       self._add_files(f['src'], f['dest'], f.get('executable', False),
                       output_path)
 
+    os.chmod(output_path, 0o755)
+
     post_processor = self._control.get('post_processor')
     if post_processor:
       self._post_process_bundle(output_path, post_processor)


### PR DESCRIPTION
Cherry-pick: https://github.com/bazelbuild/rules_apple/commit/c96d8fbe5fa344d4eecb3af4f8f695ca5b9acb66