### PR TITLE
Skip transitive Swift modules without a swiftmodule File

### DIFF
--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -165,7 +165,7 @@ def _apple_test_info_aspect_impl(target, ctx):
         module_swiftmodules = [
             module.swift.swiftmodule
             for module in all_modules
-            if module.swift
+            if module.swift and module.swift.swiftmodule
         ]
         swift_modules.append(depset(module_swiftmodules))
 


### PR DESCRIPTION
## Summary

`_apple_test_info_aspect_impl` iterates `module.swift.swiftmodule` for every transitive Swift module. With the `system_swiftmodule` rule landing in rules_swift (https://github.com/bazelbuild/rules_swift/pull/1745), prebuilt SDK swiftmodules expose their path via `swiftmodule_path` (a placeholder string) and leave the `swiftmodule` `File` slot unset, which crashes this iteration.

Skip entries where `swift.swiftmodule` is `None` so the test bundle aspect tolerates the new provider shape.

## Test plan

- [ ] Build a test bundle that depends on a `system_swiftmodule` target and confirm the aspect no longer crashes
- [ ] Existing test bundles continue to pick up their Swift module inputs