### PR TITLE
Update minimum_os_version for XCTest support in Xcode 15.3. Add addit…

### DIFF
--- a/test/starlark_tests/common.bzl
+++ b/test/starlark_tests/common.bzl
@@ -33,9 +33,9 @@ _min_os_ios = struct(
     app_intents_support = "16.0",
     appclip_support = "14.0",
     arm_sim_support = "14.0",
-    baseline = "12.0",
-    oldest_supported = "11.0",
-    nplus1 = "13.0",
+    baseline = "13.0",
+    oldest_supported = "12.0",
+    nplus1 = "14.0",
     stable_swift_abi = "12.2",
     widget_configuration_intents_support = "16.0",
 )
@@ -51,9 +51,9 @@ _min_os_macos = struct(
 _min_os_tvos = struct(
     app_intents_support = "16.0",
     arm_sim_support = "14.0",
-    baseline = "12.0",
-    nplus1 = "13.0",
-    oldest_supported = "11.0",
+    baseline = "13.0",
+    oldest_supported = "12.0",
+    nplus1 = "14.0",
     stable_swift_abi = "12.2",
 )
 

--- a/test/starlark_tests/ios_framework_tests.bzl
+++ b/test/starlark_tests/ios_framework_tests.bzl
@@ -697,6 +697,32 @@ Please remove one of the two from your rule definition.
         tags = [name],
     )
 
+    # Tests that if frameworks and applications have different minimum versions that a user
+    # actionable error is raised.
+    analysis_failure_message_test(
+        name = "{}_app_with_baseline_min_os_and_nplus1_fmwk_produces_error".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_baseline_min_os_and_nplus1_fmwk",
+        expected_error = """
+ERROR: minimum_os_version {framework_version} on the framework //test/starlark_tests/targets_under_test/ios:fmwk_min_os_nplus1 is too high compared to //test/starlark_tests/targets_under_test/ios:app_with_baseline_min_os_and_nplus1_fmwk's minimum_os_version of {app_version}
+
+Please address the minimum_os_version on framework //test/starlark_tests/targets_under_test/ios:fmwk_min_os_nplus1 to match //test/starlark_tests/targets_under_test/ios:app_with_baseline_min_os_and_nplus1_fmwk's minimum_os_version.
+""".format(app_version = common.min_os_ios.baseline, framework_version = common.min_os_ios.nplus1),
+        tags = [name],
+    )
+
+    # Tests that if data-loaded frameworks and applications have different minimum versions that a
+    # user actionable error is raised.
+    analysis_failure_message_test(
+        name = "{}_app_with_baseline_min_os_and_nplus1_transitive_data_fmwk_produces_error".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_nplus1_framework_objc_lib_using_data",
+        expected_error = """
+ERROR: minimum_os_version {framework_version} on the framework //test/starlark_tests/targets_under_test/ios:fmwk_min_os_nplus1 is too high compared to //test/starlark_tests/targets_under_test/ios:app_with_nplus1_framework_objc_lib_using_data's minimum_os_version of {app_version}
+
+Please address the minimum_os_version on framework //test/starlark_tests/targets_under_test/ios:fmwk_min_os_nplus1 to match //test/starlark_tests/targets_under_test/ios:app_with_nplus1_framework_objc_lib_using_data's minimum_os_version.
+""".format(app_version = common.min_os_ios.baseline, framework_version = common.min_os_ios.nplus1),
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1369,7 +1369,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [
@@ -1512,7 +1512,7 @@ ios_extension(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [
@@ -2171,7 +2171,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":dynamic_fmwk_depending_swift_lib",
@@ -2366,7 +2366,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":swift_static_without_module_interfaces_fmwk_depending_lib",
@@ -2407,7 +2407,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":swift_static_fmwk_depending_swift_lib",
@@ -2556,7 +2556,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":dynamic_objc_xcframework_depending_swift_lib",
@@ -2667,7 +2667,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":dynamic_swift_xcframework_depending_swift_lib",
@@ -2739,7 +2739,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":static_fmwk_depending_swift_lib",
@@ -2860,7 +2860,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":swift_static_xcframework_depending_objc_lib",
@@ -2901,7 +2901,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":swift_static_xcframework_without_swiftmodule_depending_objc_lib",
@@ -2953,7 +2953,7 @@ ios_application(
     bundle_id = "com.google.example",
     families = ["iphone"],
     infoplists = ["//test/starlark_tests/resources:Info.plist"],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":static_xcframework_depending_swift_lib",
@@ -3017,7 +3017,7 @@ ios_application(
     bundle_id = "com.google.example",
     families = ["iphone"],
     infoplists = ["//test/starlark_tests/resources:Info.plist"],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     tags = common.fixture_tags,
     deps = [
         ":static_swift_xcframework_depending_swift_lib",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -114,7 +114,7 @@ tvos_application(
     bundle_id = "com.google.example",
     extensions = [":swift_ext"],
     infoplists = ["//test/starlark_tests/resources:Info.plist"],
-    minimum_os_version = common.min_os_tvos.baseline,
+    minimum_os_version = common.min_os_tvos.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = ["//test/starlark_tests/resources:objc_main_lib"],
@@ -136,7 +136,7 @@ tvos_extension(
     bundle_id = "com.google.example.ext",
     entitlements = "//test/starlark_tests/resources:entitlements.plist",
     infoplists = ["//test/starlark_tests/resources:Info.plist"],
-    minimum_os_version = common.min_os_tvos.baseline,
+    minimum_os_version = common.min_os_tvos.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [
@@ -1061,7 +1061,7 @@ tvos_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_tvos.baseline,
+    minimum_os_version = common.min_os_tvos.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [":swift_lib"],
@@ -1073,7 +1073,7 @@ tvos_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_tvos.baseline,
+    minimum_os_version = common.min_os_tvos.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     deps = [":objc_to_swift_lib"],

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -633,7 +633,7 @@ watchos_application(
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],
-    minimum_os_version = "6.0",
+    minimum_os_version = common.min_os_watchos.baseline,
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     resources = [
         "//test/starlark_tests/resources:example_filegroup",
@@ -678,7 +678,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     watch_application = ":watchos_app_no_swift",
@@ -712,7 +712,7 @@ ios_application(
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],
-    minimum_os_version = common.min_os_ios.baseline,
+    minimum_os_version = common.min_os_ios.oldest_supported,  # Before the stable Swift ABI
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
     watch_application = ":watchos_app_swift",
@@ -824,7 +824,7 @@ watchos_application(
     infoplists = [
         "//test/starlark_tests/resources:WatchosAppInfo.plist",
     ],
-    minimum_os_version = "6.0",
+    minimum_os_version = common.min_os_watchos.stable_swift_abi,
     provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     tags = common.fixture_tags,
 )

--- a/test/starlark_tests/tvos_framework_tests.bzl
+++ b/test/starlark_tests/tvos_framework_tests.bzl
@@ -15,6 +15,10 @@
 """tvos_framework Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
+    "analysis_failure_message_test",
+)
+load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -349,6 +353,32 @@ def tvos_framework_test_suite(name):
         expected_values = {
             "CFBundleIdentifier": "com.bazel.app.example.fmwk-with-base-bundle-id-derived-bundle-id",
         },
+        tags = [name],
+    )
+
+    # Tests that if frameworks and applications have different minimum versions that a user
+    # actionable error is raised.
+    analysis_failure_message_test(
+        name = "{}_app_with_baseline_min_os_and_nplus1_fmwk_produces_error".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_baseline_min_os_and_nplus1_fmwk",
+        expected_error = """
+ERROR: minimum_os_version {framework_version} on the framework //test/starlark_tests/targets_under_test/tvos:fmwk_min_os_nplus1 is too high compared to //test/starlark_tests/targets_under_test/tvos:app_with_baseline_min_os_and_nplus1_fmwk's minimum_os_version of {app_version}
+
+Please address the minimum_os_version on framework //test/starlark_tests/targets_under_test/tvos:fmwk_min_os_nplus1 to match //test/starlark_tests/targets_under_test/tvos:app_with_baseline_min_os_and_nplus1_fmwk's minimum_os_version.
+""".format(app_version = common.min_os_tvos.baseline, framework_version = common.min_os_tvos.nplus1),
+        tags = [name],
+    )
+
+    # Tests that if data-loaded frameworks and applications have different minimum versions that a
+    # user actionable error is raised.
+    analysis_failure_message_test(
+        name = "{}_app_with_baseline_min_os_and_nplus1_transitive_data_fmwk_produces_error".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app_with_nplus1_framework_objc_lib_using_data",
+        expected_error = """
+ERROR: minimum_os_version {framework_version} on the framework //test/starlark_tests/targets_under_test/tvos:fmwk_min_os_nplus1 is too high compared to //test/starlark_tests/targets_under_test/tvos:app_with_nplus1_framework_objc_lib_using_data's minimum_os_version of {app_version}
+
+Please address the minimum_os_version on framework //test/starlark_tests/targets_under_test/tvos:fmwk_min_os_nplus1 to match //test/starlark_tests/targets_under_test/tvos:app_with_nplus1_framework_objc_lib_using_data's minimum_os_version.
+""".format(app_version = common.min_os_tvos.baseline, framework_version = common.min_os_tvos.nplus1),
         tags = [name],
     )
 

--- a/test/starlark_tests/watchos_application_swift_tests.bzl
+++ b/test/starlark_tests/watchos_application_swift_tests.bzl
@@ -119,7 +119,7 @@ def watchos_application_swift_test_suite(name):
             "bundle/Payload/companion.app/Watch/app.app/app",
             "bundle/Payload/companion.app/Watch/app.app/PlugIns/ext.appex/Info.plist",
             "bundle/Payload/companion.app/Watch/app.app/PlugIns/ext.appex/ext",
-            "bundle/SwiftSupport/iphoneos/libswiftCore.dylib",
+            "bundle/SwiftSupport/watchos/libswiftCore.dylib",
             "bundle/WatchKitSupport2/WK",
             "dossier/manifest.json",
         ],

--- a/test/testdata/binaries/BUILD
+++ b/test/testdata/binaries/BUILD
@@ -2,6 +2,10 @@ load(
     "//apple:apple_binary.bzl",
     "apple_binary",
 )
+load(
+    "//test/starlark_tests:common.bzl",
+    "common",
+)
 
 # Public only because these are used by the integration tests from generated
 # workspaces. Please no not depend on them as they can change at any time.
@@ -12,7 +16,7 @@ licenses(["notice"])
 apple_binary(
     name = "empty_tvos_dylib",
     binary_type = "dylib",
-    minimum_os_version = "11.0",
+    minimum_os_version = common.min_os_tvos.baseline,
     platform_type = "tvos",
     deps = [":dummy_lib"],
 )


### PR DESCRIPTION
…ional references to common.bzl test targets where it's convenient.

This leaves the "examples" targets alone, as we're assuming that they should be documentation.

Cherry-pick: https://github.com/bazelbuild/rules_apple/commit/ce6f443590f424fed6839a88bbf6feec301c8904