### PR TITLE
Fix bugs with macOS test runner

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -euo pipefail
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
@@ -149,11 +151,12 @@ rm -rf "$result_bundle_path"
 
 test_exit_code=0
 readonly testlog="$TEST_TMP_DIR/test.log"
+
 # Run xcodebuild with the xctestrun file just created. If the test failed, this
 # command will return non-zero, which is enough to tell bazel that the test
 # failed.
 xcodebuild test-without-building \
-    -destination "platform=macOS" \
+    -destination "platform=macOS,variant=macos,arch=$(uname -m)" \
     -resultBundlePath "$result_bundle_path" \
     -xctestrun "$XCTESTRUN" \
     2>&1 | tee -i "$testlog" \


### PR DESCRIPTION
Fixes two major issues with the `macos_unit_test` runner

- Tests were always passing because:

```
xcodebuild <...> 2>&1 | tee -i "$testlog" \
    || test_exit_code=$?
```

Without `pipefail` means the exit code of the `xcodebuild` command is dropped. This meant as of https://github.com/bazelbuild/rules_apple/pull/2649 all `macos_unit_test` were always passing even when tests failed 🙈 

- Warning when running `xcodebuild`:

```
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64e, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:x86_64, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64e, variant:Mac Catalyst, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:x86_64, variant:Mac Catalyst, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64e, variant:DriverKit, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64, variant:DriverKit, id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64e, variant:Designed for [iPad,iPhone], id:00006031-001851843684001C, name:My Mac }
{ platform:macOS, arch:arm64, variant:Designed for [iPad,iPhone], id:00006031-001851843684001C, name:My Mac }
```

The fix here is to specify `variant=macos` and `arch` so that xcodebuild always picks the right destination.