### PR TITLE
Fix bazelci on HEAD due to old dependency behavior

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,5 @@
+"""rules_apple MODULE.bazel file"""
+
 module(
     name = "rules_apple",
     version = "0",
@@ -6,10 +8,10 @@ module(
 )
 
 bazel_dep(name = "apple_support", version = "1.21.1", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "bazel_features", version = "1.9.0")
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
-bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "rules_cc", version = "0.0.10")
+bazel_dep(name = "bazel_features", version = "1.30.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(
     name = "rules_swift",
     version = "2.4.0",
@@ -28,13 +30,13 @@ bazel_dep(name = "rules_shell", version = "0.3.0")
 
 bazel_dep(
     name = "stardoc",
-    version = "0.6.2",
+    version = "0.8.0",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )
 bazel_dep(
     name = "protobuf",
-    version = "21.7",
+    version = "29.0",
     dev_dependency = True,
     repo_name = "com_google_protobuf",
 )
@@ -50,20 +52,3 @@ use_repo(provisioning_profile_repository, "local_provisioning_profiles")
 
 apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
-
-# TODO: Remove override when a protobuf release is available that supports
-# Bazel 8
-archive_override(
-    module_name = "protobuf",
-    integrity = "sha256-+dloYVexGlGsxKLTARuU4KXZ5ORo/BWPR6obFk73d+Q=",
-    strip_prefix = "protobuf-b93b8e5f64ed922d101759380d7c6a2bbe474e26",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/b93b8e5f64ed922d101759380d7c6a2bbe474e26.zip"],
-)
-
-# TODO: Remove override when a protobuf release that marks `stardoc` as a
-# dev_dependency is available, until then it's upgrading our stardoc version
-# so override it here.
-single_version_override(
-    module_name = "stardoc",
-    version = "0.6.2",
-)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "apple_support", version = "1.21.1", repo_name = "build_bazel_a
 bazel_dep(name = "bazel_features", version = "1.30.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cc", version = "0.1.2")
 bazel_dep(
     name = "rules_swift",
     version = "2.4.0",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,21 +35,15 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-# For API doc generation
-# This is a dev dependency, users should not need to install it
-# so we declare it in the WORKSPACE
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "rules_python",
-    sha256 = "2cc26bbd53854ceb76dd42a834b1002cd4ba7f8df35440cf03482e045affc244",
-    strip_prefix = "rules_python-1.3.0",
-    url = "https://github.com/bazel-contrib/rules_python/releases/download/1.3.0/rules_python-1.3.0.tar.gz",
-)
-
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
+
+# For API doc generation
+# This is a dev dependency, users should not need to install it
+# so we declare it in the WORKSPACE
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_stardoc",

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -184,9 +184,8 @@ bzl_library(
         "//apple/internal/resource_rules:apple_precompiled_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
-        "//apple/internal/resource_rules:apple_resource_locales",
-        "@rules_cc//cc:core_rules",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc:objc_library.bzl",
         "@rules_cc//cc/common",
     ],
 )

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -185,7 +185,7 @@ bzl_library(
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
         "@rules_cc//cc:find_cc_toolchain_bzl",
-        "@rules_cc//cc:objc_library.bzl",
+        "@rules_cc//cc:core_rules",
         "@rules_cc//cc/common",
     ],
 )

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -184,8 +184,8 @@ bzl_library(
         "//apple/internal/resource_rules:apple_precompiled_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_bundle",
         "//apple/internal/resource_rules:apple_resource_group",
-        "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc:core_rules",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",
     ],
 )

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -812,6 +812,7 @@ bzl_library(
     deps = [
         "//apple:providers",
         "//apple/internal/providers:apple_debug_info",
+        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 

--- a/apple/internal/multi_arch_binary_support.bzl
+++ b/apple/internal/multi_arch_binary_support.bzl
@@ -75,5 +75,4 @@ def subtract_linking_contexts(owner, linking_contexts, avoid_dep_linking_context
                 linkstamps = depset(linkstamps),
             ),
         ]),
-        owner = owner,
     )

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -21,13 +21,20 @@ boundary with well-defined public APIs for broader usage.
 ## AppleBaseBundleIdInfo
 
 <pre>
-AppleBaseBundleIdInfo(<a href="#AppleBaseBundleIdInfo-base_bundle_id">base_bundle_id</a>)
+load("@rules_apple//apple:providers.bzl", "AppleBaseBundleIdInfo")
+
+AppleBaseBundleIdInfo(<a href="#AppleBaseBundleIdInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides the base bundle ID prefix for an Apple rule.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleBaseBundleIdInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -39,7 +46,9 @@ Provides the base bundle ID prefix for an Apple rule.
 ## AppleBinaryInfo
 
 <pre>
-AppleBinaryInfo(<a href="#AppleBinaryInfo-binary">binary</a>, <a href="#AppleBinaryInfo-infoplist">infoplist</a>, <a href="#AppleBinaryInfo-product_type">product_type</a>)
+load("@rules_apple//apple:providers.bzl", "AppleBinaryInfo")
+
+AppleBinaryInfo(<a href="#AppleBinaryInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information about an Apple binary target.
@@ -47,8 +56,13 @@ Provides information about an Apple binary target.
 This provider propagates general information about an Apple binary that is not
 specific to any particular binary type.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleBinaryInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -62,6 +76,8 @@ specific to any particular binary type.
 ## AppleBinaryInfoplistInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "AppleBinaryInfoplistInfo")
+
 AppleBinaryInfoplistInfo(<a href="#AppleBinaryInfoplistInfo-infoplist">infoplist</a>)
 </pre>
 
@@ -69,7 +85,6 @@ Provides information about the Info.plist that was linked into an Apple binary
 target.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -81,18 +96,22 @@ target.
 ## AppleBundleInfo
 
 <pre>
-AppleBundleInfo(<a href="#AppleBundleInfo-archive">archive</a>, <a href="#AppleBundleInfo-archive_root">archive_root</a>, <a href="#AppleBundleInfo-binary">binary</a>, <a href="#AppleBundleInfo-bundle_extension">bundle_extension</a>, <a href="#AppleBundleInfo-bundle_id">bundle_id</a>, <a href="#AppleBundleInfo-bundle_name">bundle_name</a>,
-                <a href="#AppleBundleInfo-entitlements">entitlements</a>, <a href="#AppleBundleInfo-executable_name">executable_name</a>, <a href="#AppleBundleInfo-extension_safe">extension_safe</a>, <a href="#AppleBundleInfo-infoplist">infoplist</a>,
-                <a href="#AppleBundleInfo-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#AppleBundleInfo-minimum_os_version">minimum_os_version</a>, <a href="#AppleBundleInfo-platform_type">platform_type</a>, <a href="#AppleBundleInfo-product_type">product_type</a>,
-                <a href="#AppleBundleInfo-uses_swift">uses_swift</a>)
+load("@rules_apple//apple:providers.bzl", "AppleBundleInfo")
+
+AppleBundleInfo(<a href="#AppleBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 This provider propagates general information about an Apple bundle that is not
 specific to any particular bundle type. It is propagated by most bundling
 rules (applications, extensions, frameworks, test bundles, and so forth).
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -118,13 +137,20 @@ rules (applications, extensions, frameworks, test bundles, and so forth).
 ## AppleBundleVersionInfo
 
 <pre>
-AppleBundleVersionInfo(<a href="#AppleBundleVersionInfo-version_file">version_file</a>)
+load("@rules_apple//apple:providers.bzl", "AppleBundleVersionInfo")
+
+AppleBundleVersionInfo(<a href="#AppleBundleVersionInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides versioning information for an Apple bundle.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleBundleVersionInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -136,13 +162,20 @@ Provides versioning information for an Apple bundle.
 ## AppleCodesigningDossierInfo
 
 <pre>
-AppleCodesigningDossierInfo(<a href="#AppleCodesigningDossierInfo-dossier">dossier</a>)
+load("@rules_apple//apple:providers.bzl", "AppleCodesigningDossierInfo")
+
+AppleCodesigningDossierInfo(<a href="#AppleCodesigningDossierInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information around the use of a code signing dossier.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleCodesigningDossierInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -154,7 +187,9 @@ Provides information around the use of a code signing dossier.
 ## AppleDebugOutputsInfo
 
 <pre>
-AppleDebugOutputsInfo(<a href="#AppleDebugOutputsInfo-outputs_map">outputs_map</a>)
+load("@rules_apple//apple:providers.bzl", "AppleDebugOutputsInfo")
+
+AppleDebugOutputsInfo(<a href="#AppleDebugOutputsInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Holds debug outputs of an Apple binary rule.
@@ -166,8 +201,13 @@ The only field is `output_map`, which is a dictionary of:
 
 Where `arch` is any Apple architecture such as "arm64" or "armv7".
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleDebugOutputsInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -179,13 +219,14 @@ Where `arch` is any Apple architecture such as "arm64" or "armv7".
 ## AppleDeviceTestRunnerInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "AppleDeviceTestRunnerInfo")
+
 AppleDeviceTestRunnerInfo(<a href="#AppleDeviceTestRunnerInfo-device_type">device_type</a>, <a href="#AppleDeviceTestRunnerInfo-os_version">os_version</a>)
 </pre>
 
 Provider that device-based runner targets must propagate.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -198,13 +239,20 @@ Provider that device-based runner targets must propagate.
 ## AppleDsymBundleInfo
 
 <pre>
-AppleDsymBundleInfo(<a href="#AppleDsymBundleInfo-direct_dsyms">direct_dsyms</a>, <a href="#AppleDsymBundleInfo-transitive_dsyms">transitive_dsyms</a>)
+load("@rules_apple//apple:providers.bzl", "AppleDsymBundleInfo")
+
+AppleDsymBundleInfo(<a href="#AppleDsymBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information for an Apple dSYM bundle.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleDsymBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -217,13 +265,14 @@ Provides information for an Apple dSYM bundle.
 ## AppleDynamicFrameworkInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "AppleDynamicFrameworkInfo")
+
 AppleDynamicFrameworkInfo(<a href="#AppleDynamicFrameworkInfo-framework_dirs">framework_dirs</a>, <a href="#AppleDynamicFrameworkInfo-framework_files">framework_files</a>, <a href="#AppleDynamicFrameworkInfo-binary">binary</a>, <a href="#AppleDynamicFrameworkInfo-cc_info">cc_info</a>)
 </pre>
 
 Contains information about an Apple dynamic framework.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -238,6 +287,8 @@ Contains information about an Apple dynamic framework.
 ## AppleExecutableBinaryInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "AppleExecutableBinaryInfo")
+
 AppleExecutableBinaryInfo(<a href="#AppleExecutableBinaryInfo-objc">objc</a>, <a href="#AppleExecutableBinaryInfo-binary">binary</a>, <a href="#AppleExecutableBinaryInfo-cc_info">cc_info</a>)
 </pre>
 
@@ -245,7 +296,6 @@ Contains the executable binary output that was built using
 `link_multi_arch_binary` with the `executable` binary type.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -259,7 +309,9 @@ Contains the executable binary output that was built using
 ## AppleExtraOutputsInfo
 
 <pre>
-AppleExtraOutputsInfo(<a href="#AppleExtraOutputsInfo-files">files</a>)
+load("@rules_apple//apple:providers.bzl", "AppleExtraOutputsInfo")
+
+AppleExtraOutputsInfo(<a href="#AppleExtraOutputsInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information about extra outputs that should be produced from the build.
@@ -272,8 +324,13 @@ also being generated, we do want to produce the dSYMs for *both* application and
 extension as outputs of the build, not just the dSYMs of the explicit target
 being built (the application).
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleExtraOutputsInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -285,7 +342,9 @@ being built (the application).
 ## AppleFrameworkBundleInfo
 
 <pre>
-AppleFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "AppleFrameworkBundleInfo")
+
+AppleFrameworkBundleInfo(<a href="#AppleFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target is an Apple framework bundle.
@@ -293,8 +352,11 @@ Denotes a target is an Apple framework bundle.
 This provider does not reference 3rd party or precompiled frameworks.
 Propagated by Apple framework rules: `ios_framework`, and `tvos_framework`.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="AppleFrameworkImportInfo"></a>
@@ -302,7 +364,9 @@ Propagated by Apple framework rules: `ios_framework`, and `tvos_framework`.
 ## AppleFrameworkImportInfo
 
 <pre>
-AppleFrameworkImportInfo(<a href="#AppleFrameworkImportInfo-framework_imports">framework_imports</a>, <a href="#AppleFrameworkImportInfo-dsym_imports">dsym_imports</a>, <a href="#AppleFrameworkImportInfo-build_archs">build_archs</a>, <a href="#AppleFrameworkImportInfo-debug_info_binaries">debug_info_binaries</a>)
+load("@rules_apple//apple:providers.bzl", "AppleFrameworkImportInfo")
+
+AppleFrameworkImportInfo(<a href="#AppleFrameworkImportInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provider that propagates information about 3rd party imported framework targets.
@@ -311,8 +375,13 @@ Propagated by framework and XCFramework import rules: `apple_dynamic_framework_i
 `apple_dynamic_xcframework_import`, `apple_static_framework_import`, and
 `apple_static_xcframework_import`
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleFrameworkImportInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -327,13 +396,20 @@ Propagated by framework and XCFramework import rules: `apple_dynamic_framework_i
 ## ApplePlatformInfo
 
 <pre>
-ApplePlatformInfo(<a href="#ApplePlatformInfo-target_os">target_os</a>, <a href="#ApplePlatformInfo-target_arch">target_arch</a>, <a href="#ApplePlatformInfo-target_environment">target_environment</a>)
+load("@rules_apple//apple:providers.bzl", "ApplePlatformInfo")
+
+ApplePlatformInfo(<a href="#ApplePlatformInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information for the currently selected Apple platforms.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="ApplePlatformInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -347,13 +423,14 @@ Provides information for the currently selected Apple platforms.
 ## AppleProvisioningProfileInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "AppleProvisioningProfileInfo")
+
 AppleProvisioningProfileInfo(<a href="#AppleProvisioningProfileInfo-provisioning_profile">provisioning_profile</a>, <a href="#AppleProvisioningProfileInfo-profile_name">profile_name</a>, <a href="#AppleProvisioningProfileInfo-team_id">team_id</a>)
 </pre>
 
 Provides information about a provisioning profile.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -367,7 +444,9 @@ Provides information about a provisioning profile.
 ## AppleResourceBundleInfo
 
 <pre>
-AppleResourceBundleInfo()
+load("@rules_apple//apple:providers.bzl", "AppleResourceBundleInfo")
+
+AppleResourceBundleInfo(<a href="#AppleResourceBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an Apple resource bundle.
@@ -378,8 +457,11 @@ a "marker" to indicate that a target is specifically an Apple resource bundle
 dependency is an Apple resource bundle should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleResourceBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="AppleResourceInfo"></a>
@@ -387,15 +469,20 @@ requirement.
 ## AppleResourceInfo
 
 <pre>
-AppleResourceInfo(<a href="#AppleResourceInfo-alternate_icons">alternate_icons</a>, <a href="#AppleResourceInfo-asset_catalogs">asset_catalogs</a>, <a href="#AppleResourceInfo-datamodels">datamodels</a>, <a href="#AppleResourceInfo-framework">framework</a>, <a href="#AppleResourceInfo-infoplists">infoplists</a>, <a href="#AppleResourceInfo-metals">metals</a>,
-                  <a href="#AppleResourceInfo-mlmodels">mlmodels</a>, <a href="#AppleResourceInfo-plists">plists</a>, <a href="#AppleResourceInfo-pngs">pngs</a>, <a href="#AppleResourceInfo-processed">processed</a>, <a href="#AppleResourceInfo-storyboards">storyboards</a>, <a href="#AppleResourceInfo-strings">strings</a>, <a href="#AppleResourceInfo-texture_atlases">texture_atlases</a>,
-                  <a href="#AppleResourceInfo-unprocessed">unprocessed</a>, <a href="#AppleResourceInfo-xibs">xibs</a>, <a href="#AppleResourceInfo-owners">owners</a>, <a href="#AppleResourceInfo-processed_origins">processed_origins</a>, <a href="#AppleResourceInfo-unowned_resources">unowned_resources</a>)
+load("@rules_apple//apple:providers.bzl", "AppleResourceInfo")
+
+AppleResourceInfo(<a href="#AppleResourceInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provider that propagates buckets of resources that are differentiated by type.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleResourceInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -424,13 +511,20 @@ Provider that propagates buckets of resources that are differentiated by type.
 ## AppleSharedCapabilityInfo
 
 <pre>
-AppleSharedCapabilityInfo(<a href="#AppleSharedCapabilityInfo-base_bundle_id">base_bundle_id</a>)
+load("@rules_apple//apple:providers.bzl", "AppleSharedCapabilityInfo")
+
+AppleSharedCapabilityInfo(<a href="#AppleSharedCapabilityInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provides information on a mergeable set of shared capabilities.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleSharedCapabilityInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -442,7 +536,9 @@ Provides information on a mergeable set of shared capabilities.
 ## AppleStaticXcframeworkBundleInfo
 
 <pre>
-AppleStaticXcframeworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "AppleStaticXcframeworkBundleInfo")
+
+AppleStaticXcframeworkBundleInfo(<a href="#AppleStaticXcframeworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a static library XCFramework.
@@ -453,8 +549,11 @@ a "marker" to indicate that a target is specifically an XCFramework bundle
 dependency is an XCFramework should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleStaticXcframeworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="AppleTestInfo"></a>
@@ -462,8 +561,9 @@ requirement.
 ## AppleTestInfo
 
 <pre>
-AppleTestInfo(<a href="#AppleTestInfo-includes">includes</a>, <a href="#AppleTestInfo-module_maps">module_maps</a>, <a href="#AppleTestInfo-module_name">module_name</a>, <a href="#AppleTestInfo-non_arc_sources">non_arc_sources</a>, <a href="#AppleTestInfo-sources">sources</a>, <a href="#AppleTestInfo-swift_modules">swift_modules</a>,
-              <a href="#AppleTestInfo-test_bundle">test_bundle</a>, <a href="#AppleTestInfo-test_host">test_host</a>, <a href="#AppleTestInfo-deps">deps</a>)
+load("@rules_apple//apple:providers.bzl", "AppleTestInfo")
+
+AppleTestInfo(<a href="#AppleTestInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provider that test targets propagate to be used for IDE integration.
@@ -473,8 +573,13 @@ transitive module maps, and transitive Swift modules. Test source files are
 considered to be all of which belong to the first-level dependencies on the test
 target.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleTestInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -494,8 +599,9 @@ target.
 ## AppleTestRunnerInfo
 
 <pre>
-AppleTestRunnerInfo(<a href="#AppleTestRunnerInfo-execution_requirements">execution_requirements</a>, <a href="#AppleTestRunnerInfo-execution_environment">execution_environment</a>, <a href="#AppleTestRunnerInfo-test_environment">test_environment</a>,
-                    <a href="#AppleTestRunnerInfo-test_runner_template">test_runner_template</a>)
+load("@rules_apple//apple:providers.bzl", "AppleTestRunnerInfo")
+
+AppleTestRunnerInfo(<a href="#AppleTestRunnerInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Provider that runner targets must propagate.
@@ -503,8 +609,13 @@ Provider that runner targets must propagate.
 In addition to the fields, all the runfiles that the runner target declares will be added to the
 test rules runfiles.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleTestRunnerInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -519,7 +630,9 @@ test rules runfiles.
 ## AppleXcframeworkBundleInfo
 
 <pre>
-AppleXcframeworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "AppleXcframeworkBundleInfo")
+
+AppleXcframeworkBundleInfo(<a href="#AppleXcframeworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an XCFramework.
@@ -530,8 +643,11 @@ a "marker" to indicate that a target is specifically an XCFramework bundle
 dependency is an XCFramework should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="AppleXcframeworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="DocCBundleInfo"></a>
@@ -539,13 +655,14 @@ requirement.
 ## DocCBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "DocCBundleInfo")
+
 DocCBundleInfo(<a href="#DocCBundleInfo-bundle">bundle</a>, <a href="#DocCBundleInfo-bundle_files">bundle_files</a>)
 </pre>
 
 Provides general information about a .docc bundle.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -558,13 +675,14 @@ Provides general information about a .docc bundle.
 ## DocCSymbolGraphsInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "DocCSymbolGraphsInfo")
+
 DocCSymbolGraphsInfo(<a href="#DocCSymbolGraphsInfo-symbol_graphs">symbol_graphs</a>)
 </pre>
 
 Provides the symbol graphs required to archive a .docc bundle.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -576,7 +694,9 @@ Provides the symbol graphs required to archive a .docc bundle.
 ## IosAppClipBundleInfo
 
 <pre>
-IosAppClipBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosAppClipBundleInfo")
+
+IosAppClipBundleInfo(<a href="#IosAppClipBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS app clip.
@@ -586,8 +706,11 @@ a "marker" to indicate that a target is specifically an iOS app clip bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is an iOS app clip should use this provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosAppClipBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosApplicationBundleInfo"></a>
@@ -595,7 +718,9 @@ is an iOS app clip should use this provider to describe that requirement.
 ## IosApplicationBundleInfo
 
 <pre>
-IosApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosApplicationBundleInfo")
+
+IosApplicationBundleInfo(<a href="#IosApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS application.
@@ -606,8 +731,11 @@ a "marker" to indicate that a target is specifically an iOS application bundle
 dependency is an iOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosExtensionBundleInfo"></a>
@@ -615,7 +743,9 @@ requirement.
 ## IosExtensionBundleInfo
 
 <pre>
-IosExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosExtensionBundleInfo")
+
+IosExtensionBundleInfo(<a href="#IosExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS application extension.
@@ -626,8 +756,11 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is an iOS application extension should use this
 provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosFrameworkBundleInfo"></a>
@@ -635,7 +768,9 @@ provider to describe that requirement.
 ## IosFrameworkBundleInfo
 
 <pre>
-IosFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosFrameworkBundleInfo")
+
+IosFrameworkBundleInfo(<a href="#IosFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS dynamic framework.
@@ -646,8 +781,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS dynamic framework should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosImessageApplicationBundleInfo"></a>
@@ -655,7 +793,9 @@ that requirement.
 ## IosImessageApplicationBundleInfo
 
 <pre>
-IosImessageApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosImessageApplicationBundleInfo")
+
+IosImessageApplicationBundleInfo(<a href="#IosImessageApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS iMessage application.
@@ -666,8 +806,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS iMessage application should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosImessageApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosImessageExtensionBundleInfo"></a>
@@ -675,7 +818,9 @@ that requirement.
 ## IosImessageExtensionBundleInfo
 
 <pre>
-IosImessageExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosImessageExtensionBundleInfo")
+
+IosImessageExtensionBundleInfo(<a href="#IosImessageExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS iMessage extension.
@@ -686,8 +831,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS iMessage extension should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosImessageExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosStaticFrameworkBundleInfo"></a>
@@ -695,7 +843,9 @@ that requirement.
 ## IosStaticFrameworkBundleInfo
 
 <pre>
-IosStaticFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosStaticFrameworkBundleInfo")
+
+IosStaticFrameworkBundleInfo(<a href="#IosStaticFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is an iOS static framework.
@@ -706,8 +856,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS static framework should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosStaticFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="IosStickerPackExtensionBundleInfo"></a>
@@ -715,6 +868,8 @@ that requirement.
 ## IosStickerPackExtensionBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "IosStickerPackExtensionBundleInfo")
+
 IosStickerPackExtensionBundleInfo()
 </pre>
 
@@ -726,16 +881,15 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an iOS Sticker Pack extension should use this provider to describe
 that requirement.
 
-**FIELDS**
-
-
 
 <a id="IosXcTestBundleInfo"></a>
 
 ## IosXcTestBundleInfo
 
 <pre>
-IosXcTestBundleInfo()
+load("@rules_apple//apple:providers.bzl", "IosXcTestBundleInfo")
+
+IosXcTestBundleInfo(<a href="#IosXcTestBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target that is an iOS .xctest bundle.
@@ -745,8 +899,11 @@ a "marker" to indicate that a target is specifically an iOS .xctest bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is an iOS .xctest bundle should use this provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="IosXcTestBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosApplicationBundleInfo"></a>
@@ -754,7 +911,9 @@ is an iOS .xctest bundle should use this provider to describe that requirement.
 ## MacosApplicationBundleInfo
 
 <pre>
-MacosApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosApplicationBundleInfo")
+
+MacosApplicationBundleInfo(<a href="#MacosApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS application.
@@ -765,8 +924,11 @@ a "marker" to indicate that a target is specifically a macOS application bundle
 dependency is a macOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosBundleBundleInfo"></a>
@@ -774,7 +936,9 @@ requirement.
 ## MacosBundleBundleInfo
 
 <pre>
-MacosBundleBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosBundleBundleInfo")
+
+MacosBundleBundleInfo(<a href="#MacosBundleBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS loadable bundle.
@@ -785,8 +949,11 @@ a "marker" to indicate that a target is specifically a macOS loadable bundle
 dependency is a macOS loadable bundle should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosBundleBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosExtensionBundleInfo"></a>
@@ -794,7 +961,9 @@ requirement.
 ## MacosExtensionBundleInfo
 
 <pre>
-MacosExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosExtensionBundleInfo")
+
+MacosExtensionBundleInfo(<a href="#MacosExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS application extension.
@@ -805,8 +974,11 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a macOS application extension should use this
 provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosFrameworkBundleInfo"></a>
@@ -814,6 +986,8 @@ provider to describe that requirement.
 ## MacosFrameworkBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "MacosFrameworkBundleInfo")
+
 MacosFrameworkBundleInfo()
 </pre>
 
@@ -825,16 +999,15 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an macOS dynamic framework should use this provider to describe
 that requirement.
 
-**FIELDS**
-
-
 
 <a id="MacosKernelExtensionBundleInfo"></a>
 
 ## MacosKernelExtensionBundleInfo
 
 <pre>
-MacosKernelExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosKernelExtensionBundleInfo")
+
+MacosKernelExtensionBundleInfo(<a href="#MacosKernelExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS kernel extension.
@@ -845,8 +1018,11 @@ a "marker" to indicate that a target is specifically a macOS kernel extension
 dependency is a macOS kernel extension should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosKernelExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosQuickLookPluginBundleInfo"></a>
@@ -854,7 +1030,9 @@ requirement.
 ## MacosQuickLookPluginBundleInfo
 
 <pre>
-MacosQuickLookPluginBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosQuickLookPluginBundleInfo")
+
+MacosQuickLookPluginBundleInfo(<a href="#MacosQuickLookPluginBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS Quick Look Generator bundle.
@@ -865,8 +1043,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a macOS Quick Look generator should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosQuickLookPluginBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosSpotlightImporterBundleInfo"></a>
@@ -874,7 +1055,9 @@ that requirement.
 ## MacosSpotlightImporterBundleInfo
 
 <pre>
-MacosSpotlightImporterBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosSpotlightImporterBundleInfo")
+
+MacosSpotlightImporterBundleInfo(<a href="#MacosSpotlightImporterBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS Spotlight Importer bundle.
@@ -885,8 +1068,11 @@ a "marker" to indicate that a target is specifically a macOS Spotlight importer
 dependency is a macOS Spotlight importer should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosSpotlightImporterBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosStaticFrameworkBundleInfo"></a>
@@ -894,6 +1080,8 @@ requirement.
 ## MacosStaticFrameworkBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "MacosStaticFrameworkBundleInfo")
+
 MacosStaticFrameworkBundleInfo()
 </pre>
 
@@ -905,16 +1093,15 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is an macOS static framework should use this provider to describe
 that requirement.
 
-**FIELDS**
-
-
 
 <a id="MacosXPCServiceBundleInfo"></a>
 
 ## MacosXPCServiceBundleInfo
 
 <pre>
-MacosXPCServiceBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosXPCServiceBundleInfo")
+
+MacosXPCServiceBundleInfo(<a href="#MacosXPCServiceBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a macOS XPC Service bundle.
@@ -925,8 +1112,11 @@ a "marker" to indicate that a target is specifically a macOS XPC service
 dependency is a macOS XPC service should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosXPCServiceBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="MacosXcTestBundleInfo"></a>
@@ -934,7 +1124,9 @@ requirement.
 ## MacosXcTestBundleInfo
 
 <pre>
-MacosXcTestBundleInfo()
+load("@rules_apple//apple:providers.bzl", "MacosXcTestBundleInfo")
+
+MacosXcTestBundleInfo(<a href="#MacosXcTestBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target that is a macOS .xctest bundle.
@@ -945,8 +1137,11 @@ a "marker" to indicate that a target is specifically a macOS .xctest bundle
 dependency is a macOS .xctest bundle should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="MacosXcTestBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="TvosApplicationBundleInfo"></a>
@@ -954,7 +1149,9 @@ requirement.
 ## TvosApplicationBundleInfo
 
 <pre>
-TvosApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "TvosApplicationBundleInfo")
+
+TvosApplicationBundleInfo(<a href="#TvosApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a tvOS application.
@@ -965,8 +1162,11 @@ a "marker" to indicate that a target is specifically a tvOS application bundle
 dependency is a tvOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="TvosApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="TvosExtensionBundleInfo"></a>
@@ -974,7 +1174,9 @@ requirement.
 ## TvosExtensionBundleInfo
 
 <pre>
-TvosExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "TvosExtensionBundleInfo")
+
+TvosExtensionBundleInfo(<a href="#TvosExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a tvOS application extension.
@@ -985,8 +1187,11 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a tvOS application extension should use this
 provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="TvosExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="TvosFrameworkBundleInfo"></a>
@@ -994,7 +1199,9 @@ provider to describe that requirement.
 ## TvosFrameworkBundleInfo
 
 <pre>
-TvosFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "TvosFrameworkBundleInfo")
+
+TvosFrameworkBundleInfo(<a href="#TvosFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a tvOS dynamic framework.
@@ -1005,8 +1212,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a tvOS dynamic framework should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="TvosFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="TvosStaticFrameworkBundleInfo"></a>
@@ -1014,7 +1224,9 @@ that requirement.
 ## TvosStaticFrameworkBundleInfo
 
 <pre>
-TvosStaticFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "TvosStaticFrameworkBundleInfo")
+
+TvosStaticFrameworkBundleInfo(<a href="#TvosStaticFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a tvOS static framework.
@@ -1025,8 +1237,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a tvOS static framework should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="TvosStaticFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="TvosXcTestBundleInfo"></a>
@@ -1034,7 +1249,9 @@ that requirement.
 ## TvosXcTestBundleInfo
 
 <pre>
-TvosXcTestBundleInfo()
+load("@rules_apple//apple:providers.bzl", "TvosXcTestBundleInfo")
+
+TvosXcTestBundleInfo(<a href="#TvosXcTestBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target that is a tvOS .xctest bundle.
@@ -1044,8 +1261,11 @@ a "marker" to indicate that a target is specifically a tvOS .xctest bundle (and
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is a tvOS .xctest bundle should use this provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="TvosXcTestBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="VisionosApplicationBundleInfo"></a>
@@ -1053,7 +1273,9 @@ is a tvOS .xctest bundle should use this provider to describe that requirement.
 ## VisionosApplicationBundleInfo
 
 <pre>
-VisionosApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "VisionosApplicationBundleInfo")
+
+VisionosApplicationBundleInfo(<a href="#VisionosApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a visionOS application.
@@ -1064,8 +1286,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that 
 dependency is a visionOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="VisionosApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="VisionosExtensionBundleInfo"></a>
@@ -1073,7 +1298,9 @@ requirement.
 ## VisionosExtensionBundleInfo
 
 <pre>
-VisionosExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "VisionosExtensionBundleInfo")
+
+VisionosExtensionBundleInfo(<a href="#VisionosExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a visionOS application.
@@ -1084,8 +1311,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that 
 dependency is a visionOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="VisionosExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="VisionosFrameworkBundleInfo"></a>
@@ -1093,7 +1323,9 @@ requirement.
 ## VisionosFrameworkBundleInfo
 
 <pre>
-VisionosFrameworkBundleInfo()
+load("@rules_apple//apple:providers.bzl", "VisionosFrameworkBundleInfo")
+
+VisionosFrameworkBundleInfo(<a href="#VisionosFrameworkBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is visionOS dynamic framework.
@@ -1104,8 +1336,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a visionOS dynamic framework should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="VisionosFrameworkBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="VisionosXcTestBundleInfo"></a>
@@ -1113,7 +1348,9 @@ that requirement.
 ## VisionosXcTestBundleInfo
 
 <pre>
-VisionosXcTestBundleInfo()
+load("@rules_apple//apple:providers.bzl", "VisionosXcTestBundleInfo")
+
+VisionosXcTestBundleInfo(<a href="#VisionosXcTestBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target that is a visionOS .xctest bundle.
@@ -1124,8 +1361,11 @@ a "marker" to indicate that a target is specifically a visionOS .xctest bundle
 dependency is a visionOS .xctest bundle  should use this provider to describe
 that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="VisionosXcTestBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="WatchosApplicationBundleInfo"></a>
@@ -1133,7 +1373,9 @@ that requirement.
 ## WatchosApplicationBundleInfo
 
 <pre>
-WatchosApplicationBundleInfo()
+load("@rules_apple//apple:providers.bzl", "WatchosApplicationBundleInfo")
+
+WatchosApplicationBundleInfo(<a href="#WatchosApplicationBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a watchOS application.
@@ -1144,8 +1386,11 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a watchOS application should use this provider to describe that
 requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="WatchosApplicationBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="WatchosExtensionBundleInfo"></a>
@@ -1153,7 +1398,9 @@ requirement.
 ## WatchosExtensionBundleInfo
 
 <pre>
-WatchosExtensionBundleInfo()
+load("@rules_apple//apple:providers.bzl", "WatchosExtensionBundleInfo")
+
+WatchosExtensionBundleInfo(<a href="#WatchosExtensionBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes that a target is a watchOS application extension.
@@ -1164,8 +1411,11 @@ extension bundle (and not some other Apple bundle). Rule authors who wish to
 require that a dependency is a watchOS application extension should use this
 provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="WatchosExtensionBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="WatchosFrameworkBundleInfo"></a>
@@ -1173,6 +1423,8 @@ provider to describe that requirement.
 ## WatchosFrameworkBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "WatchosFrameworkBundleInfo")
+
 WatchosFrameworkBundleInfo()
 </pre>
 
@@ -1184,15 +1436,14 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a watchOS dynamic framework should use this provider to describe
 that requirement.
 
-**FIELDS**
-
-
 
 <a id="WatchosStaticFrameworkBundleInfo"></a>
 
 ## WatchosStaticFrameworkBundleInfo
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "WatchosStaticFrameworkBundleInfo")
+
 WatchosStaticFrameworkBundleInfo()
 </pre>
 
@@ -1204,16 +1455,15 @@ bundle (and not some other Apple bundle). Rule authors who wish to require that
 a dependency is a watchOS static framework should use this provider to describe
 that requirement.
 
-**FIELDS**
-
-
 
 <a id="WatchosXcTestBundleInfo"></a>
 
 ## WatchosXcTestBundleInfo
 
 <pre>
-WatchosXcTestBundleInfo()
+load("@rules_apple//apple:providers.bzl", "WatchosXcTestBundleInfo")
+
+WatchosXcTestBundleInfo(<a href="#WatchosXcTestBundleInfo-_init-kwargs">*kwargs</a>)
 </pre>
 
 Denotes a target that is a watchOS .xctest bundle.
@@ -1223,8 +1473,11 @@ a "marker" to indicate that a target is specifically a watchOS .xctest bundle (a
 not some other Apple bundle). Rule authors who wish to require that a dependency
 is a watchOS .xctest bundle should use this provider to describe that requirement.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="WatchosXcTestBundleInfo-_init-kwargs"></a>kwargs | <p align="center">-</p> | none |
 
 
 <a id="apple_provider.make_apple_bundle_version_info"></a>
@@ -1232,7 +1485,9 @@ is a watchOS .xctest bundle should use this provider to describe that requiremen
 ## apple_provider.make_apple_bundle_version_info
 
 <pre>
-apple_provider.make_apple_bundle_version_info(<a href="#apple_provider.make_apple_bundle_version_info-version_file">version_file</a>)
+load("@rules_apple//apple:providers.bzl", "apple_provider")
+
+apple_provider.make_apple_bundle_version_info(*, <a href="#apple_provider.make_apple_bundle_version_info-version_file">version_file</a>)
 </pre>
 
 Creates a new instance of the `AppleBundleVersionInfo` provider.
@@ -1254,7 +1509,9 @@ A new `AppleBundleVersionInfo` provider based on the supplied arguments.
 ## apple_provider.make_apple_test_runner_info
 
 <pre>
-apple_provider.make_apple_test_runner_info(<a href="#apple_provider.make_apple_test_runner_info-kwargs">kwargs</a>)
+load("@rules_apple//apple:providers.bzl", "apple_provider")
+
+apple_provider.make_apple_test_runner_info(<a href="#apple_provider.make_apple_test_runner_info-kwargs">**kwargs</a>)
 </pre>
 
 Creates a new instance of the AppleTestRunnerInfo provider.
@@ -1276,6 +1533,8 @@ A new `AppleTestRunnerInfo` provider based on the supplied arguments.
 ## apple_provider.merge_apple_framework_import_info
 
 <pre>
+load("@rules_apple//apple:providers.bzl", "apple_provider")
+
 apple_provider.merge_apple_framework_import_info(<a href="#apple_provider.merge_apple_framework_import_info-apple_framework_import_infos">apple_framework_import_infos</a>)
 </pre>
 

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -7,6 +7,8 @@
 ## apple_dynamic_framework_import
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_dynamic_framework_import")
+
 apple_dynamic_framework_import(<a href="#apple_dynamic_framework_import-name">name</a>, <a href="#apple_dynamic_framework_import-deps">deps</a>, <a href="#apple_dynamic_framework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_framework_import-dsym_imports">dsym_imports</a>, <a href="#apple_dynamic_framework_import-framework_imports">framework_imports</a>)
 </pre>
 
@@ -47,6 +49,8 @@ objc_library(
 ## apple_dynamic_xcframework_import
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_dynamic_xcframework_import")
+
 apple_dynamic_xcframework_import(<a href="#apple_dynamic_xcframework_import-name">name</a>, <a href="#apple_dynamic_xcframework_import-deps">deps</a>, <a href="#apple_dynamic_xcframework_import-bundle_only">bundle_only</a>, <a href="#apple_dynamic_xcframework_import-library_identifiers">library_identifiers</a>, <a href="#apple_dynamic_xcframework_import-xcframework_imports">xcframework_imports</a>)
 </pre>
 
@@ -88,6 +92,8 @@ objc_library(
 ## apple_static_framework_import
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_static_framework_import")
+
 apple_static_framework_import(<a href="#apple_static_framework_import-name">name</a>, <a href="#apple_static_framework_import-deps">deps</a>, <a href="#apple_static_framework_import-data">data</a>, <a href="#apple_static_framework_import-alwayslink">alwayslink</a>, <a href="#apple_static_framework_import-framework_imports">framework_imports</a>, <a href="#apple_static_framework_import-has_swift">has_swift</a>,
                               <a href="#apple_static_framework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_framework_import-sdk_frameworks">sdk_frameworks</a>, <a href="#apple_static_framework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>)
 </pre>
@@ -133,6 +139,8 @@ objc_library(
 ## apple_static_library
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_static_library")
+
 apple_static_library(<a href="#apple_static_library-name">name</a>, <a href="#apple_static_library-deps">deps</a>, <a href="#apple_static_library-data">data</a>, <a href="#apple_static_library-additional_linker_inputs">additional_linker_inputs</a>, <a href="#apple_static_library-avoid_deps">avoid_deps</a>, <a href="#apple_static_library-linkopts">linkopts</a>,
                      <a href="#apple_static_library-minimum_os_version">minimum_os_version</a>, <a href="#apple_static_library-platform_type">platform_type</a>, <a href="#apple_static_library-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_library-sdk_frameworks">sdk_frameworks</a>,
                      <a href="#apple_static_library-weak_sdk_frameworks">weak_sdk_frameworks</a>)
@@ -173,6 +181,8 @@ implementation of `apple_static_library` in Bazel core so that it can be removed
 ## apple_static_xcframework
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_static_xcframework")
+
 apple_static_xcframework(<a href="#apple_static_xcframework-name">name</a>, <a href="#apple_static_xcframework-deps">deps</a>, <a href="#apple_static_xcframework-avoid_deps">avoid_deps</a>, <a href="#apple_static_xcframework-bundle_name">bundle_name</a>, <a href="#apple_static_xcframework-executable_name">executable_name</a>, <a href="#apple_static_xcframework-families_required">families_required</a>,
                          <a href="#apple_static_xcframework-ios">ios</a>, <a href="#apple_static_xcframework-macos">macos</a>, <a href="#apple_static_xcframework-minimum_deployment_os_versions">minimum_deployment_os_versions</a>, <a href="#apple_static_xcframework-minimum_os_versions">minimum_os_versions</a>, <a href="#apple_static_xcframework-public_hdrs">public_hdrs</a>,
                          <a href="#apple_static_xcframework-umbrella_header">umbrella_header</a>)
@@ -204,6 +214,8 @@ Generates an XCFramework with static libraries for third-party distribution.
 ## apple_static_xcframework_import
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_static_xcframework_import")
+
 apple_static_xcframework_import(<a href="#apple_static_xcframework_import-name">name</a>, <a href="#apple_static_xcframework_import-deps">deps</a>, <a href="#apple_static_xcframework_import-data">data</a>, <a href="#apple_static_xcframework_import-alwayslink">alwayslink</a>, <a href="#apple_static_xcframework_import-has_swift">has_swift</a>, <a href="#apple_static_xcframework_import-includes">includes</a>,
                                 <a href="#apple_static_xcframework_import-library_identifiers">library_identifiers</a>, <a href="#apple_static_xcframework_import-linkopts">linkopts</a>, <a href="#apple_static_xcframework_import-sdk_dylibs">sdk_dylibs</a>, <a href="#apple_static_xcframework_import-sdk_frameworks">sdk_frameworks</a>,
                                 <a href="#apple_static_xcframework_import-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#apple_static_xcframework_import-xcframework_imports">xcframework_imports</a>)
@@ -253,6 +265,8 @@ objc_library(
 ## apple_universal_binary
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_universal_binary")
+
 apple_universal_binary(<a href="#apple_universal_binary-name">name</a>, <a href="#apple_universal_binary-binary">binary</a>, <a href="#apple_universal_binary-forced_cpus">forced_cpus</a>, <a href="#apple_universal_binary-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#apple_universal_binary-minimum_os_version">minimum_os_version</a>,
                        <a href="#apple_universal_binary-platform_type">platform_type</a>)
 </pre>
@@ -278,6 +292,8 @@ The `lipo` tool is used to combine built binaries of multiple architectures.
 ## apple_xcframework
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "apple_xcframework")
+
 apple_xcframework(<a href="#apple_xcframework-name">name</a>, <a href="#apple_xcframework-deps">deps</a>, <a href="#apple_xcframework-data">data</a>, <a href="#apple_xcframework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#apple_xcframework-bundle_id">bundle_id</a>, <a href="#apple_xcframework-bundle_name">bundle_name</a>,
                   <a href="#apple_xcframework-codesign_inputs">codesign_inputs</a>, <a href="#apple_xcframework-codesignopts">codesignopts</a>, <a href="#apple_xcframework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#apple_xcframework-extension_safe">extension_safe</a>,
                   <a href="#apple_xcframework-families_required">families_required</a>, <a href="#apple_xcframework-infoplists">infoplists</a>, <a href="#apple_xcframework-ios">ios</a>, <a href="#apple_xcframework-linkopts">linkopts</a>, <a href="#apple_xcframework-macos">macos</a>, <a href="#apple_xcframework-minimum_deployment_os_versions">minimum_deployment_os_versions</a>,
@@ -320,6 +336,8 @@ Builds and bundles an XCFramework for third-party distribution.
 ## local_provisioning_profile
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "local_provisioning_profile")
+
 local_provisioning_profile(<a href="#local_provisioning_profile-name">name</a>, <a href="#local_provisioning_profile-profile_extension">profile_extension</a>, <a href="#local_provisioning_profile-profile_name">profile_name</a>, <a href="#local_provisioning_profile-team_id">team_id</a>)
 </pre>
 
@@ -382,6 +400,8 @@ ios_application(
 ## provisioning_profile_repository
 
 <pre>
+load("@rules_apple//apple:apple.bzl", "provisioning_profile_repository")
+
 provisioning_profile_repository(<a href="#provisioning_profile_repository-name">name</a>, <a href="#provisioning_profile_repository-fallback_profiles">fallback_profiles</a>, <a href="#provisioning_profile_repository-repo_mapping">repo_mapping</a>)
 </pre>
 
@@ -447,6 +467,7 @@ ios_application(
 **ENVIRONMENT VARIABLES**
 
 This repository rule depends on the following environment variables:
+
 * `HOME`
 
 

--- a/doc/rules-docc.md
+++ b/doc/rules-docc.md
@@ -7,6 +7,8 @@ Defines rules for building Apple DocC targets.
 ## docc_archive
 
 <pre>
+load("@rules_apple//apple:docc.bzl", "docc_archive")
+
 docc_archive(<a href="#docc_archive-name">name</a>, <a href="#docc_archive-default_code_listing_language">default_code_listing_language</a>, <a href="#docc_archive-dep">dep</a>, <a href="#docc_archive-diagnostic_level">diagnostic_level</a>,
              <a href="#docc_archive-emit_extension_block_symbols">emit_extension_block_symbols</a>, <a href="#docc_archive-enable_inherited_docs">enable_inherited_docs</a>, <a href="#docc_archive-fallback_bundle_identifier">fallback_bundle_identifier</a>,
              <a href="#docc_archive-fallback_bundle_version">fallback_bundle_version</a>, <a href="#docc_archive-fallback_display_name">fallback_display_name</a>, <a href="#docc_archive-hosting_base_path">hosting_base_path</a>, <a href="#docc_archive-kinds">kinds</a>,

--- a/doc/rules-dtrace.md
+++ b/doc/rules-dtrace.md
@@ -7,6 +7,8 @@
 ## dtrace_compile
 
 <pre>
+load("@rules_apple//apple:dtrace.bzl", "dtrace_compile")
+
 dtrace_compile(<a href="#dtrace_compile-name">name</a>, <a href="#dtrace_compile-srcs">srcs</a>, <a href="#dtrace_compile-dtrace">dtrace</a>)
 </pre>
 

--- a/doc/rules-header_map.md
+++ b/doc/rules-header_map.md
@@ -7,6 +7,8 @@ Rules for creating header maps.
 ## header_map
 
 <pre>
+load("@rules_apple//apple:header_map.bzl", "header_map")
+
 header_map(<a href="#header_map-name">name</a>, <a href="#header_map-deps">deps</a>, <a href="#header_map-hdrs">hdrs</a>, <a href="#header_map-module_name">module_name</a>)
 </pre>
 

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -7,6 +7,8 @@
 ## ios_app_clip
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_app_clip")
+
 ios_app_clip(<a href="#ios_app_clip-name">name</a>, <a href="#ios_app_clip-deps">deps</a>, <a href="#ios_app_clip-resources">resources</a>, <a href="#ios_app_clip-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_app_clip-app_icons">app_icons</a>, <a href="#ios_app_clip-bundle_id">bundle_id</a>,
              <a href="#ios_app_clip-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_app_clip-bundle_name">bundle_name</a>, <a href="#ios_app_clip-codesign_inputs">codesign_inputs</a>, <a href="#ios_app_clip-codesignopts">codesignopts</a>, <a href="#ios_app_clip-entitlements">entitlements</a>,
              <a href="#ios_app_clip-entitlements_validation">entitlements_validation</a>, <a href="#ios_app_clip-executable_name">executable_name</a>, <a href="#ios_app_clip-exported_symbols_lists">exported_symbols_lists</a>, <a href="#ios_app_clip-extensions">extensions</a>, <a href="#ios_app_clip-families">families</a>,
@@ -59,6 +61,8 @@ Builds and bundles an iOS App Clip.
 ## ios_application
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_application")
+
 ios_application(<a href="#ios_application-name">name</a>, <a href="#ios_application-deps">deps</a>, <a href="#ios_application-resources">resources</a>, <a href="#ios_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_application-alternate_icons">alternate_icons</a>, <a href="#ios_application-app_clips">app_clips</a>,
                 <a href="#ios_application-app_icons">app_icons</a>, <a href="#ios_application-app_intents">app_intents</a>, <a href="#ios_application-bundle_id">bundle_id</a>, <a href="#ios_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_application-bundle_name">bundle_name</a>, <a href="#ios_application-codesign_inputs">codesign_inputs</a>,
                 <a href="#ios_application-codesignopts">codesignopts</a>, <a href="#ios_application-entitlements">entitlements</a>, <a href="#ios_application-entitlements_validation">entitlements_validation</a>, <a href="#ios_application-executable_name">executable_name</a>,
@@ -122,6 +126,8 @@ Builds and bundles an iOS Application.
 ## ios_build_test
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_build_test")
+
 ios_build_test(<a href="#ios_build_test-name">name</a>, <a href="#ios_build_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_build_test-platform_type">platform_type</a>, <a href="#ios_build_test-targets">targets</a>)
 </pre>
 
@@ -156,6 +162,8 @@ ios_build_test(
 ## ios_dynamic_framework
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_dynamic_framework")
+
 ios_dynamic_framework(<a href="#ios_dynamic_framework-name">name</a>, <a href="#ios_dynamic_framework-deps">deps</a>, <a href="#ios_dynamic_framework-resources">resources</a>, <a href="#ios_dynamic_framework-hdrs">hdrs</a>, <a href="#ios_dynamic_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_dynamic_framework-base_bundle_id">base_bundle_id</a>,
                       <a href="#ios_dynamic_framework-bundle_id">bundle_id</a>, <a href="#ios_dynamic_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_dynamic_framework-bundle_name">bundle_name</a>, <a href="#ios_dynamic_framework-bundle_only">bundle_only</a>, <a href="#ios_dynamic_framework-codesign_inputs">codesign_inputs</a>,
                       <a href="#ios_dynamic_framework-codesignopts">codesignopts</a>, <a href="#ios_dynamic_framework-executable_name">executable_name</a>, <a href="#ios_dynamic_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#ios_dynamic_framework-extension_safe">extension_safe</a>, <a href="#ios_dynamic_framework-families">families</a>,
@@ -205,6 +213,8 @@ Builds and bundles an iOS dynamic framework that is consumable by Xcode.
 ## ios_extension
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_extension")
+
 ios_extension(<a href="#ios_extension-name">name</a>, <a href="#ios_extension-deps">deps</a>, <a href="#ios_extension-resources">resources</a>, <a href="#ios_extension-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_extension-app_icons">app_icons</a>, <a href="#ios_extension-app_intents">app_intents</a>, <a href="#ios_extension-bundle_id">bundle_id</a>,
               <a href="#ios_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_extension-bundle_name">bundle_name</a>, <a href="#ios_extension-codesign_inputs">codesign_inputs</a>, <a href="#ios_extension-codesignopts">codesignopts</a>, <a href="#ios_extension-entitlements">entitlements</a>,
               <a href="#ios_extension-entitlements_validation">entitlements_validation</a>, <a href="#ios_extension-executable_name">executable_name</a>, <a href="#ios_extension-exported_symbols_lists">exported_symbols_lists</a>,
@@ -263,6 +273,8 @@ However, iOS 14 introduced Widget Extensions that use a traditional `main` entry
 ## ios_framework
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_framework")
+
 ios_framework(<a href="#ios_framework-name">name</a>, <a href="#ios_framework-deps">deps</a>, <a href="#ios_framework-resources">resources</a>, <a href="#ios_framework-hdrs">hdrs</a>, <a href="#ios_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_framework-base_bundle_id">base_bundle_id</a>, <a href="#ios_framework-bundle_id">bundle_id</a>,
               <a href="#ios_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_framework-bundle_name">bundle_name</a>, <a href="#ios_framework-bundle_only">bundle_only</a>, <a href="#ios_framework-codesign_inputs">codesign_inputs</a>, <a href="#ios_framework-codesignopts">codesignopts</a>,
               <a href="#ios_framework-executable_name">executable_name</a>, <a href="#ios_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#ios_framework-extension_safe">extension_safe</a>, <a href="#ios_framework-families">families</a>, <a href="#ios_framework-frameworks">frameworks</a>,
@@ -314,6 +326,8 @@ of those `ios_application` and/or `ios_extension` rules.
 ## ios_imessage_application
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_imessage_application")
+
 ios_imessage_application(<a href="#ios_imessage_application-name">name</a>, <a href="#ios_imessage_application-resources">resources</a>, <a href="#ios_imessage_application-app_icons">app_icons</a>, <a href="#ios_imessage_application-bundle_id">bundle_id</a>, <a href="#ios_imessage_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_imessage_application-bundle_name">bundle_name</a>,
                          <a href="#ios_imessage_application-entitlements">entitlements</a>, <a href="#ios_imessage_application-entitlements_validation">entitlements_validation</a>, <a href="#ios_imessage_application-executable_name">executable_name</a>, <a href="#ios_imessage_application-extension">extension</a>, <a href="#ios_imessage_application-families">families</a>,
                          <a href="#ios_imessage_application-infoplists">infoplists</a>, <a href="#ios_imessage_application-ipa_post_processor">ipa_post_processor</a>, <a href="#ios_imessage_application-locales_to_include">locales_to_include</a>,
@@ -359,6 +373,8 @@ for either an iOS iMessage extension or a Sticker Pack extension.
 ## ios_imessage_extension
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_imessage_extension")
+
 ios_imessage_extension(<a href="#ios_imessage_extension-name">name</a>, <a href="#ios_imessage_extension-deps">deps</a>, <a href="#ios_imessage_extension-resources">resources</a>, <a href="#ios_imessage_extension-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_imessage_extension-app_icons">app_icons</a>, <a href="#ios_imessage_extension-bundle_id">bundle_id</a>,
                        <a href="#ios_imessage_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_imessage_extension-bundle_name">bundle_name</a>, <a href="#ios_imessage_extension-codesign_inputs">codesign_inputs</a>, <a href="#ios_imessage_extension-codesignopts">codesignopts</a>, <a href="#ios_imessage_extension-entitlements">entitlements</a>,
                        <a href="#ios_imessage_extension-entitlements_validation">entitlements_validation</a>, <a href="#ios_imessage_extension-executable_name">executable_name</a>, <a href="#ios_imessage_extension-exported_symbols_lists">exported_symbols_lists</a>, <a href="#ios_imessage_extension-families">families</a>,
@@ -409,6 +425,8 @@ Builds and bundles an iOS iMessage Extension.
 ## ios_static_framework
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_static_framework")
+
 ios_static_framework(<a href="#ios_static_framework-name">name</a>, <a href="#ios_static_framework-deps">deps</a>, <a href="#ios_static_framework-resources">resources</a>, <a href="#ios_static_framework-hdrs">hdrs</a>, <a href="#ios_static_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#ios_static_framework-avoid_deps">avoid_deps</a>, <a href="#ios_static_framework-bundle_name">bundle_name</a>,
                      <a href="#ios_static_framework-codesign_inputs">codesign_inputs</a>, <a href="#ios_static_framework-codesignopts">codesignopts</a>, <a href="#ios_static_framework-exclude_resources">exclude_resources</a>, <a href="#ios_static_framework-executable_name">executable_name</a>,
                      <a href="#ios_static_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#ios_static_framework-families">families</a>, <a href="#ios_static_framework-ipa_post_processor">ipa_post_processor</a>, <a href="#ios_static_framework-linkopts">linkopts</a>,
@@ -488,6 +506,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## ios_sticker_pack_extension
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_sticker_pack_extension")
+
 ios_sticker_pack_extension(<a href="#ios_sticker_pack_extension-name">name</a>, <a href="#ios_sticker_pack_extension-resources">resources</a>, <a href="#ios_sticker_pack_extension-app_icons">app_icons</a>, <a href="#ios_sticker_pack_extension-bundle_id">bundle_id</a>, <a href="#ios_sticker_pack_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#ios_sticker_pack_extension-bundle_name">bundle_name</a>,
                            <a href="#ios_sticker_pack_extension-entitlements">entitlements</a>, <a href="#ios_sticker_pack_extension-entitlements_validation">entitlements_validation</a>, <a href="#ios_sticker_pack_extension-executable_name">executable_name</a>, <a href="#ios_sticker_pack_extension-families">families</a>,
                            <a href="#ios_sticker_pack_extension-infoplists">infoplists</a>, <a href="#ios_sticker_pack_extension-ipa_post_processor">ipa_post_processor</a>, <a href="#ios_sticker_pack_extension-minimum_deployment_os_version">minimum_deployment_os_version</a>,
@@ -529,6 +549,8 @@ Builds and bundles an iOS Sticker Pack Extension.
 ## ios_test_runner
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_test_runner")
+
 ios_test_runner(<a href="#ios_test_runner-name">name</a>, <a href="#ios_test_runner-device_type">device_type</a>, <a href="#ios_test_runner-execution_requirements">execution_requirements</a>, <a href="#ios_test_runner-os_version">os_version</a>, <a href="#ios_test_runner-post_action">post_action</a>,
                 <a href="#ios_test_runner-post_action_determines_exit_code">post_action_determines_exit_code</a>, <a href="#ios_test_runner-pre_action">pre_action</a>, <a href="#ios_test_runner-test_environment">test_environment</a>)
 </pre>
@@ -567,6 +589,8 @@ Outputs:
 ## ios_ui_test
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_ui_test")
+
 ios_ui_test(<a href="#ios_ui_test-name">name</a>, <a href="#ios_ui_test-deps">deps</a>, <a href="#ios_ui_test-data">data</a>, <a href="#ios_ui_test-bundle_name">bundle_name</a>, <a href="#ios_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#ios_ui_test-env">env</a>, <a href="#ios_ui_test-env_inherit">env_inherit</a>,
             <a href="#ios_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_ui_test-platform_type">platform_type</a>, <a href="#ios_ui_test-runner">runner</a>,
             <a href="#ios_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_ui_test-test_filter">test_filter</a>, <a href="#ios_ui_test-test_host">test_host</a>, <a href="#ios_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -613,6 +637,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_unit_test
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_unit_test")
+
 ios_unit_test(<a href="#ios_unit_test-name">name</a>, <a href="#ios_unit_test-deps">deps</a>, <a href="#ios_unit_test-data">data</a>, <a href="#ios_unit_test-bundle_name">bundle_name</a>, <a href="#ios_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#ios_unit_test-env">env</a>, <a href="#ios_unit_test-env_inherit">env_inherit</a>,
               <a href="#ios_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#ios_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#ios_unit_test-platform_type">platform_type</a>, <a href="#ios_unit_test-runner">runner</a>,
               <a href="#ios_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#ios_unit_test-test_filter">test_filter</a>, <a href="#ios_unit_test-test_host">test_host</a>, <a href="#ios_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -665,6 +691,8 @@ of the attributes inherited by all test rules, please check the
 ## ios_xctestrun_runner
 
 <pre>
+load("@rules_apple//apple:ios.doc.bzl", "ios_xctestrun_runner")
+
 ios_xctestrun_runner(<a href="#ios_xctestrun_runner-name">name</a>, <a href="#ios_xctestrun_runner-attachment_lifetime">attachment_lifetime</a>, <a href="#ios_xctestrun_runner-command_line_args">command_line_args</a>, <a href="#ios_xctestrun_runner-create_xcresult_bundle">create_xcresult_bundle</a>,
                      <a href="#ios_xctestrun_runner-destination_timeout">destination_timeout</a>, <a href="#ios_xctestrun_runner-device_type">device_type</a>, <a href="#ios_xctestrun_runner-os_version">os_version</a>, <a href="#ios_xctestrun_runner-post_action">post_action</a>,
                      <a href="#ios_xctestrun_runner-post_action_determines_exit_code">post_action_determines_exit_code</a>, <a href="#ios_xctestrun_runner-pre_action">pre_action</a>, <a href="#ios_xctestrun_runner-random">random</a>, <a href="#ios_xctestrun_runner-reuse_simulator">reuse_simulator</a>,
@@ -733,7 +761,9 @@ in Xcode.
 ## ios_ui_test_suite
 
 <pre>
-ios_ui_test_suite(<a href="#ios_ui_test_suite-name">name</a>, <a href="#ios_ui_test_suite-runners">runners</a>, <a href="#ios_ui_test_suite-kwargs">kwargs</a>)
+load("@rules_apple//apple:ios.doc.bzl", "ios_ui_test_suite")
+
+ios_ui_test_suite(<a href="#ios_ui_test_suite-name">name</a>, <a href="#ios_ui_test_suite-runners">runners</a>, <a href="#ios_ui_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Generates a [test_suite] containing an [ios_ui_test] for each of the given `runners`.
@@ -759,7 +789,9 @@ Generates a [test_suite] containing an [ios_ui_test] for each of the given `runn
 ## ios_unit_test_suite
 
 <pre>
-ios_unit_test_suite(<a href="#ios_unit_test_suite-name">name</a>, <a href="#ios_unit_test_suite-runners">runners</a>, <a href="#ios_unit_test_suite-kwargs">kwargs</a>)
+load("@rules_apple//apple:ios.doc.bzl", "ios_unit_test_suite")
+
+ios_unit_test_suite(<a href="#ios_unit_test_suite-name">name</a>, <a href="#ios_unit_test_suite-runners">runners</a>, <a href="#ios_unit_test_suite-kwargs">**kwargs</a>)
 </pre>
 
 Generates a [test_suite] containing an [ios_unit_test] for each of the given `runners`.

--- a/doc/rules-macos.md
+++ b/doc/rules-macos.md
@@ -7,6 +7,8 @@
 ## macos_application
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_application")
+
 macos_application(<a href="#macos_application-name">name</a>, <a href="#macos_application-deps">deps</a>, <a href="#macos_application-resources">resources</a>, <a href="#macos_application-additional_contents">additional_contents</a>, <a href="#macos_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_application-app_icons">app_icons</a>,
                   <a href="#macos_application-app_intents">app_intents</a>, <a href="#macos_application-bundle_id">bundle_id</a>, <a href="#macos_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_application-bundle_name">bundle_name</a>, <a href="#macos_application-codesign_inputs">codesign_inputs</a>,
                   <a href="#macos_application-codesignopts">codesignopts</a>, <a href="#macos_application-entitlements">entitlements</a>, <a href="#macos_application-entitlements_validation">entitlements_validation</a>, <a href="#macos_application-executable_name">executable_name</a>,
@@ -67,6 +69,8 @@ simple command line tool as a standalone binary, use
 ## macos_build_test
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_build_test")
+
 macos_build_test(<a href="#macos_build_test-name">name</a>, <a href="#macos_build_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_build_test-platform_type">platform_type</a>, <a href="#macos_build_test-targets">targets</a>)
 </pre>
 
@@ -101,6 +105,8 @@ macos_build_test(
 ## macos_bundle
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_bundle")
+
 macos_bundle(<a href="#macos_bundle-name">name</a>, <a href="#macos_bundle-deps">deps</a>, <a href="#macos_bundle-resources">resources</a>, <a href="#macos_bundle-additional_contents">additional_contents</a>, <a href="#macos_bundle-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_bundle-app_icons">app_icons</a>,
              <a href="#macos_bundle-bundle_extension">bundle_extension</a>, <a href="#macos_bundle-bundle_id">bundle_id</a>, <a href="#macos_bundle-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_bundle-bundle_loader">bundle_loader</a>, <a href="#macos_bundle-bundle_name">bundle_name</a>,
              <a href="#macos_bundle-codesign_inputs">codesign_inputs</a>, <a href="#macos_bundle-codesignopts">codesignopts</a>, <a href="#macos_bundle-entitlements">entitlements</a>, <a href="#macos_bundle-entitlements_validation">entitlements_validation</a>, <a href="#macos_bundle-executable_name">executable_name</a>,
@@ -152,6 +158,8 @@ Builds and bundles a macOS Loadable Bundle.
 ## macos_command_line_application
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_command_line_application")
+
 macos_command_line_application(<a href="#macos_command_line_application-name">name</a>, <a href="#macos_command_line_application-deps">deps</a>, <a href="#macos_command_line_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_command_line_application-base_bundle_id">base_bundle_id</a>, <a href="#macos_command_line_application-bundle_id">bundle_id</a>,
                                <a href="#macos_command_line_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_command_line_application-codesign_inputs">codesign_inputs</a>, <a href="#macos_command_line_application-codesignopts">codesignopts</a>,
                                <a href="#macos_command_line_application-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_command_line_application-infoplists">infoplists</a>, <a href="#macos_command_line_application-launchdplists">launchdplists</a>, <a href="#macos_command_line_application-linkopts">linkopts</a>,
@@ -200,6 +208,8 @@ Targets created with `macos_command_line_application` can be executed using
 ## macos_dylib
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_dylib")
+
 macos_dylib(<a href="#macos_dylib-name">name</a>, <a href="#macos_dylib-deps">deps</a>, <a href="#macos_dylib-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_dylib-base_bundle_id">base_bundle_id</a>, <a href="#macos_dylib-bundle_id">bundle_id</a>, <a href="#macos_dylib-bundle_id_suffix">bundle_id_suffix</a>,
             <a href="#macos_dylib-codesign_inputs">codesign_inputs</a>, <a href="#macos_dylib-codesignopts">codesignopts</a>, <a href="#macos_dylib-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_dylib-infoplists">infoplists</a>, <a href="#macos_dylib-linkopts">linkopts</a>,
             <a href="#macos_dylib-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_dylib-minimum_os_version">minimum_os_version</a>, <a href="#macos_dylib-platform_type">platform_type</a>, <a href="#macos_dylib-provisioning_profile">provisioning_profile</a>,
@@ -237,6 +247,8 @@ Builds a macOS Dylib binary.
 ## macos_dynamic_framework
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_dynamic_framework")
+
 macos_dynamic_framework(<a href="#macos_dynamic_framework-name">name</a>, <a href="#macos_dynamic_framework-deps">deps</a>, <a href="#macos_dynamic_framework-resources">resources</a>, <a href="#macos_dynamic_framework-hdrs">hdrs</a>, <a href="#macos_dynamic_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_dynamic_framework-base_bundle_id">base_bundle_id</a>,
                         <a href="#macos_dynamic_framework-bundle_id">bundle_id</a>, <a href="#macos_dynamic_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_dynamic_framework-bundle_name">bundle_name</a>, <a href="#macos_dynamic_framework-bundle_only">bundle_only</a>, <a href="#macos_dynamic_framework-codesign_inputs">codesign_inputs</a>,
                         <a href="#macos_dynamic_framework-codesignopts">codesignopts</a>, <a href="#macos_dynamic_framework-executable_name">executable_name</a>, <a href="#macos_dynamic_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_dynamic_framework-extension_safe">extension_safe</a>,
@@ -286,6 +298,8 @@ Builds and bundles a macOS dynamic framework that is consumable by Xcode.
 ## macos_extension
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_extension")
+
 macos_extension(<a href="#macos_extension-name">name</a>, <a href="#macos_extension-deps">deps</a>, <a href="#macos_extension-resources">resources</a>, <a href="#macos_extension-additional_contents">additional_contents</a>, <a href="#macos_extension-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_extension-app_icons">app_icons</a>,
                 <a href="#macos_extension-bundle_id">bundle_id</a>, <a href="#macos_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_extension-bundle_name">bundle_name</a>, <a href="#macos_extension-codesign_inputs">codesign_inputs</a>, <a href="#macos_extension-codesignopts">codesignopts</a>, <a href="#macos_extension-entitlements">entitlements</a>,
                 <a href="#macos_extension-entitlements_validation">entitlements_validation</a>, <a href="#macos_extension-executable_name">executable_name</a>, <a href="#macos_extension-exported_symbols_lists">exported_symbols_lists</a>,
@@ -343,6 +357,8 @@ point (typically expressed through Swift's `@main` attribute).
 ## macos_framework
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_framework")
+
 macos_framework(<a href="#macos_framework-name">name</a>, <a href="#macos_framework-deps">deps</a>, <a href="#macos_framework-resources">resources</a>, <a href="#macos_framework-hdrs">hdrs</a>, <a href="#macos_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_framework-base_bundle_id">base_bundle_id</a>, <a href="#macos_framework-bundle_id">bundle_id</a>,
                 <a href="#macos_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_framework-bundle_name">bundle_name</a>, <a href="#macos_framework-bundle_only">bundle_only</a>, <a href="#macos_framework-codesign_inputs">codesign_inputs</a>, <a href="#macos_framework-codesignopts">codesignopts</a>,
                 <a href="#macos_framework-executable_name">executable_name</a>, <a href="#macos_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_framework-extension_safe">extension_safe</a>, <a href="#macos_framework-families">families</a>, <a href="#macos_framework-frameworks">frameworks</a>,
@@ -394,6 +410,8 @@ of those `macos_application` and/or `macos_extension` rules.
 ## macos_kernel_extension
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_kernel_extension")
+
 macos_kernel_extension(<a href="#macos_kernel_extension-name">name</a>, <a href="#macos_kernel_extension-deps">deps</a>, <a href="#macos_kernel_extension-resources">resources</a>, <a href="#macos_kernel_extension-additional_contents">additional_contents</a>, <a href="#macos_kernel_extension-additional_linker_inputs">additional_linker_inputs</a>,
                        <a href="#macos_kernel_extension-bundle_id">bundle_id</a>, <a href="#macos_kernel_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_kernel_extension-bundle_name">bundle_name</a>, <a href="#macos_kernel_extension-codesign_inputs">codesign_inputs</a>, <a href="#macos_kernel_extension-codesignopts">codesignopts</a>,
                        <a href="#macos_kernel_extension-entitlements">entitlements</a>, <a href="#macos_kernel_extension-entitlements_validation">entitlements_validation</a>, <a href="#macos_kernel_extension-executable_name">executable_name</a>, <a href="#macos_kernel_extension-exported_symbols_lists">exported_symbols_lists</a>,
@@ -442,6 +460,8 @@ Builds and bundles a macOS Kernel Extension.
 ## macos_quick_look_plugin
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_quick_look_plugin")
+
 macos_quick_look_plugin(<a href="#macos_quick_look_plugin-name">name</a>, <a href="#macos_quick_look_plugin-deps">deps</a>, <a href="#macos_quick_look_plugin-resources">resources</a>, <a href="#macos_quick_look_plugin-additional_contents">additional_contents</a>, <a href="#macos_quick_look_plugin-additional_linker_inputs">additional_linker_inputs</a>,
                         <a href="#macos_quick_look_plugin-bundle_id">bundle_id</a>, <a href="#macos_quick_look_plugin-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_quick_look_plugin-bundle_name">bundle_name</a>, <a href="#macos_quick_look_plugin-codesign_inputs">codesign_inputs</a>, <a href="#macos_quick_look_plugin-codesignopts">codesignopts</a>,
                         <a href="#macos_quick_look_plugin-entitlements">entitlements</a>, <a href="#macos_quick_look_plugin-entitlements_validation">entitlements_validation</a>, <a href="#macos_quick_look_plugin-executable_name">executable_name</a>,
@@ -490,6 +510,8 @@ Builds and bundles a macOS Quick Look Plugin.
 ## macos_spotlight_importer
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_spotlight_importer")
+
 macos_spotlight_importer(<a href="#macos_spotlight_importer-name">name</a>, <a href="#macos_spotlight_importer-deps">deps</a>, <a href="#macos_spotlight_importer-resources">resources</a>, <a href="#macos_spotlight_importer-additional_contents">additional_contents</a>, <a href="#macos_spotlight_importer-additional_linker_inputs">additional_linker_inputs</a>,
                          <a href="#macos_spotlight_importer-bundle_id">bundle_id</a>, <a href="#macos_spotlight_importer-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_spotlight_importer-bundle_name">bundle_name</a>, <a href="#macos_spotlight_importer-codesign_inputs">codesign_inputs</a>, <a href="#macos_spotlight_importer-codesignopts">codesignopts</a>,
                          <a href="#macos_spotlight_importer-entitlements">entitlements</a>, <a href="#macos_spotlight_importer-entitlements_validation">entitlements_validation</a>, <a href="#macos_spotlight_importer-executable_name">executable_name</a>,
@@ -538,6 +560,8 @@ Builds and bundles a macOS Spotlight Importer.
 ## macos_static_framework
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_static_framework")
+
 macos_static_framework(<a href="#macos_static_framework-name">name</a>, <a href="#macos_static_framework-deps">deps</a>, <a href="#macos_static_framework-resources">resources</a>, <a href="#macos_static_framework-hdrs">hdrs</a>, <a href="#macos_static_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_static_framework-avoid_deps">avoid_deps</a>,
                        <a href="#macos_static_framework-bundle_name">bundle_name</a>, <a href="#macos_static_framework-codesign_inputs">codesign_inputs</a>, <a href="#macos_static_framework-codesignopts">codesignopts</a>, <a href="#macos_static_framework-exclude_resources">exclude_resources</a>, <a href="#macos_static_framework-executable_name">executable_name</a>,
                        <a href="#macos_static_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_static_framework-families">families</a>, <a href="#macos_static_framework-ipa_post_processor">ipa_post_processor</a>, <a href="#macos_static_framework-linkopts">linkopts</a>,
@@ -617,6 +641,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## macos_ui_test
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_ui_test")
+
 macos_ui_test(<a href="#macos_ui_test-name">name</a>, <a href="#macos_ui_test-deps">deps</a>, <a href="#macos_ui_test-data">data</a>, <a href="#macos_ui_test-bundle_name">bundle_name</a>, <a href="#macos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#macos_ui_test-env">env</a>, <a href="#macos_ui_test-env_inherit">env_inherit</a>,
               <a href="#macos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_ui_test-platform_type">platform_type</a>, <a href="#macos_ui_test-runner">runner</a>,
               <a href="#macos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_ui_test-test_filter">test_filter</a>, <a href="#macos_ui_test-test_host">test_host</a>, <a href="#macos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -654,6 +680,8 @@ Note: macOS UI tests are not currently supported in the default test runner.
 ## macos_unit_test
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_unit_test")
+
 macos_unit_test(<a href="#macos_unit_test-name">name</a>, <a href="#macos_unit_test-deps">deps</a>, <a href="#macos_unit_test-data">data</a>, <a href="#macos_unit_test-bundle_name">bundle_name</a>, <a href="#macos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#macos_unit_test-env">env</a>, <a href="#macos_unit_test-env_inherit">env_inherit</a>,
                 <a href="#macos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#macos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#macos_unit_test-platform_type">platform_type</a>, <a href="#macos_unit_test-runner">runner</a>,
                 <a href="#macos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#macos_unit_test-test_filter">test_filter</a>, <a href="#macos_unit_test-test_host">test_host</a>, <a href="#macos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -697,6 +725,8 @@ find more information about testing for Apple platforms
 ## macos_xpc_service
 
 <pre>
+load("@rules_apple//apple:macos.doc.bzl", "macos_xpc_service")
+
 macos_xpc_service(<a href="#macos_xpc_service-name">name</a>, <a href="#macos_xpc_service-deps">deps</a>, <a href="#macos_xpc_service-resources">resources</a>, <a href="#macos_xpc_service-additional_contents">additional_contents</a>, <a href="#macos_xpc_service-additional_linker_inputs">additional_linker_inputs</a>, <a href="#macos_xpc_service-bundle_id">bundle_id</a>,
                   <a href="#macos_xpc_service-bundle_id_suffix">bundle_id_suffix</a>, <a href="#macos_xpc_service-bundle_name">bundle_name</a>, <a href="#macos_xpc_service-codesign_inputs">codesign_inputs</a>, <a href="#macos_xpc_service-codesignopts">codesignopts</a>, <a href="#macos_xpc_service-entitlements">entitlements</a>,
                   <a href="#macos_xpc_service-entitlements_validation">entitlements_validation</a>, <a href="#macos_xpc_service-executable_name">executable_name</a>, <a href="#macos_xpc_service-exported_symbols_lists">exported_symbols_lists</a>, <a href="#macos_xpc_service-families">families</a>,

--- a/doc/rules-resources.md
+++ b/doc/rules-resources.md
@@ -7,6 +7,8 @@
 ## apple_bundle_import
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_bundle_import")
+
 apple_bundle_import(<a href="#apple_bundle_import-name">name</a>, <a href="#apple_bundle_import-bundle_imports">bundle_imports</a>)
 </pre>
 
@@ -30,6 +32,8 @@ targets (i.e. `apple_resource_bundle` and `apple_resource_group`) through the
 ## apple_core_data_model
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_core_data_model")
+
 apple_core_data_model(<a href="#apple_core_data_model-name">name</a>, <a href="#apple_core_data_model-srcs">srcs</a>, <a href="#apple_core_data_model-outs">outs</a>, <a href="#apple_core_data_model-swift_version">swift_version</a>)
 </pre>
 
@@ -53,6 +57,8 @@ as srcs of a swift_library target.
 ## apple_intent_library
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_intent_library")
+
 apple_intent_library(<a href="#apple_intent_library-name">name</a>, <a href="#apple_intent_library-src">src</a>, <a href="#apple_intent_library-class_prefix">class_prefix</a>, <a href="#apple_intent_library-class_visibility">class_visibility</a>, <a href="#apple_intent_library-header_name">header_name</a>, <a href="#apple_intent_library-language">language</a>,
                      <a href="#apple_intent_library-swift_version">swift_version</a>)
 </pre>
@@ -83,6 +89,8 @@ resides. For example, if this target's label is `//my/package:intent`, you can i
 ## apple_metal_library
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_metal_library")
+
 apple_metal_library(<a href="#apple_metal_library-name">name</a>, <a href="#apple_metal_library-srcs">srcs</a>, <a href="#apple_metal_library-out">out</a>, <a href="#apple_metal_library-hdrs">hdrs</a>, <a href="#apple_metal_library-copts">copts</a>, <a href="#apple_metal_library-includes">includes</a>)
 </pre>
 
@@ -106,6 +114,8 @@ Compiles Metal shader language sources into a Metal library.
 ## apple_precompiled_resource_bundle
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_precompiled_resource_bundle")
+
 apple_precompiled_resource_bundle(<a href="#apple_precompiled_resource_bundle-name">name</a>, <a href="#apple_precompiled_resource_bundle-resources">resources</a>, <a href="#apple_precompiled_resource_bundle-bundle_id">bundle_id</a>, <a href="#apple_precompiled_resource_bundle-bundle_name">bundle_name</a>, <a href="#apple_precompiled_resource_bundle-infoplists">infoplists</a>,
                                   <a href="#apple_precompiled_resource_bundle-strip_structured_resources_prefixes">strip_structured_resources_prefixes</a>, <a href="#apple_precompiled_resource_bundle-structured_resources">structured_resources</a>)
 </pre>
@@ -134,6 +144,8 @@ library targets through the `data` attribute.
 ## apple_resource_bundle
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_resource_bundle")
+
 apple_resource_bundle(<a href="#apple_resource_bundle-name">name</a>, <a href="#apple_resource_bundle-resources">resources</a>, <a href="#apple_resource_bundle-bundle_id">bundle_id</a>, <a href="#apple_resource_bundle-bundle_name">bundle_name</a>, <a href="#apple_resource_bundle-infoplists">infoplists</a>,
                       <a href="#apple_resource_bundle-strip_structured_resources_prefixes">strip_structured_resources_prefixes</a>, <a href="#apple_resource_bundle-structured_resources">structured_resources</a>)
 </pre>
@@ -162,6 +174,8 @@ library targets through the `data` attribute.
 ## apple_resource_group
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "apple_resource_group")
+
 apple_resource_group(<a href="#apple_resource_group-name">name</a>, <a href="#apple_resource_group-resources">resources</a>, <a href="#apple_resource_group-strip_structured_resources_prefixes">strip_structured_resources_prefixes</a>, <a href="#apple_resource_group-structured_resources">structured_resources</a>)
 </pre>
 
@@ -188,7 +202,9 @@ to library targets through the `data` attribute, or to other
 ## apple_core_ml_library
 
 <pre>
-apple_core_ml_library(<a href="#apple_core_ml_library-name">name</a>, <a href="#apple_core_ml_library-mlmodel">mlmodel</a>, <a href="#apple_core_ml_library-kwargs">kwargs</a>)
+load("@rules_apple//apple:resources.bzl", "apple_core_ml_library")
+
+apple_core_ml_library(<a href="#apple_core_ml_library-name">name</a>, <a href="#apple_core_ml_library-mlmodel">mlmodel</a>, <a href="#apple_core_ml_library-kwargs">**kwargs</a>)
 </pre>
 
 Macro to orchestrate an objc_library with generated sources for mlmodel files.
@@ -208,7 +224,9 @@ Macro to orchestrate an objc_library with generated sources for mlmodel files.
 ## objc_intent_library
 
 <pre>
-objc_intent_library(<a href="#objc_intent_library-name">name</a>, <a href="#objc_intent_library-src">src</a>, <a href="#objc_intent_library-class_prefix">class_prefix</a>, <a href="#objc_intent_library-testonly">testonly</a>, <a href="#objc_intent_library-kwargs">kwargs</a>)
+load("@rules_apple//apple:resources.bzl", "objc_intent_library")
+
+objc_intent_library(<a href="#objc_intent_library-name">name</a>, <a href="#objc_intent_library-src">src</a>, <a href="#objc_intent_library-class_prefix">class_prefix</a>, <a href="#objc_intent_library-testonly">testonly</a>, <a href="#objc_intent_library-kwargs">**kwargs</a>)
 </pre>
 
 Macro to orchestrate an objc_library with generated sources for intentdefiniton files.
@@ -230,7 +248,9 @@ Macro to orchestrate an objc_library with generated sources for intentdefiniton 
 ## resources_common.bucketize
 
 <pre>
-resources_common.bucketize(<a href="#resources_common.bucketize-allowed_buckets">allowed_buckets</a>, <a href="#resources_common.bucketize-owner">owner</a>, <a href="#resources_common.bucketize-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize-resources">resources</a>, <a href="#resources_common.bucketize-swift_module">swift_module</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.bucketize(*, <a href="#resources_common.bucketize-allowed_buckets">allowed_buckets</a>, <a href="#resources_common.bucketize-owner">owner</a>, <a href="#resources_common.bucketize-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize-resources">resources</a>, <a href="#resources_common.bucketize-swift_module">swift_module</a>)
 </pre>
 
 Separates the given resources into resource bucket types and returns an AppleResourceInfo.
@@ -260,7 +280,10 @@ An AppleResourceInfo provider with resources bucketized according to type.
 ## resources_common.bucketize_data
 
 <pre>
-resources_common.bucketize_data(<a href="#resources_common.bucketize_data-allowed_buckets">allowed_buckets</a>, <a href="#resources_common.bucketize_data-owner">owner</a>, <a href="#resources_common.bucketize_data-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize_data-resources">resources</a>, <a href="#resources_common.bucketize_data-swift_module">swift_module</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.bucketize_data(*, <a href="#resources_common.bucketize_data-allowed_buckets">allowed_buckets</a>, <a href="#resources_common.bucketize_data-owner">owner</a>, <a href="#resources_common.bucketize_data-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize_data-resources">resources</a>,
+                                <a href="#resources_common.bucketize_data-swift_module">swift_module</a>)
 </pre>
 
 Separates the given resources into resource bucket types.
@@ -305,7 +328,9 @@ A tuple with a list of owners, a list of "unowned" resources, and a dictionary w
 ## resources_common.bucketize_typed
 
 <pre>
-resources_common.bucketize_typed(<a href="#resources_common.bucketize_typed-resources">resources</a>, <a href="#resources_common.bucketize_typed-bucket_type">bucket_type</a>, <a href="#resources_common.bucketize_typed-owner">owner</a>, <a href="#resources_common.bucketize_typed-parent_dir_param">parent_dir_param</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.bucketize_typed(<a href="#resources_common.bucketize_typed-resources">resources</a>, <a href="#resources_common.bucketize_typed-bucket_type">bucket_type</a>, *, <a href="#resources_common.bucketize_typed-owner">owner</a>, <a href="#resources_common.bucketize_typed-parent_dir_param">parent_dir_param</a>)
 </pre>
 
 Collects and bucketizes a specific type of resource and returns an AppleResourceInfo.
@@ -335,7 +360,9 @@ An AppleResourceInfo provider with resources in the given bucket.
 ## resources_common.bucketize_typed_data
 
 <pre>
-resources_common.bucketize_typed_data(<a href="#resources_common.bucketize_typed_data-bucket_type">bucket_type</a>, <a href="#resources_common.bucketize_typed_data-owner">owner</a>, <a href="#resources_common.bucketize_typed_data-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize_typed_data-resources">resources</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.bucketize_typed_data(*, <a href="#resources_common.bucketize_typed_data-bucket_type">bucket_type</a>, <a href="#resources_common.bucketize_typed_data-owner">owner</a>, <a href="#resources_common.bucketize_typed_data-parent_dir_param">parent_dir_param</a>, <a href="#resources_common.bucketize_typed_data-resources">resources</a>)
 </pre>
 
 Collects and bucketizes a specific type of resource.
@@ -366,6 +393,8 @@ A tuple with a list of owners, a list of "unowned" resources, and a dictionary w
 ## resources_common.bundle_relative_parent_dir
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
 resources_common.bundle_relative_parent_dir(<a href="#resources_common.bundle_relative_parent_dir-resource">resource</a>, <a href="#resources_common.bundle_relative_parent_dir-extension">extension</a>)
 </pre>
 
@@ -395,7 +424,9 @@ The bundle relative path, rooted at the outermost bundle.
 ## resources_common.collect
 
 <pre>
-resources_common.collect(<a href="#resources_common.collect-attr">attr</a>, <a href="#resources_common.collect-res_attrs">res_attrs</a>, <a href="#resources_common.collect-split_attr_keys">split_attr_keys</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.collect(*, <a href="#resources_common.collect-attr">attr</a>, <a href="#resources_common.collect-res_attrs">res_attrs</a>, <a href="#resources_common.collect-split_attr_keys">split_attr_keys</a>)
 </pre>
 
 Collects all resource attributes present in the given attributes.
@@ -423,7 +454,9 @@ A dictionary keyed by target from the rule attr with the list of all collected r
 ## resources_common.deduplicate
 
 <pre>
-resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>, <a href="#resources_common.deduplicate-default_owner">default_owner</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.deduplicate(*, <a href="#resources_common.deduplicate-resources_provider">resources_provider</a>, <a href="#resources_common.deduplicate-avoid_providers">avoid_providers</a>, <a href="#resources_common.deduplicate-field_handler">field_handler</a>, <a href="#resources_common.deduplicate-default_owner">default_owner</a>)
 </pre>
 
 
@@ -444,7 +477,9 @@ resources_common.deduplicate(<a href="#resources_common.deduplicate-resources_pr
 ## resources_common.merge_providers
 
 <pre>
-resources_common.merge_providers(<a href="#resources_common.merge_providers-default_owner">default_owner</a>, <a href="#resources_common.merge_providers-providers">providers</a>, <a href="#resources_common.merge_providers-validate_all_resources_owned">validate_all_resources_owned</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.merge_providers(*, <a href="#resources_common.merge_providers-default_owner">default_owner</a>, <a href="#resources_common.merge_providers-providers">providers</a>, <a href="#resources_common.merge_providers-validate_all_resources_owned">validate_all_resources_owned</a>)
 </pre>
 
 Merges multiple AppleResourceInfo providers into one.
@@ -468,7 +503,9 @@ A AppleResourceInfo provider with the results of the merge of the given provider
 ## resources_common.minimize
 
 <pre>
-resources_common.minimize(<a href="#resources_common.minimize-bucket">bucket</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.minimize(*, <a href="#resources_common.minimize-bucket">bucket</a>)
 </pre>
 
 Minimizes the given list of tuples into the smallest subset possible.
@@ -496,7 +533,9 @@ A list of minimized tuples.
 ## resources_common.nest_in_bundle
 
 <pre>
-resources_common.nest_in_bundle(<a href="#resources_common.nest_in_bundle-provider_to_nest">provider_to_nest</a>, <a href="#resources_common.nest_in_bundle-nesting_bundle_dir">nesting_bundle_dir</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.nest_in_bundle(*, <a href="#resources_common.nest_in_bundle-provider_to_nest">provider_to_nest</a>, <a href="#resources_common.nest_in_bundle-nesting_bundle_dir">nesting_bundle_dir</a>)
 </pre>
 
 Nests resources in a AppleResourceInfo provider under a new parent bundle directory.
@@ -528,6 +567,8 @@ A new AppleResourceInfo provider with the resources nested under nesting_bundle_
 ## resources_common.populated_resource_fields
 
 <pre>
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
 resources_common.populated_resource_fields(<a href="#resources_common.populated_resource_fields-provider">provider</a>)
 </pre>
 
@@ -546,7 +587,9 @@ Returns a list of field names of the provider's resource buckets that are non em
 ## resources_common.process_bucketized_data
 
 <pre>
-resources_common.process_bucketized_data(<a href="#resources_common.process_bucketized_data-actions">actions</a>, <a href="#resources_common.process_bucketized_data-apple_mac_toolchain_info">apple_mac_toolchain_info</a>, <a href="#resources_common.process_bucketized_data-bucketized_owners">bucketized_owners</a>,
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.process_bucketized_data(*, <a href="#resources_common.process_bucketized_data-actions">actions</a>, <a href="#resources_common.process_bucketized_data-apple_mac_toolchain_info">apple_mac_toolchain_info</a>, <a href="#resources_common.process_bucketized_data-bucketized_owners">bucketized_owners</a>,
                                          <a href="#resources_common.process_bucketized_data-buckets">buckets</a>, <a href="#resources_common.process_bucketized_data-bundle_id">bundle_id</a>, <a href="#resources_common.process_bucketized_data-output_discriminator">output_discriminator</a>,
                                          <a href="#resources_common.process_bucketized_data-platform_prerequisites">platform_prerequisites</a>, <a href="#resources_common.process_bucketized_data-processing_owner">processing_owner</a>, <a href="#resources_common.process_bucketized_data-product_type">product_type</a>,
                                          <a href="#resources_common.process_bucketized_data-resource_types_to_process">resource_types_to_process</a>, <a href="#resources_common.process_bucketized_data-rule_label">rule_label</a>, <a href="#resources_common.process_bucketized_data-unowned_resources">unowned_resources</a>)
@@ -590,7 +633,9 @@ An AppleResourceInfo provider with resources bucketized according to
 ## resources_common.runfiles_resources_parent_dir
 
 <pre>
-resources_common.runfiles_resources_parent_dir(<a href="#resources_common.runfiles_resources_parent_dir-resource">resource</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.runfiles_resources_parent_dir(*, <a href="#resources_common.runfiles_resources_parent_dir-resource">resource</a>)
 </pre>
 
 Returns the parent directory of the file.
@@ -612,7 +657,9 @@ The package relative path to the parent directory of the resource.
 ## resources_common.structured_resources_parent_dir
 
 <pre>
-resources_common.structured_resources_parent_dir(<a href="#resources_common.structured_resources_parent_dir-parent_dir">parent_dir</a>, <a href="#resources_common.structured_resources_parent_dir-resource">resource</a>, <a href="#resources_common.structured_resources_parent_dir-strip_prefixes">strip_prefixes</a>)
+load("@rules_apple//apple:resources.bzl", "resources_common")
+
+resources_common.structured_resources_parent_dir(*, <a href="#resources_common.structured_resources_parent_dir-parent_dir">parent_dir</a>, <a href="#resources_common.structured_resources_parent_dir-resource">resource</a>, <a href="#resources_common.structured_resources_parent_dir-strip_prefixes">strip_prefixes</a>)
 </pre>
 
 Returns the package relative path for the parent directory of a resource.
@@ -636,7 +683,9 @@ The package relative path to the parent directory of the resource.
 ## swift_apple_core_ml_library
 
 <pre>
-swift_apple_core_ml_library(<a href="#swift_apple_core_ml_library-name">name</a>, <a href="#swift_apple_core_ml_library-mlmodel">mlmodel</a>, <a href="#swift_apple_core_ml_library-kwargs">kwargs</a>)
+load("@rules_apple//apple:resources.bzl", "swift_apple_core_ml_library")
+
+swift_apple_core_ml_library(<a href="#swift_apple_core_ml_library-name">name</a>, <a href="#swift_apple_core_ml_library-mlmodel">mlmodel</a>, <a href="#swift_apple_core_ml_library-kwargs">**kwargs</a>)
 </pre>
 
 Macro to orchestrate a swift_library with generated sources for mlmodel files.
@@ -656,7 +705,9 @@ Macro to orchestrate a swift_library with generated sources for mlmodel files.
 ## swift_intent_library
 
 <pre>
-swift_intent_library(<a href="#swift_intent_library-name">name</a>, <a href="#swift_intent_library-src">src</a>, <a href="#swift_intent_library-class_prefix">class_prefix</a>, <a href="#swift_intent_library-class_visibility">class_visibility</a>, <a href="#swift_intent_library-swift_version">swift_version</a>, <a href="#swift_intent_library-testonly">testonly</a>, <a href="#swift_intent_library-kwargs">kwargs</a>)
+load("@rules_apple//apple:resources.bzl", "swift_intent_library")
+
+swift_intent_library(<a href="#swift_intent_library-name">name</a>, <a href="#swift_intent_library-src">src</a>, <a href="#swift_intent_library-class_prefix">class_prefix</a>, <a href="#swift_intent_library-class_visibility">class_visibility</a>, <a href="#swift_intent_library-swift_version">swift_version</a>, <a href="#swift_intent_library-testonly">testonly</a>, <a href="#swift_intent_library-kwargs">**kwargs</a>)
 </pre>
 
 This macro supports the integration of Intents `.intentdefinition` files into Apple rules.

--- a/doc/rules-tvos.md
+++ b/doc/rules-tvos.md
@@ -7,6 +7,8 @@
 ## tvos_application
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_application")
+
 tvos_application(<a href="#tvos_application-name">name</a>, <a href="#tvos_application-deps">deps</a>, <a href="#tvos_application-resources">resources</a>, <a href="#tvos_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#tvos_application-app_icons">app_icons</a>, <a href="#tvos_application-app_intents">app_intents</a>, <a href="#tvos_application-bundle_id">bundle_id</a>,
                  <a href="#tvos_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#tvos_application-bundle_name">bundle_name</a>, <a href="#tvos_application-codesign_inputs">codesign_inputs</a>, <a href="#tvos_application-codesignopts">codesignopts</a>, <a href="#tvos_application-entitlements">entitlements</a>,
                  <a href="#tvos_application-entitlements_validation">entitlements_validation</a>, <a href="#tvos_application-executable_name">executable_name</a>, <a href="#tvos_application-exported_symbols_lists">exported_symbols_lists</a>, <a href="#tvos_application-extensions">extensions</a>,
@@ -64,6 +66,8 @@ Builds and bundles a tvOS Application.
 ## tvos_build_test
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_build_test")
+
 tvos_build_test(<a href="#tvos_build_test-name">name</a>, <a href="#tvos_build_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_build_test-platform_type">platform_type</a>, <a href="#tvos_build_test-targets">targets</a>)
 </pre>
 
@@ -98,6 +102,8 @@ tvos_build_test(
 ## tvos_dynamic_framework
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_dynamic_framework")
+
 tvos_dynamic_framework(<a href="#tvos_dynamic_framework-name">name</a>, <a href="#tvos_dynamic_framework-deps">deps</a>, <a href="#tvos_dynamic_framework-resources">resources</a>, <a href="#tvos_dynamic_framework-hdrs">hdrs</a>, <a href="#tvos_dynamic_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#tvos_dynamic_framework-base_bundle_id">base_bundle_id</a>,
                        <a href="#tvos_dynamic_framework-bundle_id">bundle_id</a>, <a href="#tvos_dynamic_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#tvos_dynamic_framework-bundle_name">bundle_name</a>, <a href="#tvos_dynamic_framework-bundle_only">bundle_only</a>, <a href="#tvos_dynamic_framework-codesign_inputs">codesign_inputs</a>,
                        <a href="#tvos_dynamic_framework-codesignopts">codesignopts</a>, <a href="#tvos_dynamic_framework-executable_name">executable_name</a>, <a href="#tvos_dynamic_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#tvos_dynamic_framework-extension_safe">extension_safe</a>,
@@ -147,6 +153,8 @@ Builds and bundles a tvOS dynamic framework that is consumable by Xcode.
 ## tvos_extension
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_extension")
+
 tvos_extension(<a href="#tvos_extension-name">name</a>, <a href="#tvos_extension-deps">deps</a>, <a href="#tvos_extension-resources">resources</a>, <a href="#tvos_extension-additional_linker_inputs">additional_linker_inputs</a>, <a href="#tvos_extension-bundle_id">bundle_id</a>, <a href="#tvos_extension-bundle_id_suffix">bundle_id_suffix</a>,
                <a href="#tvos_extension-bundle_name">bundle_name</a>, <a href="#tvos_extension-codesign_inputs">codesign_inputs</a>, <a href="#tvos_extension-codesignopts">codesignopts</a>, <a href="#tvos_extension-entitlements">entitlements</a>, <a href="#tvos_extension-entitlements_validation">entitlements_validation</a>,
                <a href="#tvos_extension-executable_name">executable_name</a>, <a href="#tvos_extension-exported_symbols_lists">exported_symbols_lists</a>, <a href="#tvos_extension-extensionkit_extension">extensionkit_extension</a>, <a href="#tvos_extension-families">families</a>, <a href="#tvos_extension-frameworks">frameworks</a>,
@@ -197,6 +205,8 @@ Builds and bundles a tvOS Extension.
 ## tvos_framework
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_framework")
+
 tvos_framework(<a href="#tvos_framework-name">name</a>, <a href="#tvos_framework-deps">deps</a>, <a href="#tvos_framework-resources">resources</a>, <a href="#tvos_framework-hdrs">hdrs</a>, <a href="#tvos_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#tvos_framework-base_bundle_id">base_bundle_id</a>, <a href="#tvos_framework-bundle_id">bundle_id</a>,
                <a href="#tvos_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#tvos_framework-bundle_name">bundle_name</a>, <a href="#tvos_framework-bundle_only">bundle_only</a>, <a href="#tvos_framework-codesign_inputs">codesign_inputs</a>, <a href="#tvos_framework-codesignopts">codesignopts</a>,
                <a href="#tvos_framework-executable_name">executable_name</a>, <a href="#tvos_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#tvos_framework-extension_safe">extension_safe</a>, <a href="#tvos_framework-families">families</a>, <a href="#tvos_framework-frameworks">frameworks</a>,
@@ -247,6 +257,8 @@ To use this framework for your app and extensions, list it in the frameworks att
 ## tvos_static_framework
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_static_framework")
+
 tvos_static_framework(<a href="#tvos_static_framework-name">name</a>, <a href="#tvos_static_framework-deps">deps</a>, <a href="#tvos_static_framework-resources">resources</a>, <a href="#tvos_static_framework-hdrs">hdrs</a>, <a href="#tvos_static_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#tvos_static_framework-avoid_deps">avoid_deps</a>,
                       <a href="#tvos_static_framework-bundle_name">bundle_name</a>, <a href="#tvos_static_framework-codesign_inputs">codesign_inputs</a>, <a href="#tvos_static_framework-codesignopts">codesignopts</a>, <a href="#tvos_static_framework-exclude_resources">exclude_resources</a>, <a href="#tvos_static_framework-executable_name">executable_name</a>,
                       <a href="#tvos_static_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#tvos_static_framework-families">families</a>, <a href="#tvos_static_framework-ipa_post_processor">ipa_post_processor</a>, <a href="#tvos_static_framework-linkopts">linkopts</a>,
@@ -326,6 +338,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## tvos_ui_test
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_ui_test")
+
 tvos_ui_test(<a href="#tvos_ui_test-name">name</a>, <a href="#tvos_ui_test-deps">deps</a>, <a href="#tvos_ui_test-data">data</a>, <a href="#tvos_ui_test-bundle_name">bundle_name</a>, <a href="#tvos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#tvos_ui_test-env">env</a>, <a href="#tvos_ui_test-env_inherit">env_inherit</a>,
              <a href="#tvos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_ui_test-platform_type">platform_type</a>, <a href="#tvos_ui_test-runner">runner</a>,
              <a href="#tvos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_ui_test-test_filter">test_filter</a>, <a href="#tvos_ui_test-test_host">test_host</a>, <a href="#tvos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -367,6 +381,8 @@ the attributes inherited by all test rules, please check the
 ## tvos_unit_test
 
 <pre>
+load("@rules_apple//apple:tvos.doc.bzl", "tvos_unit_test")
+
 tvos_unit_test(<a href="#tvos_unit_test-name">name</a>, <a href="#tvos_unit_test-deps">deps</a>, <a href="#tvos_unit_test-data">data</a>, <a href="#tvos_unit_test-bundle_name">bundle_name</a>, <a href="#tvos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#tvos_unit_test-env">env</a>, <a href="#tvos_unit_test-env_inherit">env_inherit</a>,
                <a href="#tvos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#tvos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#tvos_unit_test-platform_type">platform_type</a>, <a href="#tvos_unit_test-runner">runner</a>,
                <a href="#tvos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#tvos_unit_test-test_filter">test_filter</a>, <a href="#tvos_unit_test-test_host">test_host</a>, <a href="#tvos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)

--- a/doc/rules-versioning.md
+++ b/doc/rules-versioning.md
@@ -7,6 +7,8 @@
 ## apple_bundle_version
 
 <pre>
+load("@rules_apple//apple:versioning.bzl", "apple_bundle_version")
+
 apple_bundle_version(<a href="#apple_bundle_version-name">name</a>, <a href="#apple_bundle_version-build_label_pattern">build_label_pattern</a>, <a href="#apple_bundle_version-build_version">build_version</a>, <a href="#apple_bundle_version-capture_groups">capture_groups</a>, <a href="#apple_bundle_version-fallback_build_label">fallback_build_label</a>,
                      <a href="#apple_bundle_version-short_version_string">short_version_string</a>)
 </pre>

--- a/doc/rules-visionos.md
+++ b/doc/rules-visionos.md
@@ -7,6 +7,8 @@
 ## visionos_application
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_application")
+
 visionos_application(<a href="#visionos_application-name">name</a>, <a href="#visionos_application-deps">deps</a>, <a href="#visionos_application-resources">resources</a>, <a href="#visionos_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#visionos_application-app_icons">app_icons</a>, <a href="#visionos_application-app_intents">app_intents</a>,
                      <a href="#visionos_application-bundle_id">bundle_id</a>, <a href="#visionos_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#visionos_application-bundle_name">bundle_name</a>, <a href="#visionos_application-codesign_inputs">codesign_inputs</a>, <a href="#visionos_application-codesignopts">codesignopts</a>,
                      <a href="#visionos_application-entitlements">entitlements</a>, <a href="#visionos_application-entitlements_validation">entitlements_validation</a>, <a href="#visionos_application-executable_name">executable_name</a>, <a href="#visionos_application-exported_symbols_lists">exported_symbols_lists</a>,
@@ -62,6 +64,8 @@ Builds and bundles a visionOS Application.
 ## visionos_build_test
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_build_test")
+
 visionos_build_test(<a href="#visionos_build_test-name">name</a>, <a href="#visionos_build_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_build_test-platform_type">platform_type</a>, <a href="#visionos_build_test-targets">targets</a>)
 </pre>
 
@@ -96,6 +100,8 @@ visionos_build_test(
 ## visionos_dynamic_framework
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_dynamic_framework")
+
 visionos_dynamic_framework(<a href="#visionos_dynamic_framework-name">name</a>, <a href="#visionos_dynamic_framework-deps">deps</a>, <a href="#visionos_dynamic_framework-resources">resources</a>, <a href="#visionos_dynamic_framework-hdrs">hdrs</a>, <a href="#visionos_dynamic_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#visionos_dynamic_framework-base_bundle_id">base_bundle_id</a>,
                            <a href="#visionos_dynamic_framework-bundle_id">bundle_id</a>, <a href="#visionos_dynamic_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#visionos_dynamic_framework-bundle_name">bundle_name</a>, <a href="#visionos_dynamic_framework-bundle_only">bundle_only</a>, <a href="#visionos_dynamic_framework-codesign_inputs">codesign_inputs</a>,
                            <a href="#visionos_dynamic_framework-codesignopts">codesignopts</a>, <a href="#visionos_dynamic_framework-executable_name">executable_name</a>, <a href="#visionos_dynamic_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#visionos_dynamic_framework-extension_safe">extension_safe</a>,
@@ -145,6 +151,8 @@ Builds and bundles a visionos dynamic framework that is consumable by Xcode.
 ## visionos_framework
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_framework")
+
 visionos_framework(<a href="#visionos_framework-name">name</a>, <a href="#visionos_framework-deps">deps</a>, <a href="#visionos_framework-resources">resources</a>, <a href="#visionos_framework-hdrs">hdrs</a>, <a href="#visionos_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#visionos_framework-base_bundle_id">base_bundle_id</a>, <a href="#visionos_framework-bundle_id">bundle_id</a>,
                    <a href="#visionos_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#visionos_framework-bundle_name">bundle_name</a>, <a href="#visionos_framework-bundle_only">bundle_only</a>, <a href="#visionos_framework-codesign_inputs">codesign_inputs</a>, <a href="#visionos_framework-codesignopts">codesignopts</a>,
                    <a href="#visionos_framework-executable_name">executable_name</a>, <a href="#visionos_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#visionos_framework-extension_safe">extension_safe</a>, <a href="#visionos_framework-families">families</a>, <a href="#visionos_framework-frameworks">frameworks</a>,
@@ -195,6 +203,8 @@ To use this framework for your app and extensions, list it in the frameworks att
 ## visionos_static_framework
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_static_framework")
+
 visionos_static_framework(<a href="#visionos_static_framework-name">name</a>, <a href="#visionos_static_framework-deps">deps</a>, <a href="#visionos_static_framework-resources">resources</a>, <a href="#visionos_static_framework-hdrs">hdrs</a>, <a href="#visionos_static_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#visionos_static_framework-avoid_deps">avoid_deps</a>,
                           <a href="#visionos_static_framework-bundle_name">bundle_name</a>, <a href="#visionos_static_framework-codesign_inputs">codesign_inputs</a>, <a href="#visionos_static_framework-codesignopts">codesignopts</a>, <a href="#visionos_static_framework-exclude_resources">exclude_resources</a>,
                           <a href="#visionos_static_framework-executable_name">executable_name</a>, <a href="#visionos_static_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#visionos_static_framework-families">families</a>, <a href="#visionos_static_framework-ipa_post_processor">ipa_post_processor</a>,
@@ -274,6 +284,8 @@ i.e. `--features=-swift.no_generated_header`).
 ## visionos_ui_test
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_ui_test")
+
 visionos_ui_test(<a href="#visionos_ui_test-name">name</a>, <a href="#visionos_ui_test-deps">deps</a>, <a href="#visionos_ui_test-data">data</a>, <a href="#visionos_ui_test-bundle_name">bundle_name</a>, <a href="#visionos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#visionos_ui_test-env">env</a>, <a href="#visionos_ui_test-env_inherit">env_inherit</a>,
                  <a href="#visionos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#visionos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_ui_test-platform_type">platform_type</a>, <a href="#visionos_ui_test-runner">runner</a>,
                  <a href="#visionos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_ui_test-test_filter">test_filter</a>, <a href="#visionos_ui_test-test_host">test_host</a>, <a href="#visionos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -315,6 +327,8 @@ the attributes inherited by all test rules, please check the
 ## visionos_unit_test
 
 <pre>
+load("@rules_apple//apple:visionos.doc.bzl", "visionos_unit_test")
+
 visionos_unit_test(<a href="#visionos_unit_test-name">name</a>, <a href="#visionos_unit_test-deps">deps</a>, <a href="#visionos_unit_test-data">data</a>, <a href="#visionos_unit_test-bundle_name">bundle_name</a>, <a href="#visionos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#visionos_unit_test-env">env</a>, <a href="#visionos_unit_test-env_inherit">env_inherit</a>,
                    <a href="#visionos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#visionos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#visionos_unit_test-platform_type">platform_type</a>, <a href="#visionos_unit_test-runner">runner</a>,
                    <a href="#visionos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#visionos_unit_test-test_filter">test_filter</a>, <a href="#visionos_unit_test-test_host">test_host</a>, <a href="#visionos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)

--- a/doc/rules-watchos.md
+++ b/doc/rules-watchos.md
@@ -7,6 +7,8 @@
 ## watchos_application
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_application")
+
 watchos_application(<a href="#watchos_application-name">name</a>, <a href="#watchos_application-deps">deps</a>, <a href="#watchos_application-resources">resources</a>, <a href="#watchos_application-additional_linker_inputs">additional_linker_inputs</a>, <a href="#watchos_application-app_icons">app_icons</a>, <a href="#watchos_application-app_intents">app_intents</a>,
                     <a href="#watchos_application-bundle_id">bundle_id</a>, <a href="#watchos_application-bundle_id_suffix">bundle_id_suffix</a>, <a href="#watchos_application-bundle_name">bundle_name</a>, <a href="#watchos_application-codesign_inputs">codesign_inputs</a>, <a href="#watchos_application-codesignopts">codesignopts</a>,
                     <a href="#watchos_application-entitlements">entitlements</a>, <a href="#watchos_application-entitlements_validation">entitlements_validation</a>, <a href="#watchos_application-executable_name">executable_name</a>, <a href="#watchos_application-exported_symbols_lists">exported_symbols_lists</a>,
@@ -62,6 +64,8 @@ Builds and bundles a watchOS Application.
 ## watchos_build_test
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_build_test")
+
 watchos_build_test(<a href="#watchos_build_test-name">name</a>, <a href="#watchos_build_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_build_test-platform_type">platform_type</a>, <a href="#watchos_build_test-targets">targets</a>)
 </pre>
 
@@ -96,6 +100,8 @@ watchos_build_test(
 ## watchos_dynamic_framework
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_dynamic_framework")
+
 watchos_dynamic_framework(<a href="#watchos_dynamic_framework-name">name</a>, <a href="#watchos_dynamic_framework-deps">deps</a>, <a href="#watchos_dynamic_framework-resources">resources</a>, <a href="#watchos_dynamic_framework-hdrs">hdrs</a>, <a href="#watchos_dynamic_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#watchos_dynamic_framework-base_bundle_id">base_bundle_id</a>,
                           <a href="#watchos_dynamic_framework-bundle_id">bundle_id</a>, <a href="#watchos_dynamic_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#watchos_dynamic_framework-bundle_name">bundle_name</a>, <a href="#watchos_dynamic_framework-bundle_only">bundle_only</a>, <a href="#watchos_dynamic_framework-codesign_inputs">codesign_inputs</a>,
                           <a href="#watchos_dynamic_framework-codesignopts">codesignopts</a>, <a href="#watchos_dynamic_framework-executable_name">executable_name</a>, <a href="#watchos_dynamic_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#watchos_dynamic_framework-extension_safe">extension_safe</a>,
@@ -145,6 +151,8 @@ Builds and bundles a watchOS dynamic framework that is consumable by Xcode.
 ## watchos_extension
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_extension")
+
 watchos_extension(<a href="#watchos_extension-name">name</a>, <a href="#watchos_extension-deps">deps</a>, <a href="#watchos_extension-resources">resources</a>, <a href="#watchos_extension-additional_linker_inputs">additional_linker_inputs</a>, <a href="#watchos_extension-app_intents">app_intents</a>,
                   <a href="#watchos_extension-application_extension">application_extension</a>, <a href="#watchos_extension-bundle_id">bundle_id</a>, <a href="#watchos_extension-bundle_id_suffix">bundle_id_suffix</a>, <a href="#watchos_extension-bundle_name">bundle_name</a>, <a href="#watchos_extension-codesign_inputs">codesign_inputs</a>,
                   <a href="#watchos_extension-codesignopts">codesignopts</a>, <a href="#watchos_extension-entitlements">entitlements</a>, <a href="#watchos_extension-entitlements_validation">entitlements_validation</a>, <a href="#watchos_extension-executable_name">executable_name</a>,
@@ -198,6 +206,8 @@ Builds and bundles a watchOS Extension.
 ## watchos_framework
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_framework")
+
 watchos_framework(<a href="#watchos_framework-name">name</a>, <a href="#watchos_framework-deps">deps</a>, <a href="#watchos_framework-resources">resources</a>, <a href="#watchos_framework-hdrs">hdrs</a>, <a href="#watchos_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#watchos_framework-base_bundle_id">base_bundle_id</a>, <a href="#watchos_framework-bundle_id">bundle_id</a>,
                   <a href="#watchos_framework-bundle_id_suffix">bundle_id_suffix</a>, <a href="#watchos_framework-bundle_name">bundle_name</a>, <a href="#watchos_framework-bundle_only">bundle_only</a>, <a href="#watchos_framework-codesign_inputs">codesign_inputs</a>, <a href="#watchos_framework-codesignopts">codesignopts</a>,
                   <a href="#watchos_framework-executable_name">executable_name</a>, <a href="#watchos_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#watchos_framework-extension_safe">extension_safe</a>, <a href="#watchos_framework-families">families</a>, <a href="#watchos_framework-frameworks">frameworks</a>,
@@ -249,6 +259,8 @@ those `watchos_extension` rules.
 ## watchos_static_framework
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_static_framework")
+
 watchos_static_framework(<a href="#watchos_static_framework-name">name</a>, <a href="#watchos_static_framework-deps">deps</a>, <a href="#watchos_static_framework-resources">resources</a>, <a href="#watchos_static_framework-hdrs">hdrs</a>, <a href="#watchos_static_framework-additional_linker_inputs">additional_linker_inputs</a>, <a href="#watchos_static_framework-avoid_deps">avoid_deps</a>,
                          <a href="#watchos_static_framework-bundle_name">bundle_name</a>, <a href="#watchos_static_framework-codesign_inputs">codesign_inputs</a>, <a href="#watchos_static_framework-codesignopts">codesignopts</a>, <a href="#watchos_static_framework-exclude_resources">exclude_resources</a>,
                          <a href="#watchos_static_framework-executable_name">executable_name</a>, <a href="#watchos_static_framework-exported_symbols_lists">exported_symbols_lists</a>, <a href="#watchos_static_framework-families">families</a>, <a href="#watchos_static_framework-ipa_post_processor">ipa_post_processor</a>,
@@ -292,6 +304,8 @@ Builds and bundles a watchOS Static Framework.
 ## watchos_ui_test
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_ui_test")
+
 watchos_ui_test(<a href="#watchos_ui_test-name">name</a>, <a href="#watchos_ui_test-deps">deps</a>, <a href="#watchos_ui_test-data">data</a>, <a href="#watchos_ui_test-bundle_name">bundle_name</a>, <a href="#watchos_ui_test-collect_code_coverage">collect_code_coverage</a>, <a href="#watchos_ui_test-env">env</a>, <a href="#watchos_ui_test-env_inherit">env_inherit</a>,
                 <a href="#watchos_ui_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#watchos_ui_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_ui_test-platform_type">platform_type</a>, <a href="#watchos_ui_test-runner">runner</a>,
                 <a href="#watchos_ui_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_ui_test-test_filter">test_filter</a>, <a href="#watchos_ui_test-test_host">test_host</a>, <a href="#watchos_ui_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)
@@ -326,6 +340,8 @@ watchOS UI Test rule.
 ## watchos_unit_test
 
 <pre>
+load("@rules_apple//apple:watchos.doc.bzl", "watchos_unit_test")
+
 watchos_unit_test(<a href="#watchos_unit_test-name">name</a>, <a href="#watchos_unit_test-deps">deps</a>, <a href="#watchos_unit_test-data">data</a>, <a href="#watchos_unit_test-bundle_name">bundle_name</a>, <a href="#watchos_unit_test-collect_code_coverage">collect_code_coverage</a>, <a href="#watchos_unit_test-env">env</a>, <a href="#watchos_unit_test-env_inherit">env_inherit</a>,
                   <a href="#watchos_unit_test-minimum_deployment_os_version">minimum_deployment_os_version</a>, <a href="#watchos_unit_test-minimum_os_version">minimum_os_version</a>, <a href="#watchos_unit_test-platform_type">platform_type</a>, <a href="#watchos_unit_test-runner">runner</a>,
                   <a href="#watchos_unit_test-test_coverage_manifest">test_coverage_manifest</a>, <a href="#watchos_unit_test-test_filter">test_filter</a>, <a href="#watchos_unit_test-test_host">test_host</a>, <a href="#watchos_unit_test-test_host_is_bundle_loader">test_host_is_bundle_loader</a>)

--- a/doc/rules-xcarchive.md
+++ b/doc/rules-xcarchive.md
@@ -7,6 +7,8 @@ Rules for creating Xcode archives.
 ## xcarchive
 
 <pre>
+load("@rules_apple//apple:xcarchive.bzl", "xcarchive")
+
 xcarchive(<a href="#xcarchive-name">name</a>, <a href="#xcarchive-bundle">bundle</a>)
 </pre>
 

--- a/doc/rules-xctrunner.md
+++ b/doc/rules-xctrunner.md
@@ -8,6 +8,8 @@ platform and architectures as the given `tests` bundles.
 ## xctrunner
 
 <pre>
+load("@rules_apple//apple:xctrunner.bzl", "xctrunner")
+
 xctrunner(<a href="#xctrunner-name">name</a>, <a href="#xctrunner-tests">tests</a>, <a href="#xctrunner-verbose">verbose</a>)
 </pre>
 


### PR DESCRIPTION
- Bumped stardoc and removed overrides
- Bumped protobuf to a version without a transitive dependency on a version of aspect_bazel_lib that invoked --incompatible_use_toolchain_transition
- Bumped rules_cc to 0.1.2 to fix docs, corrected stardoc dep labels, updated docs