### PR TITLE
Remove `One of the two will be used` grep

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -521,8 +521,7 @@ if [[ "$should_use_xcodebuild" == true ]]; then
   fi
 
   xcodebuild test-without-building "${args[@]}" \
-    2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
-    || test_exit_code=$?
+    2>&1 | tee -i "$testlog" || test_exit_code=$?
 else
   platform_developer_dir="$(xcode-select -p)/Platforms/$test_execution_platform/Developer"
   xctest_binary="$platform_developer_dir/Library/Xcode/Agents/xctest"
@@ -544,8 +543,7 @@ else
     "$xctest_binary" \
     -XCTest All \
     "$test_tmp_dir/$test_bundle_name.xctest" \
-    2>&1 | tee -i "$testlog" | (grep -v "One of the two will be used" || true) \
-    || test_exit_code=$?
+    2>&1 | tee -i "$testlog" || test_exit_code=$?
 fi
 
 # Run a post-action binary, if provided.


### PR DESCRIPTION
1. It’s not needed anymore (in my testing)
2. As it stands it doesn’t flush lines immediately, and we would need `--line-buffered`