### PR TITLE
Log when BAZEL_APPLE_LAUNCH_INFO_PATH finishes writing

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -501,6 +501,9 @@ def launch_app(
               },
               indent=2,
           ))
+        logger.info(
+          "Successfully written launch info to: %s", launch_info_path
+        )
       else:
           logger.error("Failed to find PID in JSON output")
   except Exception as e:

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -809,6 +809,9 @@ def launch_app(
               },
               indent=2,
           ))
+        logger.info(
+          "Successfully written launch info to: %s", launch_info_path
+        )
       except Exception as e:
         logger.error("Failed to write launch info to file: %s", e)
     else:


### PR DESCRIPTION
This adds a small consistent log to the simulator/device launchers to make it easy for us to detect when to attach lldb in VSCode. Otherwise the only other best way is to keep track of each app's bundle ID, which adds a lot of complexity.