### PR TITLE
Fix binary stripping on Bazel <9

### DIFF
--- a/apple/internal/compilation_support.bzl
+++ b/apple/internal/compilation_support.bzl
@@ -240,12 +240,7 @@ def _classify_libraries(libraries_to_link):
     return always_link_libraries.keys(), as_needed_libraries.keys()
 
 def _emit_builtin_objc_strip_action(ctx):
-    return (
-        getattr(ctx.fragments.objc, "builtin_objc_strip_action", False) and
-        ctx.fragments.objc.builtin_objc_strip_action and
-        ctx.fragments.cpp.objc_enable_binary_stripping() and
-        ctx.fragments.cpp.compilation_mode() == "opt"
-    )
+    return ctx.fragments.cpp.objc_should_strip_binary
 
 def _register_configuration_specific_link_actions(
         name,

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -29,6 +29,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_tree_artifacts_outputs_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
@@ -71,6 +72,30 @@ load(
 load(
     ":common.bzl",
     "common",
+)
+
+_analysis_ios_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:ios_multi_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_ios_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:ios_multi_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_ios_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:ios_multi_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
 )
 
 def ios_application_test_suite(name):
@@ -142,6 +167,32 @@ def ios_application_test_suite(name):
         verifier_script = "verifier_scripts/codesign_verifier.sh",
         compilation_mode = "opt",
         objc_enable_binary_stripping = True,
+        tags = [name],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_ios_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_ios_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_ios_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -29,6 +29,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
@@ -50,6 +51,30 @@ load(
 load(
     ":common.bzl",
     "common",
+)
+
+_analysis_macos_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_macos_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_macos_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
 )
 
 def macos_application_test_suite(name):
@@ -79,6 +104,32 @@ def macos_application_test_suite(name):
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_macos_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_macos_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_macos_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -23,6 +23,10 @@ load(
     "analysis_runfiles_dsym_test",
 )
 load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "make_analysis_target_actions_test",
+)
+load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
     "apple_dsym_bundle_info_test",
 )
@@ -41,6 +45,30 @@ load(
 load(
     ":common.bzl",
     "common",
+)
+
+_analysis_macos_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_macos_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_macos_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:macos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
 )
 
 def macos_command_line_application_test_suite(name):
@@ -62,6 +90,32 @@ def macos_command_line_application_test_suite(name):
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic_swift",
         verifier_script = "verifier_scripts/codesign_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_macos_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_macos_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_macos_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [name],
     )
 

--- a/test/starlark_tests/tvos_application_tests.bzl
+++ b/test/starlark_tests/tvos_application_tests.bzl
@@ -25,6 +25,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_dsym_bundle_info_test.bzl",
@@ -49,6 +50,30 @@ load(
 load(
     ":common.bzl",
     "common",
+)
+
+_analysis_tvos_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:tvos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_tvos_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:tvos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_tvos_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:tvos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
 )
 
 def tvos_application_test_suite(name):
@@ -127,6 +152,32 @@ def tvos_application_test_suite(name):
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
         verifier_script = "verifier_scripts/entitlements_verifier.sh",
+        tags = [name],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_tvos_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_tvos_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_tvos_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/tvos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [name],
     )
 

--- a/test/starlark_tests/visionos_application_tests.bzl
+++ b/test/starlark_tests/visionos_application_tests.bzl
@@ -21,6 +21,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_target_outputs_test.bzl",
@@ -52,6 +53,30 @@ load(
 )
 
 visibility("private")
+
+_analysis_visionos_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:visionos_cpus": "sim_arm64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_visionos_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:visionos_cpus": "sim_arm64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_visionos_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:visionos_cpus": "sim_arm64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
 
 def visionos_application_test_suite(name):
     """Test suite for visionos_application.
@@ -93,6 +118,38 @@ def visionos_application_test_suite(name):
         text_test_file = "$BUNDLE_ROOT/Assets.car",
         text_test_values = ["Bazel_logo.png"],
         target_under_test = "//test/starlark_tests/targets_under_test/visionos:app",
+        tags = [
+            name,
+        ],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_visionos_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/visionos:app",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [
+            name,
+        ],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_visionos_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/visionos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [
+            name,
+        ],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_visionos_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/visionos:app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [
             name,
         ],

--- a/test/starlark_tests/watchos_application_tests.bzl
+++ b/test/starlark_tests/watchos_application_tests.bzl
@@ -21,6 +21,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_target_actions_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
@@ -38,6 +39,30 @@ load(
 load(
     ":common.bzl",
     "common",
+)
+
+_analysis_watchos_strip_enabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:watchos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_analysis_watchos_strip_disabled_opt_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:watchos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": False,
+    },
+)
+
+_analysis_watchos_strip_disabled_dbg_test = make_analysis_target_actions_test(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:watchos_cpus": "x86_64",
+        "//command_line_option:objc_enable_binary_stripping": True,
+    },
 )
 
 def watchos_application_test_suite(name):
@@ -84,6 +109,32 @@ def watchos_application_test_suite(name):
             "UIDeviceFamily:0": "4",
             "WKWatchKitApp": "true",
         },
+        tags = [name],
+    )
+
+    # Tests that strip action is registered when building in opt mode with binary stripping enabled.
+    _analysis_watchos_strip_enabled_opt_test(
+        name = "{}_binary_strip_action_enabled_in_opt_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:single_target_app",
+        target_mnemonic = "ObjcBinarySymbolStrip",
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered when in opt mode but stripping is disabled.
+    _analysis_watchos_strip_disabled_opt_test(
+        name = "{}_binary_strip_action_disabled_without_flag_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:single_target_app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
+        tags = [name],
+    )
+
+    # Tests that strip action is not registered in dbg mode even if stripping is enabled.
+    _analysis_watchos_strip_disabled_dbg_test(
+        name = "{}_binary_strip_action_disabled_in_dbg_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/watchos:single_target_app",
+        target_mnemonic = "ObjcLink",
+        not_expected_mnemonic = ["ObjcBinarySymbolStrip"],
         tags = [name],
     )
 


### PR DESCRIPTION
In https://github.com/bazelbuild/rules_apple/pull/2868 we gated binary stripping behavior by looking at `objc` fragment, more specifically `objc.builtin_objc_strip_action`. `builtin_objc_strip_action` is available only in Bazel 9+:

* [Bazel 9 objc fragment docs](https://bazel.build/versions/9.0.0/rules/lib/fragments/objc) (`builtin_objc_strip_action` present)
* [Bazel 8.6.0 objc fragment docs](https://bazel.build/versions/8.6.0/rules/lib/fragments/objc) (`builtin_objc_strip_action` not present)

This means that binary stripping action is never executed on Bazel versions <9 since the following code in [compilation_support.bzl](https://github.com/bazelbuild/rules_apple/blob/main/apple/internal/compilation_support.bzl#L242) would never resolve to true:

```
def _emit_builtin_objc_strip_action(ctx):
    return (
        getattr(ctx.fragments.objc, "builtin_objc_strip_action", False) and # Not present on bazel versions < 9
        ctx.fragments.objc.builtin_objc_strip_action and
        ctx.fragments.cpp.objc_enable_binary_stripping() and
        ctx.fragments.cpp.compilation_mode() == "opt"
    )
```

Changing it to rely on `ctx.fragments.cpp.objc_should_strip_binary` fixes it across supported bazel versions since that symbol is available.