### PR TITLE
fix: Update to rules_swift 3.0.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,15 +14,9 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_cc", version = "0.1.2")
 bazel_dep(
     name = "rules_swift",
-    version = "2.4.0",
+    version = "3.0.2",
     max_compatibility_level = 3,
     repo_name = "build_bazel_rules_swift",
-)
-
-# Test with latest rules_swift without requiring users to use this version
-single_version_override(
-    module_name = "rules_swift",
-    version = "3.0.2",
 )
 
 bazel_dep(name = "rules_python", version = "1.3.0")


### PR DESCRIPTION
Removes requirement that windows users have `swiftc.exe` installed by using version that includes https://github.com/bazelbuild/rules_swift/issues/1502