### PR TITLE
Utilize `TEST_PREMATURE_EXIT_FILE`

### DIFF
--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-if [[ -n "$TEST_PREMATURE_EXIT_FILE" ]]; then
+if [[ -n "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
   touch "$TEST_PREMATURE_EXIT_FILE"
 fi
 
@@ -305,7 +305,7 @@ fi
 
 if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
-  if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  if [[ -f "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
     rm -f "$TEST_PREMATURE_EXIT_FILE"
   fi
 
@@ -379,6 +379,6 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
   fi
 fi
 
-if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+if [[ -f "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
   rm -f "$TEST_PREMATURE_EXIT_FILE"
 fi

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -16,6 +16,10 @@
 
 set -e
 
+if [[ -n "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  touch "$TEST_PREMATURE_EXIT_FILE"
+fi
+
 basename_without_extension() {
   local full_path="$1"
   local filename
@@ -301,6 +305,10 @@ fi
 
 if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
+  if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+    rm -f "$TEST_PREMATURE_EXIT_FILE"
+  fi
+
   exit 0
 fi
 
@@ -369,4 +377,8 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     cat "$error_file" >&2
     exit 1
   fi
+fi
+
+if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  rm -f "$TEST_PREMATURE_EXIT_FILE"
 fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-if [[ -n "$TEST_PREMATURE_EXIT_FILE" ]]; then
+if [[ -n "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
   touch "$TEST_PREMATURE_EXIT_FILE"
 fi
 
@@ -666,7 +666,7 @@ fi
 
 if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
-  if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  if [[ -f "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
     rm -f "$TEST_PREMATURE_EXIT_FILE"
   fi
 
@@ -741,6 +741,6 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
   fi
 fi
 
-if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+if [[ -f "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
   rm -f "$TEST_PREMATURE_EXIT_FILE"
 fi

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+if [[ -n "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  touch "$TEST_PREMATURE_EXIT_FILE"
+fi
+
 if [[ -z "${DEVELOPER_DIR:-}" ]]; then
   echo "error: Missing \$DEVELOPER_DIR" >&2
   exit 1
@@ -487,7 +491,6 @@ if [[ "$should_use_xcodebuild" == true ]]; then
     -e "s@BAZEL_PRODUCT_PATH@$xcrun_test_bundle_path@g" \
     "%(xctestrun_template)s" > "$xctestrun_file"
 
-
   if [[ -n "${DEBUG_XCTESTRUNNER:-}" ]]; then
     echo
     echo "xctestrun contents:"
@@ -663,6 +666,10 @@ fi
 
 if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
   # Normal tests run without coverage
+  if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+    rm -f "$TEST_PREMATURE_EXIT_FILE"
+  fi
+
   exit 0
 fi
 
@@ -732,4 +739,8 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     cat "$error_file" >&2
     exit 1
   fi
+fi
+
+if [[ -f "$TEST_PREMATURE_EXIT_FILE" ]]; then
+  rm -f "$TEST_PREMATURE_EXIT_FILE"
 fi

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -20,6 +20,10 @@
 # https://github.com/bazelbuild/rules_apple/blob/master/apple/testing/apple_test_rules.bzl
 # for more info.
 
+if [[ -n "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
+  touch "$TEST_PREMATURE_EXIT_FILE"
+fi
+
 if [[ "%(test_type)s" = "XCUITEST" ]]; then
   echo "This runner only works with macos_unit_test (b/63707899)."
   exit 1
@@ -231,4 +235,8 @@ if [[ -n "${COVERAGE_PRODUCE_JSON:-}" ]]; then
     cat "$export_error_file" >&2
     exit 1
   fi
+fi
+
+if [[ -f "${TEST_PREMATURE_EXIT_FILE:-}" ]]; then
+  rm -f "$TEST_PREMATURE_EXIT_FILE"
 fi


### PR DESCRIPTION
This also makes it easier to use `TEST_PREMATURE_EXIT_FILE` in test observers, since it doesn’t need to make sure to clean up the file itself, and can (ab)use it for detecting test restarting.