### PR TITLE
Add ios arm64e archs to watchOS mappings

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -63,12 +63,14 @@ _IOS_ARCH_TO_EARLIEST_WATCHOS = {
     "x86_64": "x86_64",
     "sim_arm64": "arm64",
     "arm64": "arm64_32",
+    "arm64e": "arm64_32",
 }
 
 _IOS_ARCH_TO_64_BIT_WATCHOS = {
     "x86_64": "x86_64",
     "sim_arm64": "arm64",
     "arm64": "arm64_32",
+    "arm64e": "arm64_32",
 }
 
 def _platform_specific_cpu_setting_name(platform_type):


### PR DESCRIPTION
Cherry picks the important part of
ac50e025b67cbbe2c51588d2c727bf294af6418e while also dropping the armv7k
