### PR TITLE
Fix `COVERAGE` check

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -558,7 +558,7 @@ else
     2>&1 | tee -i "$testlog" || test_exit_code=$?
 fi
 
-if [[ "${COVERAGE:-}" -eq 1 || "${APPLE_COVERAGE:-}" -eq 1 ]]; then
+if [[ "${COVERAGE:-}" -eq 1 && "${APPLE_COVERAGE:-}" -eq 1 ]]; then
   profdata="$test_tmp_dir/$simulator_id/Coverage.profdata"
   if [[ "$should_use_xcodebuild" == false ]]; then
     profdata="$test_tmp_dir/coverage.profdata"


### PR DESCRIPTION
```
if [[ "${COVERAGE:-}" -ne 1 || "${APPLE_COVERAGE:-}" -ne 1 ]]; then
```

wasn’t properly changed. Applying De Morgan's laws means we needed to change the `||` to `&&`.