### PR TITLE
Add a build setting to disable Swift stdlib binary thinning

### DIFF
--- a/apple/build_settings/build_settings.bzl
+++ b/apple/build_settings/build_settings.bzl
@@ -26,6 +26,13 @@ parse the XCFramework bundle Info.plist file. See apple/internal/apple_xcframewo
 """,
         default = False,
     ),
+    "disable_swift_stdlib_binary_thinning": struct(
+        doc = """
+Disables binary thinning for Swift stdlib binaries, matching the most recent Xcode handling for
+Swift support dylibs.
+""",
+        default = False,
+    ),
     # TODO(b/252873771): Clean up all usages of --ios_signing_cert_name and replace them with this
     # new custom build setting.
     "signing_certificate_name": struct(

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -97,6 +97,9 @@ def _swift_dylib_action(
     if strip_bitcode:
         swift_stdlib_tool_args.add("--strip_bitcode")
 
+    if platform_prerequisites.build_settings.disable_swift_stdlib_binary_thinning:
+        swift_stdlib_tool_args.add("--disable_binary_thinning")
+
     apple_support.run(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,


### PR DESCRIPTION
This toggles a mode in support tooling to skip the "lipo" phase, instead going straight to a copy + set 0o755 operation.

(cherry picked from commit [9e5d8445a92034c879c0eda7e1f03a5a40922e46)](https://github.com/bazelbuild/rules_apple/commit/9e5d8445a92034c879c0eda7e1f03a5a40922e46)