### PR TITLE
Move `COLLECT_PROFDATA` check back outside of `COVERAGE` check

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -558,16 +558,16 @@ else
     2>&1 | tee -i "$testlog" || test_exit_code=$?
 fi
 
+profdata="$test_tmp_dir/$simulator_id/Coverage.profdata"
+if [[ "$should_use_xcodebuild" == false ]]; then
+  profdata="$test_tmp_dir/coverage.profdata"
+fi
+
+if [[ "${COLLECT_PROFDATA:-0}" == "1" && -f "$profdata" ]]; then
+  cp -R "$profdata" "$TEST_UNDECLARED_OUTPUTS_DIR"
+fi
+
 if [[ "${COVERAGE:-}" -eq 1 && "${APPLE_COVERAGE:-}" -eq 1 ]]; then
-  profdata="$test_tmp_dir/$simulator_id/Coverage.profdata"
-  if [[ "$should_use_xcodebuild" == false ]]; then
-    profdata="$test_tmp_dir/coverage.profdata"
-  fi
-
-  if [[ "${COLLECT_PROFDATA:-0}" == "1" && -f "$profdata" ]]; then
-    cp -R "$profdata" "$TEST_UNDECLARED_OUTPUTS_DIR"
-  fi
-
   if [[ "$should_use_xcodebuild" == false ]]; then
     xcrun llvm-profdata merge "$profraw" --output "$profdata"
   fi


### PR DESCRIPTION
It was originally added as a way to collect coverage data regardless of `bazel coverage` usage. Regressed with d20fc447e7ce5278780d52b75bf7c5b43d19a0ff.