### PR TITLE
Include App Clip dSYMS when include_symbols_in_bundle is True

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -765,6 +765,15 @@ def _ios_app_clip_impl(ctx):
             label_name = label.name,
             platform_prerequisites = platform_prerequisites,
         ),
+        partials.apple_symbols_file_partial(
+            actions = actions,
+            binary_artifact = binary_artifact,
+            dependency_targets = embeddable_targets + ctx.attr.deps,
+            dsym_binaries = debug_outputs.dsym_binaries,
+            label_name = label.name,
+            include_symbols_in_bundle = False,
+            platform_prerequisites = platform_prerequisites,
+        ),
     ]
 
     if platform_prerequisites.platform.is_device:

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -608,6 +608,19 @@ def ios_application_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_ext_and_fmwk_and_symbols_in_bundle",
     )
 
+    # Tests that app clips also contribute .symbols package files when
+    # `include_symbols_in_bundle` is enabled on the embedding application.
+    apple_symbols_file_test(
+        name = "{}_archive_contains_apple_symbols_files_with_app_clip_test".format(name),
+        binary_paths = [
+            "Payload/app_with_app_clip_and_symbols_in_bundle.app/app_with_app_clip_and_symbols_in_bundle",
+            "Payload/app_with_app_clip_and_symbols_in_bundle.app/AppClips/app_clip.app/app_clip",
+        ],
+        build_type = "simulator",
+        tags = [name],
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_app_clip_and_symbols_in_bundle",
+    )
+
     # Tests that the archive contains .symbols package files generated from
     # imported frameworks when `include_symbols_in_bundle` is enabled.
     apple_symbols_file_test(

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1128,6 +1128,24 @@ ios_application(
     ],
 )
 
+ios_application(
+    name = "app_with_app_clip_and_symbols_in_bundle",
+    app_clips = [":app_clip"],
+    bundle_id = "com.google.example",
+    entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    families = ["iphone"],
+    include_symbols_in_bundle = True,
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.appclip_support,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 ios_app_clip(
     name = "app_clip",
     bundle_id = "com.google.example.clip",


### PR DESCRIPTION
According to the documentation, setting `include_symbols_in_bundle` to `True` includes dSYMs "for the application and its dependencies". So App Clips, if any, should be included.