### PR TITLE
Remove unnecessary exported API

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -145,14 +145,13 @@ def _archive_multi_arch_static_library(
 def _link_multi_arch_binary(
         *,
         ctx,
-        avoid_deps = [],
+        avoid_deps,
         cc_toolchains,
-        extra_linkopts = [],
-        extra_link_inputs = [],
-        extra_requested_features = [],
-        extra_disabled_features = [],
-        stamp = -1,
-        variables_extension = {}):
+        extra_linkopts,
+        extra_link_inputs,
+        extra_requested_features,
+        extra_disabled_features,
+        stamp):
     """Links a (potentially multi-architecture) binary targeting Apple platforms.
 
     This method comprises a bulk of the logic of the Starlark `apple_binary`
@@ -182,8 +181,6 @@ def _link_multi_arch_binary(
             If -1 (the default), then the behavior is determined by the --[no]stamp
             flag. This should be set to 0 when generating the executable output for
             test rules.
-        variables_extension: A dictionary of user-defined variables to be added to the
-            toolchain configuration when create link command line.
 
     Returns:
         A `struct` which contains the following fields:
@@ -318,7 +315,7 @@ def _link_multi_arch_binary(
             build_config = child_config,
             extra_link_args = extra_linkopts,
             stamp = stamp,
-            user_variable_extensions = variables_extension | extensions,
+            user_variable_extensions = extensions,
             additional_outputs = additional_outputs,
             extra_link_inputs = extra_link_inputs,
             attr_linkopts = attr_linkopts,
@@ -660,7 +657,6 @@ def _lipo_or_symlink_inputs(*, actions, inputs, output, apple_fragment, xcode_co
 
 linking_support = struct(
     debug_outputs_by_architecture = _debug_outputs_by_architecture,
-    link_multi_arch_binary = _link_multi_arch_binary,
     lipo_or_symlink_inputs = _lipo_or_symlink_inputs,
     register_binary_linking_action = _register_binary_linking_action,
     register_static_library_archive_action = _register_static_library_archive_action,


### PR DESCRIPTION
This API isn't public (it's in an internal file) and there is only 1
use. This drops the unused `variables_extension` parameter and requires
all other arguments be passed.
