### PR TITLE
Improve performance of test filter creation

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -353,39 +353,24 @@ if [[ -n "${TESTBRIDGE_TEST_ONLY:-}" || -n "${TEST_FILTER:-}" ]]; then
     ALL_TESTS="$TEST_FILTER"
   fi
 
+  SKIP_TESTS_ARRAY=()
+  ONLY_TESTS_ARRAY=()
   saved_IFS=$IFS
   IFS=","; for TEST in $ALL_TESTS; do
     if [[ $TEST == -* ]]; then
-      if [[ -n "${SKIP_TESTS:-}" ]]; then
-        SKIP_TESTS+=",${TEST:1}"
-      else
-        SKIP_TESTS="${TEST:1}"
-      fi
+      SKIP_TESTS_ARRAY+=("${TEST:1}")
     else
-      if [[ -n "${ONLY_TESTS:-}" ]]; then
-          ONLY_TESTS+=",$TEST"
-      else
-          ONLY_TESTS="$TEST"
-      fi
+      ONLY_TESTS_ARRAY+=("$TEST")
     fi
   done
-
   IFS=$saved_IFS
 
-  if [[ -n "${SKIP_TESTS:-}" ]]; then
-    xctestrun_skip_test_section="\n"
-    for skip_test in ${SKIP_TESTS//,/ }; do
-      xctestrun_skip_test_section+="      <string>$skip_test</string>\n"
-    done
-    xctestrun_skip_test_section="    <key>SkipTestIdentifiers</key>\n    <array>$xctestrun_skip_test_section    </array>"
+  if (( ${#SKIP_TESTS_ARRAY[@]} )); then
+    xctestrun_skip_test_section="    <key>SkipTestIdentifiers</key>\n    <array>\n$(printf '      <string>%s</string>\\n' "${SKIP_TESTS_ARRAY[@]}")    </array>"
   fi
 
-  if [[ -n "${ONLY_TESTS:-}" ]]; then
-    xctestrun_only_test_section="\n"
-    for only_test in ${ONLY_TESTS//,/ }; do
-      xctestrun_only_test_section+="      <string>$only_test</string>\n"
-    done
-    xctestrun_only_test_section="    <key>OnlyTestIdentifiers</key>\n    <array>$xctestrun_only_test_section    </array>"
+  if (( ${#ONLY_TESTS_ARRAY[@]} )); then
+    xctestrun_only_test_section="    <key>OnlyTestIdentifiers</key>\n    <array>\n$(printf '      <string>%s</string>\\n' "${ONLY_TESTS_ARRAY[@]}")    </array>"
   fi
 fi
 


### PR DESCRIPTION
We're using test filters to skip over flaky tests on CI

That list of flaky tests sometimes gets quite long and causes performance issues with he `ios_xctestrun_runner` script.

This change significantly improves the performance of constructing `xctestrun_skip_test_section` and `xctestrun_only_test_section` by using bash arrays and printf rather than repeated string concatenation. 