### PR TITLE
Remove obsolete "xcrun simctl" cmds from presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,17 +4,6 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   common: &common
     platform: macos_arm64
-    shell_commands:
-    - xcrun simctl runtime list
-    - xcrun simctl runtime delete 22D8075 || true
-    - xcrun simctl runtime delete 21F79 || true
-    - xcrun simctl runtime list
-    - xcrun simctl runtime match list
-    - xcrun simctl runtime match set xros2.2 22N895
-    - xcrun simctl runtime match list
-    post_shell_commands:
-    - xcrun simctl runtime match set xros2.2 --default
-    - xcrun simctl runtime match list
     build_targets:
     - "tools/..."
     - "test/..."


### PR DESCRIPTION
We've upgraded all CI workers from Xcode 16.2 to 16.4.