### PR TITLE
4.x: Bump Swift stdlib presence thresholds for Span compatibility (#2915)

### DIFF
--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -57,22 +57,22 @@ File object that represents a directory containing the Swift dylibs to package f
     },
 )
 
-# Minimum OS versions for which we no longer need to potentially bundle any
-# Swift dylibs with the application. The first cutoff point was when the
-# platforms bundled the standard libraries, the second was when they started
-# bundling the Concurrency library. There may be future libraries that require
-# us to continue bumping these values. The tool is smart enough only to bundle
-# those libraries required by the minimum OS version of the scanned binaries.
+# For each platform, the minimum OS version at which we no longer need to bundle
+# any Swift dylibs with the application -- either the pre-ABI-stable runtime or
+# back-deployed runtimes (e.g., Concurrency and Span). We do not need to
+# consider each of these cases individually; `swift-stdlib-tool` will only
+# bundle the libraries required based on the minimum OS version of the scanned
+# binaries.
 #
-# Values are the first version where bundling is no longer required and should
-# correspond with the Swift compilers values for these which is the source of
-# truth https://github.com/apple/swift/blob/998d3518938bd7229e7c5e7b66088d0501c02051/lib/Basic/Platform.cpp#L82-L105
+# These values should be kept in sync with the values in
+# `swift::tripleRequiresRPathForSwiftLibrariesInOS` defined in:
+# https://github.com/apple/swift/blob/main/lib/Basic/Platform.cpp.
 _MIN_OS_PLATFORM_SWIFT_PRESENCE = {
-    "ios": apple_common.dotted_version("15.0"),
-    "macos": apple_common.dotted_version("12.0"),
-    "tvos": apple_common.dotted_version("15.0"),
-    "visionos": apple_common.dotted_version("1.0"),
-    "watchos": apple_common.dotted_version("8.0"),
+    "ios": apple_common.dotted_version("26.0"),
+    "macos": apple_common.dotted_version("26.0"),
+    "tvos": apple_common.dotted_version("26.0"),
+    "visionos": apple_common.dotted_version("26.0"),
+    "watchos": apple_common.dotted_version("26.0"),
 }
 
 def _swift_dylib_action(

--- a/test/starlark_tests/common.bzl
+++ b/test/starlark_tests/common.bzl
@@ -38,6 +38,7 @@ _min_os_ios = struct(
     icon_bundle_required = "26.0",
     oldest_supported = "11.0",
     nplus1 = "13.0",
+    span_in_os = "26.0",
     stable_swift_abi = "12.2",
     widget_configuration_intents_support = "16.0",
 )

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -237,6 +237,54 @@ def ios_application_test_suite(name):
         tags = [name],
     )
 
+    archive_contents_test(
+        name = "{}_device_swift_span_compatibility_dylib_present_on_older_os".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_using_span_pre_26",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/libswiftCompatibilitySpan.dylib",
+            "$ARCHIVE_ROOT/SwiftSupport/iphoneos/libswiftCompatibilitySpan.dylib",
+        ],
+        tags = [
+            name,
+        ],
+    )
+    archive_contents_test(
+        name = "{}_simulator_swift_span_compatibility_dylib_present_on_older_os".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_using_span_pre_26",
+        contains = [
+            "$BUNDLE_ROOT/Frameworks/libswiftCompatibilitySpan.dylib",
+        ],
+        tags = [
+            name,
+        ],
+    )
+
+    archive_contents_test(
+        name = "{}_device_swift_span_compatibility_dylib_not_present_on_newer_os".format(name),
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_using_span_post_26",
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/libswiftCompatibilitySpan.dylib",
+            "$ARCHIVE_ROOT/SwiftSupport/iphoneos/libswiftCompatibilitySpan.dylib",
+        ],
+        tags = [
+            name,
+        ],
+    )
+    archive_contents_test(
+        name = "{}_simulator_swift_span_compatibility_dylib_not_present_on_newer_os".format(name),
+        build_type = "simulator",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_app_using_span_post_26",
+        not_contains = [
+            "$BUNDLE_ROOT/Frameworks/libswiftCompatibilitySpan.dylib",
+        ],
+        tags = [
+            name,
+        ],
+    )
+
     apple_verification_test(
         name = "{}_imported_fmwk_codesign_test".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -238,6 +238,12 @@ swift_library(
 )
 
 swift_library(
+    name = "swift_span_main_lib",
+    srcs = ["span_main.swift"],
+    tags = common.fixture_tags,
+)
+
+swift_library(
     name = "swift_lib_with_structured_resources",
     testonly = True,
     srcs = [

--- a/test/starlark_tests/resources/span_main.swift
+++ b/test/starlark_tests/resources/span_main.swift
@@ -1,0 +1,24 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+@main
+struct App {
+    static func main() {
+      // Many back-deployed functions are `@_alwaysEmitIntoClient` so referencing them won't
+      // necessarily require the dylib to be linked. Type metadata, on the other hand, will always
+      // require the dylib to be linked.
+      print(Span<Int>.self)
+    }
+}

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -147,6 +147,36 @@ xcarchive(
 )
 
 ios_application(
+    name = "swift_app_using_span_pre_26",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.stable_swift_abi,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_span_main_lib",
+    ],
+)
+
+ios_application(
+    name = "swift_app_using_span_post_26",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.span_in_os,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:swift_span_main_lib",
+    ],
+)
+
+ios_application(
     name = "app_minimal_with_deployment_version",
     bundle_id = "com.google.example",
     families = ["iphone"],


### PR DESCRIPTION
Swift 6.2 introduced `libswiftCompatibilitySpan.dylib`, a back-deployment compatibility library for the `Span` type that must be embedded in app bundles targeting OS versions prior to the 2025 releases (iOS 26, macOS 26, etc.).

The `_MIN_OS_PLATFORM_SWIFT_PRESENCE` thresholds previously assumed all Swift dylibs were present in the OS starting at iOS 15 / macOS 12, causing `swift-stdlib-tool` to skip scanning binaries entirely for apps with higher minimum deployment targets. This meant `libswiftCompatibilitySpan.dylib` was never embedded, resulting in a launch crash:

```
Library not loaded: @rpath/libswiftCompatibilitySpan.dylib
```

This bumps all platform thresholds to 26.0 so the tool runs and embeds the compatibility dylib when needed.

Based on the same internal change as #2909, with tests and updated comments included.

## Test plan

- Built an iOS app targeting iOS 18.0 with Bazel and confirmed `libswiftCompatibilitySpan.dylib` is now embedded in the `.app` bundle
- Ran `swift stdlib-tool --print --scan-folder <app>.app --platform iphoneos` and confirmed no additional libs are needed
- Added `archive_contents_test` cases verifying the dylib is present for pre-26 targets and absent for post-26 targets

(cherry picked from commit f16d670abcf7ea4ddb0599f2c290b6057309482f)