### PR TITLE
Add `@loader_path/Frameworks` rpath when building dynamic xcframeworks

### DIFF
--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -596,6 +596,7 @@ def _apple_xcframework_impl(ctx):
             # executables. Only macOS (which is not yet supported) is an outlier; this will require
             # changes to native Bazel linking logic for Apple binary targets.
             "-Wl,-rpath,@executable_path/Frameworks",
+            "-Wl,-rpath,@loader_path/Frameworks",
             "-dynamiclib",
             "-Wl,-install_name,@rpath/{name}{extension}/{name}".format(
                 extension = nested_bundle_extension,

--- a/test/starlark_tests/apple_xcframework_tests.bzl
+++ b/test/starlark_tests/apple_xcframework_tests.bzl
@@ -143,6 +143,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/ios_dynamic_xcframework.framework/ios_dynamic_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         contains = [
             "$BUNDLE_ROOT/ios-arm64/ios_dynamic_xcframework.framework/Headers/shared.h",
@@ -164,6 +165,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/ios_dynamic_xcframework.framework/ios_dynamic_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         contains = [
             "$BUNDLE_ROOT/ios-x86_64-simulator/ios_dynamic_xcframework.framework/Headers/shared.h",
@@ -185,6 +187,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         contains = [
             "$BUNDLE_ROOT/ios-arm64_arm64e/ios_dynamic_lipoed_xcframework.framework/Headers/shared.h",
@@ -206,6 +209,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/ios_dynamic_lipoed_xcframework.framework/ios_dynamic_lipoed_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         contains = [
             "$BUNDLE_ROOT/ios-arm64_x86_64-simulator/ios_dynamic_lipoed_xcframework.framework/Headers/shared.h",
@@ -570,6 +574,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/tvos_dynamic_xcframework.framework/tvos_dynamic_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         tags = [name],
     )
@@ -582,6 +587,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/tvos_dynamic_xcframework.framework/tvos_dynamic_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         tags = [name],
     )
@@ -594,6 +600,7 @@ def apple_xcframework_test_suite(name):
         macho_load_commands_contain = [
             "name @rpath/tvos_dynamic_xcframework.framework/tvos_dynamic_xcframework (offset 24)",
             "path @executable_path/Frameworks (offset 12)",
+            "path @loader_path/Frameworks (offset 12)",
         ],
         tags = [name],
     )


### PR DESCRIPTION
(cherry picked from commit [cedcaecd8fa3a247ecee5e6c8b238b665acd17eb](https://github.com/bazelbuild/rules_apple/commit/cedcaecd8fa3a247ecee5e6c8b238b665acd17eb))