### PR TITLE
Fix rules_apple device runner crash on Rapid Security Response versions

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -30,6 +30,8 @@
 # 1. Installs and launches the application on a device corresponding to `device_identifier`.
 # 2. Displays the application's output on the console
 
+import re
+
 import collections.abc
 import contextlib
 import json
@@ -189,8 +191,11 @@ def os_version_number_to_int(version: str) -> int:
     An integer in the form 0xAABBCC, where AA is the major version, BB is
     the minor version, and CC is the micro version.
   """
-  # Pad the version to major.minor.micro.
-  version_components = (version.split(".") + ["0"] * 3)[:3]
+  # Strip non-numeric suffixes (e.g. Rapid Security Response "(a)") from each
+  # component, then pad to major.minor.micro.
+  version_components = (
+      [re.sub(r"[^0-9].*", "", c) or "0" for c in version.split(".")] + ["0"] * 3
+  )[:3]
   result = 0
   for component in version_components:
     result = (result << 8) | int(component)


### PR DESCRIPTION
Devices running an Apple RSR update report OS versions like "18.3.1 (a)". The rules_apple device runner fails to parse the "(a)" suffix:

```
  ValueError: invalid literal for int() with base 10: '1 (a)'
```

Patch rules_apple 4.5.1 to strip non-numeric suffixes from each version component before integer conversion.


## Test plan

`bazel run` an iOS application target on a physical device (builds, uploads, and runs)

Fixes https://github.com/bazelbuild/rules_apple/issues/2900