### PR TITLE
Support xcarchive on MacOS

### DIFF
--- a/tools/xcarchivetool/make_xcarchive.py
+++ b/tools/xcarchivetool/make_xcarchive.py
@@ -130,7 +130,7 @@ def _main(
 
   # If is an .ipa, extract and copy .app to destination
   # Else Copy the archive contents to the destination.
-  if bundle_path.suffix == ".ipa":
+  if bundle_path.suffix in [".ipa", ".zip"]:
     _extract_app_from_ipa(bundle_path, bundle_dest_path)
   else:
     shutil.copytree(bundle_path, bundle_dest_path,


### PR DESCRIPTION
Resolves issue on zipped ".app" targets for MacOS, and resolves issue:
`
ERROR: /Users/marek/source-code/ledger/BUILD:11:18: XCArchive ledger/Ledger.xcarchive failed: (Exit 1): make_xcarchive failed: error executing XCArchive command (from target //ledger:archive) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_apple+/tools/xcarchivetool/make_xcarchive --info_plist ... (remaining 5 arguments skipped)
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_marek/2449a56c93ddd6c135146dab9dca5580/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_apple+/tools/xcarchivetool/make_xcarchive.runfiles/_main/../rules_apple+/tools/xcarchivetool/make_xcarchive.py", line 193, in <module>
    _main(
  File "/private/var/tmp/_bazel_marek/2449a56c93ddd6c135146dab9dca5580/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_apple+/tools/xcarchivetool/make_xcarchive.runfiles/_main/../rules_apple+/tools/xcarchivetool/make_xcarchive.py", line 140, in _main
    shutil.copytree(
  File "/private/var/tmp/_bazel_marek/2449a56c93ddd6c135146dab9dca5580/external/rules_python++python+python_3_11_aarch64-apple-darwin/lib/python3.11/shutil.py", line 571, in copytree
    with os.scandir(src) as itr:
         ^^^^^^^^^^^^^^^
NotADirectoryError: [Errno 20] Not a directory: 'bazel-out/darwin_arm64-fastbuild-macos-arm64-min14.0-applebin_macos-ST-a610dfc02e27/bin/ledger/ledger.zip'
`