### PR TITLE
Pass explicit modules through to framework imports

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -256,6 +256,7 @@ def _apple_dynamic_framework_import_impl(ctx):
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
                 ctx = ctx,
+                default_precompiled_modules = ctx.attr._default_precompiled_modules,
                 deps = deps,
                 disabled_features = disabled_features,
                 features = features,
@@ -406,6 +407,7 @@ def _apple_static_framework_import_impl(ctx):
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
                 ctx = ctx,
+                default_precompiled_modules = ctx.attr._default_precompiled_modules,
                 deps = deps,
                 disabled_features = disabled_features,
                 features = features,
@@ -479,6 +481,7 @@ to manually dlopen the framework at runtime.
                 doc = "The C++ toolchain to use.",
             ),
         },
+        swift_common.default_precompiled_modules_attrs(),
     ),
     doc = """
 This rule encapsulates an already-built dynamic framework. It is defined by a list of
@@ -585,6 +588,7 @@ not include Swift interface or Swift module files.
                 doc = "The C++ toolchain to use.",
             ),
         },
+        swift_common.default_precompiled_modules_attrs(),
     ),
     doc = """
 This rule encapsulates an already-built static framework. It is defined by a list of

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -562,6 +562,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
                 ctx = ctx,
+                default_precompiled_modules = ctx.attr._default_precompiled_modules,
                 deps = deps,
                 disabled_features = disabled_features,
                 features = features,
@@ -712,6 +713,7 @@ def _apple_static_xcframework_import_impl(ctx):
             framework_import_support.swift_info_from_module_interface(
                 actions = actions,
                 ctx = ctx,
+                default_precompiled_modules = ctx.attr._default_precompiled_modules,
                 deps = deps,
                 disabled_features = disabled_features,
                 features = features,
@@ -806,6 +808,7 @@ Unnecssary and ignored, will be removed in the future.
                 doc = "The C++ toolchain to use.",
             ),
         },
+        swift_common.default_precompiled_modules_attrs(),
     ),
     exec_groups = dicts.add(
         {
@@ -949,6 +952,7 @@ Unnecssary and ignored, will be removed in the future.
                 doc = "The C++ toolchain to use.",
             ),
         },
+        swift_common.default_precompiled_modules_attrs(),
     ),
     exec_groups = dicts.add(
         {

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -464,6 +464,7 @@ def _swift_info_from_module_interface(
         *,
         actions,
         ctx,
+        default_precompiled_modules,
         deps,
         disabled_features,
         features,
@@ -480,6 +481,8 @@ def _swift_info_from_module_interface(
     Args:
         actions: The actions provider from `ctx.actions`.
         ctx: The Starlark context for a rule target being built.
+        default_precompiled_modules: The `Target` configured by the calling
+            rule's `_default_precompiled_modules` attribute.
         deps: List of dependencies for a given target to retrieve transitive CcInfo providers.
         disabled_features: List of features to be disabled for cc_common.compile
         features: List of features to be enabled for cc_common.compile.
@@ -502,6 +505,12 @@ def _swift_info_from_module_interface(
         requested_features = features,
         unsupported_features = disabled_features,
     )
+    extra_cc_infos, extra_swift_infos = (
+        swift_common.default_precompiled_modules_providers(
+            default_precompiled_modules,
+            feature_configuration,
+        )
+    )
     direct_compilation_context = cc_common.create_compilation_context(
         headers = depset(hdrs + swiftinterface_files),
         framework_includes = depset(framework_includes),
@@ -512,9 +521,12 @@ def _swift_info_from_module_interface(
             dep[CcInfo].compilation_context
             for dep in deps
             if CcInfo in dep
-        ] + [direct_compilation_context],
+        ] + [direct_compilation_context] + [
+            cc_info.compilation_context
+            for cc_info in extra_cc_infos
+        ],
     )
-    swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
+    swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep] + extra_swift_infos
 
     clang_module = None
     if hdrs and module_map:


### PR DESCRIPTION
Framework importing potentially generates a pcm for objc, and a
swiftmodule from a swiftinterface. Both of these need the implicit
precompiled modules if they're enabled
