### PR TITLE
Stop xctrunnertool from silencing exceptions

### DIFF
--- a/tools/xctrunnertool/lib/logger.py
+++ b/tools/xctrunnertool/lib/logger.py
@@ -2,28 +2,7 @@
 
 import logging
 import os
-import sys
 from lib.model import Configuration
-
-
-class StreamToLogger(object):
-    """
-    Fake file-like stream object that redirects writes to a logger instance.
-    """
-
-    def __init__(self, logger, level):
-        self.logger = logger
-        self.level = level
-        self.linebuf = ""
-
-    def write(self, buf):
-        "Writes to file"
-        for line in buf.rstrip().splitlines():
-            self.logger.log(self.level, line.rstrip())
-
-    def flush(self):
-        "Flushes IO buffer"
-        pass
 
 
 class Logger:
@@ -52,6 +31,4 @@ class Logger:
 
     def get(self, name: str) -> logging.Logger:
         "Returns logger with the given name."
-        log = logging.getLogger(name)
-        sys.stderr = StreamToLogger(log, logging.ERROR)
-        return log
+        return logging.getLogger(name)


### PR DESCRIPTION
If there is noise from this tool we can silence individual spots, but
this ate all output which makes it harder to debug.
