### PR TITLE
Ensure the app bundle is writable before signing an app bundle "in place" in dossier codesigning.

### DIFF
--- a/tools/dossier_codesigningtool/dossier_codesigning_reader.py
+++ b/tools/dossier_codesigningtool/dossier_codesigning_reader.py
@@ -1081,6 +1081,8 @@ def _sign_bundle(parsed_args):
               '--output_artifact support for app bundles has not yet been'
               ' implemented!'
           )
+        # Ensure that the app bundle is writable before we attempt to sign it.
+        subprocess.check_call(['chmod', '-R', 'u+w', input_fullpath])
         manifest = read_manifest_from_dossier(dossier_directory.path)
         _sign_bundle_with_manifest(input_fullpath, manifest,
                                    dossier_directory.path, codesign_path,


### PR DESCRIPTION
PiperOrigin-RevId: 566315443
(cherry picked from commit c4cbd826827a38d13ae54a44e30eb68683a476dc)