### PR TITLE
Make app intents metadata processor output deterministic

### DIFF
--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -120,7 +120,7 @@ temporary_actionsdata_file={output_dir}/extract_sorted.actionsdata
 # Set write permission to allow rewrite extract.actionsdata
 chmod -R +w {output_dir}
 # Write extract.actionsdata with sorted keys
-/usr/bin/python3 -m json.tool --compact --sort-keys "$original_actionsdata_file" > "$temporary_actionsdata_file"
+"$DEVELOPER_DIR/usr/bin/python3" -m json.tool --compact --sort-keys "$original_actionsdata_file" > "$temporary_actionsdata_file"
 # Remove the original unsorted extract.actionsdata file
 rm "$original_actionsdata_file"
 # Rename the sorted file to the original name


### PR DESCRIPTION
We noticed that `xcrun appintentsmetadataprocessor` produces non-deterministic `Metadata.appintents/extract.actionsdata` JSON outputs (unstable json key order) resulting in different hashes for extract.actionsdata  when building the same target on different machines.
```
Tree Digest: root:  {
  files:  {
    name:  "extract.actionsdata"
    digest:  {
      hash:  "1a5948b0129723785ddccd42ec3e6f0315d43dbb77db291c890cf314b0f42b1b"
      size_bytes:  2981
    }
    is_executable:  true
  }
```
```
Tree Digest: root:  {
  files:  {
    name:  "extract.actionsdata"
    digest:  {
      hash:  "278dbe486ed21bebe61a5fef6dab2be05ba5fae588d7b330eb0200b8300e23e9"
      size_bytes:  2981
    }
    is_executable:  true
  }
```

**Changes**
Sort the keys of `Metadata.appintents/extract.actionsdata` directory tree output using `/usr/bin/python3 -m json.tool` to make it deterministic.

Fixes https://github.com/bazelbuild/rules_apple/issues/2760
