### PR TITLE
Support macOS tree-artifact bundling for imported versioned frameworks

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -46,16 +46,8 @@ load(
     "group_files_by_directory",
 )
 load(
-    "//apple/internal:apple_toolchains.bzl",
-    "AppleXPlatToolsToolchainInfo",
-)
-load(
     "//apple/internal:cc_toolchain_info_support.bzl",
     "cc_toolchain_info_support",
-)
-load(
-    "//apple/internal:experimental.bzl",
-    "is_experimental_tree_artifact_enabled",
 )
 load(
     "//apple/internal:framework_import_support.bzl",
@@ -171,7 +163,6 @@ def _framework_search_paths(header_imports):
 def _apple_dynamic_framework_import_impl(ctx):
     """Implementation for the apple_dynamic_framework_import rule."""
     actions = ctx.actions
-    apple_xplat_toolchain_info = ctx.attr._xplat_toolchain[AppleXPlatToolsToolchainInfo]
     cc_toolchain = find_cc_toolchain(ctx)
     deps = ctx.attr.deps
     disabled_features = ctx.disabled_features
@@ -179,22 +170,7 @@ def _apple_dynamic_framework_import_impl(ctx):
     framework_imports = ctx.files.framework_imports
     label = ctx.label
 
-    # TODO(b/258492867): Add tree artifacts support when Bazel can handle remote actions with
-    # symlinks. See https://github.com/bazelbuild/bazel/issues/16361.
     target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
-    has_versioned_framework_files = framework_import_support.has_versioned_framework_files(
-        framework_imports,
-    )
-    tree_artifact_enabled = (
-        apple_xplat_toolchain_info.build_settings.use_tree_artifacts_outputs or
-        is_experimental_tree_artifact_enabled(config_vars = ctx.var)
-    )
-    if target_triplet.os == "macos" and has_versioned_framework_files and tree_artifact_enabled:
-        fail("The apple_dynamic_framework_import rule does not yet support versioned " +
-             "frameworks with the experimental tree artifact feature/build setting. " +
-             "Please ensure that the `apple.experimental.tree_artifact_outputs` variable is not " +
-             "set to 1 on the command line or in your active build configuration.")
-
     providers = []
     framework = framework_import_support.classify_framework_imports(
         ctx.var,

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -35,10 +35,6 @@ load(
     "cc_toolchain_info_support",
 )
 load(
-    "//apple/internal:experimental.bzl",
-    "is_experimental_tree_artifact_enabled",
-)
-load(
     "//apple/internal:framework_import_support.bzl",
     "framework_import_support",
 )
@@ -495,22 +491,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     xcframework_imports = ctx.files.xcframework_imports
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
-    # TODO(b/258492867): Add tree artifacts support when Bazel can handle remote actions with
-    # symlinks. See https://github.com/bazelbuild/bazel/issues/16361.
     target_triplet = cc_toolchain_info_support.get_apple_clang_triplet(cc_toolchain)
-    has_versioned_framework_files = framework_import_support.has_versioned_framework_files(
-        xcframework_imports,
-    )
-    tree_artifact_enabled = (
-        apple_xplat_toolchain_info.build_settings.use_tree_artifacts_outputs or
-        is_experimental_tree_artifact_enabled(config_vars = ctx.var)
-    )
-    if target_triplet.os == "macos" and has_versioned_framework_files and tree_artifact_enabled:
-        fail("The apple_dynamic_xcframework_import rule does not yet support versioned " +
-             "frameworks with the experimental tree artifact feature/build setting. " +
-             "Please ensure that the `apple.experimental.tree_artifact_outputs` variable is not " +
-             "set to 1 on the command line or in your active build configuration.")
-
     xcframework = _classify_xcframework_imports(ctx.var, xcframework_imports)
     if xcframework.bundle_type == _BUNDLE_TYPE.libraries:
         fail("Importing XCFrameworks with dynamic libraries is not supported.")

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -21,7 +21,6 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
     "analysis_failure_message_test",
-    "analysis_failure_message_with_tree_artifact_outputs_test",
 )
 load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
@@ -40,6 +39,10 @@ load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
     "binary_contents_test",
+)
+load(
+    "//test/starlark_tests/rules:directory_test.bzl",
+    "directory_test",
 )
 
 analysis_output_group_info_files_with_xcframework_processor_test = make_analysis_output_group_info_files_test({
@@ -483,14 +486,23 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
 
-    # Verify importing XCFramework with versioned frameworks and tree artifacts fails.
-    analysis_failure_message_with_tree_artifact_outputs_test(
-        name = "{}_fails_with_versioned_frameworks_and_tree_artifact_outputs_test".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_versioned_xcframework",
-        expected_error = (
-            "The apple_dynamic_xcframework_import rule does not yet support versioned " +
-            "frameworks with the experimental tree artifact feature/build setting."
-        ),
+    directory_test(
+        name = "{}_bundles_versioned_frameworks_with_tree_artifact_outputs_test".format(name),
+        build_settings = {
+            build_settings_labels.use_tree_artifacts_outputs: "True",
+        },
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_dynamic_versioned_xcframework_tree_artifacts",
+        expected_directories = {
+            "app_with_imported_dynamic_versioned_xcframework_tree_artifacts.app": [
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/Resources/Info.plist",
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/Resources/Info.plist",
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/Resources/Info.plist",
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/generated_dynamic_macos_versioned_xcframework",
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/Versions/Current/generated_dynamic_macos_versioned_xcframework",
+                "Contents/Frameworks/generated_dynamic_macos_versioned_xcframework.framework/Versions/A/generated_dynamic_macos_versioned_xcframework",
+            ],
+        },
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -15,8 +15,8 @@
 """macos_application Starlark tests."""
 
 load(
-    "//test/starlark_tests/rules:analysis_failure_message_test.bzl",
-    "analysis_failure_message_with_tree_artifact_outputs_test",
+    "//apple/build_settings:build_settings.bzl",
+    "build_settings_labels",
 )
 load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
@@ -43,6 +43,10 @@ load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "apple_symbols_file_test",
     "archive_contents_test",
+)
+load(
+    "//test/starlark_tests/rules:directory_test.bzl",
+    "directory_test",
 )
 load(
     "//test/starlark_tests/rules:infoplist_contents_test.bzl",
@@ -416,14 +420,23 @@ def macos_application_test_suite(name):
         tags = [name],
     )
 
-    # Verify importing versioned framework with tree artifacts enabled fails.
-    analysis_failure_message_with_tree_artifact_outputs_test(
-        name = "{}_fails_with_imported_versioned_framework_and_tree_artifact_outputs".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_versioned_fmwk",
-        expected_error = (
-            "The apple_dynamic_framework_import rule does not yet support versioned " +
-            "frameworks with the experimental tree artifact feature/build setting."
-        ),
+    directory_test(
+        name = "{}_bundles_imported_versioned_framework_with_tree_artifact_outputs".format(name),
+        build_settings = {
+            build_settings_labels.use_tree_artifacts_outputs: "True",
+        },
+        build_type = "device",
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_with_imported_versioned_fmwk_tree_artifacts",
+        expected_directories = {
+            "app_with_imported_versioned_fmwk_tree_artifacts.app": [
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/Resources/Info.plist",
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/Resources/Info.plist",
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/Resources/Info.plist",
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/generated_macos_dynamic_versioned_fmwk",
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/Versions/Current/generated_macos_dynamic_versioned_fmwk",
+                "Contents/Frameworks/generated_macos_dynamic_versioned_fmwk.framework/Versions/A/generated_macos_dynamic_versioned_fmwk",
+            ],
+        },
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -2175,6 +2175,20 @@ macos_application(
     ],
 )
 
+macos_application(
+    name = "app_with_imported_versioned_fmwk_tree_artifacts",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_versioned_fmwk_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 objc_library(
     name = "dynamic_versioned_fmwk_depending_lib",
     tags = common.fixture_tags,
@@ -2254,6 +2268,20 @@ macos_application(
         "//test/starlark_tests/resources:Info.plist",
     ],
     ipa_post_processor = "//test/starlark_tests/targets_under_test/apple:ipa_post_processor_verify_codesigning",
+    minimum_os_version = common.min_os_macos.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":dynamic_versioned_xcframework_depending_lib",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
+macos_application(
+    name = "app_with_imported_dynamic_versioned_xcframework_tree_artifacts",
+    bundle_id = "com.google.example",
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
     minimum_os_version = common.min_os_macos.baseline,
     tags = common.fixture_tags,
     deps = [

--- a/tools/bundletool/BUILD
+++ b/tools/bundletool/BUILD
@@ -32,6 +32,16 @@ py_binary(
     visibility = [
         "//apple/internal:__pkg__",
     ],
+    deps = [":bundletool_experimental_lib"],
+)
+
+py_library(
+    name = "bundletool_experimental_lib",
+    srcs = [
+        "__init__.py",
+        "bundletool_experimental.py",
+    ],
+    srcs_version = "PY3",
 )
 
 py_test(
@@ -39,6 +49,13 @@ py_test(
     srcs = ["bundletool_test.py"],
     python_version = "PY3",
     deps = [":bundletool_lib"],
+)
+
+py_test(
+    name = "bundletool_experimental_test",
+    srcs = ["bundletool_experimental_test.py"],
+    python_version = "PY3",
+    deps = [":bundletool_experimental_lib"],
 )
 
 filegroup(

--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -52,6 +52,7 @@ import json
 import os
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import zipfile
@@ -72,6 +73,13 @@ def _load_clonefile():
 
 BUNDLE_CONFLICT_MSG_TEMPLATE = (
     'Cannot place two files at the same location %r in the bundle')
+
+INVALID_BUNDLE_PATH_MSG_TEMPLATE = (
+    'Cannot place bundle entry %r outside the bundle root')
+
+INVALID_SYMLINK_TARGET_MSG_TEMPLATE = (
+    'Cannot create bundle symlink %r -> %r because the target escapes the '
+    'bundle root')
 
 CODE_SIGN_ERROR_MSG_TEMPLATE = 'Code signing failed with exit code %d'
 
@@ -96,6 +104,24 @@ class CodeSignError(EnvironmentError):
   def __init__(self, exit_code):
     self.exit_code = exit_code
     EnvironmentError.__init__(self, CODE_SIGN_ERROR_MSG_TEMPLATE % exit_code)
+
+
+class BundlePathError(ValueError):
+  """Raised when a bundle path escapes the bundle root."""
+
+  def __init__(self, dest):
+    self.dest = dest
+    ValueError.__init__(self, INVALID_BUNDLE_PATH_MSG_TEMPLATE % dest)
+
+
+class BundleSymlinkError(ValueError):
+  """Raised when a bundle symlink target escapes the bundle root."""
+
+  def __init__(self, dest, target):
+    self.dest = dest
+    self.target = target
+    ValueError.__init__(
+        self, INVALID_SYMLINK_TARGET_MSG_TEMPLATE % (dest, target))
 
 
 class PostProcessorError(EnvironmentError):
@@ -165,15 +191,33 @@ class Bundler(object):
       bundle_root: The bundle root directory into which the files should be
           added.
     """
-    if os.path.isdir(src):
-      for root, _, files in os.walk(src):
+    if os.path.islink(src) and os.path.isdir(src):
+      self._copy_symlink(src, dest, bundle_root)
+    elif os.path.isdir(src):
+      for root, dirs, files in os.walk(src):
         relpath = os.path.relpath(root, src)
+        symlink_dirs = []
+        for dirname in dirs:
+          dirsrc = os.path.join(root, dirname)
+          if os.path.islink(dirsrc):
+            symlink_dirs.append(dirname)
+            dirdest = os.path.normpath(os.path.join(dest, relpath, dirname))
+            self._copy_symlink(dirsrc, dirdest, bundle_root)
+
+        for dirname in symlink_dirs:
+          dirs.remove(dirname)
+
         for filename in files:
           fsrc = os.path.join(root, filename)
           fdest = os.path.normpath(os.path.join(dest, relpath, filename))
-          self._copy_file(fsrc, fdest, executable, bundle_root)
+          if os.path.islink(fsrc):
+            self._copy_symlink(fsrc, fdest, bundle_root)
+          else:
+            self._copy_file(fsrc, fdest, executable, bundle_root)
     elif os.path.isfile(src):
       self._copy_file(src, dest, executable, bundle_root)
+    elif os.path.islink(src):
+      self._copy_symlink(src, dest, bundle_root)
 
   def _add_zip_contents(self, src, dest, bundle_root):
     """Adds the contents of another ZIP file/App to the bundle.
@@ -193,7 +237,8 @@ class Bundler(object):
         # If so, we can just copy those into the expected location
         # without any additional processing
         app_name = os.path.basename(src)
-        shutil.copytree(src, os.path.join(bundle_root, dest, app_name))
+        shutil.copytree(
+            src, os.path.join(bundle_root, dest, app_name), symlinks=True)
     else:
         with zipfile.ZipFile(src, "r") as src_zip:
             for src_zipinfo in src_zip.infolist():
@@ -203,6 +248,10 @@ class Bundler(object):
                 file_dest = os.path.normpath(
                     os.path.join(dest, src_zipinfo.filename)
                 )
+                if self._is_zipinfo_symlink(src_zipinfo):
+                    symlink_target = src_zip.read(src_zipinfo).decode("utf-8")
+                    self._write_symlink(file_dest, symlink_target, bundle_root)
+                    continue
                 if src_zipinfo.filename.endswith("/"):
                     continue
 
@@ -210,6 +259,10 @@ class Bundler(object):
                 executable = src_zipinfo.external_attr >> 16 & 0o111 != 0
                 data = src_zip.read(src_zipinfo)
                 self._write_entry(file_dest, data, executable, bundle_root)
+
+  def _copy_symlink(self, src, dest, bundle_root):
+    """Copies a symbolic link into the bundle."""
+    self._write_symlink(dest, os.readlink(src), bundle_root)
 
   def _copy_file(self, src, dest, executable, bundle_root):
     """Copies a file into the bundle.
@@ -224,6 +277,7 @@ class Bundler(object):
           added.
     """
     full_dest = os.path.join(bundle_root, dest)
+    self._validate_dest_in_bundle(full_dest, bundle_root, dest)
     if (os.path.isfile(full_dest) and
         not filecmp.cmp(full_dest, src, shallow=False)):
       raise BundleConflictError(dest)
@@ -243,6 +297,19 @@ class Bundler(object):
       shutil.copy(src, full_dest)
     os.chmod(full_dest, 0o755 if executable else 0o644)
 
+  def _write_symlink(self, dest, target, bundle_root):
+    """Writes the given symbolic link in the output bundle."""
+    full_dest = os.path.join(bundle_root, dest)
+    self._validate_dest_in_bundle(full_dest, bundle_root, dest)
+    self._validate_symlink_target(full_dest, target, bundle_root, dest)
+    if os.path.lexists(full_dest):
+      if not os.path.islink(full_dest) or os.readlink(full_dest) != target:
+        raise BundleConflictError(dest)
+      return
+
+    self._makedirs_safely(os.path.dirname(full_dest))
+    os.symlink(target, full_dest)
+
   def _write_entry(self, dest, data, executable, bundle_root):
     """Writes the given data as a file in the output ZIP archive.
 
@@ -259,6 +326,7 @@ class Bundler(object):
           at the same location in the ZIP file.
     """
     full_dest = os.path.join(bundle_root, dest)
+    self._validate_dest_in_bundle(full_dest, bundle_root, dest)
     if os.path.isfile(full_dest):
       with open(full_dest, "rb") as f:
         if f.read() != data:
@@ -268,6 +336,28 @@ class Bundler(object):
     with open(full_dest, 'wb') as f:
       f.write(data)
     os.chmod(full_dest, 0o755 if executable else 0o644)
+
+  def _is_zipinfo_symlink(self, zipinfo):
+    """Returns whether a zip entry stores a symbolic link."""
+    return stat.S_ISLNK(zipinfo.external_attr >> 16)
+
+  def _validate_dest_in_bundle(self, full_dest, bundle_root, dest):
+    """Validates that a destination path resolves within the bundle root."""
+    bundle_root_real = os.path.realpath(bundle_root)
+    dest_real = os.path.realpath(full_dest)
+    if os.path.commonpath([bundle_root_real, dest_real]) != bundle_root_real:
+      raise BundlePathError(dest)
+
+  def _validate_symlink_target(self, full_dest, target, bundle_root, dest):
+    """Validates that a symlink target does not escape the bundle root."""
+    if os.path.isabs(target):
+      raise BundleSymlinkError(dest, target)
+
+    bundle_root_real = os.path.realpath(bundle_root)
+    target_path = os.path.normpath(os.path.join(os.path.dirname(full_dest), target))
+    target_real = os.path.realpath(target_path)
+    if os.path.commonpath([bundle_root_real, target_real]) != bundle_root_real:
+      raise BundleSymlinkError(dest, target)
 
   def _makedirs_safely(self, path):
     """Creates a new directory, silently succeeding if it already exists.
@@ -292,7 +382,9 @@ class Bundler(object):
     # bundle, but keep the work_dir for compatibility with the bundletool post
     # processing.
     try:
-      subprocess.check_call((post_processor, work_dir), env={"TREE_ARTIFACT_OUTPUT": bundle_root})
+      env = os.environ.copy()
+      env["TREE_ARTIFACT_OUTPUT"] = bundle_root
+      subprocess.check_call((post_processor, work_dir), env=env)
     except subprocess.CalledProcessError as e:
       raise PostProcessorError(e.returncode) from e
 

--- a/tools/bundletool/bundletool_experimental_test.py
+++ b/tools/bundletool/bundletool_experimental_test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python3
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the experimental tree-artifact bundler."""
+
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+import zipfile
+
+from tools.bundletool import bundletool_experimental
+
+
+class BundlerExperimentalTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._scratch_dir = tempfile.mkdtemp("bundlerExperimentalScratch")
+
+  def tearDown(self):
+    super().tearDown()
+    shutil.rmtree(self._scratch_dir)
+
+  def _run_bundler(self, control):
+    output = os.path.join(self._scratch_dir, "output")
+    control["output"] = output
+    bundletool_experimental.Bundler(control).run()
+    return output
+
+  def _scratch_file(self, path, content=""):
+    full_path = os.path.join(self._scratch_dir, path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "w", encoding="utf-8") as fp:
+      fp.write(content)
+    return full_path
+
+  def _scratch_symlink(self, path, target):
+    full_path = os.path.join(self._scratch_dir, path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    os.symlink(target, full_path)
+    return full_path
+
+  def _scratch_zip(self, name):
+    path = os.path.join(self._scratch_dir, name)
+    with zipfile.ZipFile(path, "w") as zf:
+      self._add_zip_file(
+          zf, "Foo.framework/Versions/A/Foo", "framework-binary")
+      self._add_zip_file(
+          zf,
+          "Foo.framework/Versions/A/Resources/Info.plist",
+          "plist-content",
+      )
+      self._add_zip_symlink(
+          zf, "Foo.framework/Versions/Current", "A")
+      self._add_zip_symlink(
+          zf, "Foo.framework/Foo", "Versions/Current/Foo")
+      self._add_zip_symlink(
+          zf, "Foo.framework/Resources", "Versions/Current/Resources")
+    return path
+
+  def _add_zip_file(self, zf, path, content):
+    zipinfo = zipfile.ZipInfo(path)
+    zipinfo.external_attr = (stat.S_IFREG | 0o644) << 16
+    zipinfo.compress_type = zipfile.ZIP_STORED
+    zf.writestr(zipinfo, content)
+
+  def _add_zip_symlink(self, zf, path, target):
+    zipinfo = zipfile.ZipInfo(path)
+    zipinfo.external_attr = (stat.S_IFLNK | 0o777) << 16
+    zipinfo.compress_type = zipfile.ZIP_STORED
+    zf.writestr(zipinfo, target)
+
+  def _assert_symlink(self, path, target):
+    self.assertTrue(os.path.islink(path), msg=f"{path} should be a symlink")
+    self.assertEqual(target, os.readlink(path))
+
+  def test_bundle_merge_files_preserves_symlinked_files_and_directories(self):
+    framework_root = os.path.join(self._scratch_dir, "Foo.framework")
+    self._scratch_file(
+        "Foo.framework/Versions/A/Foo", "framework-binary")
+    self._scratch_file(
+        "Foo.framework/Versions/A/Resources/Info.plist", "plist-content")
+    self._scratch_symlink("Foo.framework/Versions/Current", "A")
+    self._scratch_symlink("Foo.framework/Foo", "Versions/Current/Foo")
+    self._scratch_symlink(
+        "Foo.framework/Resources", "Versions/Current/Resources")
+
+    output = self._run_bundler({
+        "bundle_merge_files": [{
+            "src": framework_root,
+            "dest": "Contents/Frameworks/Foo.framework",
+        }],
+    })
+
+    bundled_framework = os.path.join(output, "Contents/Frameworks/Foo.framework")
+    self.assertTrue(os.path.isfile(os.path.join(
+        bundled_framework, "Versions/A/Foo")))
+    self.assertTrue(os.path.isfile(os.path.join(
+        bundled_framework, "Versions/A/Resources/Info.plist")))
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Versions/Current"), "A")
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Foo"), "Versions/Current/Foo")
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Resources"), "Versions/Current/Resources")
+
+  def test_bundle_merge_zips_preserves_symlink_entries(self):
+    framework_zip = self._scratch_zip("Foo.zip")
+
+    output = self._run_bundler({
+        "bundle_merge_zips": [{
+            "src": framework_zip,
+            "dest": "Contents/Frameworks",
+        }],
+    })
+
+    bundled_framework = os.path.join(output, "Contents/Frameworks/Foo.framework")
+    self.assertTrue(os.path.isfile(os.path.join(
+        bundled_framework, "Versions/A/Foo")))
+    self.assertTrue(os.path.isfile(os.path.join(
+        bundled_framework, "Versions/A/Resources/Info.plist")))
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Versions/Current"), "A")
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Foo"), "Versions/Current/Foo")
+    self._assert_symlink(os.path.join(
+        bundled_framework, "Resources"), "Versions/Current/Resources")
+
+  def test_bundle_merge_zips_rejects_absolute_symlink_targets(self):
+    framework_zip = os.path.join(self._scratch_dir, "Foo.zip")
+    with zipfile.ZipFile(framework_zip, "w") as zf:
+      self._add_zip_symlink(zf, "Foo.framework/Foo", "/tmp/outside")
+
+    with self.assertRaisesRegex(
+        bundletool_experimental.BundleSymlinkError,
+        r"Cannot create bundle symlink .* escapes the bundle root",
+    ):
+      self._run_bundler({
+          "bundle_merge_zips": [{
+              "src": framework_zip,
+              "dest": "Contents/Frameworks",
+          }],
+      })
+
+  def test_bundle_merge_zips_rejects_relative_symlink_targets_that_escape(self):
+    framework_zip = os.path.join(self._scratch_dir, "Foo.zip")
+    with zipfile.ZipFile(framework_zip, "w") as zf:
+      self._add_zip_symlink(zf, "Foo.framework/Foo", "../../../../outside")
+
+    with self.assertRaisesRegex(
+        bundletool_experimental.BundleSymlinkError,
+        r"Cannot create bundle symlink .* escapes the bundle root",
+    ):
+      self._run_bundler({
+          "bundle_merge_zips": [{
+              "src": framework_zip,
+              "dest": "Contents/Frameworks",
+          }],
+      })
+
+  def test_bundle_merge_zips_rejects_writes_through_escaping_symlink_ancestors(self):
+    framework_zip = os.path.join(self._scratch_dir, "Foo.zip")
+    with zipfile.ZipFile(framework_zip, "w") as zf:
+      self._add_zip_symlink(zf, "Foo", "bar")
+      self._add_zip_file(zf, "bar/.keep", "")
+      self._add_zip_file(zf, "Foo/Contents/file.txt", "payload")
+
+    output = self._run_bundler({
+        "bundle_merge_zips": [{
+            "src": framework_zip,
+            "dest": "",
+        }],
+    })
+
+    self._assert_symlink(os.path.join(output, "Foo"), "bar")
+    self.assertTrue(os.path.isfile(os.path.join(output, "bar/Contents/file.txt")))
+
+    escaping_zip = os.path.join(self._scratch_dir, "Escaping.zip")
+    with zipfile.ZipFile(escaping_zip, "w") as zf:
+      self._add_zip_symlink(zf, "Foo", "../outside")
+      self._add_zip_file(zf, "Foo/Contents/file.txt", "payload")
+
+    with self.assertRaisesRegex(
+        bundletool_experimental.BundleSymlinkError,
+        r"Cannot create bundle symlink .* escapes the bundle root",
+    ):
+      self._run_bundler({
+          "bundle_merge_zips": [{
+              "src": escaping_zip,
+              "dest": "",
+          }],
+      })
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
+++ b/tools/imported_dynamic_framework_processor/imported_dynamic_framework_processor_test.py
@@ -14,6 +14,8 @@
 """Tests for xcframework_processor_tool."""
 
 import os
+import shutil
+import tempfile
 import unittest
 from unittest import mock
 
@@ -23,6 +25,21 @@ from tools.wrapper_common import lipo
 
 
 class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._scratch_dir = tempfile.mkdtemp("importedDynamicFrameworkProcessor")
+
+  def tearDown(self):
+    super().tearDown()
+    shutil.rmtree(self._scratch_dir)
+
+  def _scratch_file(self, path, content=""):
+    full_path = os.path.join(self._scratch_dir, path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "w", encoding="utf-8") as fp:
+      fp.write(content)
+    return full_path
 
   @mock.patch.object(execute, "execute_and_filter_output")
   def test_get_install_path_for_binary(self, mock_execute):
@@ -172,6 +189,88 @@ class ImportedDynamicFrameworkProcessorTest(unittest.TestCase):
         "/tmp/path/to/fake/binary",
         executable=True,
         output_path="/tmp/path/to/outputs")
+
+  @mock.patch.object(
+      imported_dynamic_framework_processor.codesigningtool,
+      "find_identity_and_sign_bundle_paths")
+  @mock.patch.object(
+      imported_dynamic_framework_processor.execute, "execute_and_filter_output")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_update_modified_timestamps")
+  @mock.patch.object(
+      imported_dynamic_framework_processor, "_try_get_framework_version_from_structure")
+  @mock.patch.object(
+      imported_dynamic_framework_processor.argparse.ArgumentParser, "parse_args")
+  def test_main_reconstructs_versioned_framework_and_signs_current_version(
+      self,
+      mock_parse_args,
+      mock_try_get_framework_version_from_structure,
+      mock_update_modified_timestamps,
+      mock_execute,
+      mock_sign):
+    framework_binary = self._scratch_file(
+        "Foo.framework/Versions/A/Foo", "framework-binary")
+    framework_resource = self._scratch_file(
+        "Foo.framework/Versions/A/Resources/Info.plist", "plist-content")
+    self._scratch_file("Foo.framework/Versions/B/Resources/Info.plist", "other")
+    temp_path = os.path.join(self._scratch_dir, "out", "Foo.framework")
+    output_zip = os.path.join(self._scratch_dir, "Foo.zip")
+
+    mock_parse_args.return_value = mock.Mock(
+        framework_binary=framework_binary,
+        framework_file=[
+            framework_binary,
+            framework_resource,
+            os.path.join(
+                self._scratch_dir,
+                "Foo.framework/Versions/B/Resources/Info.plist",
+            ),
+        ],
+        slice=["x86_64"],
+        strip_bitcode=False,
+        temp_path=temp_path,
+        output_zip=output_zip,
+        disable_signing=False,
+        target_to_sign=[],
+    )
+    mock_try_get_framework_version_from_structure.return_value = "A"
+    mock_sign.return_value = 0
+
+    with mock.patch.object(
+        imported_dynamic_framework_processor,
+        "_strip_or_copy_binary",
+        side_effect=lambda **kwargs: (
+            imported_dynamic_framework_processor._copy_framework_file(
+                kwargs["framework_binary"],
+                executable=True,
+                output_path=kwargs["output_path"],
+            )
+        ),
+    ):
+      imported_dynamic_framework_processor.main()
+
+    self.assertTrue(os.path.exists(os.path.join(temp_path, "Versions/A/Foo")))
+    self.assertTrue(os.path.exists(os.path.join(
+        temp_path, "Versions/A/Resources/Info.plist")))
+    self.assertFalse(os.path.exists(os.path.join(
+        temp_path, "Versions/B/Resources/Info.plist")))
+    self.assertTrue(os.path.islink(os.path.join(temp_path, "Versions/Current")))
+    self.assertEqual("A", os.readlink(os.path.join(temp_path, "Versions/Current")))
+    self.assertTrue(os.path.islink(os.path.join(temp_path, "Foo")))
+    self.assertEqual(
+        "Versions/Current/Foo", os.readlink(os.path.join(temp_path, "Foo")))
+    self.assertTrue(os.path.islink(os.path.join(temp_path, "Resources")))
+    self.assertEqual(
+        "Versions/Current/Resources",
+        os.readlink(os.path.join(temp_path, "Resources")),
+    )
+    self.assertEqual(
+        [os.path.join(temp_path, "Versions", "A")],
+        mock_parse_args.return_value.target_to_sign,
+    )
+    mock_sign.assert_called_once()
+    mock_update_modified_timestamps.assert_called_once_with(temp_path)
+    mock_execute.assert_called_once()
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
We are enabling macOS tree-artifact builds to bundle imported versioned dynamic frameworks from both `apple_dynamic_framework_import` and `apple_dynamic_xcframework_import` to unblock https://github.com/bazelbuild/rules_apple/pull/2839

The bulk of the implementation is in bundletool_experimental.py, which now preserves symlinks when merging directory and zip inputs into tree-artifact bundle outputs. That allows versioned framework layouts such as Versions/Current, top-level
  binary symlinks, and Resources symlinks to survive final app bundling. The bundler also validates symlink targets and resolved write destinations so bundle contents cannot escape the output directory.