### PR TITLE
Add a build setting for debugger entitlements

### DIFF
--- a/apple/build_settings/build_settings.bzl
+++ b/apple/build_settings/build_settings.bzl
@@ -84,9 +84,13 @@ physical devices) or `xcrun simctl list devices` (for simulators).
     ),
     "add_debugger_entitlement": struct(
         doc = """
-Controls whether debug entitlements are added to non-macOS targets.
+Overrides whether rules_apple should include debugger entitlements in bundled
+entitlements.
+
+Use the empty string to defer to the built-in --[no]device_debug_entitlements
+behavior. Use "true" or "false" to force a specific value.
 """,
-        default = False,
+        default = "",
     ),
 }
 

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -97,6 +97,15 @@ def _include_debug_entitlements(*, platform_prerequisites):
     """
     if platform_prerequisites.platform_type == apple_common.platform_type.macos:
         return False
+    build_setting = platform_prerequisites.build_settings.add_debugger_entitlement
+    if build_setting != "":
+        if build_setting == "true":
+            return True
+        if build_setting == "false":
+            return False
+        fail(
+            "Expected add_debugger_entitlement build setting to be one of '', 'true', or 'false', got '{}'".format(build_setting),
+        )
     add_debugger_entitlement = defines.bool_value(
         config_vars = platform_prerequisites.config_vars,
         default = None,
@@ -104,10 +113,6 @@ def _include_debug_entitlements(*, platform_prerequisites):
     )
     if add_debugger_entitlement != None:
         return add_debugger_entitlement
-
-    build_settings = platform_prerequisites.build_settings
-    if build_settings and build_settings.add_debugger_entitlement:
-        return True
 
     if not platform_prerequisites.objc_fragment.uses_device_debug_entitlements:
         return False

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -99,9 +99,10 @@ def _include_debug_entitlements(*, platform_prerequisites):
         return False
     build_setting = platform_prerequisites.build_settings.add_debugger_entitlement
     if build_setting != "":
-        if build_setting == "true":
+        normalized_build_setting = build_setting.lower()
+        if normalized_build_setting == "true":
             return True
-        if build_setting == "false":
+        if normalized_build_setting == "false":
             return False
         fail(
             "Expected add_debugger_entitlement build setting to be one of '', 'true', or 'false', got '{}'".format(build_setting),

--- a/test/starlark_tests/ios_application_tests.bzl
+++ b/test/starlark_tests/ios_application_tests.bzl
@@ -727,6 +727,26 @@ def ios_application_test_suite(name):
         },
     )
 
+    _debugger_entitlements_contents_tests(
+        suite_name = name,
+        test_name = "{}_debugger_entitlements_forced_false_lowercase".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_debugger_entitlements",
+        expected_get_task_allow = False,
+        build_settings = {
+            build_settings_labels.add_debugger_entitlement: "false",
+        },
+    )
+
+    _debugger_entitlements_contents_tests(
+        suite_name = name,
+        test_name = "{}_debugger_entitlements_forced_true_lowercase".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_debugger_entitlements_without_get_task_allow",
+        expected_get_task_allow = True,
+        build_settings = {
+            build_settings_labels.add_debugger_entitlement: "true",
+        },
+    )
+
     archive_contents_test(
         name = "{}_custom_executable_name_test".format(name),
         build_type = "simulator",


### PR DESCRIPTION
This lets downstream users override debugger entitlement inclusion with a transitionable build setting while preserving the existing `--define=apple.add_debugger_entitlement` and native `--[no]device_debug_entitlements` fallback behavior.