### PR TITLE
Update the API of `swift_common.compile_module_interface`.

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -549,12 +549,7 @@ def _swift_info_from_module_interface(
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
     )
-
-    # TODO: Remove once we don't support rules_swift <4.x
-    if hasattr(compile_result, "module_context"):
-        module_context = compile_result.module_context
-    else:
-        module_context = compile_result
+    module_context = compile_result.module_context
 
     return SwiftInfo(
         modules = [module_context],


### PR DESCRIPTION
This adds the `target_name` argument that is present in other compile APIs so that supplemental outputs can get unique names based on the name of the Bazel target being compiled (will be used in a follow-up change).

Likewise, this changes the return type of the function from just the module context to a `struct` that contains two fields: `module_context` (the original value), and `supplemental_outputs`, which will eventually be used to provide an indexstore (supported starting from Swift 6.2/Xcode 16.3).

PiperOrigin-RevId: 741516048
(cherry picked from commit 47a7501b13a174ea3fbdddf6253efbaff8237e5b)
