### PR TITLE
Remove usage of legacy `apple_common.get_split_build_configs(...)`, retrieving configs from the cc_toolchains that are the source of truth for the linking via public starlark APIs.

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -204,7 +204,6 @@ def _link_multi_arch_binary(
             stamp = stamp,
         )
 
-    split_build_configs = apple_common.get_split_build_configs(ctx)
     split_deps = ctx.split_attr.deps
 
     if split_deps and split_deps.keys() != cc_toolchains.keys():
@@ -272,7 +271,7 @@ def _link_multi_arch_binary(
             avoid_dep_linking_contexts = avoid_cc_linking_contexts,
         )
 
-        child_config = split_build_configs.get(split_transition_key)
+        child_config = child_toolchain[ApplePlatformInfo].target_build_config
 
         additional_outputs = []
         extensions = {}

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -112,6 +112,7 @@ def _apple_platform_info_from_rule_ctx(ctx):
     """Returns an ApplePlatformInfo provider from a rule context, needed to resolve constraints."""
     return new_appleplatforminfo(
         target_arch = apple_support.target_arch_from_rule_ctx(ctx),
+        target_build_config = ctx.configuration,
         target_environment = apple_support.target_environment_from_rule_ctx(ctx),
         target_os = apple_support.target_os_from_rule_ctx(ctx),
     )

--- a/apple/internal/providers.bzl
+++ b/apple/internal/providers.bzl
@@ -392,14 +392,17 @@ def merge_apple_framework_import_info(apple_framework_import_infos):
 ApplePlatformInfo, new_appleplatforminfo = provider(
     doc = "Provides information for the currently selected Apple platforms.",
     fields = {
-        "target_os": """
-`String` representing the selected Apple OS.
-""",
         "target_arch": """
 `String` representing the selected target architecture or cpu type.
 """,
+        "target_build_config": """
+'configuration' representing the selected target's build configuration.
+""",
         "target_environment": """
 `String` representing the selected target environment (e.g. "device", "simulator").
+""",
+        "target_os": """
+`String` representing the selected Apple OS.
 """,
     },
     init = _make_banned_init(provider_name = "ApplePlatformInfo"),

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -125,9 +125,7 @@ def _common_linking_api_attrs(*, deps_cfg):
             providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],
             default = "//apple:default_cc_toolchain_forwarder",
         ),
-        # TODO(b/251837356): Eliminate this attr when the Bazel Starlark API
-        # `apple_common.get_split_build_configs(...)`` doesn't require that this attr be called
-        # `_child_configuration_dummy` in Apple multiarch APIs.
+        # TODO: Remove this when we drop bazel 7.x
         "_child_configuration_dummy": attr.label(
             cfg = deps_cfg,
             providers = [cc_common.CcToolchainInfo, ApplePlatformInfo],

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -413,9 +413,10 @@ Provides information for the currently selected Apple platforms.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="ApplePlatformInfo-target_os"></a>target_os |  `String` representing the selected Apple OS.    |
 | <a id="ApplePlatformInfo-target_arch"></a>target_arch |  `String` representing the selected target architecture or cpu type.    |
+| <a id="ApplePlatformInfo-target_build_config"></a>target_build_config |  'configuration' representing the selected target's build configuration.    |
 | <a id="ApplePlatformInfo-target_environment"></a>target_environment |  `String` representing the selected target environment (e.g. "device", "simulator").    |
+| <a id="ApplePlatformInfo-target_os"></a>target_os |  `String` representing the selected Apple OS.    |
 
 
 <a id="AppleProvisioningProfileInfo"></a>


### PR DESCRIPTION
Required for Bazel 9+

Cherry-pick: https://github.com/bazelbuild/rules_apple/commit/cd1e1a4da722a9405c0fc683277ca7bb470b5c50