### PR TITLE
Support module.private.modulemap in framework and xcframework imports

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -222,10 +222,12 @@ def _apple_dynamic_framework_import_impl(ctx):
         ),
     ))
 
-    # Create CcInfo provider.
+    # Collect header imports
     header_imports = list(framework.header_imports)
     if framework.private_module_map_imports:
         header_imports.extend(framework.private_module_map_imports)
+
+    # Create CcInfo provider.
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         cc_toolchain = cc_toolchain,
@@ -368,10 +370,12 @@ def _apple_static_framework_import_impl(ctx):
             linkopts.append("-weak_framework")
             linkopts.append(sdk_framework)
 
-    # Create CcInfo provider
+    # Collect header imports
     header_imports = list(framework.header_imports)
     if framework.private_module_map_imports:
         header_imports.extend(framework.private_module_map_imports)
+
+    # Create CcInfo provider
     providers.append(
         framework_import_support.cc_info_with_dependencies(
             actions = actions,

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -223,6 +223,9 @@ def _apple_dynamic_framework_import_impl(ctx):
     ))
 
     # Create CcInfo provider.
+    header_imports = list(framework.header_imports)
+    if framework.private_module_map_imports:
+        header_imports.extend(framework.private_module_map_imports)
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         cc_toolchain = cc_toolchain,
@@ -235,7 +238,7 @@ def _apple_dynamic_framework_import_impl(ctx):
             framework.swift_interface_imports +
             framework.swift_module_imports,
         ),
-        header_imports = framework.header_imports,
+        header_imports = header_imports,
         kind = "dynamic",
         label = label,
         libraries = [] if ctx.attr.bundle_only else framework.binary_imports,
@@ -366,6 +369,9 @@ def _apple_static_framework_import_impl(ctx):
             linkopts.append(sdk_framework)
 
     # Create CcInfo provider
+    header_imports = list(framework.header_imports)
+    if framework.private_module_map_imports:
+        header_imports.extend(framework.private_module_map_imports)
     providers.append(
         framework_import_support.cc_info_with_dependencies(
             actions = actions,
@@ -381,7 +387,7 @@ def _apple_static_framework_import_impl(ctx):
                 framework.swift_interface_imports +
                 framework.swift_module_imports,
             ),
-            header_imports = framework.header_imports,
+            header_imports = header_imports,
             kind = "static",
             label = label,
             libraries = framework.binary_imports,

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -209,6 +209,7 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
     framework_imports = filter_by_library_identifier(files_by_category.bundling_imports)
     headers = filter_by_library_identifier(files_by_category.header_imports)
     module_maps = filter_by_library_identifier(files_by_category.module_map_imports)
+    private_module_maps = filter_by_library_identifier(files_by_category.private_module_map_imports)
     dsyms = filter_by_library_identifier(files_by_category.dsym_imports)
     dsym_binaries = framework_import_support.get_dsym_binaries(dsyms)
     debug_info_binaries = framework_import_support.get_debug_info_binaries(
@@ -254,6 +255,7 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
         headers = headers,
         includes = includes,
         clang_module_map = module_maps[0] if module_maps else None,
+        private_clang_module_map = private_module_maps[0] if private_module_maps else None,
         swiftmodule = swiftmodules,
         swift_module_interface = swift_module_interfaces[0] if swift_module_interfaces else None,
     )
@@ -315,6 +317,15 @@ def _get_xcframework_library_with_xcframework_processor(
         **intermediates_common
     )
 
+    files_by_category = xcframework.files_by_category
+
+    private_module_map_file = None
+    if files_by_category.private_module_map_imports:
+        private_module_map_file = intermediates.file(
+            file_name = paths.join(modules_dir_path, "module.private.modulemap"),
+            **intermediates_common
+        )
+
     args = actions.args()
     args.add("--bundle_name", xcframework.bundle_name)
     args.add("--info_plist", xcframework.info_plist.path)
@@ -323,11 +334,11 @@ def _get_xcframework_library_with_xcframework_processor(
     args.add("--architecture", target_triplet.architecture)
     args.add("--environment", target_triplet.environment)
 
-    files_by_category = xcframework.files_by_category
     args.add_all(files_by_category.binary_imports, before_each = "--binary_file")
     args.add_all(files_by_category.bundling_imports, before_each = "--bundle_file")
     args.add_all(files_by_category.header_imports, before_each = "--header_file")
     args.add_all(files_by_category.module_map_imports, before_each = "--modulemap_file")
+    args.add_all(files_by_category.private_module_map_imports, before_each = "--private_modulemap_file")
 
     args.add("--binary", binary.path)
     args.add("--library_dir", binary.dirname)
@@ -343,6 +354,8 @@ def _get_xcframework_library_with_xcframework_processor(
         headers_dir,
         module_map_file,
     ]
+    if private_module_map_file:
+        outputs.append(private_module_map_file)
 
     swiftinterface_file = None
     if files_by_category.swift_interface_imports:
@@ -414,6 +427,7 @@ def _get_xcframework_library_with_xcframework_processor(
         headers = [headers_dir],
         includes = includes,
         clang_module_map = module_map_file,
+        private_clang_module_map = private_module_map_file,
         swiftmodule = [],
         swift_module_interface = swiftinterface_file,
         framework_files = [],
@@ -537,6 +551,9 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     providers.append(apple_framework_import_info)
 
     # Create CcInfo provider
+    header_imports = list(xcframework_library.headers)
+    if xcframework_library.private_clang_module_map:
+        header_imports.append(xcframework_library.private_clang_module_map)
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         cc_toolchain = cc_toolchain,
@@ -545,7 +562,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
         disabled_features = disabled_features,
         features = features,
         framework_includes = xcframework_library.framework_includes,
-        header_imports = xcframework_library.headers,
+        header_imports = header_imports,
         kind = "dynamic",
         label = label,
         libraries = [] if ctx.attr.bundle_only else [xcframework_library.binary],
@@ -673,6 +690,9 @@ def _apple_static_xcframework_import_impl(ctx):
         sdk_linkopts.append(sdk_framework)
 
     # Create CcInfo provider
+    header_imports = list(xcframework_library.headers)
+    if xcframework_library.private_clang_module_map:
+        header_imports.append(xcframework_library.private_clang_module_map)
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         additional_cc_infos = additional_cc_infos,
@@ -682,7 +702,7 @@ def _apple_static_xcframework_import_impl(ctx):
         deps = deps,
         disabled_features = disabled_features,
         features = features,
-        header_imports = xcframework_library.headers,
+        header_imports = header_imports,
         kind = "static",
         label = label,
         libraries = [xcframework_library.binary],

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -158,6 +158,8 @@ def _get_xcframework_library(
             headers: List of File referencing XCFramework library header files. This can be either
                 a single tree artifact or a list of regular artifacts.
             clang_module_map: File referencing the XCFramework library Clang modulemap file.
+            private_clang_module_map: File referencing the XCFramework library private Clang
+                modulemap file.
             swift_module_interface: File referencing the XCFramework library Swift module interface
                 file (`.swiftinterface`).
     """
@@ -550,10 +552,12 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     )
     providers.append(apple_framework_import_info)
 
-    # Create CcInfo provider
+    # Collect header imports
     header_imports = list(xcframework_library.headers)
     if xcframework_library.private_clang_module_map:
         header_imports.append(xcframework_library.private_clang_module_map)
+
+    # Create CcInfo provider
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         cc_toolchain = cc_toolchain,
@@ -689,10 +693,12 @@ def _apple_static_xcframework_import_impl(ctx):
         sdk_linkopts.append("-weak_framework")
         sdk_linkopts.append(sdk_framework)
 
-    # Create CcInfo provider
+    # Collect header imports
     header_imports = list(xcframework_library.headers)
     if xcframework_library.private_clang_module_map:
         header_imports.append(xcframework_library.private_clang_module_map)
+
+    # Create CcInfo provider
     cc_info = framework_import_support.cc_info_with_dependencies(
         actions = actions,
         additional_cc_infos = additional_cc_infos,

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -152,6 +152,7 @@ def _classify_file_imports(config_vars, import_files):
         A struct containing classified import files by categories:
             - header_imports: Objective-C(++) header imports.
             - module_map_imports: Clang modulemap imports.
+            - private_module_map_imports: Clang private modulemap imports (module.private.modulemap).
             - swift_module_imports: Swift module imports.
             - swift_interface_imports: Swift module interface imports.
             - dsym_imports: dSYM imports.
@@ -162,6 +163,7 @@ def _classify_file_imports(config_vars, import_files):
     dsym_imports = []
     header_imports = []
     module_map_imports = []
+    private_module_map_imports = []
     swift_module_imports = []
     swift_interface_imports = []
     for file in import_files:
@@ -185,7 +187,14 @@ def _classify_file_imports(config_vars, import_files):
                 default = False,
             ):
                 header_imports.append(file)
-            module_map_imports.append(file)
+
+            # Clang supports module.private.modulemap as a standard convention
+            # for private submodule declarations. Classify these separately so
+            # they don't get confused with the public module map.
+            if file.basename == "module.private.modulemap":
+                private_module_map_imports.append(file)
+            else:
+                module_map_imports.append(file)
             continue
         if file_extension == "swiftmodule":
             swift_module_imports.append(file)
@@ -221,6 +230,7 @@ def _classify_file_imports(config_vars, import_files):
         dsym_imports = dsym_imports,
         header_imports = header_imports,
         module_map_imports = module_map_imports,
+        private_module_map_imports = private_module_map_imports,
         swift_interface_imports = swift_interface_imports,
         swift_module_imports = swift_module_imports,
         bundling_imports = bundling_imports,
@@ -272,6 +282,7 @@ def _classify_framework_imports(config_vars, framework_imports):
         dsym_imports = framework_imports_by_category.dsym_imports,
         header_imports = framework_imports_by_category.header_imports,
         module_map_imports = framework_imports_by_category.module_map_imports,
+        private_module_map_imports = framework_imports_by_category.private_module_map_imports,
         swift_interface_imports = framework_imports_by_category.swift_interface_imports,
         swift_module_imports = framework_imports_by_category.swift_module_imports,
     )

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -278,6 +278,14 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name],
     )
 
+    # Verify static XCFramework with module.private.modulemap builds successfully.
+    analysis_contains_xcframework_processor_action_test(
+        name = "{}_ios_static_xcframework_with_private_modulemap_registers_action".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_static_xcframework_with_private_modulemap",
+        target_mnemonic = "ProcessXCFrameworkFiles",
+        tags = [name],
+    )
+
     native.test_suite(
         name = name,
         tags = [name],

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -443,6 +443,16 @@ def _generate_static_xcframework_impl(ctx):
                 ),
             )
 
+        if ctx.attr.generate_private_modulemap:
+            modulemaps.append(
+                generation_support.generate_private_module_map(
+                    actions = actions,
+                    bundle_name = label.name,
+                    label = label,
+                    module_map_path = headers_path,
+                ),
+            )
+
         libraries.append(static_library)
 
     # Create static XCFramework
@@ -671,6 +681,11 @@ represented as a dotted version number as values.
                 doc = "Flag to indicate if modulemap generation is enabled.",
                 mandatory = False,
                 default = True,
+            ),
+            "generate_private_modulemap": attr.bool(
+                doc = "Flag to indicate if a module.private.modulemap should be generated.",
+                mandatory = False,
+                default = False,
             ),
             "swift_library": attr.label(
                 allow_files = True,

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -807,6 +807,37 @@ def _generate_module_map(
 
     return modulemap_file
 
+def _generate_private_module_map(
+        *,
+        actions,
+        bundle_name,
+        label,
+        module_map_path):
+    """Generates a module.private.modulemap file for testing.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        bundle_name: Name of the framework/XCFramework bundle.
+        label: Label of the target being built.
+        module_map_path: Base path for the generated modulemap file.
+    Returns:
+        File for the generated private modulemap file.
+    """
+    modulemap_content = actions.args()
+    modulemap_content.set_param_file_format("multiline")
+    modulemap_content.add("explicit module %s.Private {" % bundle_name)
+    modulemap_content.add("}")
+
+    modulemap_file = intermediates.file(
+        actions = actions,
+        file_name = paths.join(module_map_path, "module.private.modulemap"),
+        output_discriminator = None,
+        target_name = label.name,
+    )
+    actions.write(output = modulemap_file, content = modulemap_content)
+
+    return modulemap_file
+
 generation_support = struct(
     compile_binary = _compile_binary,
     copy_file = _copy_file,
@@ -816,5 +847,6 @@ generation_support = struct(
     create_static_library = _create_static_library,
     get_file_with_extension = _get_file_with_extension,
     generate_module_map = _generate_module_map,
+    generate_private_module_map = _generate_private_module_map,
     generate_umbrella_header = _generate_umbrella_header,
 )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3249,6 +3249,36 @@ generate_static_xcframework(
     tags = common.fixture_tags,
 )
 
+apple_static_xcframework_import(
+    name = "ios_imported_static_xcframework_with_private_modulemap",
+    features = ["-swift.layering_check"],
+    tags = common.fixture_tags,
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_static_xcframework_with_private_modulemap"],
+)
+
+generate_static_xcframework(
+    name = "generated_static_xcframework_with_private_modulemap",
+    srcs = ["//test/starlark_tests/resources/frameworks:SharedClass.m"],
+    hdrs = ["//test/starlark_tests/resources/frameworks:SharedClass.h"],
+    generate_private_modulemap = True,
+    minimum_os_versions = {
+        "ios_simulator": common.min_os_ios.baseline,
+        "ios": common.min_os_ios.baseline,
+    },
+    platforms = {
+        "ios_simulator": [
+            "x86_64",
+            "arm64",
+        ],
+        "ios": [
+            "arm64",
+            "arm64e",
+        ],
+    },
+    tags = common.fixture_tags,
+)
+
 # Swift app with imported Swift XCFramework
 ios_application(
     name = "swift_app_with_imported_swift_xcframework_with_static_library",

--- a/tools/xcframework_processor_tool/xcframework_processor_tool.py
+++ b/tools/xcframework_processor_tool/xcframework_processor_tool.py
@@ -106,6 +106,7 @@ def _create_args_parser() -> argparse.ArgumentParser:
   optional_list_args = {
       "bundle_file": "Imported XCFramework bundle file path.",
       "modulemap_file": "Imported XCFramework modulemap file path.",
+      "private_modulemap_file": "Imported XCFramework private modulemap file path.",
       "swiftinterface_file": "Imported XCFramework Swift module file path.",
       "dsym": "Imported XCFramework dSYM bundle path.",
   }
@@ -330,6 +331,11 @@ def main() -> int:
       library_identifier=library_identifier,
       output_directories=[modules_dir],
       xcframework_files=args.modulemap_files)
+
+  _copy_xcframework_files(
+      library_identifier=library_identifier,
+      output_directories=[modules_dir],
+      xcframework_files=args.private_modulemap_files)
 
   swiftmodule_dir = os.path.join(modules_dir, f"{bundle_name}.swiftmodule")
   _copy_xcframework_files(


### PR DESCRIPTION
I ran into issues compiling https://github.com/mapbox/mapbox-common-ios through rules_swift_package_manager when using RBE. I believe the issue is that the `module.private.modulemap` file wasn't being handled by `apple_dynamic_xcframework_import`

https://github.com/swiftlang/llvm-project/blob/next/clang/docs/Modules.rst#private-module-map-files

Claude wrote most of this code. I'm not totally clear on why `xcframework_library.private_clang_module_map` is being added to `header_imports` when `xcframework_library.clang_module_map` is not, but I tried removing it and my build broke.

Should the private module map info be included in this block of code somehow?
```star lark
        # Create SwiftInteropInfo provider for swift_clang_module_aspect
        swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
            deps = deps,
            module_name = framework.bundle_name,
            module_map_imports = framework.module_map_imports,
        )
```