### PR TITLE
run subshells in bundletool_experimental using subprocess API

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -309,7 +309,7 @@ class Bundler(object):
       try:
         subprocess.check_call(argv, env={})
       except subprocess.CalledProcessError as e:
-        raise PostProcessorError(e.returncode) from e
+        raise CodeSignError(e.returncode) from e
 
 
 def _main(control_path):


### PR DESCRIPTION
Fixes #2843

use `subprocess.check_call` instead of `os.system` to support stronger
security guarantees and block environment variables from the running
environment from affecting subprocesses. Fixes usage of rules_apple
when using rules_python 1.7.0+.
