### PR TITLE
fix: Relax exec_compatible_with requirement on dtrace rules.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,3 +36,5 @@ use_repo(provisioning_profile_repository, "local_provisioning_profiles")
 
 apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
+
+register_toolchains("//apple:dtrace_toolchain")

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -1,7 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//apple/internal/aspects:resource_aspect_hint.bzl", "apple_resource_hint", "apple_resource_hint_action")
 load(":cc_toolchain_forwarder.bzl", "cc_toolchain_forwarder")
-load(":dtrace.bzl", "dtrace_wrapper")
+load(":dtrace.bzl", "dtrace_toolchain")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -349,9 +349,21 @@ apple_resource_hint(
     action = apple_resource_hint_action.suppress,
 )
 
-dtrace_wrapper(
-    name = "dtrace_wrapper",
-    target_compatible_with = [
+toolchain_type(
+    name = "dtrace_toolchain_type",
+)
+
+dtrace_toolchain(
+    name = "dtrace_toolchain_impl",
+    # If no label specified the system dtrace binary is used.
+    dtrace = None,
+)
+
+toolchain(
+    name = "dtrace_toolchain",
+    exec_compatible_with = [
         "@platforms//os:macos",
     ],
+    toolchain = ":dtrace_toolchain_impl",
+    toolchain_type = ":dtrace_toolchain_type",
 )

--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -33,6 +33,27 @@ load(
     "bundle_paths",
 )
 
+def _dtrace_toolchain_impl(ctx):
+    """Implementation for dtrace_toolchain."""
+    return [
+        platform_common.ToolchainInfo(
+            dtrace_executable = ctx.executable.dtrace or "/usr/sbin/dtrace",
+        ),
+    ]
+
+dtrace_toolchain = rule(
+    implementation = _dtrace_toolchain_impl,
+    attrs = {
+        "dtrace": attr.label(
+            doc = "dtrace binary to use. If not set /usr/sbin/dtrace is used.",
+            mandatory = False,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    doc = "Defines a toolchain for dtrace_compile rules.",
+)
+
 def _dtrace_compile_impl(ctx):
     """Implementation for dtrace_compile."""
     apple_fragment = ctx.fragments.apple
@@ -41,7 +62,9 @@ def _dtrace_compile_impl(ctx):
     output_hdrs = []
     include_dir = None
 
-    dtrace = ctx.executable.dtrace
+    # Get dtrace executable from toolchain
+    dtrace_toolchain = ctx.toolchains["//apple:dtrace_toolchain_type"]
+    dtrace = dtrace_toolchain.dtrace_executable
 
     for src in ctx.files.srcs:
         owner_relative_path = bundle_paths.owner_relative_path(src)
@@ -81,19 +104,13 @@ def _dtrace_compile_impl(ctx):
 dtrace_compile = rule(
     implementation = _dtrace_compile_impl,
     attrs = dicts.add(apple_support.action_required_attrs(), {
-        "dtrace": attr.label(
-            doc = "dtrace binary to use.",
-            mandatory = False,
-            executable = True,
-            cfg = "exec",
-            default = "//apple:dtrace_wrapper",
-        ),
         "srcs": attr.label_list(
             allow_files = [".d"],
             allow_empty = False,
             doc = "dtrace(.d) source files to be compiled.",
         ),
     }),
+    toolchains = ["//apple:dtrace_toolchain_type"],
     fragments = ["apple"],
     doc = """
 Compiles
@@ -111,16 +128,4 @@ structure. For example with a directory structure of
 and a target named `dtrace_gen` the header path would be
 `<GENFILES>/dtrace_gen/foo/bar.h`.
 """,
-)
-
-def _dtrace_wrapper_impl(ctx):
-    dtrace_wrapper = ctx.actions.declare_file("%s.sh" % ctx.label.name)
-    contents = """#!/bin/bash
-exec /usr/sbin/dtrace "$@"
-"""
-    ctx.actions.write(dtrace_wrapper, contents, is_executable = True)
-    return [DefaultInfo(files = depset([dtrace_wrapper]), executable = dtrace_wrapper)]
-
-dtrace_wrapper = rule(
-    implementation = _dtrace_wrapper_impl,
 )


### PR DESCRIPTION
In #2661 the `exec_compatible_with` was added. This breaks some of our Linux-based tests where we use systemtap dtrace. I was hoping we could move the constraint onto the tool itself (that way we can supply one that's Linux-compatible and things keep working).`target_compatible_with` works for my usecase, but it's not exactly the same as the previous solution. @brentleyjones, could you have a look and let me know if this works for you?