### PR TITLE
Simplify apple_metal_library

### DIFF
--- a/test/apple_metal_library_test.sh
+++ b/test/apple_metal_library_test.sh
@@ -37,6 +37,7 @@ apple_metal_library(
     name = "SampleMetal",
     hdrs = ["@build_bazel_rules_apple//test/testdata/resources:metal_hdrs"],
     srcs = ["@build_bazel_rules_apple//test/testdata/resources:metal_srcs"],
+    copts = ["-frecord-sources"]
 )
 
 objc_library(


### PR DESCRIPTION
Closes: https://github.com/bazelbuild/rules_apple/issues/2502

There is no need to generate an air file for each metal file.
Metal CLI can do it behind the scene (as per Apple's [docs](https://developer.apple.com/documentation/metal/generating-and-loading-a-metal-library-symbol-file?language=objc#Generate-a-Symbol-File-with-a-Single-Command)), so just one CLI call is sufficient to build entire metallib.
The new implementation a much simpler as well as makes it easier to pass additional flags (such as "generate debug symbols" as described in the original issue).