### PR TITLE
Fix removal of signing_certificate_name

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,11 +40,11 @@ tasks:
     bazel: 9.x
     <<: *common
 
-  # TODO: Enable ASAP when we remove usage of `//command_line_option:incompatible_enable_apple_toolchain_resolution`
-  # macos_last_green:
-  #   name: "Last Green Bazel"
-  #   bazel: last_green
-  #   <<: *common
+  macos_last_green:
+    name: "Last Green Bazel"
+    # TODO: Switch back to last_green when possible
+    bazel: cb541be1eea5aafcce370ef8078b2e03537c0233
+    <<: *common
 
   doc_tests:
     name: "Doc tests"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,3 +82,13 @@ apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.
 use_repo(apple_cc_configure, "local_config_apple_cc")
 
 register_toolchains("//apple/internal:apple_xplat_toolchain")
+
+single_version_override(
+    module_name = "bazel_features",
+    patch_strip = 1,
+    patches = [
+        # NOTE: Only required until we get past 84c0253add3784b75ff08b6d049a7f152c7b7532 on 10.x CI
+        # https://github.com/bazel-contrib/bazel_features/pull/144
+        "//:bazel_features.patch",
+    ],
+)

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -86,7 +86,8 @@ def _preferred_codesigning_identity(platform_prerequisites):
             # TODO(b/252873771): Remove this fallback when the native Bazel flag
             # ios_signing_cert_name is removed.
             return (build_settings.signing_certificate_name or
-                    objc_fragment.signing_certificate_name)
+                    # TODO: Remove when we drop bazel 9.x support
+                    getattr(objc_fragment, "signing_certificate_name", None))
         else:
             return build_settings.signing_certificate_name
     return None

--- a/bazel_features.patch
+++ b/bazel_features.patch
@@ -1,0 +1,13 @@
+diff --git a/features.bzl b/features.bzl
+index a28387c..2d16914 100644
+--- a/features.bzl
++++ b/features.bzl
+@@ -179,7 +179,7 @@ _rules = struct(
+ 
+     # Whether ctx.configuration.is_tool_configuration is public API
+     # https://github.com/bazelbuild/bazel/commit/84c0253add3784b75ff08b6d049a7f152c7b7532
+-    is_tool_configuration_public = ge_same_major("8.7.0") or ge_same_major("9.1.0") or ge("10.0.0-pre.20260329.2"),
++    is_tool_configuration_public = ge_same_major("8.7.0") or ge_same_major("9.1.0") or ge_same_major("10.0.0-pre.20260329.2"),
+ 
+     # Internal only, don't use outside rules_java, rules_python & rules_shell.
+     # TODO: Use a larger version range after cherry-picking

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -64,7 +64,7 @@ cases you can use the `--ios_signing_cert_name` flag to force the signing
 identity to be used when codesigning your app.
 
 ```shell
-bazel build //your/target --ios_signing_cert_name="iPhone Developer: [CERT OWNER NAME]"
+bazel build //your/target --@rules_apple//apple/build_settings:signing_certificate_name="iPhone Developer: [CERT OWNER NAME]"
 ```
 
 To make this easier to use, we recommend adding the following to the
@@ -72,7 +72,17 @@ To make this easier to use, we recommend adding the following to the
 invocations:
 
 ```text
-build --ios_signing_cert_name="iPhone Developer: [CERT OWNER NAME]"
+build --@rules_apple//apple/build_settings:signing_certificate_name="iPhone Developer: [CERT OWNER NAME]"
+```
+
+Note this was previously builtin to bazel with `--ios_signing_cert_name`
+but has been removed for the 10.x release cycle.
+
+If you would like to maintain the shorter command line argument name,
+you can put this in your `.bazelrc`:
+
+```
+build --flag_alias=ios_signing_cert_name=@rules_apple//apple/build_settings:signing_certificate_name
 ```
 
 <!-- End-External -->


### PR DESCRIPTION
This maintains compatibility with the removed flag, but we now recommend
our starlark flag.

From https://github.com/bazelbuild/bazel/commit/cb541be1eea5aafcce370ef8078b2e03537c0233

This cherry picks enough of f7e5aa895eac9a929b664362e5d397b57aa7b6cc,
the rest will be after we drop 9.x we can cleanup this unused arg
