### PR TITLE
Add Swift deterministic hashing to the environment variables passed to all actions generated by the Apple rules.

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -250,6 +250,7 @@ bzl_library(
     deps = [
         "//apple/internal:apple_toolchains",
         "//apple/internal:providers",
+        "//apple/internal:shared_environment",
         "@bazel_skylib//lib:dicts",
     ],
 )

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -121,6 +121,7 @@ bzl_library(
         ":framework_import_support",
         ":intermediates",
         ":rule_attrs",
+        ":shared_environment",
         "//apple:providers",
         "//apple/internal/aspects:swift_usage_aspect",
         "@bazel_skylib//lib:dicts",
@@ -188,6 +189,7 @@ bzl_library(
     deps = [
         ":intermediates",
         ":rule_support",
+        ":shared_environment",
         "//apple/internal/utils:defines",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
@@ -203,6 +205,7 @@ bzl_library(
     ],
     deps = [
         ":platform_support",
+        ":shared_environment",
         "@bazel_skylib//lib:paths",
         "@rules_cc//cc/common",
     ],
@@ -218,6 +221,7 @@ bzl_library(
         ":apple_product_type",
         ":bundling_support",
         ":resource_actions",
+        ":shared_environment",
         "//apple:common",
         "//apple/internal/utils:defines",
         "@build_bazel_apple_support//lib:apple_support",
@@ -234,8 +238,18 @@ bzl_library(
         ":apple_toolchains",
         ":platform_support",
         ":rule_attrs",
+        ":shared_environment",
         "@bazel_skylib//lib:dicts",
         "@build_bazel_apple_support//lib:apple_support",
+    ],
+)
+
+bzl_library(
+    name = "shared_environment",
+    srcs = ["shared_environment.bzl"],
+    visibility = [
+        "//apple:__subpackages__",
+        "//test:__subpackages__",
     ],
 )
 
@@ -420,6 +434,7 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
+        ":shared_environment",
         "@rules_cc//cc/common",
     ],
 )
@@ -630,6 +645,7 @@ bzl_library(
     ],
     deps = [
         ":intermediates",
+        ":shared_environment",
         "@build_bazel_apple_support//lib:apple_support",
         "@build_bazel_apple_support//lib:lipo",
     ],

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -50,6 +50,10 @@ load(
 )
 load("//apple/internal:rule_attrs.bzl", "rule_attrs")
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/aspects:swift_usage_aspect.bzl",
     "SwiftUsageInfo",
 )
@@ -389,6 +393,7 @@ def _get_xcframework_library_with_xcframework_processor(
         actions = actions,
         apple_fragment = apple_fragment,
         arguments = [args],
+        env = shared_environment.default_env,
         executable = xcframework_processor_tool,
         inputs = inputs,
         mnemonic = "ProcessXCFrameworkFiles",

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -35,6 +35,10 @@ load(
     "rule_support",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:defines.bzl",
     "defines",
 )
@@ -561,6 +565,7 @@ def _generate_codesigning_dossier_action(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = args,
+        env = shared_environment.default_env,
         executable = dossier_codesigningtool,
         inputs = input_files,
         mnemonic = mnemonic,
@@ -720,6 +725,7 @@ def _post_process_and_sign_archive_action(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
             arguments = arguments,
+            env = shared_environment.default_env,
             executable = process_and_sign_expanded_template,
             execution_requirements = execution_requirements,
             inputs = input_files + codesign_inputs,
@@ -732,6 +738,7 @@ def _post_process_and_sign_archive_action(
     else:
         actions.run(
             arguments = arguments,
+            env = shared_environment.default_env,
             executable = process_and_sign_expanded_template,
             inputs = input_files,
             mnemonic = mnemonic,
@@ -800,6 +807,7 @@ def _sign_binary_action(
             input_binary = input_binary.path,
             output_binary = output_binary.path,
         ) + "\n" + signing_commands,
+        env = shared_environment.default_env,
         execution_requirements = execution_requirements,
         inputs = [input_binary] + codesign_inputs,
         mnemonic = "SignBinary",

--- a/apple/internal/compilation_support.bzl
+++ b/apple/internal/compilation_support.bzl
@@ -26,6 +26,10 @@ load(
     "//apple/internal:platform_support.bzl",
     "platform_support",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 visibility([
     "//apple/...",
@@ -181,8 +185,11 @@ def _register_binary_strip_action(
 
     ctx.actions.run(
         arguments = [args],
-        env = apple_common.apple_host_system_env(xcode_config) |
-              apple_common.target_apple_env(xcode_config, apple_common_platform),
+        env = (
+            shared_environment.default_env |
+            apple_common.apple_host_system_env(xcode_config) |
+            apple_common.target_apple_env(xcode_config, apple_common_platform)
+        ),
         executable = "/usr/bin/xcrun",
         execution_requirements = xcode_config.execution_info(),
         inputs = [binary],

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -35,6 +35,10 @@ load(
     "resource_actions",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:defines.bzl",
     "defines",
 )
@@ -176,6 +180,7 @@ def _extract_signing_info(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
             arguments = [control_file.path],
+            env = shared_environment.default_env,
             executable = provisioning_profile_tool,
             # Since the tools spawns openssl and/or security tool, it doesn't
             # support being sandboxed.
@@ -399,6 +404,7 @@ def _generate_der_entitlements(
             der_entitlements.path,
             "--raw",
         ],
+        env = shared_environment.default_env,
         executable = "/usr/bin/derq",
         inputs = [entitlements],
         mnemonic = "ProcessDEREntitlements",

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -40,6 +40,10 @@ load(
     "//apple/internal:rule_attrs.bzl",
     "rule_attrs",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def _environment_plist_impl(ctx):
     # Only need as much platform information as this rule is able to give, for environment plist
@@ -68,6 +72,7 @@ def _environment_plist_impl(ctx):
     apple_support.run(
         actions = ctx.actions,
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         arguments = [
             "--platform",
             (platform.name_in_plist + str(sdk_version)).lower(),

--- a/apple/internal/order_file.bzl
+++ b/apple/internal/order_file.bzl
@@ -18,6 +18,10 @@ A rule for providing support for order files during build.
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 visibility([
     "//apple/...",
@@ -39,6 +43,7 @@ def _concatenate_files(*, actions, files, name):
     out_file = actions.declare_file("%s_concat.order" % name)
 
     actions.run_shell(
+        env = shared_environment.default_env,
         inputs = files,
         outputs = [out_file],
         progress_message = "Concatenating order files into %s" % out_file.short_path,
@@ -64,6 +69,7 @@ def _dedup_file(*, actions, file, name):
     out_file = actions.declare_file("%s_dedup.order" % name)
 
     actions.run_shell(
+        env = shared_environment.default_env,
         inputs = [file],
         outputs = [out_file],
         progress_message = "Deduping order files into %s" % out_file.short_path,

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -97,6 +97,7 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:partial",
         "@build_bazel_apple_support//lib:apple_support",
@@ -149,6 +150,7 @@ bzl_library(
         "//apple/internal:intermediates",
         "//apple/internal:providers",
         "//apple/internal:resource_actions",
+        "//apple/internal:shared_environment",
         "//apple/internal/providers:apple_debug_info",
         "//apple/internal/utils:defines",
         "@bazel_skylib//lib:partial",
@@ -218,6 +220,7 @@ bzl_library(
         "//apple/internal:codesigning_support",
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:bundle_paths",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
@@ -324,6 +327,7 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:defines",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -31,6 +31,10 @@ load(
     "processor",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:clang_rt_dylibs.bzl",
     "clang_rt_dylibs",
 )
@@ -63,6 +67,7 @@ def _clang_rt_dylibs_partial_impl(
                 binary_artifact.path,
                 clang_rt_zip.path,
             ],
+            env = shared_environment.default_env,
             executable = clangrttool,
             # This action needs to read the contents of the Xcode bundle.
             execution_requirements = {"no-sandbox": "1"},

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -46,6 +46,10 @@ load(
     "resource_actions",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/providers:apple_debug_info.bzl",
     "AppleDebugInfo",
 )
@@ -347,7 +351,7 @@ def _bundle_dsym_files(
             inputs = generated_dsym_binaries + [dsym_plist] + found_binaries_by_arch.values(),
             outputs = [dsym_bundle_dir],
             command = ("mkdir -p \"${OUTPUT_DIR}/Contents/Resources/DWARF\" && " + dsyms_command + " && " + plist_command),
-            env = {
+            env = shared_environment.default_env | {
                 "OUTPUT_DIR": dsym_bundle_dir.path,
             },
             mnemonic = "DSYMBundleCopy",

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -43,6 +43,10 @@ load(
     "processor",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:bundle_paths.bzl",
     "bundle_paths",
 )
@@ -198,6 +202,7 @@ def _framework_import_partial_impl(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
             arguments = [args],
+            env = shared_environment.default_env,
             executable = imported_dynamic_framework_processor,
             execution_requirements = execution_requirements,
             inputs = input_files,

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -35,6 +35,10 @@ load(
     "processor",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:defines.bzl",
     "defines",
 )
@@ -104,6 +108,7 @@ def _swift_dylib_action(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = [swift_stdlib_tool_args],
+        env = shared_environment.default_env,
         executable = swift_stdlib_tool,
         inputs = binary_files,
         mnemonic = "SwiftStdlibCopy",

--- a/apple/internal/resource_actions/BUILD
+++ b/apple/internal/resource_actions/BUILD
@@ -17,6 +17,7 @@ bzl_library(
         "//apple:utils",
         "//apple/internal:apple_product_type",
         "//apple/internal:bundling_support",
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
@@ -31,6 +32,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal:intermediates",
+        "//apple/internal:shared_environment",
         "@build_bazel_apple_support//lib:apple_support",
     ],
 )
@@ -42,6 +44,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
         "@build_bazel_apple_support//lib:apple_support",
     ],
@@ -54,6 +57,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
@@ -106,6 +110,7 @@ bzl_library(
         "//apple:providers",
         "//apple/internal:intermediates",
         "//apple/internal:platform_support",
+        "//apple/internal:shared_environment",
         "@bazel_skylib//lib:paths",
         "@build_bazel_apple_support//lib:apple_support",
     ],
@@ -118,6 +123,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//apple/internal:shared_environment",
         "@build_bazel_apple_support//lib:apple_support",
     ],
 )
@@ -129,6 +135,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "//apple/internal:shared_environment",
         "@build_bazel_apple_support//lib:apple_support",
     ],
 )

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -47,6 +47,10 @@ load(
     "intermediates",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
@@ -619,6 +623,7 @@ def compile_asset_catalog(
         actions = actions,
         arguments = [args],
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         execution_requirements = {"no-sandbox": "1"},
         inputs = asset_files,

--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -16,6 +16,7 @@
 
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load("//apple/internal:intermediates.bzl", "intermediates")
+load("//apple/internal:shared_environment.bzl", "shared_environment")
 
 # Maps the strings passed in to the "families" attribute to the string represention used as an input
 # for the App Intents Metadata Processor tool.
@@ -128,6 +129,7 @@ an issue with the Apple BUILD rules with repro steps.
         actions = actions,
         apple_fragment = apple_fragment,
         arguments = [args],
+        env = shared_environment.default_env,
         command = '''\
 set -euo pipefail
 

--- a/apple/internal/resource_actions/datamodel.bzl
+++ b/apple/internal/resource_actions/datamodel.bzl
@@ -19,6 +19,10 @@ load(
     "apple_support",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
@@ -61,6 +65,7 @@ def compile_datamodels(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = args,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         inputs = input_files,
         mnemonic = "MomCompile",
@@ -95,6 +100,7 @@ def compile_mappingmodel(
         actions = actions,
         arguments = [args],
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         inputs = input_files,
         mnemonic = "MappingModelCompile",
@@ -145,6 +151,7 @@ def generate_datamodels(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = [args],
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         inputs = input_files,
         mnemonic = "MomGenerate",

--- a/apple/internal/resource_actions/ibtool.bzl
+++ b/apple/internal/resource_actions/ibtool.bzl
@@ -23,6 +23,10 @@ load(
     "apple_support",
 )
 load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
+load(
     "//apple/internal/utils:xctoolrunner.bzl",
     xctoolrunner_support = "xctoolrunner",
 )
@@ -77,6 +81,7 @@ def compile_storyboard(
         actions = actions,
         arguments = [args],
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         execution_requirements = {"no-sandbox": "1"},
         inputs = [input_file],
@@ -130,6 +135,7 @@ def link_storyboards(
         actions = actions,
         arguments = [args],
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         execution_requirements = {"no-sandbox": "1"},
         inputs = storyboardc_dirs,
@@ -184,6 +190,7 @@ def compile_xib(
         actions = actions,
         arguments = [args],
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         executable = xctoolrunner,
         execution_requirements = {"no-sandbox": "1"},
         inputs = [input_file],

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -38,6 +38,10 @@ load(
     "//apple/internal:platform_support.bzl",
     "platform_support",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def plisttool_action(
         *,
@@ -67,6 +71,7 @@ def plisttool_action(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         arguments = [control_file.path],
+        env = shared_environment.default_env,
         executable = plisttool,
         inputs = inputs + [control_file],
         mnemonic = mnemonic,
@@ -104,6 +109,7 @@ def compile_plist(*, actions, input_file, output_file, platform_prerequisites):
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
         command = complete_command,
+        env = shared_environment.default_env,
         inputs = [input_file],
         mnemonic = mnemonic,
         outputs = [output_file],

--- a/apple/internal/resource_actions/png.bzl
+++ b/apple/internal/resource_actions/png.bzl
@@ -18,6 +18,10 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def copy_png(*, actions, input_file, output_file, platform_prerequisites):
     """Creates an action that copies and compresses a png using copypng.
@@ -56,6 +60,7 @@ def copy_png(*, actions, input_file, output_file, platform_prerequisites):
                 input_file.path,
                 output_file.path,
             ],
+            env = shared_environment.default_env,
             executable = "/usr/bin/xcrun",
             inputs = [input_file],
             mnemonic = "CopyPng",

--- a/apple/internal/resource_actions/texture_atlas.bzl
+++ b/apple/internal/resource_actions/texture_atlas.bzl
@@ -18,6 +18,10 @@ load(
     "@build_bazel_apple_support//lib:apple_support.bzl",
     "apple_support",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def compile_texture_atlas(
         *,
@@ -38,6 +42,7 @@ def compile_texture_atlas(
     apple_support.run(
         actions = actions,
         apple_fragment = platform_prerequisites.apple_fragment,
+        env = shared_environment.default_env,
         arguments = [
             "TextureAtlas",
             input_path,

--- a/apple/internal/shared_environment.bzl
+++ b/apple/internal/shared_environment.bzl
@@ -1,0 +1,30 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Environment related functions and providers.
+"""
+
+visibility([
+    "//apple/...",
+    "//test/...",
+])
+
+_DEFAULT_ENV = {
+    "SWIFT_DETERMINISTIC_HASHING": "1",
+}
+
+shared_environment = struct(
+    default_env = _DEFAULT_ENV,
+)

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -26,6 +26,10 @@ load(
     "//apple/internal:intermediates.bzl",
     "intermediates",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def _create_stub_binary(
         *,
@@ -75,6 +79,7 @@ def _create_stub_binary(
         apple_support.run_shell(
             actions = actions,
             apple_fragment = platform_prerequisites.apple_fragment,
+            env = shared_environment.default_env,
             command = "cp -f \"$SDKROOT/{xcode_stub_path}\" {output_path}".format(
                 output_path = binary_artifact.path,
                 xcode_stub_path = xcode_stub_path,

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -27,6 +27,10 @@ load(
     "//apple/internal:providers.bzl",
     "new_applebundleversioninfo",
 )
+load(
+    "//apple/internal:shared_environment.bzl",
+    "shared_environment",
+)
 
 def _collect_group_names(s):
     """Returns the list of placeholder names found in the given string.
@@ -138,6 +142,7 @@ def _apple_bundle_version_impl(ctx):
     ctx.actions.run(
         executable = versiontool,
         arguments = [control_file.path, bundle_version_file.path],
+        env = shared_environment.default_env,
         inputs = inputs,
         outputs = [bundle_version_file],
         mnemonic = "AppleBundleVersion",

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -217,6 +217,7 @@ bzl_library(
     deps = [
         "//apple:linker",
         "//apple/build_settings",
+        "//apple/internal:shared_environment",
         "//test/starlark_tests/rules:test_rules",
     ],
 )

--- a/test/starlark_tests/ios_application_resources_test.bzl
+++ b/test/starlark_tests/ios_application_resources_test.bzl
@@ -268,16 +268,6 @@ Found the following legacy .appiconset files: """,
         tags = [name],
     )
 
-    # Tests that icon composer icons will be flagged when building against Xcode 16 instead of 26.
-    analysis_failure_message_test(
-        name = "{}_test_xcode_16_with_icon_composer_icons_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_icon_bundle_only_for_low_minimum_os_version",
-        expected_error = """
-Found Icon Composer .icon bundles among the assigned app_icons. These are only supported on Xcode 26 or later.""",
-        # Skip on CI since we no longer run tests using Xcode 16.
-        tags = [name] + common.skip_ci_tags,
-    )
-
     # Tests that the launch storyboard is bundled with the application and that
     # the bundler inserts the correct key/value into Info.plist.
     archive_contents_test(

--- a/test/starlark_tests/order_file_tests.bzl
+++ b/test/starlark_tests/order_file_tests.bzl
@@ -121,12 +121,11 @@ def order_file_test_suite(*, name):
     apple_verification_test(
         name = "{}_not_applied_test".format(name),
         build_type = "simulator",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_minimal_order_file",
         verifier_script = "verifier_scripts/order_file_verifier.sh",
         env = {
             # No apple_order_file in ios_application deps, so order file shouldn't be applied.
-            "FIRST_SYMBOL": ["dyld_stub_binder"],
-            "ORDERED_SYMBOLS": ["dyld_stub_binder", "__mh_execute_header", "_dontCallMeMain", "_anotherFunctionMain", "_main"],
+            "ORDERED_SYMBOLS": ["__mh_execute_header", "_dontCallMeMain", "_anotherFunctionMain", "_main"],
         },
         tags = [name],
         timeout = "short",
@@ -135,12 +134,11 @@ def order_file_test_suite(*, name):
     apple_verification_test(
         name = "{}_not_opt_test".format(name),
         build_type = "simulator",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_order_file",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_order_file_symbols",
         verifier_script = "verifier_scripts/order_file_verifier.sh",
         env = {
             # Not "opt" build, so order file shouldn't be applied.
-            "FIRST_SYMBOL": ["dyld_stub_binder"],
-            "ORDERED_SYMBOLS": ["dyld_stub_binder", "__mh_execute_header", "_dontCallMeMain", "_anotherFunctionMain", "_main"],
+            "ORDERED_SYMBOLS": ["__mh_execute_header", "_dontCallMeMain", "_anotherFunctionMain", "_main"],
         },
         tags = [name],
         timeout = "short",
@@ -149,12 +147,11 @@ def order_file_test_suite(*, name):
     apple_verification_test(
         name = "{}_test".format(name),
         build_type = "simulator",
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_order_file",
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_order_file_symbols",
         verifier_script = "verifier_scripts/order_file_verifier.sh",
         env = {
             # Order file should be applied.
-            "FIRST_SYMBOL": ["dyld_stub_binder"],
-            "ORDERED_SYMBOLS": ["dyld_stub_binder", "__mh_execute_header", "_main", "_dontCallMeMain", "_anotherFunctionMain"],
+            "ORDERED_SYMBOLS": ["__mh_execute_header", "_main", "_dontCallMeMain", "_anotherFunctionMain"],
         },
         tags = [name],
         timeout = "short",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -120,6 +120,12 @@ objc_library(
 )
 
 objc_library(
+    name = "objc_order_file_main_lib",
+    srcs = ["order_file_main.m"],
+    tags = common.fixture_tags,
+)
+
+objc_library(
     name = "objc_lib_with_sdk_dylibs",
     srcs = ["common.m"],
     hdrs = ["common.h"],

--- a/test/starlark_tests/resources/order_file_main.m
+++ b/test/starlark_tests/resources/order_file_main.m
@@ -1,0 +1,29 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+__attribute__((used)) void dontCallMeMain() {
+  int *foo = NULL;
+  *foo = 0;
+}
+
+__attribute__((used)) void anotherFunctionMain() {
+  int *foo = NULL;
+  *foo = 0;
+}
+
+int main() {
+  return 0;
+}

--- a/test/starlark_tests/rules/BUILD
+++ b/test/starlark_tests/rules/BUILD
@@ -15,6 +15,7 @@ bzl_library(
         "//apple/internal:apple_product_type",
         "//apple/internal:intermediates",
         "//apple/internal:providers",
+        "//apple/internal:shared_environment",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:new_sets",
         "@bazel_skylib//lib:paths",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -125,6 +125,21 @@ ios_application(
 )
 
 ios_application(
+    name = "app_minimal_order_file",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        "//test/starlark_tests/resources:objc_order_file_main_lib",
+    ],
+)
+
+ios_application(
     name = "app_minimal_with_space_and_post_processor",
     bundle_id = "com.google.example",
     bundle_name = "app minimal",
@@ -5543,6 +5558,22 @@ ios_application(
     deps = [
         ":app_order_file",
         "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+ios_application(
+    name = "app_with_order_file_symbols",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    provisioning_profile = "//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    tags = common.fixture_tags,
+    deps = [
+        ":app_order_file",
+        "//test/starlark_tests/resources:objc_order_file_main_lib",
     ],
 )
 

--- a/test/starlark_tests/verifier_scripts/order_file_verifier.sh
+++ b/test/starlark_tests/verifier_scripts/order_file_verifier.sh
@@ -37,8 +37,10 @@ set -euo pipefail
 #    This is a trivial way to test that the order file has been applied to the
 #    binary and that the symbols inside have been re-ordered as a result.
 #
-#  ORDERED_SYMBOLS: Will be compared against all symbols found in the binary.
-#    This is a more thorough test that the order file has been applied.
+#  ORDERED_SYMBOLS: Will be compared against a contiguous block of symbols
+#    found in the binary, starting at the first expected symbol. This tolerates
+#    extra leading toolchain symbols while still asserting that the ordered
+#    symbols stay grouped together in the expected order.
 #
 
 something_tested=false
@@ -62,10 +64,31 @@ if [[ -n "${ORDERED_SYMBOLS-}" ]]; then
   something_tested=true
 
   ordered_symbols_length=${#ORDERED_SYMBOLS[@]}
-  IFS=$'\n' symbols_output_idx=($(head -n $ordered_symbols_length "$symbols_output"))
+  first_expected_symbol="${ORDERED_SYMBOLS[0]}"
+  first_expected_line=""
+  current_line=0
+
+  while IFS= read -r symbol; do
+    ((current_line += 1))
+    if [[ "$symbol" == "$first_expected_symbol" ]]; then
+      first_expected_line=$current_line
+      break
+    fi
+  done < "$symbols_output"
+
+  if [[ -z "$first_expected_line" ]]; then
+    fail "First ordered symbol not found: $first_expected_symbol"
+  fi
+
+  last_expected_line=$((first_expected_line + ordered_symbols_length - 1))
+  IFS=$'\n' contiguous_symbols=($(sed -n "${first_expected_line},${last_expected_line}p" "$symbols_output"))
+
+  if (( ${#contiguous_symbols[@]} != ordered_symbols_length )); then
+    fail "Expected ${ordered_symbols_length} contiguous ordered symbols starting at line ${first_expected_line}, got ${#contiguous_symbols[@]}"
+  fi
 
   for ((idx=0; idx<ordered_symbols_length; ++idx)); do
-    assert_equals "${ORDERED_SYMBOLS[idx]}" "${symbols_output_idx[idx]}"
+    assert_equals "${ORDERED_SYMBOLS[idx]}" "${contiguous_symbols[idx]}"
   done
 fi
 


### PR DESCRIPTION
In certain controlled environments, such as executing tools in exec config, it may be helpful to selectively disable hash seed randomization, so that hash values and the order of elements in set and dictionary values remain consistent across executions. We disable  hash seed randomization by defining the environment variable SWIFT_DETERMINISTIC_HASHING with the value of 1. The Swift runtime looks at this variable during process startup and, if it’s defined, replaces the random seed with a constant value. ([SE-0206](https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md))

(cherry picked from commit [878dd666e24189fa13a715995f702f10aa478795)](https://github.com/bazelbuild/rules_apple/commit/878dd666e24189fa13a715995f702f10aa478795)