### PR TITLE
Correctly handle module.private.modulemap files

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,10 +24,10 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 # TODO: Remove before the major release after bumping to >=4
 archive_override(
     module_name = "rules_swift",
-    integrity = "sha256-7B5bIDydWD9OV0eMeh5uJpK2EN2wzlPP7DqyTC/XKu8=",
-    strip_prefix = "rules_swift-bc51c2a824f221e4162dc21e049cb99fd81d8152",
+    integrity = "sha256-DVKVdue0x3jsbTZhdp8vk6XgUeosWTLCl4Mh4w14nlw=",
+    strip_prefix = "rules_swift-f9f6fc9e308a18bfb2ea4797fea6c52fe134b980",
     urls = [
-        "https://github.com/bazelbuild/rules_swift/archive/bc51c2a824f221e4162dc21e049cb99fd81d8152.tar.gz",
+        "https://github.com/bazelbuild/rules_swift/archive/f9f6fc9e308a18bfb2ea4797fea6c52fe134b980.tar.gz",
     ],
 )
 

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -261,7 +261,7 @@ def _apple_dynamic_framework_import_impl(ctx):
                 features = features,
                 framework_includes = framework_includes,
                 hdrs = framework.header_imports,
-                module_map = framework.module_map_imports[0] if framework.module_map_imports else None,
+                module_maps = framework.module_map_imports,
                 module_name = framework.bundle_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
@@ -269,14 +269,32 @@ def _apple_dynamic_framework_import_impl(ctx):
             ),
         )
     else:
-        # Create _SwiftInteropInfo provider.
-        swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
-            deps = deps,
-            module_name = framework.bundle_name,
-            module_map_imports = framework.module_map_imports,
-        )
-        if swift_interop_info:
-            providers.append(swift_interop_info)
+        swift_info = None
+        if framework_import_support.has_private_module_map(framework.module_map_imports):
+            swift_toolchains = swift_common.find_all_toolchains(ctx)
+            swift_info = framework_import_support.swift_info_from_module_maps(
+                actions = actions,
+                cc_info = cc_info,
+                ctx = ctx,
+                deps = deps,
+                disabled_features = disabled_features,
+                features = features,
+                framework_includes = framework_includes,
+                module_name = framework.bundle_name,
+                module_maps = framework.module_map_imports,
+                swift_toolchains = swift_toolchains,
+            )
+        if swift_info:
+            providers.append(swift_info)
+        else:
+            # Create _SwiftInteropInfo provider.
+            swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+                deps = deps,
+                module_name = framework.bundle_name,
+                module_map_imports = framework.module_map_imports,
+            )
+            if swift_interop_info:
+                providers.append(swift_interop_info)
 
     return providers
 
@@ -368,26 +386,25 @@ def _apple_static_framework_import_impl(ctx):
     )
 
     # Create CcInfo provider
-    providers.append(
-        framework_import_support.cc_info_with_dependencies(
-            actions = actions,
-            additional_cc_infos = additional_cc_infos,
-            alwayslink = alwayslink,
-            cc_toolchain = cc_toolchain,
-            ctx = ctx,
-            deps = deps,
-            disabled_features = disabled_features,
-            features = features,
-            framework_includes = framework_includes,
-            header_imports = framework.header_imports,
-            kind = "static",
-            label = label,
-            libraries = framework.binary_imports,
-            linkopts = linkopts,
-            swiftinterface_imports = framework.swift_interface_imports,
-            swiftmodule_imports = framework.swift_module_imports,
-        ),
+    cc_info = framework_import_support.cc_info_with_dependencies(
+        actions = actions,
+        additional_cc_infos = additional_cc_infos,
+        alwayslink = alwayslink,
+        cc_toolchain = cc_toolchain,
+        ctx = ctx,
+        deps = deps,
+        disabled_features = disabled_features,
+        features = features,
+        framework_includes = framework_includes,
+        header_imports = framework.header_imports,
+        kind = "static",
+        label = label,
+        libraries = framework.binary_imports,
+        linkopts = linkopts,
+        swiftinterface_imports = framework.swift_interface_imports,
+        swiftmodule_imports = framework.swift_module_imports,
     )
+    providers.append(cc_info)
 
     swiftinterface_files = []
     if (
@@ -411,7 +428,7 @@ def _apple_static_framework_import_impl(ctx):
                 features = features,
                 framework_includes = framework_includes,
                 hdrs = framework.header_imports,
-                module_map = framework.module_map_imports[0] if framework.module_map_imports else None,
+                module_maps = framework.module_map_imports,
                 module_name = framework.bundle_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
@@ -419,14 +436,32 @@ def _apple_static_framework_import_impl(ctx):
             ),
         )
     else:
-        # Create SwiftInteropInfo provider for swift_clang_module_aspect
-        swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
-            deps = deps,
-            module_name = framework.bundle_name,
-            module_map_imports = framework.module_map_imports,
-        )
-        if swift_interop_info:
-            providers.append(swift_interop_info)
+        swift_info = None
+        if framework_import_support.has_private_module_map(framework.module_map_imports):
+            swift_toolchains = swift_common.find_all_toolchains(ctx)
+            swift_info = framework_import_support.swift_info_from_module_maps(
+                actions = actions,
+                cc_info = cc_info,
+                ctx = ctx,
+                deps = deps,
+                disabled_features = disabled_features,
+                features = features,
+                framework_includes = framework_includes,
+                module_name = framework.bundle_name,
+                module_maps = framework.module_map_imports,
+                swift_toolchains = swift_toolchains,
+            )
+        if swift_info:
+            providers.append(swift_info)
+        else:
+            # Create SwiftInteropInfo provider for swift_clang_module_aspect
+            swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+                deps = deps,
+                module_name = framework.bundle_name,
+                module_map_imports = framework.module_map_imports,
+            )
+            if swift_interop_info:
+                providers.append(swift_interop_info)
 
     # Create AppleFrameworkImportBundleInfo provider.
     bundle_files = [x for x in framework_imports if ".bundle/" in x.short_path]

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -164,7 +164,8 @@ def _get_xcframework_library(
                 bundles.
             headers: List of File referencing XCFramework library header files. This can be either
                 a single tree artifact or a list of regular artifacts.
-            clang_module_map: File referencing the XCFramework library Clang modulemap file.
+            clang_module_maps: List of Files referencing all XCFramework library Clang modulemap
+                files.
             swift_module_interfaces: List of File referencing all XCFramework library Swift
                 module interface files required during compilation.
     """
@@ -260,7 +261,7 @@ def _get_xcframework_library_from_paths(*, target_triplet, xcframework):
         framework_includes = framework_includes,
         headers = headers,
         includes = includes,
-        clang_module_map = module_maps[0] if module_maps else None,
+        clang_module_maps = module_maps,
         swiftmodule = swiftmodules,
         swift_module_interfaces = swift_module_interfaces,
     )
@@ -316,11 +317,14 @@ def _get_xcframework_library_with_xcframework_processor(
         dir_name = paths.join(library_path, "Headers"),
         **intermediates_common
     )
+    files_by_category = xcframework.files_by_category
     modules_dir_path = paths.join(library_path, "Modules")
-    module_map_file = intermediates.file(
-        file_name = paths.join(modules_dir_path, "module.modulemap"),
-        **intermediates_common
-    )
+    module_map_files = []
+    for module_map_import in files_by_category.module_map_imports:
+        module_map_files.append(intermediates.file(
+            file_name = paths.join(modules_dir_path, module_map_import.basename),
+            **intermediates_common
+        ))
 
     args = actions.args()
     args.add("--bundle_name", xcframework.library_name)
@@ -330,7 +334,6 @@ def _get_xcframework_library_with_xcframework_processor(
     args.add("--architecture", target_triplet.architecture)
     args.add("--environment", target_triplet.environment)
 
-    files_by_category = xcframework.files_by_category
     args.add_all(files_by_category.binary_imports, before_each = "--binary_file")
     args.add_all(files_by_category.bundling_imports, before_each = "--bundle_file")
     args.add_all(files_by_category.header_imports, before_each = "--header_file")
@@ -348,8 +351,7 @@ def _get_xcframework_library_with_xcframework_processor(
         binary,
         framework_imports_dir,
         headers_dir,
-        module_map_file,
-    ]
+    ] + module_map_files
 
     swiftinterface_file = None
     if files_by_category.swift_interface_imports:
@@ -421,7 +423,7 @@ def _get_xcframework_library_with_xcframework_processor(
         framework_includes = framework_includes,
         headers = [headers_dir],
         includes = includes,
-        clang_module_map = module_map_file,
+        clang_module_maps = module_map_files,
         swiftmodule = [],
         swift_module_interfaces = [swiftinterface_file] if swiftinterface_file else [],
         framework_files = [],
@@ -568,22 +570,57 @@ def _apple_dynamic_xcframework_import_impl(ctx):
                 features = features,
                 framework_includes = xcframework_library.framework_includes,
                 hdrs = xcframework_library.headers,
-                module_map = xcframework_library.clang_module_map,
+                module_maps = xcframework_library.clang_module_maps,
                 module_name = xcframework.library_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
                 swiftinterface_files = xcframework_library.swift_module_interfaces,
             ),
         )
-    else:
-        # Create SwiftInteropInfo provider for swift_clang_module_aspect
-        swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+    elif xcframework_library.swiftmodule:
+        swift_toolchains = swift_common.find_all_toolchains(ctx)
+        swift_info = framework_import_support.swift_info_from_swiftmodule(
+            actions = actions,
+            cc_info = cc_info,
+            ctx = ctx,
             deps = deps,
+            disabled_features = disabled_features,
+            features = features,
+            framework_includes = xcframework_library.framework_includes,
+            module_maps = xcframework_library.clang_module_maps,
             module_name = xcframework.library_name,
-            module_map_imports = [xcframework_library.clang_module_map],
+            swift_toolchains = swift_toolchains,
+            swiftmodule_files = xcframework_library.swiftmodule,
         )
-        if swift_interop_info:
-            providers.append(swift_interop_info)
+        if swift_info:
+            providers.append(swift_info)
+    else:
+        swift_info = None
+        if framework_import_support.has_private_module_map(xcframework_library.clang_module_maps):
+            swift_toolchains = swift_common.find_all_toolchains(ctx)
+            swift_info = framework_import_support.swift_info_from_module_maps(
+                actions = actions,
+                cc_info = cc_info,
+                ctx = ctx,
+                deps = deps,
+                disabled_features = disabled_features,
+                features = features,
+                framework_includes = xcframework_library.framework_includes,
+                module_maps = xcframework_library.clang_module_maps,
+                module_name = xcframework.library_name,
+                swift_toolchains = swift_toolchains,
+            )
+        if swift_info:
+            providers.append(swift_info)
+        else:
+            # Create SwiftInteropInfo provider for swift_clang_module_aspect
+            swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+                deps = deps,
+                module_name = xcframework.library_name,
+                module_map_imports = xcframework_library.clang_module_maps,
+            )
+            if swift_interop_info:
+                providers.append(swift_interop_info)
 
     return providers
 
@@ -719,22 +756,57 @@ def _apple_static_xcframework_import_impl(ctx):
                 framework_includes = xcframework_library.framework_includes,
                 hdrs = xcframework_library.headers,
                 includes = xcframework_library.includes,
-                module_map = xcframework_library.clang_module_map,
+                module_maps = xcframework_library.clang_module_maps,
                 module_name = xcframework.library_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
                 swiftinterface_files = xcframework_library.swift_module_interfaces,
             ),
         )
-    else:
-        # Create SwiftInteropInfo provider for swift_clang_module_aspect
-        swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+    elif xcframework_library.swiftmodule:
+        swift_toolchains = swift_common.find_all_toolchains(ctx)
+        swift_info = framework_import_support.swift_info_from_swiftmodule(
+            actions = actions,
+            cc_info = cc_info,
+            ctx = ctx,
             deps = deps,
+            disabled_features = disabled_features,
+            features = features,
+            framework_includes = xcframework_library.framework_includes,
+            module_maps = xcframework_library.clang_module_maps,
             module_name = xcframework.library_name,
-            module_map_imports = [xcframework_library.clang_module_map],
+            swift_toolchains = swift_toolchains,
+            swiftmodule_files = xcframework_library.swiftmodule,
         )
-        if swift_interop_info:
-            providers.append(swift_interop_info)
+        if swift_info:
+            providers.append(swift_info)
+    else:
+        swift_info = None
+        if framework_import_support.has_private_module_map(xcframework_library.clang_module_maps):
+            swift_toolchains = swift_common.find_all_toolchains(ctx)
+            swift_info = framework_import_support.swift_info_from_module_maps(
+                actions = actions,
+                cc_info = cc_info,
+                ctx = ctx,
+                deps = deps,
+                disabled_features = disabled_features,
+                features = features,
+                framework_includes = xcframework_library.framework_includes,
+                module_maps = xcframework_library.clang_module_maps,
+                module_name = xcframework.library_name,
+                swift_toolchains = swift_toolchains,
+            )
+        if swift_info:
+            providers.append(swift_info)
+        else:
+            # Create SwiftInteropInfo provider for swift_clang_module_aspect
+            swift_interop_info = framework_import_support.swift_interop_info_with_dependencies(
+                deps = deps,
+                module_name = xcframework.library_name,
+                module_map_imports = xcframework_library.clang_module_maps,
+            )
+            if swift_interop_info:
+                providers.append(swift_interop_info)
 
     # Create AppleFrameworkImportBundleInfo provider.
     bundle_files = [x for x in xcframework_library.framework_files if ".bundle/" in x.short_path]

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -15,7 +15,12 @@
 """Support methods for Apple framework import rules."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@build_bazel_rules_swift//swift:providers.bzl", "create_clang_module_inputs")
+load(
+    "@build_bazel_rules_swift//swift:providers.bzl",
+    "create_clang_module_inputs",
+    "create_swift_module_context",
+    "create_swift_module_inputs",
+)
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "SwiftInfo",
@@ -471,7 +476,7 @@ def _swift_info_from_module_interface(
         framework_includes = [],
         hdrs = [],
         includes = [],
-        module_map = None,
+        module_maps = [],
         module_name,
         rule_label,  # @unused
         swift_toolchains,
@@ -487,13 +492,15 @@ def _swift_info_from_module_interface(
         framework_includes: List of framework search paths to be used during compilation. Defaults to [].
         hdrs: List of header files for the underlying C module, if it has one.
         includes: List of header search paths to be used during compilation. Defaults to [].
-        module_map: Module map file for the underlying C module, if it has one.
+        module_maps: List of all module map files for the underlying C module, if any.
         module_name: Swift module name.
         rule_label: The label of the rule being built.
         swift_toolchains: The Swift and C++ toolchains for the current target.
-        swiftinterface_files: List of `.swiftinterface` Files for the module. The first entry is
-            compiled; any remaining entries (e.g. `.private.swiftinterface`) are declared as action
-            inputs so the compiler can resolve sibling references in the sandbox.
+        swiftinterface_files: List of `.swiftinterface` Files for the module. If a
+            `.private.swiftinterface` is present, it is compiled so downstream
+            `@_spi` imports can resolve SPI declarations. All entries are
+            declared as action inputs so the compiler can resolve sibling
+            references in the sandbox.
     Returns:
         A SwiftInfo provider.
     """
@@ -517,48 +524,249 @@ def _swift_info_from_module_interface(
     )
     swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
 
-    clang_module = None
-    if hdrs and module_map:
-        clang_result = swift_common.precompile_clang_module(
-            actions = actions,
-            cc_compilation_context = merged_compilation_context,
-            feature_configuration = feature_configuration,
-            module_map_file = module_map,
-            module_name = module_name,
-            swift_infos = swift_infos,
-            target_name = ctx.label.name,
-            toolchains = swift_toolchains,
-        )
-        if clang_result:
-            clang_module = clang_result.clang_module
-        else:
-            clang_module = create_clang_module_inputs(
-                compilation_context = merged_compilation_context,
-                module_map = module_map,
-            )
+    precompiled_module_contexts = _precompile_module_maps(
+        actions = actions,
+        cc_compilation_context = merged_compilation_context,
+        ctx = ctx,
+        feature_configuration = feature_configuration,
+        is_framework = bool(framework_includes),
+        module_maps = module_maps if hdrs else [],
+        module_name = module_name,
+        swift_infos = swift_infos,
+        swift_toolchains = swift_toolchains,
+    )
 
     compile_result = swift_common.compile_module_interface(
         actions = actions,
         additional_inputs = swiftinterface_files,
-        clang_module = clang_module,
         compilation_contexts = [merged_compilation_context],
         feature_configuration = feature_configuration,
+        is_framework = bool(framework_includes),
         module_name = module_name,
-        swiftinterface_file = swiftinterface_files[0],
-        swift_infos = swift_infos,
+        swiftinterface_file = _preferred_swiftinterface(swiftinterface_files),
+        # TODO: Ideally we would pass through precompiled_module_contexts in the clang_module parameter
+        swift_infos = swift_infos + [SwiftInfo(modules = precompiled_module_contexts)],
         target_name = ctx.label.name,
         toolchains = swift_toolchains,
     )
     module_context = compile_result.module_context
 
     return SwiftInfo(
-        modules = [module_context],
+        modules = [module_context] + precompiled_module_contexts,
         swift_infos = swift_infos,
     )
 
+def _swift_info_from_swiftmodule(
+        *,
+        actions,
+        cc_info,
+        ctx,
+        deps,
+        disabled_features,
+        features,
+        framework_includes = [],
+        module_maps = [],
+        module_name,
+        swift_toolchains,
+        swiftmodule_files):
+    """Returns SwiftInfo provider for an imported binary Swift module.
+
+    Args:
+        actions: The actions provider from `ctx.actions`.
+        cc_info: CcInfo for the imported framework.
+        ctx: The Starlark context for a rule target being built.
+        deps: List of dependencies for a given target to retrieve transitive SwiftInfo providers.
+        disabled_features: List of features to be disabled for swift_common.configure_features.
+        features: List of features to be enabled for swift_common.configure_features.
+        framework_includes: List of framework search paths to be used during compilation. Defaults to [].
+        module_maps: List of all module map files for the underlying C module, if any.
+        module_name: Swift module name.
+        swift_toolchains: All Swift toolchains for the current target.
+        swiftmodule_files: List of `.swiftmodule` Files for the module.
+    Returns:
+        A SwiftInfo provider, or None if no `.swiftmodule` file was provided.
+    """
+    if not swiftmodule_files:
+        return None
+
+    feature_configuration = swift_common.configure_features(
+        ctx = ctx,
+        toolchains = swift_toolchains,
+        requested_features = features,
+        unsupported_features = disabled_features,
+    )
+    swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
+    primary_module_map = _primary_module_map(module_maps)
+    precompiled_module_contexts = _precompile_module_maps(
+        actions = actions,
+        cc_compilation_context = cc_info.compilation_context,
+        ctx = ctx,
+        feature_configuration = feature_configuration,
+        is_framework = bool(framework_includes),
+        module_maps = module_maps,
+        module_name = module_name,
+        swift_infos = swift_infos,
+        swift_toolchains = swift_toolchains,
+    )
+
+    if precompiled_module_contexts:
+        clang_module = precompiled_module_contexts[0].clang
+        extra_module_contexts = precompiled_module_contexts[1:]
+    else:
+        clang_module = create_clang_module_inputs(
+            compilation_context = cc_info.compilation_context,
+            module_map = primary_module_map,
+        )
+        extra_module_contexts = []
+
+    module_context = create_swift_module_context(
+        name = module_name,
+        clang = clang_module,
+        is_framework = bool(framework_includes),
+        swift = create_swift_module_inputs(
+            swiftdoc = None,
+            swiftinterface = None,
+            swiftmodule = swiftmodule_files[0],
+        ),
+    )
+
+    return SwiftInfo(
+        modules = [module_context] + extra_module_contexts,
+        swift_infos = swift_infos,
+    )
+
+def _swift_info_from_module_maps(
+        *,
+        actions,
+        cc_info,
+        ctx,
+        deps,
+        disabled_features,
+        features,
+        framework_includes = [],
+        module_maps = [],
+        module_name,
+        swift_toolchains):
+    """Returns SwiftInfo for imported Clang modules that need explicit module providers."""
+    if not _has_private_module_map(module_maps):
+        return None
+
+    feature_configuration = swift_common.configure_features(
+        ctx = ctx,
+        toolchains = swift_toolchains,
+        requested_features = features,
+        unsupported_features = disabled_features,
+    )
+    swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
+    module_contexts = _precompile_module_maps(
+        actions = actions,
+        cc_compilation_context = cc_info.compilation_context,
+        ctx = ctx,
+        feature_configuration = feature_configuration,
+        is_framework = bool(framework_includes),
+        module_maps = module_maps,
+        module_name = module_name,
+        swift_infos = swift_infos,
+        swift_toolchains = swift_toolchains,
+    )
+    if not module_contexts:
+        return None
+
+    return SwiftInfo(
+        modules = module_contexts,
+        swift_infos = swift_infos,
+    )
+
+def _preferred_swiftinterface(swiftinterface_files):
+    """Returns the Swift interface file to compile for an imported framework."""
+    for swiftinterface in swiftinterface_files:
+        if swiftinterface.basename.endswith(".private.swiftinterface"):
+            return swiftinterface
+    return swiftinterface_files[0]
+
+def _precompile_module_maps(
+        *,
+        actions,
+        cc_compilation_context,
+        ctx,
+        feature_configuration,
+        is_framework,
+        module_maps,
+        module_name,
+        swift_infos,
+        swift_toolchains):
+    """Precompiles a framework's Clang module maps and returns Swift module contexts."""
+    primary_module_map = _primary_module_map(module_maps)
+    if not primary_module_map:
+        return []
+
+    module_contexts = []
+    extra_module_maps = [m for m in module_maps if m != primary_module_map]
+    compiled_modules = {}
+
+    # Private modules must be compiled after the public module, with the public
+    # module provided as a dependency.
+    for module_map in [primary_module_map] + extra_module_maps:
+        current_module_name = _module_name_for_module_map(module_name, module_map)
+
+        # Ignore duplicate modulemaps caused by symlinks in macOS frameworks.
+        if current_module_name in compiled_modules:
+            continue
+        compiled_modules[current_module_name] = True
+        current_swift_infos = swift_infos + [SwiftInfo(modules = module_contexts)]
+
+        clang_result = swift_common.precompile_clang_module(
+            actions = actions,
+            cc_compilation_context = cc_compilation_context,
+            feature_configuration = feature_configuration,
+            module_map_file = module_map,
+            module_name = current_module_name,
+            swift_infos = current_swift_infos,
+            toolchains = swift_toolchains,
+            target_name = "{}_{}".format(ctx.label.name, current_module_name),
+        )
+        if clang_result:
+            current_clang_module = clang_result.clang_module
+        else:
+            current_clang_module = create_clang_module_inputs(
+                compilation_context = cc_compilation_context,
+                module_map = module_map,
+            )
+
+        module_contexts.append(
+            create_swift_module_context(
+                name = current_module_name,
+                clang = current_clang_module,
+                is_framework = is_framework,
+            ),
+        )
+
+    return module_contexts
+
+def _module_name_for_module_map(module_name, module_map):
+    """Returns the Swift module name represented by a framework module map."""
+    if module_map.basename == "module.private.modulemap":
+        return module_name + "_Private"
+    return module_name
+
+def _has_private_module_map(module_maps):
+    """Returns True if the imported framework has a private module map."""
+    for module_map in module_maps:
+        if module_map.basename == "module.private.modulemap":
+            return True
+    return False
+
+def _primary_module_map(module_maps):
+    """Returns the public module map for an imported framework, if present."""
+    for module_map in module_maps:
+        if module_map.basename == "module.modulemap":
+            return module_map
+    return module_maps[0] if module_maps else None
+
 def _swift_interop_info_with_dependencies(deps, module_name, module_map_imports):
     """Return a Swift interop provider for the framework if it has a module map."""
-    if not module_map_imports:
+    module_map = _primary_module_map(module_map_imports)
+    if not module_map:
         return None
 
     # Assume that there is only a single module map file (the legacy
@@ -568,13 +776,13 @@ def _swift_interop_info_with_dependencies(deps, module_name, module_map_imports)
     # TODO: Use the free function when rules_apple sets min for rules_swift to v3+
     if hasattr(swift_common, "create_swift_interop_info"):
         return swift_common.create_swift_interop_info(
-            module_map = module_map_imports[0],
+            module_map = module_map,
             module_name = module_name,
             swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep],
         )
     else:
         return create_swift_interop_info(
-            module_map = module_map_imports[0],
+            module_map = module_map,
             module_name = module_name,
             swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep],
         )
@@ -587,7 +795,10 @@ framework_import_support = struct(
     get_swift_module_files_with_target_triplet = _get_swift_module_files_with_target_triplet,
     get_dsym_binaries = _get_dsym_binaries,
     get_debug_info_binaries = _get_debug_info_binaries,
+    has_private_module_map = _has_private_module_map,
     has_versioned_framework_files = _has_versioned_framework_files,
     swift_info_from_module_interface = _swift_info_from_module_interface,
+    swift_info_from_module_maps = _swift_info_from_module_maps,
+    swift_info_from_swiftmodule = _swift_info_from_swiftmodule,
     swift_interop_info_with_dependencies = _swift_interop_info_with_dependencies,
 )

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -172,12 +172,97 @@ def apple_dynamic_xcframework_import_test_suite(name):
         ],
         tags = [name],
     )
+    action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_compiles_private_modulemap_from_swiftinterface_implicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_modulemap",
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+            "Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+            "Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        ],
+        tags = [name],
+    )
+    action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_precompiles_private_modulemap_from_swiftinterface_explicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_modulemap_explicit_modules",
+        mnemonic = "SwiftPrecompileCModule",
+        expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+        ],
+        tags = [name],
+    )
+    action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_precompiles_private_modulemap_without_swiftmodule_explicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_dynamic_xcframework_with_private_modulemap_no_swiftmodule_explicit_modules",
+        mnemonic = "SwiftPrecompileCModule",
+        expected_inputs = [
+            "Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+            "Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+        ],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_swiftinterface_implicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_swift_xcframework_with_private_modulemap_depending_swift_lib"],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_swiftinterface_explicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_swift_xcframework_with_private_modulemap_explicit_modules_depending_swift_lib"],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_direct_private_import_implicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_swift_xcframework_with_private_modulemap_direct_private_import_depending_swift_lib"],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_direct_private_import_explicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_swift_xcframework_with_private_modulemap_direct_private_import_explicit_modules_depending_swift_lib"],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_without_swiftmodule_direct_private_import_implicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_xcframework_with_private_modulemap_no_swiftmodule_direct_private_import_depending_swift_lib"],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_private_modulemap_without_swiftmodule_direct_private_import_explicit_modules_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:dynamic_xcframework_with_private_modulemap_no_swiftmodule_direct_private_import_explicit_modules_depending_swift_lib"],
+        tags = [name],
+    )
 
     # Framework with swiftmodule and generated modulemap
     ios_build_test(
         name = "{}_swiftmodule_xcframework_build_test".format(name),
         minimum_os_version = common.min_os_ios.baseline,
         targets = ["//test/starlark_tests/targets_under_test/ios:swiftmodule_xcframework_consumer"],
+        tags = [name],
+    )
+    action_inputs_with_ios_x86_64_platform_test(
+        name = "{}_swiftmodule_xcframework_with_modulemap_precompiles_modulemap".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_xcframework_swiftmodule_with_modulemap",
+        mnemonic = "SwiftPrecompileCModule",
+        expected_inputs = [
+            "Swift3PFmwkBinarySwiftmodule.framework/Headers/Swift3PFmwkBinarySwiftmodule.h",
+            "Swift3PFmwkBinarySwiftmodule.framework/Modules/module.modulemap",
+        ],
+        tags = [name],
+    )
+    ios_build_test(
+        name = "{}_swiftmodule_xcframework_with_modulemap_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:swiftmodule_xcframework_with_modulemap_consumer"],
         tags = [name],
     )
     ios_build_test(

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -3750,11 +3750,239 @@ genrule(
     tags = common.fixture_tags,
 )
 
+genrule(
+    name = "ios_swift_dynamic_xcframework_with_private_modulemap",
+    srcs = [":ios_swift_dynamic_xcframework"],
+    outs = [
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/Info.plist",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftdoc",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/arm64.swiftinterface",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftdoc",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/Swift3PFmwkWithGenHeader.swiftmodule/x86_64.swiftinterface",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+    ],
+    cmd = """
+set -eu
+
+for src in $(SRCS); do
+  rel_path="$${src#*Swift3PFmwkWithGenHeader.xcframework/}"
+  output_path="$(RULEDIR)/private_modulemap/Swift3PFmwkWithGenHeader.xcframework/$$rel_path"
+  mkdir -p "$$(dirname "$$output_path")"
+  cp "$$src" "$$output_path"
+done
+
+for framework in \
+  "$(RULEDIR)/private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework" \
+  "$(RULEDIR)/private_modulemap/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework"; do
+  mkdir -p "$$framework/PrivateHeaders"
+  cat > "$$framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h" <<'EOF'
+#pragma once
+
+int Swift3PFmwkWithGenHeaderPrivateValue(void);
+EOF
+  cat > "$$framework/Modules/module.private.modulemap" <<'EOF'
+framework module Swift3PFmwkWithGenHeader_Private {
+  header "Swift3PFmwkWithGenHeader_Private.h"
+  export *
+}
+EOF
+  for swiftinterface in "$$framework"/Modules/Swift3PFmwkWithGenHeader.swiftmodule/*.swiftinterface; do
+    perl -0pi -e 's/import Foundation\\n/import Swift3PFmwkWithGenHeader_Private\\nimport Foundation\\n/' "$$swiftinterface"
+  done
+done
+""",
+    tags = common.fixture_tags,
+)
+
+genrule(
+    name = "ios_dynamic_xcframework_with_private_modulemap_no_swiftmodule",
+    srcs = [":ios_swift_dynamic_xcframework"],
+    outs = [
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/Info.plist",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Swift3PFmwkWithGenHeader",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Headers/Swift3PFmwkWithGenHeader.h",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Info.plist",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/module.modulemap",
+        "private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework/Modules/module.private.modulemap",
+    ],
+    cmd = """
+set -eu
+
+for src in $(SRCS); do
+  rel_path="$${src#*Swift3PFmwkWithGenHeader.xcframework/}"
+  case "$$rel_path" in
+    */Modules/Swift3PFmwkWithGenHeader.swiftmodule/*) continue ;;
+  esac
+
+  output_path="$(RULEDIR)/private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/$$rel_path"
+  mkdir -p "$$(dirname "$$output_path")"
+  cp "$$src" "$$output_path"
+done
+
+for framework in \
+  "$(RULEDIR)/private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64/Swift3PFmwkWithGenHeader.framework" \
+  "$(RULEDIR)/private_modulemap_no_swiftmodule/Swift3PFmwkWithGenHeader.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkWithGenHeader.framework"; do
+  mkdir -p "$$framework/PrivateHeaders"
+  cat > "$$framework/PrivateHeaders/Swift3PFmwkWithGenHeader_Private.h" <<'EOF'
+#pragma once
+
+int Swift3PFmwkWithGenHeaderPrivateValue(void);
+EOF
+  cat > "$$framework/Modules/module.private.modulemap" <<'EOF'
+framework module Swift3PFmwkWithGenHeader_Private {
+  header "Swift3PFmwkWithGenHeader_Private.h"
+  export *
+}
+EOF
+done
+""",
+    tags = common.fixture_tags,
+)
+
 swift_library(
     name = "dynamic_swift_xcframework_with_private_swiftinterface_depending_swift_lib",
     srcs = [":swift_with_dynamic_swift_framework_src"],
     tags = common.fixture_tags,
     deps = [":ios_imported_swift_dynamic_xcframework_with_private_swiftinterface"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_swift_dynamic_xcframework_with_private_modulemap",
+    features = ["-swift.layering_check"],
+    tags = common.fixture_tags,
+    xcframework_imports = [":ios_swift_dynamic_xcframework_with_private_modulemap"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_swift_dynamic_xcframework_with_private_modulemap_explicit_modules",
+    features = [
+        "-swift.layering_check",
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    xcframework_imports = [":ios_swift_dynamic_xcframework_with_private_modulemap"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_dynamic_xcframework_with_private_modulemap_no_swiftmodule",
+    features = ["-swift.layering_check"],
+    tags = common.fixture_tags,
+    xcframework_imports = [":ios_dynamic_xcframework_with_private_modulemap_no_swiftmodule"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_dynamic_xcframework_with_private_modulemap_no_swiftmodule_explicit_modules",
+    features = [
+        "-swift.layering_check",
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    xcframework_imports = [":ios_dynamic_xcframework_with_private_modulemap_no_swiftmodule"],
+)
+
+swift_library(
+    name = "dynamic_swift_xcframework_with_private_modulemap_depending_swift_lib",
+    srcs = [":swift_with_dynamic_swift_framework_src"],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_swift_dynamic_xcframework_with_private_modulemap"],
+)
+
+swift_library(
+    name = "dynamic_swift_xcframework_with_private_modulemap_explicit_modules_depending_swift_lib",
+    srcs = [":swift_with_dynamic_swift_framework_src"],
+    features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_swift_dynamic_xcframework_with_private_modulemap_explicit_modules"],
+)
+
+write_file(
+    name = "swift_with_dynamic_swift_framework_private_module_src",
+    out = "SwiftWithDynamicSwiftFrameworkPrivateModule.swift",
+    content = ["""
+import Swift3PFmwkWithGenHeader
+@_implementationOnly import Swift3PFmwkWithGenHeader_Private
+
+func swift_with_dynamic_swift_framework_private_module_function() {
+  let sc = Swift3PFmwkWithGenHeader.SharedClass()
+  sc.doSomethingShared()
+}
+"""],
+    tags = common.fixture_tags,
+)
+
+write_file(
+    name = "swift_with_dynamic_framework_private_clang_module_src",
+    out = "SwiftWithDynamicFrameworkPrivateClangModule.swift",
+    content = ["""
+import Swift3PFmwkWithGenHeader
+@_implementationOnly import Swift3PFmwkWithGenHeader_Private
+
+func swift_with_dynamic_framework_private_clang_module_function() {
+  _ = Swift3PFmwkWithGenHeaderPrivateValue()
+}
+"""],
+    tags = common.fixture_tags,
+)
+
+swift_library(
+    name = "dynamic_swift_xcframework_with_private_modulemap_direct_private_import_depending_swift_lib",
+    srcs = [":swift_with_dynamic_swift_framework_private_module_src"],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_swift_dynamic_xcframework_with_private_modulemap"],
+)
+
+swift_library(
+    name = "dynamic_swift_xcframework_with_private_modulemap_direct_private_import_explicit_modules_depending_swift_lib",
+    srcs = [":swift_with_dynamic_swift_framework_private_module_src"],
+    features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_swift_dynamic_xcframework_with_private_modulemap_explicit_modules"],
+)
+
+swift_library(
+    name = "dynamic_xcframework_with_private_modulemap_no_swiftmodule_direct_private_import_depending_swift_lib",
+    srcs = [":swift_with_dynamic_framework_private_clang_module_src"],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_dynamic_xcframework_with_private_modulemap_no_swiftmodule"],
+)
+
+swift_library(
+    name = "dynamic_xcframework_with_private_modulemap_no_swiftmodule_direct_private_import_explicit_modules_depending_swift_lib",
+    srcs = [":swift_with_dynamic_framework_private_clang_module_src"],
+    features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_dynamic_xcframework_with_private_modulemap_no_swiftmodule_explicit_modules"],
 )
 
 genrule(
@@ -3779,6 +4007,30 @@ genrule(
     tags = common.fixture_tags,
 )
 
+genrule(
+    name = "swiftmodule_xcframework_with_modulemap",
+    srcs = ["//test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_binary_swiftmodule"],
+    outs = [
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/Info.plist",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Info.plist",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Swift3PFmwkBinarySwiftmodule",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Headers/Swift3PFmwkBinarySwiftmodule.h",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftdoc",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftmodule",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64/Swift3PFmwkBinarySwiftmodule.framework/Modules/module.modulemap",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Swift3PFmwkBinarySwiftmodule",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Headers/Swift3PFmwkBinarySwiftmodule.h",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Info.plist",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftdoc",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftmodule",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/x86_64.swiftdoc",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/x86_64.swiftmodule",
+        "with_modulemap/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework/Modules/module.modulemap",
+    ],
+    cmd = "unzip -qq $(execpath //test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_binary_swiftmodule) -d $(RULEDIR)/with_modulemap",
+    tags = common.fixture_tags,
+)
+
 apple_dynamic_xcframework_import(
     name = "ios_imported_xcframework_swiftmodule_no_modulemap",
     features = [
@@ -3788,6 +4040,17 @@ apple_dynamic_xcframework_import(
     ],
     tags = common.fixture_tags,
     xcframework_imports = [":swiftmodule_xcframework"],
+)
+
+apple_dynamic_xcframework_import(
+    name = "ios_imported_xcframework_swiftmodule_with_modulemap",
+    features = [
+        "-swift.layering_check",
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    xcframework_imports = [":swiftmodule_xcframework_with_modulemap"],
 )
 
 write_file(
@@ -3806,6 +4069,31 @@ swift_library(
     ],
     tags = common.fixture_tags,
     deps = [":ios_imported_xcframework_swiftmodule_no_modulemap"],
+)
+
+write_file(
+    name = "use_swiftmodule_framework_with_modulemap",
+    out = "SwiftWithBinarySwiftmoduleAndModulemapFramework.swift",
+    content = ["""
+import Swift3PFmwkBinarySwiftmodule
+
+func swift_with_binary_swiftmodule_and_modulemap_framework_function() {
+  let sc = Swift3PFmwkBinarySwiftmodule.SharedClass()
+  sc.doSomethingShared()
+}
+"""],
+    tags = common.fixture_tags,
+)
+
+swift_library(
+    name = "swiftmodule_xcframework_with_modulemap_consumer",
+    srcs = [":use_swiftmodule_framework_with_modulemap"],
+    features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+    ],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_xcframework_swiftmodule_with_modulemap"],
 )
 
 # Swift app with imported Objective-C static framework.


### PR DESCRIPTION
Modules can contain `module.private.modulemap` alongside
`module.modulemap`. In this case we have to precompile both for explicit
modules, and the private module must be precompiled with the public
module as a dependency. We now handle this by using lists of modulemaps

This change also revealed that we weren't correctly handling frameworks that
were missing modulemaps but had a swiftmodule.
