### PR TITLE
Fix `apple_precompiled_resource_bundle` for recent changes

### DIFF
--- a/apple/internal/resources.bzl
+++ b/apple/internal/resources.bzl
@@ -526,7 +526,7 @@ def _process_bucketized_data(
 
             # Store each origin as a tuple in an array, to keep this knowledge as a low-memory
             # reference within a depset.
-            for processed_resource, processed_origin in result.processed_origins.items():
+            for processed_resource, processed_origin in getattr(result, "processed_origins", {}).items():
                 processed_origins.append((processed_resource, tuple(processed_origin)))
 
             processed_field = {}


### PR DESCRIPTION
Not adding a test because https://github.com/bazelbuild/rules_apple/pull/2659 will cause this path to be hit.