### PR TITLE
Add `@loader_path/../Frameworks` rpath for macOS extensions and ExtensionKit

### DIFF
--- a/apple/internal/rule_support.bzl
+++ b/apple/internal/rule_support.bzl
@@ -346,6 +346,7 @@ _RULE_TYPE_DESCRIPTORS = {
                 # Application.app/Contents/PlugIns/Extension.appex/Contents/Frameworks
                 # or Application.app/Contents/Frameworks
                 "@executable_path/../Frameworks",
+                "@loader_path/../Frameworks",
                 "@executable_path/../../../../Frameworks",
             ],
         ),
@@ -361,7 +362,11 @@ _RULE_TYPE_DESCRIPTORS = {
             rpaths = [
                 # ExtensionKit binaries live in
                 # Application.app/Contents/Extensions/Extension.appex/Contents/MacOS/Extension
-                # Frameworks are packaged in Application.app/Contents/Frameworks
+                # Frameworks are packaged in
+                # Application.app/Contents/Extensions/Extension.appex/Contents/Frameworks
+                # or Application.app/Contents/Frameworks
+                "@executable_path/../Frameworks",
+                "@loader_path/../Frameworks",
                 "@executable_path/../../../../Frameworks",
             ],
         ),

--- a/test/starlark_tests/macos_extension_tests.bzl
+++ b/test/starlark_tests/macos_extension_tests.bzl
@@ -44,6 +44,7 @@ def macos_extension_test_suite(name):
         binary_test_file = "$CONTENT_ROOT/MacOS/ext",
         macho_load_commands_contain = [
             "path @executable_path/../Frameworks (offset 12)",
+            "path @loader_path/../Frameworks (offset 12)",
             "path @executable_path/../../../../Frameworks (offset 12)",
         ],
         target_under_test = "//test/starlark_tests/targets_under_test/macos:ext",


### PR DESCRIPTION
Similar to what was done in https://github.com/bazelbuild/rules_apple/pull/2852 and https://github.com/bazelbuild/rules_apple/pull/2850

This is what Xcode does and solves specific issue that I ran into while developing Xcode source editor extension.