### PR TITLE
Fix an unexpected duplicated instance of the SwiftSupport libraries for app clip targets.

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -755,7 +755,6 @@ def _ios_app_clip_impl(ctx):
             bundle_dylibs = True,
             dependency_targets = embeddable_targets,
             label_name = label.name,
-            package_swift_support_if_needed = True,
             platform_prerequisites = platform_prerequisites,
         ),
     ]

--- a/test/starlark_tests/ios_app_clip_tests.bzl
+++ b/test/starlark_tests/ios_app_clip_tests.bzl
@@ -160,6 +160,22 @@ def ios_app_clip_test_suite(name):
         tags = [name],
     )
 
+    # Verify that Swift dylibs are packaged with the application, when the application uses Swift.
+    archive_contents_test(
+        name = "{}_device_swift_dylibs_present".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_app_clip_with_swift_support",
+        contains = [
+            "$ARCHIVE_ROOT/SwiftSupport/iphoneos/libswift_Concurrency.dylib",
+            "$BUNDLE_ROOT/AppClips/app_clip_with_swift_support.app/Frameworks/libswift_Concurrency.dylib",
+            "$BUNDLE_ROOT/Frameworks/libswift_Concurrency.dylib",
+        ],
+        not_contains = [
+            "$BUNDLE_ROOT/AppClips/SwiftSupport/iphoneos/libswift_Concurrency.dylib",
+        ],
+        tags = [name],
+    )
+
     # Test dSYM binaries and linkmaps from framework embedded via 'data' are propagated correctly
     # at the top-level ios_extension rule, and present through the 'dsysms' and 'linkmaps' output
     # groups.

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1057,6 +1057,39 @@ ios_app_clip(
     ],
 )
 
+ios_application(
+    name = "app_with_app_clip_with_swift_support",
+    app_clips = [":app_clip_with_swift_support"],
+    bundle_id = "com.google.example",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.appclip_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_concurrency_main_lib",
+    ],
+)
+
+ios_app_clip(
+    name = "app_clip_with_swift_support",
+    bundle_id = "com.google.example.clip",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.appclip_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_concurrency_main_lib",
+    ],
+)
+
 # ---------------------------------------------------------------------------------------
 
 ios_application(


### PR DESCRIPTION
This applies for cases where deployment target is below iOS 15.

Cherry pick: [adf76def7810198cc240b3d15c6cb1a98bdad402](https://github.com/bazelbuild/rules_apple/commit/adf76def7810198cc240b3d15c6cb1a98bdad402)