### PR TITLE
Don't set the Apple Configuration Distinguisher. This is not necessary, and it is a no-op now.

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -246,11 +246,11 @@ def _command_line_options(
     default_platforms = [settings[_CPU_TO_DEFAULT_PLATFORM_FLAG[cpu]]] if _is_bazel_7 else []
     return {
         build_settings_labels.use_tree_artifacts_outputs: force_bundle_outputs if force_bundle_outputs else settings[build_settings_labels.use_tree_artifacts_outputs],
-        "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,
         "//command_line_option:apple_platform_type": platform_type,
         "//command_line_option:apple_platforms": apple_platforms,
-        # `apple_split_cpu` is used by the Bazel Apple configuration distinguisher to distinguish
-        # architecture and environment, therefore we set `environment_arch` when it is available.
+        # apple_split_cpu is still needed for Bazel built-in objc_library transition logic and Apple
+        # fragment APIs, and it's also required to keep Bazel from optimizing away splits when deps
+        # are identical between platforms.
         "//command_line_option:apple_split_cpu": environment_arch if environment_arch else "",
         "//command_line_option:compiler": None,
         "//command_line_option:cpu": cpu,
@@ -397,7 +397,6 @@ _apple_platform_transition_inputs = _apple_platforms_rule_base_transition_inputs
 ]
 _apple_rule_base_transition_outputs = [
     build_settings_labels.use_tree_artifacts_outputs,
-    "//command_line_option:apple configuration distinguisher",
     "//command_line_option:apple_platform_type",
     "//command_line_option:apple_platforms",
     "//command_line_option:apple_split_cpu",


### PR DESCRIPTION
PiperOrigin-RevId: 585665894
(cherry picked from commit 4d950051e1ca463d0e7cd0513c34404b345b424a)