### PR TITLE
Manually compile from swiftinterface files by default

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,10 +24,10 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 # TODO: Remove before the major release after bumping to >=4
 archive_override(
     module_name = "rules_swift",
-    integrity = "sha256-4chJk5OXis0vpf+S4TP2438gEABkzTGXDBMegPkGEn0=",
-    strip_prefix = "rules_swift-5b33243ffe5cbc2f5c99e182df236d13ddec9c0d",
+    integrity = "sha256-A9PbyySU0twu1+bH88emRvV6fXPiqyqh16IseIPviaY=",
+    strip_prefix = "rules_swift-bf7f4b7759917689c8e6517a9c99c1c47da00c7a",
     urls = [
-        "https://github.com/bazelbuild/rules_swift/archive/5b33243ffe5cbc2f5c99e182df236d13ddec9c0d.tar.gz",
+        "https://github.com/bazelbuild/rules_swift/archive/bf7f4b7759917689c8e6517a9c99c1c47da00c7a.tar.gz",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,16 @@ bazel_dep(
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
+# TODO: Remove before the major release after bumping to >=4
+archive_override(
+    module_name = "rules_swift",
+    integrity = "sha256-4chJk5OXis0vpf+S4TP2438gEABkzTGXDBMegPkGEn0=",
+    strip_prefix = "rules_swift-5b33243ffe5cbc2f5c99e182df236d13ddec9c0d",
+    urls = [
+        "https://github.com/bazelbuild/rules_swift/archive/5b33243ffe5cbc2f5c99e182df236d13ddec9c0d.tar.gz",
+    ],
+)
+
 bazel_dep(
     name = "stardoc",
     version = "0.8.0",

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -237,16 +237,19 @@ def _apple_dynamic_framework_import_impl(ctx):
         framework_files = depset(framework_imports),
     ))
 
+    swiftinterface_files = []
     if (
         "apple.import_framework_via_swiftinterface" not in disabled_features and
         framework.swift_interface_imports
     ):
-        # Create SwiftInfo provider
-        swift_toolchain = swift_common.get_toolchain(ctx)
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
             swift_module_files = framework.swift_interface_imports,
             target_triplet = target_triplet,
         )
+
+    if swiftinterface_files:
+        # Create SwiftInfo provider
+        swift_toolchain = swift_common.get_toolchain(ctx)
         providers.append(
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
@@ -256,7 +259,7 @@ def _apple_dynamic_framework_import_impl(ctx):
                 features = features,
                 module_name = framework.bundle_name,
                 swift_toolchain = swift_toolchain,
-                swiftinterface_file = swiftinterface_files[0],
+                swiftinterface_files = swiftinterface_files,
             ),
         )
     else:
@@ -378,16 +381,19 @@ def _apple_static_framework_import_impl(ctx):
         ),
     )
 
+    swiftinterface_files = []
     if (
         "apple.import_framework_via_swiftinterface" not in disabled_features and
         framework.swift_interface_imports
     ):
-        # Create SwiftInfo provider
-        swift_toolchain = swift_common.get_toolchain(ctx)
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
             swift_module_files = framework.swift_interface_imports,
             target_triplet = target_triplet,
         )
+
+    if swiftinterface_files:
+        # Create SwiftInfo provider
+        swift_toolchain = swift_common.get_toolchain(ctx)
         providers.append(
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
@@ -397,7 +403,7 @@ def _apple_static_framework_import_impl(ctx):
                 features = features,
                 module_name = framework.bundle_name,
                 swift_toolchain = swift_toolchain,
-                swiftinterface_file = swiftinterface_files[0],
+                swiftinterface_files = swiftinterface_files,
             ),
         )
     else:

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -237,7 +237,10 @@ def _apple_dynamic_framework_import_impl(ctx):
         framework_files = depset(framework_imports),
     ))
 
-    if "apple._import_framework_via_swiftinterface" in features and framework.swift_interface_imports:
+    if (
+        "apple.import_framework_via_swiftinterface" not in disabled_features and
+        framework.swift_interface_imports
+    ):
         # Create SwiftInfo provider
         swift_toolchain = swift_common.get_toolchain(ctx)
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
@@ -375,7 +378,10 @@ def _apple_static_framework_import_impl(ctx):
         ),
     )
 
-    if "apple._import_framework_via_swiftinterface" in features and framework.swift_interface_imports:
+    if (
+        "apple.import_framework_via_swiftinterface" not in disabled_features and
+        framework.swift_interface_imports
+    ):
         # Create SwiftInfo provider
         swift_toolchain = swift_common.get_toolchain(ctx)
         swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -567,7 +567,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
                 features = features,
                 module_name = xcframework.bundle_name,
                 swift_toolchain = swift_toolchain,
-                swiftinterface_file = xcframework_library.swift_module_interfaces[0],
+                swiftinterface_files = xcframework_library.swift_module_interfaces,
             ),
         )
     else:
@@ -713,7 +713,7 @@ def _apple_static_xcframework_import_impl(ctx):
                 features = features,
                 module_name = xcframework.bundle_name,
                 swift_toolchain = swift_toolchain,
-                swiftinterface_file = xcframework_library.swift_module_interfaces[0],
+                swiftinterface_files = xcframework_library.swift_module_interfaces,
             ),
         )
     else:

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -553,7 +553,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     providers.append(apple_dynamic_framework_info)
 
     if (
-        "apple._import_framework_via_swiftinterface" in features and
+        "apple.import_framework_via_swiftinterface" not in disabled_features and
         xcframework_library.swift_module_interfaces
     ):
         # Create SwiftInfo provider
@@ -699,7 +699,7 @@ def _apple_static_xcframework_import_impl(ctx):
     providers.append(cc_info)
 
     if (
-        "apple._import_framework_via_swiftinterface" in features and
+        "apple.import_framework_via_swiftinterface" not in disabled_features and
         xcframework_library.swift_module_interfaces
     ):
         # Create SwiftInfo provider

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -503,6 +503,7 @@ def _swift_info_from_module_interface(
     )
     compile_result = swift_common.compile_module_interface(
         actions = actions,
+        additional_inputs = swiftinterface_files,
         compilation_contexts = compilation_contexts,
         feature_configuration = swift_common.configure_features(
             ctx = ctx,

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -472,7 +472,7 @@ def _swift_info_from_module_interface(
         features,
         module_name,
         swift_toolchain,
-        swiftinterface_file):
+        swiftinterface_files):
     """Returns SwiftInfo provider for a pre-compiled Swift module compiling it's interface file.
 
 
@@ -484,18 +484,26 @@ def _swift_info_from_module_interface(
         features: List of features to be enabled for cc_common.compile.
         module_name: Swift module name.
         swift_toolchain: SwiftToolchainInfo provider for current target.
-        swiftinterface_file: `.swiftinterface` File to compile.
+        swiftinterface_files: List of `.swiftinterface` Files for the module. The first entry is
+            compiled; any remaining entries (e.g. `.private.swiftinterface`) are declared as action
+            inputs so the compiler can resolve sibling references in the sandbox.
     Returns:
         A SwiftInfo provider.
     """
     swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
-    module_context = swift_common.compile_module_interface(
+    compilation_contexts = [
+        dep[CcInfo].compilation_context
+        for dep in deps
+        if CcInfo in dep
+    ]
+    compilation_contexts.append(
+        cc_common.create_compilation_context(
+            headers = depset(swiftinterface_files),
+        ),
+    )
+    compile_result = swift_common.compile_module_interface(
         actions = actions,
-        compilation_contexts = [
-            dep[CcInfo].compilation_context
-            for dep in deps
-            if CcInfo in dep
-        ],
+        compilation_contexts = compilation_contexts,
         feature_configuration = swift_common.configure_features(
             ctx = ctx,
             swift_toolchain = swift_toolchain,
@@ -503,11 +511,17 @@ def _swift_info_from_module_interface(
             unsupported_features = disabled_features,
         ),
         module_name = module_name,
-        swiftinterface_file = swiftinterface_file,
+        swiftinterface_file = swiftinterface_files[0],
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
     )
+
+    # TODO: Remove once we don't support rules_swift <4.x
+    if hasattr(compile_result, "module_context"):
+        module_context = compile_result.module_context
+    else:
+        module_context = compile_result
 
     return SwiftInfo(
         modules = [module_context],

--- a/test/starlark_tests/BUILD
+++ b/test/starlark_tests/BUILD
@@ -5,6 +5,7 @@ load(":apple_core_data_model_tests.bzl", "apple_core_data_model_test_suite")
 load(":apple_core_ml_library_tests.bzl", "apple_core_ml_library_test_suite")
 load(":apple_dynamic_xcframework_import_tests.bzl", "apple_dynamic_xcframework_import_test_suite")
 load(":apple_metal_library_tests.bzl", "apple_metal_library_test_suite")
+load(":apple_static_framework_import_tests.bzl", "apple_static_framework_import_test_suite")
 load(":apple_static_library_tests.bzl", "apple_static_library_test_suite")
 load(":apple_static_xcframework_import_tests.bzl", "apple_static_xcframework_import_test_suite")
 load(":apple_static_xcframework_tests.bzl", "apple_static_xcframework_test_suite")
@@ -81,6 +82,8 @@ apple_core_ml_library_test_suite(name = "apple_core_ml_library")
 apple_dynamic_xcframework_import_test_suite(name = "apple_dynamic_xcframework_import")
 
 apple_metal_library_test_suite(name = "apple_metal_library")
+
+apple_static_framework_import_test_suite(name = "apple_static_framework_import")
 
 apple_static_library_test_suite(name = "apple_static_library")
 

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -148,6 +148,18 @@ def apple_dynamic_xcframework_import_test_suite(name):
         ],
         tags = [name],
     )
+
+    # Make sure the SwiftCompileModuleInterface action codepath is used
+    action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_compiles_module_from_swiftinterface".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        ],
+        tags = [name],
+    )
+
     archive_contents_test(
         name = "{}_contains_implementation_deps_imported_xcframework_framework_files".format(name),
         build_type = "simulator",

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -156,6 +156,7 @@ def apple_dynamic_xcframework_import_test_suite(name):
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [
             "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+            "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.private.swiftinterface",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/apple_static_framework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_framework_import_tests.bzl
@@ -1,0 +1,47 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""apple_static_framework_import Starlark tests."""
+
+load(
+    "//test/starlark_tests/rules:action_inputs_test.bzl",
+    "make_action_inputs_test_rule",
+)
+
+_action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
+
+def apple_static_framework_import_test_suite(name):
+    """Test suite for apple_static_framework_import.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+
+    # Make sure the SwiftCompileModuleInterface action codepath is used
+    _action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_compiles_module_from_swiftinterface".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSImportedSwiftStaticFramework",
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/starlark_tests/apple_static_framework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_framework_import_tests.bzl
@@ -37,6 +37,7 @@ def apple_static_framework_import_test_suite(name):
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [
             "iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
+            "iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.private.swiftinterface",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -58,6 +58,7 @@ def apple_static_xcframework_import_test_suite(name):
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [
             "generated_swift_static_xcframework.xcframework/ios-x86_64-simulator/generated_swift_static_xcframework.swiftmodule/x86_64.swiftinterface",
+            "generated_swift_static_xcframework.xcframework/ios-x86_64-simulator/generated_swift_static_xcframework.swiftmodule/x86_64.private.swiftinterface",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -19,6 +19,10 @@ load(
     "build_settings_labels",
 )
 load(
+    "//test/starlark_tests/rules:action_inputs_test.bzl",
+    "make_action_inputs_test_rule",
+)
+load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_contains_xcframework_processor_action_test",
 )
@@ -26,6 +30,10 @@ load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
+
+_action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
 
 def apple_static_xcframework_import_test_suite(name):
     """Test suite for apple_static_xcframework_import.
@@ -40,6 +48,17 @@ def apple_static_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_swift_multi_level_static_xcframework",
         contains = ["$ARCHIVE_ROOT/Payload"],
         build_type = "simulator",
+        tags = [name],
+    )
+
+    # Make sure the SwiftCompileModuleInterface action codepath is used
+    _action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_compiles_module_from_swiftinterface".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_static_xcframework",
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "generated_swift_static_xcframework.xcframework/ios-x86_64-simulator/generated_swift_static_xcframework.swiftmodule/x86_64.swiftinterface",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/rules/generate_framework.bzl
+++ b/test/starlark_tests/rules/generate_framework.bzl
@@ -137,6 +137,25 @@ def _generate_import_framework_impl(ctx):
                             environment = "-simulator" if sdk.endswith("simulator") else "",
                         ),
                     ),
+                    # Emit a sibling `.private.swiftinterface` (same content as
+                    # the public one) so test fixtures look like real-world
+                    # frameworks that ship SPI interfaces.
+                    generation_support.copy_file(
+                        actions = actions,
+                        file = swiftinterface,
+                        label = label,
+                        target_filename = "%s.private.swiftinterface" % architectures[0],
+                    ),
+                    generation_support.copy_file(
+                        actions = actions,
+                        file = swiftinterface,
+                        label = label,
+                        target_filename = "{arch}-apple-{os}{environment}.private.swiftinterface".format(
+                            arch = architectures[0],
+                            os = target_os,
+                            environment = "-simulator" if sdk.endswith("simulator") else "",
+                        ),
+                    ),
                 ])
             else:
                 swiftmodule = generation_support.get_file_with_extension(

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -416,6 +416,26 @@ def _generate_static_xcframework_impl(ctx):
                     if interface_file.extension.startswith("swift")
                 ]
 
+                # Emit a sibling `.private.swiftinterface` (same content as
+                # the public one) so test fixtures look like real-world
+                # frameworks that ship SPI interfaces.
+                swiftinterface_file = generation_support.get_file_with_extension(
+                    files = swift_library,
+                    extension = "swiftinterface",
+                )
+                if swiftinterface_file:
+                    module_interfaces.append(
+                        generation_support.copy_file(
+                            actions = actions,
+                            base_path = swiftmodule_path,
+                            file = swiftinterface_file,
+                            label = label,
+                            target_filename = "{architecture}.private.swiftinterface".format(
+                                architecture = architectures[0],
+                            ),
+                        ),
+                    )
+
             # Copy swiftc generated headers to intermediate directory
             headers.append(
                 generation_support.copy_file(

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3004,7 +3004,6 @@ apple_dynamic_xcframework_import(
     name = "ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
     features = [
         "-swift.layering_check",
-        "-apple.import_framework_via_swiftinterface",
     ],
     tags = common.fixture_tags,
     xcframework_imports = [

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3002,7 +3002,10 @@ apple_dynamic_xcframework_import(
 
 apple_dynamic_xcframework_import(
     name = "ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
-    features = ["-swift.layering_check"],
+    features = [
+        "-swift.layering_check",
+        "-apple.import_framework_via_swiftinterface",
+    ],
     tags = common.fixture_tags,
     xcframework_imports = [
         "//test/starlark_tests/targets_under_test/apple:swift_3p_xcframework_with_generated_header_and_private_swiftinterface",
@@ -3429,10 +3432,7 @@ ios_application(
 
 apple_static_xcframework_import(
     name = "ios_imported_swift_static_xcframework",
-    features = [
-        "-swift.layering_check",
-        "apple._import_framework_via_swiftinterface",
-    ],
+    features = ["-swift.layering_check"],
     tags = common.fixture_tags,
     visibility = ["//visibility:public"],
     xcframework_imports = [":generated_swift_static_xcframework"],


### PR DESCRIPTION
We flipped this off because of breakages in the past, but this is
required for explicit modules. Users can still opt out with
`-apple.import_framework_via_swiftinterface` in the features, but we're
also trying to iron out the issues.
