### PR TITLE
Cover `tvos` and `visionos` icon processing with tests for bazel 7

### DIFF
--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -673,6 +673,15 @@ def tvos_application_test_suite(name):
         tags = [name],
     )
 
+    # Test that tvOS apps include the --app-icon argument in actool command.
+    analysis_target_actions_test(
+        name = "{}_includes_app_icon_in_actool_command".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        target_mnemonic = "AssetCatalogCompile",
+        expected_argv = ["--app-icon TVBrandAssets"],
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/visionos_application_tests.bzl
+++ b/test/starlark_tests/visionos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "analysis_output_group_info_files_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "analysis_target_actions_test",
+)
+load(
     "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
     "analysis_target_outputs_test",
 )
@@ -324,6 +328,15 @@ def visionos_application_test_suite(name):
         tags = [
             name,
         ],
+    )
+
+    # Test that visionOS apps include the --app-icon argument in actool command.
+    analysis_target_actions_test(
+        name = "{}_includes_app_icon_in_actool_command".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/visionos:app",
+        target_mnemonic = "AssetCatalogCompile",
+        expected_argv = ["--app-icon AppIcon"],
+        tags = [name],
     )
 
     # TODO(b/288582842): Support an IPA output via this output group. This will require some changes


### PR DESCRIPTION
Regressed in https://github.com/bazelbuild/rules_apple/pull/2804 and fixed in https://github.com/bazelbuild/rules_apple/pull/2841.

This affects only bazel 7 users as the comparison succeeds on bazel 8+.