### PR TITLE
Share configs with build and test on CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -5,21 +5,19 @@ x_defaults:
   common: &common
     platform: macos_arm64
     shell_commands:
-    - xcodebuild -downloadComponent metalToolchain
+      - xcodebuild -downloadComponent metalToolchain
     build_targets:
-    - "tools/..."
-    - "test/..."
+      - "examples/..."
+      - "test/..."
+      - "tools/..."
     build_flags:
-    - --modify_execution_info=AssetCatalogCompile=+exclusive
+      - --config=ci
     test_targets:
-    - "tools/..."
-    - "test/..."
-    - "examples/..."
+      - "examples/..."
+      - "test/..."
+      - "tools/..."
     test_flags:
-    - --local_test_jobs=2
-    - --modify_execution_info=AssetCatalogCompile=+exclusive
-    - --test_tag_filters=-skipci
-    - --ios_simulator_device=iPhone 16
+      - --config=ci
     include_json_profile:
       - build
       - test

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,7 +19,7 @@ build --check_direct_dependencies=off
 build --spawn_strategy=sandboxed,local
 build --worker_sandboxing=true
 
-build:ci --ios_simulator_device=iPhone 16
+build:ci --ios_simulator_device="iPhone 16"
 build:ci --local_test_jobs=2
 build:ci --modify_execution_info=AssetCatalogCompile=+exclusive
 build:ci --test_tag_filters=-skipci

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,11 @@ build --check_direct_dependencies=off
 build --spawn_strategy=sandboxed,local
 build --worker_sandboxing=true
 
+build:ci --ios_simulator_device=iPhone 16
+build:ci --local_test_jobs=2
+build:ci --modify_execution_info=AssetCatalogCompile=+exclusive
+build:ci --test_tag_filters=-skipci
+
 # Use llvm-cov instead of gcov (default).
 coverage --experimental_use_llvm_covmap
 


### PR DESCRIPTION
Otherwise this drops the analysis cache for ios_simulator_device changes
