### PR TITLE
Migrate all usage of `ctx.fragments.apple.single_arch_platform(...)` to platform constraints

### DIFF
--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -850,6 +850,10 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
+        "//apple/internal:apple_toolchains",
+        "//apple/internal:features_support",
+        "//apple/internal:platform_support",
+        "//apple/internal:swift_support",
         "//apple/internal/aspects:docc_archive_aspect",
         "@bazel_skylib//lib:dicts",
         "@build_bazel_apple_support//lib:apple_support",

--- a/apple/internal/resource_actions/metals.bzl
+++ b/apple/internal/resource_actions/metals.bzl
@@ -33,7 +33,7 @@ def _metal_apple_target_triple(platform_prerequisites):
     """
     target_os_version = platform_prerequisites.minimum_os
 
-    platform = platform_prerequisites.apple_fragment.single_arch_platform
+    platform = platform_prerequisites.platform
     platform_string = str(platform.platform_type)
     if platform_string == "macos":
         platform_string = "macosx"

--- a/apple/internal/resource_rules/apple_metal_library.bzl
+++ b/apple/internal/resource_rules/apple_metal_library.bzl
@@ -51,7 +51,7 @@ def _metal_apple_target_triple(platform_prerequisites):
     """
     target_os_version = platform_prerequisites.minimum_os
 
-    platform = platform_prerequisites.apple_fragment.single_arch_platform
+    platform = platform_prerequisites.platform
     platform_string = str(platform.platform_type)
     if platform_string == "macos":
         platform_string = "macosx"

--- a/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
@@ -75,8 +75,10 @@ def _apple_precompiled_resource_bundle_impl(ctx):
     owner = str(label)
     bucketize_args = {}
 
+    platform_info = platform_support.apple_platform_info_from_rule_ctx(ctx)
+
     rule_descriptor = rule_support.rule_descriptor(
-        platform_type = str(ctx.fragments.apple.single_arch_platform.platform_type),
+        platform_type = platform_info.target_os,
         product_type = apple_product_type.application,
     )
 


### PR DESCRIPTION
Required for Bazel 9+