### PR TITLE
Stop setting toolchains where not used

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -184,7 +184,6 @@ def _create_apple_test_rule(*, doc, implementation, platform_type):
             "@platforms//os:macos",
         ],
         test = True,
-        toolchains = use_cpp_toolchain(),
     )
 
 rule_factory = struct(


### PR DESCRIPTION
Fixes an issue with multi-platform builds and rules_cc 0.1.2.