### PR TITLE
fix: preserve Apple tool arguments

### DIFF
--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -152,20 +152,24 @@ def _local_provisioning_profile(ctx):
     selected_profile_path = profile_name + ctx.attr.profile_extension
     selected_profile = ctx.actions.declare_file(selected_profile_path)
 
-    args = ctx.actions.args()
-    args.add(profile_name)
-    args.add(selected_profile)
-    if ctx.attr.team_id:
-        args.add("--team_id", ctx.attr.team_id)
-    if ctx.files._local_srcs:
-        args.add_all("--local_profiles", ctx.files._local_srcs)
-    if ctx.files._fallback_srcs:
-        args.add_all("--fallback_profiles", ctx.files._fallback_srcs)
+    control_file = ctx.actions.declare_file(
+        ctx.label.name + ".local_provisioning_profile_finder-control",
+    )
+    ctx.actions.write(
+        output = control_file,
+        content = json.encode({
+            "fallback_profiles": [f.path for f in ctx.files._fallback_srcs],
+            "local_profiles": [f.path for f in ctx.files._local_srcs],
+            "name": profile_name,
+            "output": selected_profile.path,
+            "team_id": ctx.attr.team_id,
+        }),
+    )
 
     ctx.actions.run(
         executable = ctx.executable._finder,
-        arguments = [args],
-        inputs = ctx.files._local_srcs + ctx.files._fallback_srcs,
+        arguments = ["--control", control_file.path],
+        inputs = [control_file] + ctx.files._local_srcs + ctx.files._fallback_srcs,
         outputs = [selected_profile],
         mnemonic = "FindProvisioningProfile",
         execution_requirements = {"no-sandbox": "1", "no-remote-exec": "1"},

--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -67,15 +67,21 @@ def generate_intent_classes_sources(
         xctoolrunner_support.prefixed_path(input_file.path),
         "-language",
         language,
-        "-classPrefix",
-        class_prefix,
-        "-swiftVersion",
-        swift_version,
     ]
+    if class_prefix:
+        arguments += [
+            "-classPrefix",
+            class_prefix,
+        ]
+    if swift_version:
+        arguments += [
+            "-swiftVersion",
+            swift_version,
+        ]
 
     # Starting Xcode 12, intentbuilderc accepts new parameters
     xcode_version = str(platform_prerequisites.xcode_version_config.xcode_version())
-    if versions.is_at_least("12.0.0", xcode_version):
+    if class_visibility and versions.is_at_least("12.0.0", xcode_version):
         arguments += [
             "-visibility",
             class_visibility,

--- a/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
+++ b/tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import json
 import plistlib
 import shutil
 import subprocess
@@ -10,8 +11,14 @@ _USE_SECURITY = sys.platform == "darwin"
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("name", help="The name (or UUID) of the profile to find")
-    parser.add_argument("output", help="The path to copy the profile to")
+    parser.add_argument(
+        "name", nargs="?", help="The name (or UUID) of the profile to find"
+    )
+    parser.add_argument("output", nargs="?", help="The path to copy the profile to")
+    parser.add_argument(
+        "--control",
+        help="Path to a JSON control file with the profile search parameters",
+    )
     parser.add_argument(
         "--local_profiles",
         nargs="*",
@@ -29,6 +36,18 @@ def _build_parser() -> argparse.ArgumentParser:
         type=str,
     )
     return parser
+
+
+def _args_from_control(control: str) -> argparse.Namespace:
+    with open(control) as control_file:
+        control_data = json.load(control_file)
+    return argparse.Namespace(
+        name=control_data["name"],
+        output=control_data["output"],
+        local_profiles=control_data.get("local_profiles", []),
+        fallback_profiles=control_data.get("fallback_profiles", []),
+        team_id=control_data.get("team_id"),
+    )
 
 
 def _profile_contents(profile: str) -> Tuple[str, datetime.datetime, str]:
@@ -92,6 +111,12 @@ def _find_profile(
 
 if __name__ == "__main__":
     args = _build_parser().parse_args()
+    if args.control:
+        args = _args_from_control(args.control)
+    if not args.name or not args.output:
+        _build_parser().error(
+            "name and output are required unless --control is provided"
+        )
     _find_profile(
         args.name,
         args.team_id,


### PR DESCRIPTION
## Summary
- avoid passing empty intentbuilderc options
- pass local provisioning profile search data through a JSON control file so names and paths with spaces are preserved

## Test
- pre-commit run --files apple/internal/resource_actions/intent.bzl apple/internal/local_provisioning_profiles.bzl tools/local_provisioning_profile_finder/local_provisioning_profile_finder.py
- bazel test //tools/xctoolrunner:xctoolrunner_test
- bazel build //tools/local_provisioning_profile_finder:local_provisioning_profile_finder