### PR TITLE
Add `BAZEL_SIMCTL_LAUNCH_FLAGS` and `BAZEL_DEVICECTL_LAUNCH_FLAGS` env variable options

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -39,6 +39,7 @@ import os.path
 import pathlib
 import platform
 import plistlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -407,6 +408,13 @@ def run_app(
         check=True
     )
     app_bundle_id = bundle_id(app_path)
+    launch_args = shlex.split(
+      os.environ.get(
+        "BAZEL_DEVICECTL_LAUNCH_FLAGS",
+        # Attaches the application to the console and waits for it to exit.
+        "--console",
+      ),
+    )
     logger.info(
         "Launching app %s on %s", app_bundle_id, device_identifier
     )
@@ -415,7 +423,7 @@ def run_app(
         "device",
         "process",
         "launch",
-        "--console",  # Attaches the application to the console and waits for it to exit.
+        *launch_args,
         "--device",
         device_identifier,
         app_bundle_id,

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -52,6 +52,7 @@ import os.path
 import pathlib
 import platform
 import plistlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -681,13 +682,20 @@ def run_app_in_simulator(
         [simctl_path, "install", simulator_udid, app_path], check=True
     )
     app_bundle_id = bundle_id(app_path)
+    launch_args = shlex.split(
+      os.environ.get(
+        "BAZEL_SIMCTL_LAUNCH_FLAGS",
+        # Attaches the application to the console and waits for it to exit.
+        "--console-pty",
+      ),
+    )
     logger.info(
         "Launching app %s in simulator %s", app_bundle_id, simulator_udid
     )
     args = [
         simctl_path,
         "launch",
-        "--console-pty",
+        *launch_args,
         simulator_udid,
         app_bundle_id,
     ]


### PR DESCRIPTION
Setting these allows you to adjust the launch flags for `bazel run` of simulator and device applications respectively, e.g. setting `--wait-for-debugger`. They default to `--console-pty` and `--console` to keep existing behavior.