### PR TITLE
Fix implicit module building swiftinterfaces

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -15,6 +15,7 @@
 """Support methods for Apple framework import rules."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@build_bazel_rules_swift//swift:providers.bzl", "create_clang_module_inputs")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
@@ -530,6 +531,11 @@ def _swift_info_from_module_interface(
         )
         if clang_result:
             clang_module = clang_result.clang_module
+        else:
+            clang_module = create_clang_module_inputs(
+                compilation_context = merged_compilation_context,
+                module_map = module_map,
+            )
 
     compile_result = swift_common.compile_module_interface(
         actions = actions,

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -151,6 +151,8 @@ def apple_dynamic_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:dynamic_swift_xcframework_with_private_swiftinterface_depending_swift_lib",
         mnemonic = "SwiftCompile",
         expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
             "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
             "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.private.swiftinterface",
         ],
@@ -163,6 +165,8 @@ def apple_dynamic_xcframework_import_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
             "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
             "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.private.swiftinterface",
         ],


### PR DESCRIPTION
If you don't enable `swift.emit_c_module` the resulting `clang_module`
here was none, and then the swiftinterface build would fail. We can
propagate the necessary deps for an implicit pcm creation instead. We
can do what google does and error in this case at some point, but I
don't think we want to force `swift.emit_c_module` here yet.
