### PR TITLE
Remove objc_library archive from runfiles

### DIFF
--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -106,7 +106,6 @@ def apple_static_library_test_suite(name):
         target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_arm_sim_support",
         expected_runfiles = [
             "test/starlark_tests/targets_under_test/apple/static_library/example_library_arm_sim_support_lipo.a",
-            "test/starlark_tests/targets_under_test/apple/static_library/libmain_lib.a",
         ],
         tags = [name],
     )


### PR DESCRIPTION
This was always weird and was removed from objc_library in https://github.com/bazelbuild/rules_cc/commit/d305b348ed81f86f305c064f5f756614124ef6ae

The one from apple_static_library still exists, but that makes a bit
more sense since it's meant to be redistributable.
