### PR TITLE
Add app run modes to Apple application runners

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -50,6 +50,16 @@ from typing import Any, Dict, Optional
 from uuid import uuid4
 import zipfile
 
+_RUN_MODE_ENV_VAR = "BAZEL_APPLE_RUN_MODE"
+_RUN_MODE_INSTALL_AND_RUN = "install_and_run"
+_RUN_MODE_INSTALL_WITHOUT_RUNNING = "install_without_running"
+_RUN_MODE_RUN_WITHOUT_INSTALLING = "run_without_installing"
+_VALID_RUN_MODES = frozenset((
+    _RUN_MODE_INSTALL_AND_RUN,
+    _RUN_MODE_INSTALL_WITHOUT_RUNNING,
+    _RUN_MODE_RUN_WITHOUT_INSTALLING,
+))
+
 
 logging.basicConfig(
     format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s",
@@ -395,6 +405,37 @@ def devicectl_launch_environ(device_identifier: str) -> Dict[str, str]:
   return result
 
 
+def app_run_mode() -> str:
+  """Returns the configured app run mode."""
+  run_mode = os.environ.get(_RUN_MODE_ENV_VAR, _RUN_MODE_INSTALL_AND_RUN)
+  if run_mode not in _VALID_RUN_MODES:
+    valid_modes = ", ".join(sorted(_VALID_RUN_MODES))
+    raise ValueError(
+        f"Invalid {_RUN_MODE_ENV_VAR} value {run_mode!r}; "
+        f"expected one of: {valid_modes}"
+    )
+  return run_mode
+
+
+def clear_launch_info_path() -> None:
+  """Deletes any stale launch info file written by a prior run."""
+  launch_info_path = os.environ.get("BAZEL_APPLE_LAUNCH_INFO_PATH")
+  if not launch_info_path:
+    return
+
+  try:
+    os.remove(launch_info_path)
+  except FileNotFoundError:
+    pass
+
+
+def ensure_devicectl_terminate_existing(launch_args: list[str]) -> list[str]:
+  """Ensures `devicectl launch` terminates any existing app instance first."""
+  if "--terminate-existing" in launch_args:
+    return launch_args
+  return launch_args + ["--terminate-existing"]
+
+
 def run_app(
     *,
     device_identifier: str,
@@ -402,7 +443,7 @@ def run_app(
     application_output_path: str,
     app_name: str,
 ) -> None:
-  """Installs and runs an app on the specified device.
+  """Installs and/or runs an app on the specified device.
 
   Args:
     device_identifier: The identifier of the device.
@@ -412,20 +453,27 @@ def run_app(
   """
   root_dir = os.path.dirname(application_output_path)
   register_dsyms(root_dir)
+  run_mode = app_run_mode()
   with extracted_app(application_output_path, app_name) as app_path:
-    logger.info("Installing app %s to device %s", app_path, device_identifier)
-    subprocess.run(
-        [
-          devicectl_path,
-          "device",
-          "install",
-          "app",
-          "--device",
-          device_identifier,
-          app_path
-        ],
-        check=True,
-    )
+    if run_mode != _RUN_MODE_RUN_WITHOUT_INSTALLING:
+      logger.info("Installing app %s to device %s", app_path, device_identifier)
+      subprocess.run(
+          [
+            devicectl_path,
+            "device",
+            "install",
+            "app",
+            "--device",
+            device_identifier,
+            app_path,
+          ],
+          check=True,
+      )
+
+    if run_mode == _RUN_MODE_INSTALL_WITHOUT_RUNNING:
+      clear_launch_info_path()
+      return
+
     app_bundle_id = bundle_id(app_path)
     launch_args = shlex.split(
       os.environ.get(
@@ -446,6 +494,7 @@ def run_app(
         "--device",
         device_identifier,
     ]
+    launch_args = ensure_devicectl_terminate_existing(launch_args)
     # Append optional launch arguments.
     app_args = [app_bundle_id] + sys.argv[1:]
     launch_app(

--- a/apple/internal/templates/apple_simulator.template.py
+++ b/apple/internal/templates/apple_simulator.template.py
@@ -62,6 +62,16 @@ import tempfile
 from typing import IO, Dict, Optional, Sequence
 import zipfile
 
+_RUN_MODE_ENV_VAR = "BAZEL_APPLE_RUN_MODE"
+_RUN_MODE_INSTALL_AND_RUN = "install_and_run"
+_RUN_MODE_INSTALL_WITHOUT_RUNNING = "install_without_running"
+_RUN_MODE_RUN_WITHOUT_INSTALLING = "run_without_installing"
+_VALID_RUN_MODES = frozenset((
+    _RUN_MODE_INSTALL_AND_RUN,
+    _RUN_MODE_INSTALL_WITHOUT_RUNNING,
+    _RUN_MODE_RUN_WITHOUT_INSTALLING,
+))
+
 
 # Custom type for methods yielding an Apple simulator UDID.
 AppleSimulatorUDID = collections.abc.Generator[str, None, None]
@@ -662,6 +672,47 @@ def simctl_launch_environ() -> Dict[str, str]:
   return result
 
 
+def app_run_mode() -> str:
+  """Returns the configured app run mode."""
+  run_mode = os.environ.get(_RUN_MODE_ENV_VAR, _RUN_MODE_INSTALL_AND_RUN)
+  if run_mode not in _VALID_RUN_MODES:
+    valid_modes = ", ".join(sorted(_VALID_RUN_MODES))
+    raise ValueError(
+        f"Invalid {_RUN_MODE_ENV_VAR} value {run_mode!r}; "
+        f"expected one of: {valid_modes}"
+    )
+  return run_mode
+
+
+def clear_launch_info_path() -> None:
+  """Deletes any stale launch info file written by a prior run."""
+  launch_info_path = os.environ.get("BAZEL_APPLE_LAUNCH_INFO_PATH")
+  if not launch_info_path:
+    return
+
+  try:
+    os.remove(launch_info_path)
+  except FileNotFoundError:
+    pass
+
+
+def terminate_existing_app(
+    *,
+    simctl_path: str,
+    simulator_udid: str,
+    app_bundle_id: str,
+) -> None:
+  """Best-effort terminate of any running app instance."""
+  logger.debug(
+      "Terminating existing instances of %s in %s", app_bundle_id, simulator_udid
+  )
+  subprocess.run(
+      [simctl_path, "terminate", simulator_udid, app_bundle_id],
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
+  )
+
+
 @contextlib.contextmanager
 def apple_simulator(
     *,
@@ -714,7 +765,7 @@ def run_app_in_simulator(
     application_output_path: str,
     app_name: str,
 ) -> None:
-  """Installs and runs an app in the specified simulator.
+  """Installs and/or runs an app in the specified simulator.
 
   Args:
     simulator_udid: The UDID of the simulator in which to run the app.
@@ -730,25 +781,27 @@ def run_app_in_simulator(
   )
   root_dir = os.path.dirname(application_output_path)
   register_dsyms(root_dir)
+  run_mode = app_run_mode()
   with extracted_app(application_output_path, app_name) as app_path:
     app_bundle_id = bundle_id(app_path)
-    logger.info("Will install app %s to simulator %s", app_path, simulator_udid)
-    # First, quietly kill any existing instances of the app to match Xcode's behavior.
-    # Otherwise we've observed that the simulator gets confused when trying to re-install the app.
-    logger.debug(
-        "Terminating existing instances of %s in %s", app_bundle_id, simulator_udid
+    terminate_existing_app(
+        simctl_path=simctl_path,
+        simulator_udid=simulator_udid,
+        app_bundle_id=app_bundle_id,
     )
-    subprocess.run(
-        [simctl_path, "terminate", simulator_udid, app_bundle_id],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-    # We should now be able to install and run it.
-    logger.debug("Installing...")
-    subprocess.run(
-        [simctl_path, "install", simulator_udid, app_path],
-        check=True,
-    )
+
+    if run_mode != _RUN_MODE_RUN_WITHOUT_INSTALLING:
+      # We should now be able to install and run it.
+      logger.debug("Installing...")
+      subprocess.run(
+          [simctl_path, "install", simulator_udid, app_path],
+          check=True,
+      )
+
+    if run_mode == _RUN_MODE_INSTALL_WITHOUT_RUNNING:
+      clear_launch_info_path()
+      return
+
     launch_args = shlex.split(
       os.environ.get(
         "BAZEL_SIMCTL_LAUNCH_FLAGS",

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -260,6 +260,25 @@ ios_application(
 )
 ```
 
+### Running applications
+
+When using `bazel run` with Apple application targets, the generated simulator
+and device runners support additional control via the
+`BAZEL_APPLE_RUN_MODE` environment variable.
+
+Supported values are:
+
+*   `install_and_run` (default): Terminates any existing instance, installs the
+    app, and launches it.
+*   `install_without_running`: Terminates any existing instance, installs the
+    app, and exits without launching it.
+*   `run_without_installing`: Terminates any existing instance and launches the
+    existing installed app without reinstalling it.
+
+If `BAZEL_APPLE_RUN_MODE=install_without_running` is used together with
+`BAZEL_APPLE_LAUNCH_INFO_PATH`, the runner removes any stale launch info file
+and does not write a new one, since no process is launched.
+
 ### Localization Handling
 
 The Apple bundling rules have two flags for limiting which \*.lproj directories


### PR DESCRIPTION
Adds a `BAZEL_APPLE_RUN_MODE` control to the device and simulator application runners so callers can install without launching or relaunch without reinstalling. This also clears stale launch info for install-only runs and uses explicit terminate-before-launch behavior for deterministic profiling workflows.
