### PR TITLE
environment_plist: lower the entire --platform string

### DIFF
--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -70,7 +70,7 @@ def _environment_plist_impl(ctx):
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = [
             "--platform",
-            platform.name_in_plist.lower() + str(sdk_version),
+            (platform.name_in_plist + str(sdk_version)).lower(),
             "--output",
             ctx.outputs.plist.path,
         ],


### PR DESCRIPTION
The `xcrun --sdk` argument expects only lowercase letters and numbers. SDK version is usually just numbers, but in the exceptional case where it also has letters, we need to .lower() the entire string that we pass, and not just the platform name. We're slightly modifying `_environment_plist_impl()` in that commit to support that use-case.