### PR TITLE
Update rules_apple to use the the new `swift_common` toolchain APIs.

### DIFF
--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -562,7 +562,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
 
     if "apple._import_framework_via_swiftinterface" in features and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
-        swift_toolchain = swift_common.get_toolchain(ctx)
+        swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
@@ -571,7 +571,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
                 disabled_features = disabled_features,
                 features = features,
                 module_name = xcframework.bundle_name,
-                swift_toolchain = swift_toolchain,
+                swift_toolchains = swift_toolchains,
                 swiftinterface_file = xcframework_library.swift_module_interface,
             ),
         )
@@ -639,7 +639,7 @@ def _apple_static_xcframework_import_impl(ctx):
     if xcframework.files_by_category.swift_interface_imports or \
        xcframework.files_by_category.swift_module_imports or \
        has_swift:
-        swift_toolchain = swift_common.get_toolchain(ctx)
+        swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(SwiftUsageInfo())
 
         # The Swift toolchain propagates Swift-specific linker flags (e.g.,
@@ -647,11 +647,11 @@ def _apple_static_xcframework_import_impl(ctx):
         # rare case that a binary has a Swift framework import dependency but
         # no other Swift dependencies, make sure we pick those up so that it
         # links to the standard libraries correctly.
-        additional_cc_infos.extend(swift_toolchain.implicit_deps_providers.cc_infos)
+        additional_cc_infos.extend(swift_toolchains.swift.implicit_deps_providers.cc_infos)
 
         # TODO: remove this once rules_swift 3+ is required
-        if hasattr(swift_toolchain.implicit_deps_providers, "objc_infos"):
-            additional_objc_providers.extend(swift_toolchain.implicit_deps_providers.objc_infos)
+        if hasattr(swift_toolchains.swift.implicit_deps_providers, "objc_infos"):
+            additional_objc_providers.extend(swift_toolchains.swift.implicit_deps_providers.objc_infos)
 
     # Create Objc provider
     additional_objc_providers.extend([
@@ -696,7 +696,7 @@ def _apple_static_xcframework_import_impl(ctx):
 
     if "apple._import_framework_via_swiftinterface" in features and xcframework_library.swift_module_interface:
         # Create SwiftInfo provider
-        swift_toolchain = swift_common.get_toolchain(ctx)
+        swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
@@ -705,7 +705,7 @@ def _apple_static_xcframework_import_impl(ctx):
                 disabled_features = disabled_features,
                 features = features,
                 module_name = xcframework.bundle_name,
-                swift_toolchain = swift_toolchain,
+                swift_toolchains = swift_toolchains,
                 swiftinterface_file = xcframework_library.swift_module_interface,
             ),
         )
@@ -797,7 +797,7 @@ Unnecssary and ignored, will be removed in the future.
         CcInfo,
         AppleDynamicFrameworkInfo,
     ],
-    toolchains = swift_common.use_toolchain() + use_cpp_toolchain(),
+    toolchains = swift_common.use_all_toolchains() + use_cpp_toolchain(),
 )
 
 apple_static_xcframework_import = rule(
@@ -927,5 +927,5 @@ Unnecssary and ignored, will be removed in the future.
         },
     ),
     fragments = ["apple", "cpp", "objc"],
-    toolchains = swift_common.use_toolchain() + use_cpp_toolchain(),
+    toolchains = swift_common.use_all_toolchains() + use_cpp_toolchain(),
 )

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -465,7 +465,7 @@ def _swift_info_from_module_interface(
         disabled_features,
         features,
         module_name,
-        swift_toolchain,
+        swift_toolchains,
         swiftinterface_file):
     """Returns SwiftInfo provider for a pre-compiled Swift module compiling it's interface file.
 
@@ -477,7 +477,7 @@ def _swift_info_from_module_interface(
         disabled_features: List of features to be disabled for cc_common.compile
         features: List of features to be enabled for cc_common.compile.
         module_name: Swift module name.
-        swift_toolchain: SwiftToolchainInfo provider for current target.
+        swift_toolchains: A struct containing the SwiftToolchainInfo and CcToolchainInfo provider for current target.
         swiftinterface_file: `.swiftinterface` File to compile.
     Returns:
         A SwiftInfo provider.
@@ -492,14 +492,14 @@ def _swift_info_from_module_interface(
         ],
         feature_configuration = swift_common.configure_features(
             ctx = ctx,
-            swift_toolchain = swift_toolchain,
+            toolchains = swift_toolchains,
             requested_features = features,
             unsupported_features = disabled_features,
         ),
         module_name = module_name,
         swiftinterface_file = swiftinterface_file,
         swift_infos = swift_infos,
-        swift_toolchain = swift_toolchain,
+        toolchains = swift_toolchains,
         target_name = ctx.label.name,
     )
 


### PR DESCRIPTION
Also remove the explicit execution group and the workaround that disabled auto-exec-groups, because the underlying problem with the Swift rules has been fixed.

Note: Even though `swift_toolchain.use_all_toolchains()` also requests the C++ toolchain, adding `use_cpp_toolchain()` to that is fine; the duplication is harmless. This lets us express more explicitly "the rule depends on the Swift (and C++) toolchains, but it also uses the C++ toolchain for other things". PiperOrigin-RevId: 755951150
(cherry picked from commit 3da7b31bcb8c4190f13adce9ef289ee0ff923979)