### PR TITLE
Update the examples to load `objc_library` from rules_cc.

### DIFF
--- a/examples/ios/HelloWorld/BUILD
+++ b/examples/ios/HelloWorld/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("//apple:ios.bzl", "ios_application")
 load(
     "//apple:versioning.bzl",

--- a/examples/ios/PrenotCalculator/BUILD
+++ b/examples/ios/PrenotCalculator/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_application",

--- a/examples/macos/CommandLine/BUILD
+++ b/examples/macos/CommandLine/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:macos.bzl",
     "macos_command_line_application",

--- a/examples/macos/HelloToday/BUILD
+++ b/examples/macos/HelloToday/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:macos.bzl",
     "macos_application",

--- a/examples/macos/HelloWorld/BUILD
+++ b/examples/macos/HelloWorld/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:macos.bzl",
     "macos_application",

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -3,6 +3,7 @@ load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_library",
 )
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_application",

--- a/examples/tvos/HelloWorld/BUILD
+++ b/examples/tvos/HelloWorld/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:tvos.bzl",
     "tvos_application",

--- a/examples/watchos/HelloWorld/BUILD
+++ b/examples/watchos/HelloWorld/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_application",


### PR DESCRIPTION
Cherry pick [993d05120465bc7b61334397d70d9dedc5aa287f](https://github.com/bazelbuild/rules_apple/commit/993d05120465bc7b61334397d70d9dedc5aa287f)