### PR TITLE
Make `//test:ios_coverage_test` run exclusively

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -207,6 +207,7 @@ apple_shell_test(
     name = "ios_coverage_test",
     size = "large",
     src = "ios_coverage_test.sh",
+    tags = ["exclusive"],
 )
 
 apple_shell_test(


### PR DESCRIPTION
Run this test exclusively, because it runs a handful of tests under instrumentation (including an `ios_ui_test`). 