### PR TITLE
[7.x] Fix *_build_test rules with bazel 9.x

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-rolling
+9.x

--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -121,6 +121,9 @@ number (for example, `"9.0"`).
             ),
         },
         doc = doc,
+        exec_groups = {
+            "test": exec_group(),
+        },
         implementation = _apple_build_test_rule_impl,
         test = True,
         cfg = transition_support.apple_rule_transition,

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -18,6 +18,7 @@ load(":generate_import_framework_tests.bzl", "generate_import_framework_test_sui
 load(":ios_app_clip_tests.bzl", "ios_app_clip_test_suite")
 load(":ios_application_resources_test.bzl", "ios_application_resources_test_suite")
 load(":ios_application_tests.bzl", "ios_application_test_suite")
+load(":ios_build_test_tests.bzl", "ios_build_test_test_suite")
 load(":ios_dynamic_framework_tests.bzl", "ios_dynamic_framework_test_suite")
 load(":ios_extension_tests.bzl", "ios_extension_test_suite")
 load(":ios_framework_tests.bzl", "ios_framework_test_suite")
@@ -29,6 +30,7 @@ load(":ios_ui_test_tests.bzl", "ios_ui_test_test_suite")
 load(":ios_unit_test_tests.bzl", "ios_unit_test_test_suite")
 load(":macos_application_resources_tests.bzl", "macos_application_resources_test_suite")
 load(":macos_application_tests.bzl", "macos_application_test_suite")
+load(":macos_build_test_tests.bzl", "macos_build_test_test_suite")
 load(":macos_bundle_tests.bzl", "macos_bundle_test_suite")
 load(":macos_command_line_application_tests.bzl", "macos_command_line_application_test_suite")
 load(":macos_dylib_tests.bzl", "macos_dylib_test_suite")
@@ -42,6 +44,7 @@ load(":macos_unit_test_tests.bzl", "macos_unit_test_test_suite")
 load(":order_file_tests.bzl", "order_file_test_suite")
 load(":tvos_application_swift_tests.bzl", "tvos_application_swift_test_suite")
 load(":tvos_application_tests.bzl", "tvos_application_test_suite")
+load(":tvos_build_test_tests.bzl", "tvos_build_test_test_suite")
 load(":tvos_dynamic_framework_tests.bzl", "tvos_dynamic_framework_test_suite")
 load(":tvos_extension_tests.bzl", "tvos_extension_test_suite")
 load(":tvos_framework_tests.bzl", "tvos_framework_test_suite")
@@ -49,8 +52,10 @@ load(":tvos_static_framework_tests.bzl", "tvos_static_framework_test_suite")
 load(":tvos_ui_test_tests.bzl", "tvos_ui_test_test_suite")
 load(":tvos_unit_test_tests.bzl", "tvos_unit_test_test_suite")
 load(":visionos_application_tests.bzl", "visionos_application_test_suite")
+load(":visionos_build_test_tests.bzl", "visionos_build_test_test_suite")
 load(":watchos_application_swift_tests.bzl", "watchos_application_swift_test_suite")
 load(":watchos_application_tests.bzl", "watchos_application_test_suite")
+load(":watchos_build_test_tests.bzl", "watchos_build_test_test_suite")
 load(":watchos_dynamic_framework_tests.bzl", "watchos_dynamic_framework_test_suite")
 load(":watchos_extension_tests.bzl", "watchos_extension_test_suite")
 load(":watchos_framework_tests.bzl", "watchos_framework_test_suite")
@@ -100,6 +105,8 @@ ios_application_test_suite(name = "ios_application")
 
 ios_app_clip_test_suite(name = "ios_app_clip")
 
+ios_build_test_test_suite(name = "ios_build_test")
+
 ios_extension_test_suite(name = "ios_extension")
 
 ios_framework_test_suite(name = "ios_framework")
@@ -117,6 +124,8 @@ ios_sticker_pack_extension_test_suite(name = "ios_sticker_pack_extension")
 ios_ui_test_test_suite(name = "ios_ui_test")
 
 ios_unit_test_test_suite(name = "ios_unit_test")
+
+macos_build_test_test_suite(name = "macos_build_test")
 
 macos_application_resources_test_suite(name = "macos_application_resources")
 
@@ -147,6 +156,8 @@ macos_unit_test_test_suite(name = "macos_unit_test")
 
 order_file_test_suite(name = "order_file")
 
+tvos_build_test_test_suite(name = "tvos_build_test")
+
 tvos_application_swift_test_suite(name = "tvos_application_swift")
 
 tvos_application_test_suite(name = "tvos_application")
@@ -163,7 +174,11 @@ tvos_ui_test_test_suite(name = "tvos_ui_test")
 
 tvos_unit_test_test_suite(name = "tvos_unit_test")
 
+visionos_build_test_test_suite(name = "visionos_build_test")
+
 visionos_application_test_suite(name = "visionos_application")
+
+watchos_build_test_test_suite(name = "watchos_build_test")
 
 watchos_application_swift_test_suite(name = "watchos_application_swift")
 

--- a/test/starlark_tests/ios_build_test_tests.bzl
+++ b/test/starlark_tests/ios_build_test_tests.bzl
@@ -1,0 +1,45 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ios_build_test Starlark tests."""
+
+load(
+    "//apple:ios.bzl",
+    "ios_build_test",
+)
+load(
+    ":common.bzl",
+    "common",
+)
+
+def ios_build_test_test_suite(name):
+    """Test suite for ios_build_test.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    ios_build_test(
+        name = "{}_builds_simple_library".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = [
+            "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/macos_build_test_tests.bzl
+++ b/test/starlark_tests/macos_build_test_tests.bzl
@@ -1,0 +1,45 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""macos_build_test Starlark tests."""
+
+load(
+    "//apple:macos.bzl",
+    "macos_build_test",
+)
+load(
+    ":common.bzl",
+    "common",
+)
+
+def macos_build_test_test_suite(name):
+    """Test suite for macos_build_test.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    macos_build_test(
+        name = "{}_builds_simple_library".format(name),
+        minimum_os_version = common.min_os_macos.baseline,
+        targets = [
+            "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/tvos_build_test_tests.bzl
+++ b/test/starlark_tests/tvos_build_test_tests.bzl
@@ -1,0 +1,45 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tvos_build_test Starlark tests."""
+
+load(
+    "//apple:tvos.bzl",
+    "tvos_build_test",
+)
+load(
+    ":common.bzl",
+    "common",
+)
+
+def tvos_build_test_test_suite(name):
+    """Test suite for tvos_build_test.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    tvos_build_test(
+        name = "{}_builds_simple_library".format(name),
+        minimum_os_version = common.min_os_tvos.baseline,
+        targets = [
+            "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/visionos_build_test_tests.bzl
+++ b/test/starlark_tests/visionos_build_test_tests.bzl
@@ -1,0 +1,45 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""visionos_build_test Starlark tests."""
+
+load(
+    "//apple:visionos.bzl",
+    "visionos_build_test",
+)
+load(
+    ":common.bzl",
+    "common",
+)
+
+def visionos_build_test_test_suite(name):
+    """Test suite for visionos_build_test.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    visionos_build_test(
+        name = "{}_builds_simple_library".format(name),
+        minimum_os_version = common.min_os_visionos.baseline,
+        targets = [
+            "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/watchos_build_test_tests.bzl
+++ b/test/starlark_tests/watchos_build_test_tests.bzl
@@ -1,0 +1,45 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""watchos_build_test Starlark tests."""
+
+load(
+    "//apple:watchos.bzl",
+    "watchos_build_test",
+)
+load(
+    ":common.bzl",
+    "common",
+)
+
+def watchos_build_test_test_suite(name):
+    """Test suite for watchos_build_test.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    watchos_build_test(
+        name = "{}_builds_simple_library".format(name),
+        minimum_os_version = common.min_os_watchos.baseline,
+        targets = [
+            "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )


### PR DESCRIPTION
This will be part of a point release just to do one last release that
supports 7.x all the way to 9.x

(cherry picked from commit 5d249abe7a75d60d48dc56b3882cda5f0456539d)
