### PR TITLE
[doc] update docs to reflect bazel upstream changes

### DIFF
--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -402,7 +402,7 @@ ios_application(
 <pre>
 load("@rules_apple//apple:apple.bzl", "provisioning_profile_repository")
 
-provisioning_profile_repository(<a href="#provisioning_profile_repository-name">name</a>, <a href="#provisioning_profile_repository-fallback_profiles">fallback_profiles</a>, <a href="#provisioning_profile_repository-repo_mapping">repo_mapping</a>)
+provisioning_profile_repository(<a href="#provisioning_profile_repository-name">name</a>, <a href="#provisioning_profile_repository-fallback_profiles">fallback_profiles</a>)
 </pre>
 
 This rule declares an external repository for discovering locally installed
@@ -462,7 +462,6 @@ ios_application(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="provisioning_profile_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="provisioning_profile_repository-fallback_profiles"></a>fallback_profiles |  -   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="provisioning_profile_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`), it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 
 **ENVIRONMENT VARIABLES**
 


### PR DESCRIPTION
bazelbuild/bazel@02df95c1aa7d4be70fdf72d69356f0674d4a994d has removed repo_mapping from stardoc's data source, so it's no longer emitted to generated docs. This PR fixes CI to reflect. Note that running stardoc without using `last_green` Bazel produces different output, because of this change.
