### PR TITLE
use xctestrunner which works correctly with Xcode 16.3 and newer

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -142,9 +142,9 @@ def apple_rules_dependencies(ignore_version_differences = False, include_bzlmod_
         http_archive,
         name = "xctestrunner",
         urls = [
-            "https://github.com/google/xctestrunner/archive/8710f141dfb0a3efe2744f865f914783259c24b0.tar.gz",
+            "https://github.com/DoDoENT/xctestrunner/archive/5f53db6acbc094635d1a9468cf16af089246226a.tar.gz",
         ],
-        strip_prefix = "xctestrunner-8710f141dfb0a3efe2744f865f914783259c24b0",
-        sha256 = "34d3b9bcb3dcb5b2a0bf2cd4be58c03f6a0f0eb4329f87cd758461aeb00e9326",
+        strip_prefix = "xctestrunner-5f53db6acbc094635d1a9468cf16af089246226a",
+        sha256 = "81dc9e12ee22d1be8f2be81848d2d0dad85cc0c19da238011677bfb94ad6bed7",
         ignore_version_differences = ignore_version_differences,
     )


### PR DESCRIPTION
This commit fixes [the issue](https://github.com/bazelbuild/rules_apple/issues/1215#issuecomment-3103193605) I encountered when attempting to run iOS unit tests on a real device using Xcode 16.3 or newer.

Note: I updated the `xctestrunner` dependency to point to [my fork](https://github.com/DoDoENT/xctestrunner/tree/master) that contains the fix. I've also opened a [pull request](https://github.com/google/xctestrunner/pull/71) in the xctestrunner project, which we'll probably want to merge prior to updating the URL in this PR and merging it.