### PR TITLE
Ability to explicitly specify output files in apple_core_data_model rule

### DIFF
--- a/apple/internal/resource_actions/datamodel.bzl
+++ b/apple/internal/resource_actions/datamodel.bzl
@@ -109,6 +109,7 @@ def generate_datamodels(
         datamodel_path,
         input_files,
         output_dir,
+        outputs,
         platform_prerequisites,
         xctoolrunner,
         swift_version = None):
@@ -119,6 +120,7 @@ def generate_datamodels(
         datamodel_path: The path to the directory containing the datamodels.
         input_files: The list of files to process for the given datamodel.
         output_dir: The output directory reference where generated datamodel classes will be.
+        outputs: The list of generated datamodel files or the directory containing those files.
         platform_prerequisites: Struct containing information on the platform being targeted.
         xctoolrunner: A files_to_run for the wrapper around the "xcrun" tool.
         swift_version: (optional) Target Swift version for generated datamodel classes.
@@ -136,9 +138,9 @@ def generate_datamodels(
         args.add("--swift-version", swift_version)
 
     args.add(xctoolrunner_support.prefixed_path(datamodel_path))
-    args.add(xctoolrunner_support.prefixed_path(output_dir.path))
+    args.add(xctoolrunner_support.prefixed_path(output_dir))
 
-    args.add("--xctoolrunner_assert_nonempty_dir", output_dir.path)
+    args.add("--xctoolrunner_assert_nonempty_dir", output_dir)
 
     apple_support.run(
         actions = actions,
@@ -147,6 +149,6 @@ def generate_datamodels(
         executable = xctoolrunner,
         inputs = input_files,
         mnemonic = "MomGenerate",
-        outputs = [output_dir],
+        outputs = outputs,
         xcode_config = platform_prerequisites.xcode_version_config,
     )

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -140,8 +140,8 @@ apple_core_data_model = rule(
                 doc = """
 An optional list of expected output files. If not empty, the rule will
 return these files individually rather than returning a directory.
-"""
-            )
+""",
+            ),
         },
     ),
     fragments = ["apple"],

--- a/test/starlark_tests/apple_core_data_model_tests.bzl
+++ b/test/starlark_tests/apple_core_data_model_tests.bzl
@@ -61,6 +61,17 @@ def apple_core_data_model_test_suite(name):
         tags = [name],
     )
 
+    # Test outputs a list of files rather than directories
+    analysis_target_outputs_test(
+        name = "{}_outputs_explicit_swift_files_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/apple:explicit_outs_data_model",
+        expected_outputs = [
+            "swift_datamodel.explicit_outs_data_model.coredata.sources/Item+CoreDataProperties.swift",
+            "swift_datamodel.explicit_outs_data_model.coredata.sources/swift_datamodel+CoreDataModel.swift",
+        ],
+        tags = [name],
+    )
+
     # Test registered actions and mnemonics for Obj-C and Swift data models.
     analysis_target_actions_test(
         name = "{}_actions_swift_test".format(name),

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -254,6 +254,18 @@ apple_core_data_model(
     tags = common.fixture_tags,
 )
 
+apple_core_data_model(
+    name = "explicit_outs_data_model",
+    srcs = [
+        "//test/starlark_tests/resources:swift_datamodel",
+    ],
+    outs = [
+        "swift_datamodel.explicit_outs_data_model.coredata.sources/Item+CoreDataProperties.swift",
+        "swift_datamodel.explicit_outs_data_model.coredata.sources/swift_datamodel+CoreDataModel.swift",
+    ],
+    tags = common.fixture_tags,
+)
+
 objc_library(
     name = "fmwk_lib",
     srcs = [


### PR DESCRIPTION
This PR contains one of the two fixes mentioned in #2726. This change makes it possible to explicitly specify the output files that are expected to be generated from the provided core data models. This causes the rule to return a provider containing these individual Swift files rather than just the containing folder.