### PR TITLE
transform XCTRunner.app Info.plist to xml before sed'ing it

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -216,13 +216,16 @@ if [[ -n "$test_host_path" ]]; then
     fi
     xcrun_test_bundle_path="__TESTHOST__/PlugIns/$test_bundle_name.xctest"
 
+    runner_app_infoplist="$runner_app_destination/Info.plist"
+    /usr/bin/plutil -convert xml1 "$runner_app_infoplist"
     /usr/bin/sed \
       -e "s@\$(WRAPPEDPRODUCTNAME)@XCTRunner@g"\
       -e "s@WRAPPEDPRODUCTNAME@XCTRunner@g"\
       -e "s@\$(WRAPPEDPRODUCTBUNDLEIDENTIFIER)@$xcrun_test_host_bundle_identifier@g"\
       -e "s@WRAPPEDPRODUCTBUNDLEIDENTIFIER@$xcrun_test_host_bundle_identifier@g"\
       -i "" \
-      "$runner_app_destination/Info.plist"
+      "$runner_app_infoplist"
+    /usr/bin/plutil -convert binary1 "$runner_app_infoplist"
 
     readonly runner_app_frameworks_destination="$runner_app_destination/Frameworks"
     mkdir -p "$runner_app_frameworks_destination"


### PR DESCRIPTION
Handle the new case in Xcode 26 where the Info.plist in the XCTRunner.app is a binary plist, rather than an XML plist in Xcode 16. Coercing the plist to xml works whether or not it is originally a plist, and Xcode 16 handles the case of a binary plist adequately.

Also willing to rework this to do keypath-based substitution instead of using sed, though the sed approach has definitely proven resilient up to now. 