### PR TITLE
Allow using `@rules_apple//apple/build_settings:ios_device` with running on simulator

### DIFF
--- a/apple/build_settings/build_settings.bzl
+++ b/apple/build_settings/build_settings.bzl
@@ -42,7 +42,9 @@ Enables Bazel's tree artifacts for Apple bundle rules (instead of archives).
         doc = """
 The identifier, ECID, serial number, UDID, user-provided name, or DNS name
 of the device for running an iOS application.
-You can get a list of devices by running 'xcrun devicectl list devices`.
+
+You can get a list of devices by running `xcrun devicectl list devices` (for
+physical devices) or `xcrun simctl list devices` (for simulators).
 """,
         default = "",
     ),

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -496,6 +496,9 @@ def _ios_application_impl(ctx):
             rule_descriptor = rule_descriptor,
             runner_template = ctx.file._simulator_runner_template,
             simulator_device = ctx.fragments.objc.ios_simulator_device,
+            simulator_identifier = (
+                apple_xplat_toolchain_info.build_settings.ios_device
+            ),
             simulator_version = ctx.fragments.objc.ios_simulator_version,
         )
 

--- a/apple/internal/run_support.bzl
+++ b/apple/internal/run_support.bzl
@@ -31,6 +31,7 @@ def _register_simulator_executable(
         rule_descriptor,
         runner_template,
         simulator_device = None,
+        simulator_identifier = None,
         simulator_version = None):
     """Registers an action that runs the bundled app in the iOS simulator.
 
@@ -45,10 +46,12 @@ def _register_simulator_executable(
       rule_descriptor: The rule descriptor for the given rule.
       runner_template: The simulator runner template as a `File`.
       simulator_device: The type of device (e.g. 'iPhone 6') to use when running on the simulator.
+      simulator_identifier: The identifier of the simulator (<uuid>).
       simulator_version: The SDK version of the simulator to use when running on the simulator.
     """
 
     sim_device = str(simulator_device or "")
+    sim_identifier = str(simulator_identifier or "")
     sim_os_version = str(simulator_version or "")
     minimum_os = str(platform_prerequisites.minimum_os)
     platform_type = str(platform_prerequisites.platform_type)
@@ -72,6 +75,7 @@ def _register_simulator_executable(
             "%minimum_os%": minimum_os,
             "%platform_type%": platform_type,
             "%sim_device%": sim_device,
+            "%sim_identifier%": sim_identifier,
             "%sim_os_version%": sim_os_version,
         },
     )


### PR DESCRIPTION
Sometimes it’s nice to target a specific simulator.