### PR TITLE
Drop `rolling` bazel version from the BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  bazel: ["7.x", "rolling"]
+  bazel: ["7.x", "8.x"]
 
 tasks:
   verify_targets:


### PR DESCRIPTION
`rules_apple` no longer works on rolling releases so we reflect that in the `./.bcr/pre-submit.yaml` so that we no longer manually require pushing to the branch on BCR like @keith needed to in https://github.com/bazelbuild/bazel-central-registry/pull/6579