### PR TITLE
Remove the extra coverage file support.

### DIFF
--- a/apple/internal/rule_factory.bzl
+++ b/apple/internal/rule_factory.bzl
@@ -80,10 +80,6 @@ AppleTestRunnerInfo provider.
         aspects = [coverage_files_aspect],
         providers = [AppleBundleInfo],
     ),
-    "_apple_coverage_support": attr.label(
-        cfg = config.exec(exec_group = "test"),
-        default = Label("@build_bazel_apple_support//tools:coverage_support"),
-    ),
     "_lcov_merger": attr.label(
         default = configuration_field(
             fragment = "coverage",

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -337,7 +337,6 @@ def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):
         if test_coverage_manifest:
             direct_runfiles.append(test_coverage_manifest)
 
-        apple_coverage_support_files = ctx.attr._apple_coverage_support.files
         covered_binaries = test_bundle_target[_CoverageFilesInfo].covered_binaries
 
         execution_environment = dicts.add(
@@ -348,7 +347,6 @@ def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):
         )
 
         transitive_runfiles.extend([
-            apple_coverage_support_files,
             covered_binaries,
             test_bundle_target[_CoverageFilesInfo].coverage_files,
         ])


### PR DESCRIPTION
This has always been empty

PiperOrigin-RevId: 774770081
(cherry picked from commit 8a292e643de72c79728c273f47617c0d5469e4d0)
