### PR TITLE
Stop using repo_name and remove bazel_build_ prefix

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -14,6 +14,6 @@ This release is compatible with: TODO
 ## MODULE.bazel Snippet
 
 \`\`\`bzl
-bazel_dep(name = "rules_apple", version = "$new_version", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_apple", version = "$new_version")
 \`\`\`
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "apple_support", version = "2.5.4", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "2.5.4")
 bazel_dep(name = "bazel_features", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
@@ -16,7 +16,6 @@ bazel_dep(
     name = "rules_swift",
     version = "3.5.0",
     max_compatibility_level = 3,
-    repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(name = "rules_python", version = "1.7.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
@@ -31,7 +30,7 @@ archive_override(
     ],
 )
 
-system_sdk = use_extension("@build_bazel_rules_swift//swift:extensions.bzl", "system_sdk")
+system_sdk = use_extension("@rules_swift//swift:extensions.bzl", "system_sdk")
 system_sdk.configure_sdks(
     # NOTE: This doesn't apply to downstream repos
     exclude_modules = {
@@ -78,7 +77,7 @@ use_repo(non_module_deps, "xctestrunner")
 provisioning_profile_repository = use_extension("//apple:apple.bzl", "provisioning_profile_repository_extension")
 use_repo(provisioning_profile_repository, "local_provisioning_profiles")
 
-apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
+apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
 
 register_toolchains("//apple/internal:apple_xplat_toolchain")

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Copy the latest `MODULE.bazel` snippet from [the releases page](https://github.c
 Minimal example:
 
 ```python
-load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_apple//apple:ios.bzl", "ios_application")
+load("@rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "MyLibrary",

--- a/apple/BUILD
+++ b/apple/BUILD
@@ -26,7 +26,7 @@ exports_files(
 [
     alias(
         name = arch,
-        actual = "@build_bazel_apple_support//configs:{}".format(arch),
+        actual = "@apple_support//configs:{}".format(arch),
     )
     for arch in [
         "darwin_x86_64",
@@ -71,7 +71,7 @@ bzl_library(
         "//apple/internal:rule_attrs",
         "//apple/internal:rule_factory",
         "//apple/internal:transition_support",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -111,8 +111,8 @@ bzl_library(
         ":providers",
         "//apple/internal:platform_support",
         "//apple/internal:providers",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
         "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
@@ -127,9 +127,9 @@ bzl_library(
     srcs = ["dtrace.bzl"],
     deps = [
         "//apple/internal/utils:bundle_paths",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
         "@rules_cc//cc/common",
     ],
 )

--- a/apple/apple_binary.bzl
+++ b/apple/apple_binary.bzl
@@ -15,7 +15,7 @@
 """Starlark implementation of `apple_binary` to transition from native Bazel."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/cc_toolchain_forwarder.bzl
+++ b/apple/cc_toolchain_forwarder.bzl
@@ -17,12 +17,12 @@ A rule for handling the cc_toolchains and their constraints for a potential "fat
 """
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "@rules_cc//cc:find_cc_toolchain.bzl",

--- a/apple/dtrace.bzl
+++ b/apple/dtrace.bzl
@@ -15,16 +15,16 @@
 """# Bazel rules for working with dtrace."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")

--- a/apple/internal/BUILD
+++ b/apple/internal/BUILD
@@ -78,8 +78,8 @@ bzl_library(
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:sets",
-        "@build_bazel_rules_swift//swift",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_swift//swift",
     ],
 )
 
@@ -133,11 +133,11 @@ bzl_library(
         ":shared_environment",
         "//apple:providers",
         "//apple/internal/aspects:swift_usage_aspect",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_swift//swift",
     ],
 )
 
@@ -200,9 +200,9 @@ bzl_library(
         ":rule_support",
         ":shared_environment",
         "//apple/internal/utils:defines",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -233,7 +233,7 @@ bzl_library(
         ":shared_environment",
         "//apple:common",
         "//apple/internal/utils:defines",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -248,8 +248,8 @@ bzl_library(
         ":platform_support",
         ":rule_attrs",
         ":shared_environment",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -296,7 +296,7 @@ bzl_library(
         "//apple/internal:providers",
         "//apple/internal/utils:files",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -346,11 +346,11 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/utils:clang_rt_dylibs",
         "//apple/internal/utils:main_thread_checker_dylibs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:collections",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
-        "@build_bazel_rules_swift//swift:providers",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_swift//swift",
+        "@rules_swift//swift:providers",
     ],
 )
 
@@ -370,8 +370,8 @@ bzl_library(
         ":intermediates",
         ":providers",
         ":rule_support",
+        "@apple_support//lib:lipo",
         "@bazel_skylib//lib:collections",
-        "@build_bazel_apple_support//lib:lipo",
         "@rules_cc//cc/private/rules_impl:objc_common",
     ],
 )
@@ -394,8 +394,8 @@ bzl_library(
         ":rule_support",
         ":transition_support",
         "//apple:providers",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -432,7 +432,7 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/utils:clang_rt_dylibs",
         "//apple/internal/utils:main_thread_checker_dylibs",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -519,7 +519,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal:providers",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -536,9 +536,9 @@ bzl_library(
         ":outputs",
         "//apple/internal/utils:bundle_paths",
         "//apple/internal/utils:defines",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -605,9 +605,9 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/testing:apple_test_bundle_support",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -631,8 +631,8 @@ bzl_library(
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/testing:apple_test_bundle_support",
         "//apple/internal/testing:apple_test_rule_support",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
         "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
@@ -669,8 +669,8 @@ bzl_library(
     deps = [
         ":intermediates",
         ":shared_environment",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_apple_support//lib:lipo",
+        "@apple_support//lib:apple_support",
+        "@apple_support//lib:lipo",
     ],
 )
 
@@ -683,7 +683,7 @@ bzl_library(
     deps = [
         ":intermediates",
         "@bazel_skylib//lib:sets",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -704,8 +704,8 @@ bzl_library(
     ],
     deps = [
         "//apple/build_settings",
+        "@apple_support//configs:platforms",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//configs:platforms",
     ],
 )
 
@@ -742,10 +742,10 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/utils:clang_rt_dylibs",
         "//apple/internal/utils:main_thread_checker_dylibs",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
-        "@build_bazel_rules_swift//swift:providers",
+        "@apple_support//lib:apple_support",
         "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_swift//swift",
+        "@rules_swift//swift:providers",
     ],
 )
 
@@ -781,8 +781,8 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/utils:clang_rt_dylibs",
         "//apple/internal/utils:main_thread_checker_dylibs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:sets",
-        "@build_bazel_apple_support//lib:apple_support",
         "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
@@ -819,8 +819,8 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/utils:clang_rt_dylibs",
         "//apple/internal/utils:main_thread_checker_dylibs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:sets",
-        "@build_bazel_apple_support//lib:apple_support",
         "@rules_cc//cc:find_cc_toolchain_bzl",
     ],
 )
@@ -854,10 +854,10 @@ bzl_library(
         "//apple/internal/aspects:resource_aspect_hint",
         "//apple/internal/aspects:swift_usage_aspect",
         "//apple/internal/utils:files",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -893,7 +893,7 @@ bzl_library(
     deps = [
         "//apple:providers",
         "//apple/internal/providers:apple_debug_info",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -910,8 +910,8 @@ bzl_library(
         "//apple/internal:platform_support",
         "//apple/internal:swift_support",
         "//apple/internal/aspects:docc_archive_aspect",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -922,8 +922,8 @@ bzl_library(
         "//apple:__subpackages__",
     ],
     deps = [
-        "@build_bazel_rules_swift//swift",
         "@rules_cc//cc/common",
+        "@rules_swift//swift",
     ],
 )
 

--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -31,16 +31,16 @@ load(
     "sets",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_clang_module_aspect",
-    "swift_common",
-)
-load(
     "@rules_cc//cc:find_cc_toolchain.bzl",
     "find_cc_toolchain",
     "use_cc_toolchain",
 )
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "swift_clang_module_aspect",
+    "swift_common",
+)
 load(
     "//apple:providers.bzl",
     "AppleFrameworkImportInfo",

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -14,20 +14,20 @@
 
 """Implementation of XCFramework import rules."""
 
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_clang_module_aspect",
-    "swift_common",
-)
 load(
     "@rules_cc//cc:find_cc_toolchain.bzl",
     "find_cc_toolchain",
     "use_cc_toolchain",
 )
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "swift_clang_module_aspect",
+    "swift_common",
+)
 load("//apple:providers.bzl", "AppleFrameworkImportInfo")
 load(
     "//apple/internal:apple_toolchains.bzl",

--- a/apple/internal/aspects/BUILD
+++ b/apple/internal/aspects/BUILD
@@ -16,10 +16,10 @@ bzl_library(
     deps = [
         "//apple/internal:cc_info_support",
         "//apple/internal/providers:app_intents_info",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:collections",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
-        "@build_bazel_rules_swift//swift:module_name",
+        "@rules_swift//swift",
+        "@rules_swift//swift:module_name",
     ],
 )
 
@@ -51,10 +51,10 @@ bzl_library(
         "//apple/internal:swift_support",
         "//apple/internal/providers:apple_debug_info",
         "//apple/internal/providers:framework_import_bundle_info",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:partial",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -66,7 +66,7 @@ bzl_library(
         "//apple/internal/testing:__pkg__",
     ],
     deps = [
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -77,7 +77,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -88,7 +88,7 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -100,7 +100,7 @@ bzl_library(
     ],
     deps = [
         "//apple:providers",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 

--- a/apple/internal/aspects/app_intents_aspect.bzl
+++ b/apple/internal/aspects/app_intents_aspect.bzl
@@ -15,19 +15,19 @@
 """Implementation of the aspect that propagates AppIntentsInfo providers."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:collections.bzl",
     "collections",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:module_name.bzl",
+    "@rules_swift//swift:module_name.bzl",
     "derive_swift_module_name",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
 load("//apple/internal:cc_info_support.bzl", "cc_info_support")

--- a/apple/internal/aspects/docc_archive_aspect.bzl
+++ b/apple/internal/aspects/docc_archive_aspect.bzl
@@ -15,11 +15,11 @@
 """Defines aspects for collecting information required to build .docc and .doccarchive files."""
 
 load(
-    "@build_bazel_rules_swift//swift:providers.bzl",
+    "@rules_swift//swift:providers.bzl",
     "SwiftSymbolGraphInfo",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift_symbol_graph_aspect.bzl",
+    "@rules_swift//swift:swift_symbol_graph_aspect.bzl",
     "swift_symbol_graph_aspect",
 )
 load(

--- a/apple/internal/aspects/resource_aspect.bzl
+++ b/apple/internal/aspects/resource_aspect.bzl
@@ -14,17 +14,17 @@
 
 """Implementation of the resource propagation aspect."""
 
+load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
 load(

--- a/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
+++ b/apple/internal/aspects/swift_dynamic_framework_aspect.bzl
@@ -14,11 +14,11 @@
 
 """Aspect implementation for Swift dynamic framework support."""
 
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 SwiftDynamicFrameworkInfo = provider(
     fields = {

--- a/apple/internal/aspects/swift_usage_aspect.bzl
+++ b/apple/internal/aspects/swift_usage_aspect.bzl
@@ -15,7 +15,7 @@
 """An aspect that collects information about Swift usage among dependencies."""
 
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
 

--- a/apple/internal/codesigning_support.bzl
+++ b/apple/internal/codesigning_support.bzl
@@ -15,16 +15,16 @@
 """Actions related to codesigning."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
 load(
     "@bazel_skylib//lib:shell.bzl",
     "shell",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple/internal:intermediates.bzl",

--- a/apple/internal/docc.bzl
+++ b/apple/internal/docc.bzl
@@ -15,12 +15,12 @@
 """Defines rules for building Apple DocC targets."""
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "//apple:providers.bzl",
@@ -219,7 +219,7 @@ NOTE: At this time Swift is the only supported language for this rule.
 Example:
 
 ```starlark
-load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
+load("@rules_apple//apple:docc.bzl", "docc_archive")
 
 docc_archive(
     name = "Lib.doccarchive",

--- a/apple/internal/entitlements_support.bzl
+++ b/apple/internal/entitlements_support.bzl
@@ -15,7 +15,7 @@
 """Actions that manipulate entitlements and provisioning profiles."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -17,12 +17,12 @@ A rule for generating the environment plist
 """
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "//apple/internal:apple_toolchains.bzl",

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -15,20 +15,20 @@
 """Support methods for Apple framework import rules."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
-    "@build_bazel_rules_swift//swift:providers.bzl",
+    "@rules_swift//swift:providers.bzl",
     "create_clang_module_inputs",
     "create_swift_module_context",
     "create_swift_module_inputs",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
     "swift_common",
 )
-load("@build_bazel_rules_swift//swift:swift_interop_info.bzl", "create_swift_interop_info")
-load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_swift//swift:swift_interop_info.bzl", "create_swift_interop_info")
 load("//apple:providers.bzl", "AppleFrameworkImportInfo")
 load("//apple:utils.bzl", "group_files_by_directory")
 load("//apple/internal:providers.bzl", "new_appleframeworkimportinfo")

--- a/apple/internal/header_map.bzl
+++ b/apple/internal/header_map.bzl
@@ -14,10 +14,10 @@
 
 """Rule for creating header_maps."""
 
-load("@build_bazel_rules_swift//swift:providers.bzl", "SwiftInfo")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_common")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_swift//swift:providers.bzl", "SwiftInfo")
+load("@rules_swift//swift:swift.bzl", "swift_common")
 
 HeaderMapInfo = provider(
     doc = "Provides information about created `.hmap` (header map) files",

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -14,15 +14,15 @@
 
 """Implementation of iOS rules."""
 
-load("@bazel_skylib//lib:collections.bzl", "collections")
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     "//apple:providers.bzl",
     "AppleBundleInfo",

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -14,7 +14,7 @@
 
 """Support for linking related actions."""
 
-load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
+load("@apple_support//lib:lipo.bzl", "lipo")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(

--- a/apple/internal/local_provisioning_profiles.bzl
+++ b/apple/internal/local_provisioning_profiles.bzl
@@ -77,7 +77,7 @@ You only need this in the case you want to setup fallback profiles, otherwise
 it can be ommitted when using bzlmod.
 
 ```bzl
-provisioning_profile_repository = use_extension("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
+provisioning_profile_repository = use_extension("@rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
 provisioning_profile_repository.setup(
     fallback_profiles = "//path/to/some:filegroup", # Profiles to use if one isn't found locally
 )

--- a/apple/internal/macos_binary_support.bzl
+++ b/apple/internal/macos_binary_support.bzl
@@ -15,12 +15,12 @@
 """Internal helper definitions used by macOS command line rules."""
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "//apple:providers.bzl",

--- a/apple/internal/macos_rules.bzl
+++ b/apple/internal/macos_rules.bzl
@@ -15,16 +15,16 @@
 """Implementation of macOS rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 load(
     "//apple:providers.bzl",
     "AppleBinaryInfoplistInfo",

--- a/apple/internal/partials/BUILD
+++ b/apple/internal/partials/BUILD
@@ -55,9 +55,9 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:shell",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -83,8 +83,8 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:processor",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -99,8 +99,8 @@ bzl_library(
         "//apple/internal:processor",
         "//apple/internal:shared_environment",
         "//apple/internal/utils:clang_rt_dylibs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -114,8 +114,8 @@ bzl_library(
         "//apple/internal:intermediates",
         "//apple/internal:processor",
         "//apple/internal/utils:main_thread_checker_dylibs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -152,9 +152,9 @@ bzl_library(
         "//apple/internal:shared_environment",
         "//apple/internal/providers:apple_debug_info",
         "//apple/internal/utils:defines",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:shell",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -221,9 +221,9 @@ bzl_library(
         "//apple/internal:processor",
         "//apple/internal:shared_environment",
         "//apple/internal/utils:bundle_paths",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -328,9 +328,9 @@ bzl_library(
         "//apple/internal:processor",
         "//apple/internal:shared_environment",
         "//apple/internal/utils:defines",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 

--- a/apple/internal/partials/apple_symbols_file.bzl
+++ b/apple/internal/partials/apple_symbols_file.bzl
@@ -15,14 +15,14 @@
 """Partial implementation for Apple .symbols file processing."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
 load(
     "//apple:providers.bzl",
     "AppleFrameworkImportInfo",

--- a/apple/internal/partials/clang_rt_dylibs.bzl
+++ b/apple/internal/partials/clang_rt_dylibs.bzl
@@ -15,12 +15,12 @@
 """Partial implementation for Clang runtime libraries processing."""
 
 load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
 )
 load(
     "//apple/internal:intermediates.bzl",

--- a/apple/internal/partials/debug_symbols.bzl
+++ b/apple/internal/partials/debug_symbols.bzl
@@ -15,6 +15,11 @@
 """Partial implementation for debug symbol file processing."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load("@apple_support//lib:lipo.bzl", "lipo")
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
@@ -22,11 +27,6 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
-)
-load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load(
     "//apple:providers.bzl",
     "AppleBundleVersionInfo",

--- a/apple/internal/partials/framework_import.bzl
+++ b/apple/internal/partials/framework_import.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for framework import file processing."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple:providers.bzl",

--- a/apple/internal/partials/main_thread_checker_dylibs.bzl
+++ b/apple/internal/partials/main_thread_checker_dylibs.bzl
@@ -15,12 +15,12 @@
 """Partial implementation for Main Thread Checker libraries processing."""
 
 load(
-    "@bazel_skylib//lib:partial.bzl",
-    "partial",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:partial.bzl",
+    "partial",
 )
 load(
     "//apple/internal:intermediates.bzl",

--- a/apple/internal/partials/swift_dylibs.bzl
+++ b/apple/internal/partials/swift_dylibs.bzl
@@ -15,16 +15,16 @@
 """Partial implementation for Swift dylib processing for bundles."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple/internal:intermediates.bzl",

--- a/apple/internal/platform_support.bzl
+++ b/apple/internal/platform_support.bzl
@@ -15,7 +15,7 @@
 """Support functions for working with Apple platforms and device families."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/processor.bzl
+++ b/apple/internal/processor.bzl
@@ -64,16 +64,16 @@ rule.
 """
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
 )
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple/internal:codesigning_support.bzl",

--- a/apple/internal/resource_actions/BUILD
+++ b/apple/internal/resource_actions/BUILD
@@ -19,8 +19,8 @@ bzl_library(
         "//apple/internal:bundling_support",
         "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -33,7 +33,7 @@ bzl_library(
     deps = [
         "//apple/internal:intermediates",
         "//apple/internal:shared_environment",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -46,7 +46,7 @@ bzl_library(
     deps = [
         "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -59,8 +59,8 @@ bzl_library(
     deps = [
         "//apple/internal:shared_environment",
         "//apple/internal/utils:xctoolrunner",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -71,8 +71,8 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:versions",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -83,8 +83,8 @@ bzl_library(
         "//apple/internal:__pkg__",
     ],
     deps = [
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -96,7 +96,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal/utils:xctoolrunner",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -111,8 +111,8 @@ bzl_library(
         "//apple/internal:intermediates",
         "//apple/internal:platform_support",
         "//apple/internal:shared_environment",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -124,7 +124,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal:shared_environment",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -136,7 +136,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal:shared_environment",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -148,7 +148,7 @@ bzl_library(
     ],
     deps = [
         "//apple/internal/utils:xctoolrunner",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 

--- a/apple/internal/resource_actions/actool.bzl
+++ b/apple/internal/resource_actions/actool.bzl
@@ -15,6 +15,10 @@
 """ACTool related actions."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:collections.bzl",
     "collections",
 )
@@ -25,10 +29,6 @@ load(
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple:utils.bzl",

--- a/apple/internal/resource_actions/app_intents.bzl
+++ b/apple/internal/resource_actions/app_intents.bzl
@@ -14,7 +14,7 @@
 
 """AppIntents intents related actions."""
 
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("//apple/internal:intermediates.bzl", "intermediates")
 load("//apple/internal:shared_environment.bzl", "shared_environment")
 

--- a/apple/internal/resource_actions/datamodel.bzl
+++ b/apple/internal/resource_actions/datamodel.bzl
@@ -15,7 +15,7 @@
 """Datamodel related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/resource_actions/ibtool.bzl
+++ b/apple/internal/resource_actions/ibtool.bzl
@@ -15,12 +15,12 @@
 """IBTool related actions."""
 
 load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
 )
 load(
     "//apple/internal:shared_environment.bzl",

--- a/apple/internal/resource_actions/intent.bzl
+++ b/apple/internal/resource_actions/intent.bzl
@@ -15,12 +15,12 @@
 """Intent definitions related actions."""
 
 load(
-    "@bazel_skylib//lib:versions.bzl",
-    "versions",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:versions.bzl",
+    "versions",
 )
 load(
     "//apple/internal/utils:xctoolrunner.bzl",

--- a/apple/internal/resource_actions/metals.bzl
+++ b/apple/internal/resource_actions/metals.bzl
@@ -15,12 +15,12 @@
 """Metal related actions."""
 
 load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
 )
 
 def _metal_apple_target_triple(platform_prerequisites):

--- a/apple/internal/resource_actions/mlmodel.bzl
+++ b/apple/internal/resource_actions/mlmodel.bzl
@@ -15,7 +15,7 @@
 """CoreML related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/resource_actions/plist.bzl
+++ b/apple/internal/resource_actions/plist.bzl
@@ -15,16 +15,16 @@
 """Plist related actions."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
 load(
     "@bazel_skylib//lib:shell.bzl",
     "shell",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple:providers.bzl",

--- a/apple/internal/resource_actions/png.bzl
+++ b/apple/internal/resource_actions/png.bzl
@@ -15,7 +15,7 @@
 """PNG related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/resource_actions/texture_atlas.bzl
+++ b/apple/internal/resource_actions/texture_atlas.bzl
@@ -15,7 +15,7 @@
 """Texture atlas related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/resource_actions/xcstrings.bzl
+++ b/apple/internal/resource_actions/xcstrings.bzl
@@ -1,7 +1,7 @@
 """xcstrings related actions."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/resource_rules/BUILD
+++ b/apple/internal/resource_rules/BUILD
@@ -30,9 +30,9 @@ bzl_library(
         "//apple/internal:platform_support",
         "//apple/internal:resource_actions",
         "//apple/internal:swift_support",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -47,9 +47,9 @@ bzl_library(
         "//apple/internal:features_support",
         "//apple/internal:platform_support",
         "//apple/internal:resources",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -65,9 +65,9 @@ bzl_library(
         "//apple/internal:resource_actions",
         "//apple/internal:rule_attrs",
         "//apple/internal:swift_support",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 
@@ -83,9 +83,9 @@ bzl_library(
         "//apple/internal:platform_support",
         "//apple/internal:resource_actions",
         "//apple/internal:rule_attrs",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
-        "@build_bazel_apple_support//lib:apple_support",
     ],
 )
 

--- a/apple/internal/resource_rules/apple_core_data_model.bzl
+++ b/apple/internal/resource_rules/apple_core_data_model.bzl
@@ -14,14 +14,14 @@
 
 """Implementation of Apple Core Data Model resource rule."""
 
+load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple:utils.bzl",

--- a/apple/internal/resource_rules/apple_core_ml_library.bzl
+++ b/apple/internal/resource_rules/apple_core_ml_library.bzl
@@ -14,14 +14,14 @@
 
 """Implementation of Apple CoreML library rule."""
 
+load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple/internal:apple_toolchains.bzl",

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -15,12 +15,12 @@
 """Implementation of ObjC/Swift Intent library rule."""
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "//apple/internal:apple_toolchains.bzl",

--- a/apple/internal/resource_rules/apple_metal_library.bzl
+++ b/apple/internal/resource_rules/apple_metal_library.bzl
@@ -15,12 +15,12 @@
 """Implementation of Metal shader library rule."""
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load(
     "//apple/internal:apple_toolchains.bzl",

--- a/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
+++ b/apple/internal/resource_rules/apple_precompiled_resource_bundle.bzl
@@ -15,16 +15,16 @@
 """Implementation of apple_precompiled_resource_bundle rule."""
 
 load(
+    "@apple_support//lib:apple_support.bzl",
+    "apple_support",
+)
+load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
 load(
     "@bazel_skylib//lib:partial.bzl",
     "partial",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
-    "apple_support",
 )
 load(
     "//apple:providers.bzl",

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -15,18 +15,18 @@
 """Common sets of attributes to be shared between the Apple rules."""
 
 load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
 )
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 load(
     "//apple:common.bzl",
     "entitlements_validation_mode",
@@ -332,7 +332,7 @@ def _test_bundle_attrs():
         "test_bundle_output": attr.output(mandatory = True),
         "_swizzle_absolute_xcttestsourcelocation": attr.label(
             default = Label(
-                "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation",
+                "@apple_support//lib:swizzle_absolute_xcttestsourcelocation",
             ),
         ),
     }

--- a/apple/internal/stub_support.bzl
+++ b/apple/internal/stub_support.bzl
@@ -15,11 +15,11 @@
 """Stub binary creation support methods."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
-    "@build_bazel_apple_support//lib:lipo.bzl",
+    "@apple_support//lib:lipo.bzl",
     "lipo",
 )
 load(

--- a/apple/internal/swift_info_support.bzl
+++ b/apple/internal/swift_info_support.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
 load(

--- a/apple/internal/testing/BUILD
+++ b/apple/internal/testing/BUILD
@@ -39,7 +39,7 @@ bzl_library(
         "//apple/internal:swift_support",
         "//apple/internal/utils:clang_rt_dylibs",
         "@bazel_skylib//lib:types",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 
@@ -106,7 +106,7 @@ bzl_library(
         "//apple/internal:transition_support",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -128,7 +128,7 @@ bzl_library(
         "//apple/internal:transition_support",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -150,7 +150,7 @@ bzl_library(
         "//apple/internal:transition_support",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 
@@ -172,7 +172,7 @@ bzl_library(
         "//apple/internal:transition_support",
         "//apple/internal/aspects:framework_provider_aspect",
         "//apple/internal/aspects:resource_aspect",
-        "@build_bazel_apple_support//lib:apple_support",
+        "@apple_support//lib:apple_support",
     ],
 )
 

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -18,11 +18,11 @@ load(
     "@bazel_skylib//lib:types.bzl",
     "types",
 )
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "SwiftInfo",
 )
-load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//apple:providers.bzl",
     "AppleBundleInfo",

--- a/apple/internal/testing/ios_rules.bzl
+++ b/apple/internal/testing/ios_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of iOS test rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/testing/macos_rules.bzl
+++ b/apple/internal/testing/macos_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of macOS test rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/testing/tvos_rules.bzl
+++ b/apple/internal/testing/tvos_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of tvOS test rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/testing/visionos_rules.bzl
+++ b/apple/internal/testing/visionos_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of visionOS test rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/testing/watchos_rules.bzl
+++ b/apple/internal/testing/watchos_rules.bzl
@@ -15,7 +15,7 @@
 """Implementation of watchOS test rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -74,35 +74,35 @@ _IOS_ARCH_TO_64_BIT_WATCHOS = {
 }
 
 _MACOS_PLATFORM_TO_ENV_ARCH = {
-    Label("@build_bazel_apple_support//platforms:darwin_x86_64"): "x86_64",
-    Label("@build_bazel_apple_support//platforms:darwin_arm64"): "arm64",
-    Label("@build_bazel_apple_support//platforms:darwin_arm64e"): "arm64e",
+    Label("@apple_support//platforms:darwin_x86_64"): "x86_64",
+    Label("@apple_support//platforms:darwin_arm64"): "arm64",
+    Label("@apple_support//platforms:darwin_arm64e"): "arm64e",
 }
 
 _IOS_PLATFORM_TO_ENV_ARCH = {
-    Label("@build_bazel_apple_support//platforms:ios_arm64"): "arm64",
-    Label("@build_bazel_apple_support//platforms:ios_arm64e"): "arm64e",
-    Label("@build_bazel_apple_support//platforms:ios_sim_arm64"): "sim_arm64",
-    Label("@build_bazel_apple_support//platforms:ios_x86_64"): "x86_64",
+    Label("@apple_support//platforms:ios_arm64"): "arm64",
+    Label("@apple_support//platforms:ios_arm64e"): "arm64e",
+    Label("@apple_support//platforms:ios_sim_arm64"): "sim_arm64",
+    Label("@apple_support//platforms:ios_x86_64"): "x86_64",
 }
 
 _TVOS_PLATFORM_TO_ENV_ARCH = {
-    Label("@build_bazel_apple_support//platforms:tvos_arm64"): "arm64",
-    Label("@build_bazel_apple_support//platforms:tvos_sim_arm64"): "sim_arm64",
-    Label("@build_bazel_apple_support//platforms:tvos_x86_64"): "x86_64",
+    Label("@apple_support//platforms:tvos_arm64"): "arm64",
+    Label("@apple_support//platforms:tvos_sim_arm64"): "sim_arm64",
+    Label("@apple_support//platforms:tvos_x86_64"): "x86_64",
 }
 
 _VISIONOS_PLATFORM_TO_ENV_ARCH = {
-    Label("@build_bazel_apple_support//platforms:visionos_arm64"): "arm64",
-    Label("@build_bazel_apple_support//platforms:visionos_sim_arm64"): "sim_arm64",
+    Label("@apple_support//platforms:visionos_arm64"): "arm64",
+    Label("@apple_support//platforms:visionos_sim_arm64"): "sim_arm64",
 }
 
 _WATCHOS_PLATFORM_TO_ENV_ARCH = {
-    Label("@build_bazel_apple_support//platforms:watchos_arm64"): "arm64",
-    Label("@build_bazel_apple_support//platforms:watchos_arm64_32"): "arm64_32",
-    Label("@build_bazel_apple_support//platforms:watchos_device_arm64"): "device_arm64",
-    Label("@build_bazel_apple_support//platforms:watchos_device_arm64e"): "device_arm64e",
-    Label("@build_bazel_apple_support//platforms:watchos_x86_64"): "x86_64",
+    Label("@apple_support//platforms:watchos_arm64"): "arm64",
+    Label("@apple_support//platforms:watchos_arm64_32"): "arm64_32",
+    Label("@apple_support//platforms:watchos_device_arm64"): "device_arm64",
+    Label("@apple_support//platforms:watchos_device_arm64e"): "device_arm64e",
+    Label("@apple_support//platforms:watchos_x86_64"): "x86_64",
 }
 
 def _platform_specific_cpu_setting_name(platform_type):
@@ -159,8 +159,8 @@ def _watchos_environment_archs_from_ios(*, cpu_value, minimum_os_version, platfo
         if ios_arch:
             ios_archs = [ios_arch]
         elif platform in [
-            Label("@build_bazel_apple_support//platforms:darwin_arm64"),
-            Label("@build_bazel_apple_support//platforms:darwin_arm64e"),
+            Label("@apple_support//platforms:darwin_arm64"),
+            Label("@apple_support//platforms:darwin_arm64e"),
         ]:
             ios_archs = ["sim_arm64"]
     if not ios_archs:
@@ -217,8 +217,8 @@ def _environment_archs(
             if ios_arch:
                 environment_archs = [ios_arch]
             elif platform in [
-                Label("@build_bazel_apple_support//platforms:darwin_arm64"),
-                Label("@build_bazel_apple_support//platforms:darwin_arm64e"),
+                Label("@apple_support//platforms:darwin_arm64"),
+                Label("@apple_support//platforms:darwin_arm64e"),
             ]:
                 environment_archs = ["sim_arm64"]
         if platform_type == "tvos":

--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -32,11 +32,11 @@ part on the language used for XCFramework library identifiers:
     getting the right Apple toolchain to build outputs with from the Apple Crosstool.
 """
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "@build_bazel_apple_support//configs:platforms.bzl",
+    "@apple_support//configs:platforms.bzl",
     "CPU_TO_DEFAULT_PLATFORM_NAME",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
@@ -53,7 +53,7 @@ _PLATFORM_TYPE_TO_CPUS_FLAG = {
 }
 
 _CPU_TO_DEFAULT_PLATFORM_FLAG = {
-    cpu: "@build_bazel_apple_support//platforms:{}_platform".format(
+    cpu: "@apple_support//platforms:{}_platform".format(
         platform_name,
     )
     for cpu, platform_name in CPU_TO_DEFAULT_PLATFORM_NAME.items()

--- a/apple/internal/tvos_rules.bzl
+++ b/apple/internal/tvos_rules.bzl
@@ -15,16 +15,16 @@
 """Implementation of tvOS rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 load(
     "//apple:providers.bzl",
     "AppleBundleInfo",

--- a/apple/internal/visionos_rules.bzl
+++ b/apple/internal/visionos_rules.bzl
@@ -15,16 +15,16 @@
 """Implementation of visionOS rules."""
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
-)
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
 )
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 load(
     "//apple/internal:apple_product_type.bzl",
     "apple_product_type",

--- a/apple/internal/watchos_rules.bzl
+++ b/apple/internal/watchos_rules.bzl
@@ -15,20 +15,20 @@
 """Implementation of watchOS rules."""
 
 load(
-    "@bazel_skylib//lib:new_sets.bzl",
-    "sets",
-)
-load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
+    "@bazel_skylib//lib:new_sets.bzl",
+    "sets",
 )
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
 load(
     "//apple:providers.bzl",
     "AppleBundleInfo",

--- a/apple/internal/xcframework_rules.bzl
+++ b/apple/internal/xcframework_rules.bzl
@@ -14,13 +14,13 @@
 
 """Implementation of the xcframework rules."""
 
-load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     "//apple:providers.bzl",
     "AppleBundleVersionInfo",

--- a/apple/internal/xctrunner.bzl
+++ b/apple/internal/xctrunner.bzl
@@ -18,7 +18,7 @@ platform and architectures as the given `tests` bundles.
 """
 
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
 load(
@@ -187,7 +187,7 @@ load("//apple:xctrunner.bzl", "xctrunner")
 ios_ui_test(
     name = "HelloWorldSwiftUITests",
     minimum_os_version = "15.0",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    runner = "@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     test_host = ":HelloWorldSwift",
     deps = [":UITests"],
 )

--- a/apple/resources.bzl
+++ b/apple/resources.bzl
@@ -14,8 +14,8 @@
 
 """# Rules related to Apple resources and resource bundles."""
 
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
+load("@rules_swift//swift:swift.bzl", "swift_library")
 load(
     "//apple/internal:resources.bzl",
     _resources_common = "resources",

--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -44,8 +44,8 @@ bzl_library(
     visibility = ["//apple:__pkg__"],
     deps = [
         "//apple:providers",
+        "@apple_support//xcode:providers",
         "@bazel_skylib//rules:common_settings",
-        "@build_bazel_apple_support//xcode:providers",
     ],
 )
 
@@ -54,7 +54,7 @@ bzl_library(
     srcs = ["macos_test_runner.bzl"],
     deps = [
         "//apple:providers",
-        "@build_bazel_apple_support//lib:xcode_support",
+        "@apple_support//lib:xcode_support",
     ],
 )
 

--- a/apple/testing/default_runner/ios_test_runner.bzl
+++ b/apple/testing/default_runner/ios_test_runner.bzl
@@ -14,8 +14,8 @@
 
 """iOS test runner rule."""
 
+load("@apple_support//xcode:providers.bzl", "XcodeVersionPropertiesInfo")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@build_bazel_apple_support//xcode:providers.bzl", "XcodeVersionPropertiesInfo")
 load(
     "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",

--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -3,12 +3,12 @@ An iOS test runner rule that uses xctestrun files to run unit test bundles on
 simulators. This rule currently doesn't support UI tests or running on device.
 """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeVersionInfo",
     "XcodeVersionPropertiesInfo",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "//apple:providers.bzl",
     "AppleDeviceTestRunnerInfo",
@@ -300,13 +300,13 @@ You can use this rule directly if you need to override 'device_type' or
 'os_version', otherwise you can use the predefined runners:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+"@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
 ```
 
 or:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+"@rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
 ```
 
 Depending on if you want random test ordering or not. Set these as the `runner`
@@ -316,7 +316,7 @@ attribute on your `ios_unit_test` target:
 ios_unit_test(
     name = "Tests",
     minimum_os_version = "15.5",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    runner = "@rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":TestsLib"],
 )
 ```

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -15,7 +15,7 @@
 """Sample Apple test runner rule."""
 
 load(
-    "@build_bazel_apple_support//lib:xcode_support.bzl",
+    "@apple_support//lib:xcode_support.bzl",
     "xcode_support",
 )
 load(

--- a/doc/README.md
+++ b/doc/README.md
@@ -23,7 +23,7 @@ extensions, and frameworks) and for running unit tests and UI tests.
   <tbody>
     <tr>
       <th align="left" valign="top">iOS</th>
-      <td valign="top"><code>@build_bazel_rules_apple//apple:ios.bzl</code></td>
+      <td valign="top"><code>@rules_apple//apple:ios.bzl</code></td>
       <td valign="top">
         <code><a href="rules-ios.md#ios_app_clip">ios_app_clip</a></code><br/>
         <code><a href="rules-ios.md#ios_application">ios_application</a></code><br/>
@@ -46,7 +46,7 @@ extensions, and frameworks) and for running unit tests and UI tests.
     </tr>
     <tr>
       <th align="left" valign="top">macOS</th>
-      <td valign="top"><code>@build_bazel_rules_apple//apple:macos.bzl</code></td>
+      <td valign="top"><code>@rules_apple//apple:macos.bzl</code></td>
       <td valign="top">
         <code><a href="rules-macos.md#macos_application">macos_application</a></code><br/>
         <code><a href="rules-macos.md#macos_bundle">macos_bundle</a></code><br/>
@@ -59,7 +59,7 @@ extensions, and frameworks) and for running unit tests and UI tests.
       </td>
     <tr>
       <th align="left" valign="top">tvOS</th>
-      <td valign="top"><code>@build_bazel_rules_apple//apple:tvos.bzl</code></td>
+      <td valign="top"><code>@rules_apple//apple:tvos.bzl</code></td>
       <td valign="top">
         <code><a href="rules-tvos.md#tvos_application">tvos_application</a></code><br/>
         <code><a href="rules-tvos.md#tvos_dynamic_framework">tvos_dynamic_framework</a></code><br/>
@@ -75,7 +75,7 @@ extensions, and frameworks) and for running unit tests and UI tests.
     </tr>
     <tr>
       <th align="left" valign="top">watchOS</th>
-      <td valign="top"><code>@build_bazel_rules_apple//apple:watchos.bzl</code></td>
+      <td valign="top"><code>@rules_apple//apple:watchos.bzl</code></td>
       <td valign="top">
         <code><a href="rules-watchos.md#watchos_application">watchos_application</a></code><br/>
         <code><a href="rules-watchos.md#watchos_dynamic_framework">watchos_dynamic_framework</a></code><br/>
@@ -109,7 +109,7 @@ below.
     <tr>
       <th align="left" valign="top" rowspan="6">General</th>
       <tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:apple.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:apple.bzl</code></td>
         <td valign="top">
           <code><a href="rules-apple.md#apple_dynamic_framework_import">apple_dynamic_framework_import</a></code><br/>
           <code><a href="rules-apple.md#apple_dynamic_xcframework_import">apple_dynamic_xcframework_import</a></code><br/>
@@ -125,33 +125,33 @@ below.
         </td>
       </tr>
       <tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:docc.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:docc.bzl</code></td>
         <td valign="top">
           <code><a href="rules-docc.md#docc_archive">docc_archive</a></code>
         </td>
       </tr>
       <tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:header_map.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:header_map.bzl</code></td>
         <td valign="top">
           <code><a href="rules-header_map.md#header_map">header_map</a></code>
         </td>
       </tr>
       <tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:xcarchive.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:xcarchive.bzl</code></td>
         <td valign="top"><code><a href="rules-xcarchive.md#xcarchive">xcarchive</a></code></td>
       </tr>
       </tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:versioning.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:versioning.bzl</code></td>
         <td valign="top"><code><a href="rules-versioning.md#apple_bundle_version">apple_bundle_version</a></code><br/></td>
       </tr>
       <tr>
-        <td valign="top"><code>@build_bazel_rules_apple//apple:xctrunner.bzl</code></td>
+        <td valign="top"><code>@rules_apple//apple:xctrunner.bzl</code></td>
         <td valign="top"><code><a href="rules-xctrunner.md#xctrunner">xctrunner</a></code></td>
       </tr>
     </tr>
     <tr>
       <th align="left" valign="top" rowspan="1">Resources</th>
-      <td valign="top"><code>@build_bazel_rules_apple//apple:resources.bzl</code></td>
+      <td valign="top"><code>@rules_apple//apple:resources.bzl</code></td>
       <td valign="top">
         <code><a href="rules-resources.md#apple_bundle_import">apple_bundle_import</a></code><br/>
         <code><a href="rules-resources.md#apple_core_data_model">apple_core_data_model</a></code><br/>

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -260,11 +260,11 @@ ios_application(
         "//conditions:default": [],
     }),
     codesign_inputs = select({
-        ":dbg": ["@build_bazel_rules_apple//tools/codesigningtool:disable_signing_resource_rules"],
+        ":dbg": ["@rules_apple//tools/codesigningtool:disable_signing_resource_rules"],
         "//conditions:default": [],
     }),
     toolchains = select({
-        "//:dbg": ["@build_bazel_rules_apple//tools/codesigningtool:disable_signing_resource_rules"],
+        "//:dbg": ["@rules_apple//tools/codesigningtool:disable_signing_resource_rules"],
         "//conditions:default": [],
     }),
 )

--- a/doc/rules-apple.md
+++ b/doc/rules-apple.md
@@ -426,7 +426,7 @@ You only need this in the case you want to setup fallback profiles, otherwise
 it can be ommitted when using bzlmod.
 
 ```bzl
-provisioning_profile_repository = use_extension("@build_bazel_rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
+provisioning_profile_repository = use_extension("@rules_apple//apple:apple.bzl", "provisioning_profile_repository_extension")
 provisioning_profile_repository.setup(
     fallback_profiles = "//path/to/some:filegroup", # Profiles to use if one isn't found locally
 )

--- a/doc/rules-docc.md
+++ b/doc/rules-docc.md
@@ -23,7 +23,7 @@ NOTE: At this time Swift is the only supported language for this rule.
 Example:
 
 ```starlark
-load("@build_bazel_rules_apple//apple:docc.bzl", "docc_archive")
+load("@rules_apple//apple:docc.bzl", "docc_archive")
 
 docc_archive(
     name = "Lib.doccarchive",

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -654,13 +654,13 @@ You can use this rule directly if you need to override 'device_type' or
 'os_version', otherwise you can use the predefined runners:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
+"@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner"
 ```
 
 or:
 
 ```
-"@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
+"@rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner"
 ```
 
 Depending on if you want random test ordering or not. Set these as the `runner`
@@ -670,7 +670,7 @@ attribute on your `ios_unit_test` target:
 ios_unit_test(
     name = "Tests",
     minimum_os_version = "15.5",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
+    runner = "@rules_apple//apple/testing/default_runner:ios_xctestrun_random_runner",
     deps = [":TestsLib"],
 )
 ```

--- a/doc/rules-xctrunner.md
+++ b/doc/rules-xctrunner.md
@@ -24,7 +24,7 @@ load("//apple:xctrunner.bzl", "xctrunner")
 ios_ui_test(
     name = "HelloWorldSwiftUITests",
     minimum_os_version = "15.0",
-    runner = "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
+    runner = "@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner",
     test_host = ":HelloWorldSwift",
     deps = [":UITests"],
 )

--- a/doc/types.md
+++ b/doc/types.md
@@ -70,11 +70,11 @@ Example usage:
 
 ```python
 load(
-    "@build_bazel_rules_apple//apple:common.bzl",
+    "@rules_apple//apple:common.bzl",
     "entitlements_validation_mode",
 )
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
 )
 

--- a/examples/ios/HelloWorldSwift/BUILD
+++ b/examples/ios/HelloWorldSwift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_swift//swift:swift.bzl", "swift_library")
 load("//apple:docc.bzl", "docc_archive")
 load("//apple:ios.bzl", "ios_application", "ios_ui_test", "ios_unit_test")
 load("//apple:xctrunner.bzl", "xctrunner")

--- a/examples/ios/iMessageApp/BUILD
+++ b/examples/ios/iMessageApp/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
 load(

--- a/examples/macos/CommandLineSwift/BUILD
+++ b/examples/macos/CommandLineSwift/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
 load(

--- a/examples/macos/HelloWorldSwift/BUILD
+++ b/examples/macos/HelloWorldSwift/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
 load(

--- a/examples/macos/XPCServiceApp/BUILD
+++ b/examples/macos/XPCServiceApp/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
 load(

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -1,9 +1,9 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
-load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:ios.bzl",
     "ios_application",

--- a/examples/visionos/HelloWorld/BUILD
+++ b/examples/visionos/HelloWorld/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
 load("//apple:versioning.bzl", "apple_bundle_version")

--- a/test/apple_shell_testutils.sh
+++ b/test/apple_shell_testutils.sh
@@ -470,7 +470,7 @@ function do_action() {
       # directory gets mapped into the bazel-bin symlink.
       "--use_top_level_targets_for_symlinks"
       "--enable_bzlmod"
-      "--@build_bazel_rules_apple//apple/build_settings:ios_simulator_device=iPhone 16"
+      "--@rules_apple//apple/build_settings:ios_simulator_device=iPhone 16"
   )
 
   if [[ -n "${XCODE_VERSION_FOR_TESTS-}" ]]; then

--- a/test/bazel_testrunner.sh
+++ b/test/bazel_testrunner.sh
@@ -73,19 +73,19 @@ function create_new_workspace() {
 
   touch MODULE.bazel
   cat > MODULE.bazel <<EOF
-module(name = "build_bazel_rules_apple_integration_tests", version = "0")
+module(name = "rules_apple_integration_tests", version = "0")
 
 # Specify oldest possible bzlmod versions and let rules_apple versions take precedence
-bazel_dep(name = "apple_support", version = "0.11.0", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "rules_swift", version = "2.0.0", max_compatibility_level = 3, repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "rules_apple", version = "0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "apple_support", version = "0.11.0")
+bazel_dep(name = "rules_swift", version = "2.0.0", max_compatibility_level = 3)
+bazel_dep(name = "rules_apple", version = "0")
 bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
 xcode_configure = use_extension("@bazel_tools//tools/osx:xcode_configure.bzl", "xcode_configure_extension")
 use_repo(xcode_configure, "local_config_xcode")
 
-apple_cc_configure = use_extension("@build_bazel_apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
+apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
 
 local_path_override(

--- a/test/ios_test_runner_ui_test.sh
+++ b/test/ios_test_runner_ui_test.sh
@@ -27,15 +27,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_ui_test"
  )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
     "ios_test_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
@@ -86,7 +86,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "${MIN_OS_IOS_NPLUS1}",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
 EOF

--- a/test/ios_test_runner_unit_test.sh
+++ b/test/ios_test_runner_unit_test.sh
@@ -27,15 +27,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_unit_test"
 )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
     "ios_test_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
@@ -144,7 +144,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "${MIN_OS_IOS}",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
 EOF

--- a/test/ios_test_runner_unit_test_14.x.sh
+++ b/test/ios_test_runner_unit_test_14.x.sh
@@ -27,15 +27,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_unit_test"
 )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_test_runner.bzl",
     "ios_test_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")

--- a/test/ios_xctest_swift_testing_runner_unit_test_17.x.sh
+++ b/test/ios_xctest_swift_testing_runner_unit_test_17.x.sh
@@ -29,15 +29,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_unit_test"
 )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     "ios_xctestrun_runner"
 )
 

--- a/test/ios_xctestrun_runner_ui_test.sh
+++ b/test/ios_xctestrun_runner_ui_test.sh
@@ -27,15 +27,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_ui_test"
  )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     "ios_xctestrun_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
@@ -87,7 +87,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "${MIN_OS_IOS_NPLUS1}",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
 EOF

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -27,15 +27,15 @@ function tear_down() {
 function create_sim_runners() {
   cat > ios/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:ios.bzl",
+    "@rules_apple//apple:ios.bzl",
     "ios_application",
     "ios_unit_test"
 )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     "ios_xctestrun_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
@@ -149,7 +149,7 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "${MIN_OS_IOS}",
-    provisioning_profile = "@build_bazel_rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
 )
 EOF

--- a/test/macos_test_runner_unit_test.sh
+++ b/test/macos_test_runner_unit_test.sh
@@ -27,14 +27,14 @@ function tear_down() {
 function create_runners() {
   cat > macos/BUILD <<EOF
 load(
-    "@build_bazel_rules_apple//apple:macos.bzl",
+    "@rules_apple//apple:macos.bzl",
     "macos_unit_test"
 )
-load("@build_bazel_rules_swift//swift:swift.bzl",
+load("@rules_swift//swift:swift.bzl",
      "swift_library"
 )
 load(
-    "@build_bazel_rules_apple//apple/testing/default_runner:macos_test_runner.bzl",
+    "@rules_apple//apple/testing/default_runner:macos_test_runner.bzl",
     "macos_test_runner"
 )
 load("@rules_cc//cc:objc_library.bzl", "objc_library")

--- a/test/starlark_tests/apple_core_data_model_tests.bzl
+++ b/test/starlark_tests/apple_core_data_model_tests.bzl
@@ -29,7 +29,7 @@ visibility("private")
 analysis_macos_arm64_platform_target_actions_test = make_analysis_target_actions_test(
     config_settings = {
         "//command_line_option:platforms": [
-            str(Label("@build_bazel_apple_support//platforms:darwin_arm64")),
+            str(Label("@apple_support//platforms:darwin_arm64")),
         ],
     },
 )
@@ -37,7 +37,7 @@ analysis_macos_arm64_platform_target_actions_test = make_analysis_target_actions
 analysis_macos_arm64_platform_target_outputs_test = make_analysis_target_outputs_test(
     config_settings = {
         "//command_line_option:platforms": [
-            str(Label("@build_bazel_apple_support//platforms:darwin_arm64")),
+            str(Label("@apple_support//platforms:darwin_arm64")),
         ],
     },
 )

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -70,11 +70,11 @@ action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_act
     "//command_line_option:features": [
         "apple._import_framework_via_swiftinterface",
     ],
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 def apple_dynamic_xcframework_import_test_suite(name):

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -63,7 +63,7 @@ analysis_output_group_info_files_with_xcframework_processor_test = make_analysis
 })
 
 action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_action_inputs_test_rule({

--- a/test/starlark_tests/apple_static_framework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_framework_import_tests.bzl
@@ -27,11 +27,11 @@ _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_ac
     "//command_line_option:features": [
         "apple._import_framework_via_swiftinterface",
     ],
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 _analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 def apple_static_framework_import_test_suite(name):

--- a/test/starlark_tests/apple_static_library_tests.bzl
+++ b/test/starlark_tests/apple_static_library_tests.bzl
@@ -172,7 +172,7 @@ def apple_static_library_test_suite(name):
         build_type = "device",
         target_under_test = "//test/starlark_tests/targets_under_test/apple/static_library:example_library_arm_sim_support",
         cpus = {
-            "platforms": ["@build_bazel_apple_support//platforms:ios_arm64"],
+            "platforms": ["@apple_support//platforms:ios_arm64"],
             "ios_multi_cpus": [],
         },
         binary_test_file = "$BINARY",

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -35,7 +35,7 @@ _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_ac
     "//command_line_option:features": [
         "apple._import_framework_via_swiftinterface",
     ],
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
 })
 
 def apple_static_xcframework_import_test_suite(name):

--- a/test/starlark_tests/ios_static_framework_tests.bzl
+++ b/test/starlark_tests/ios_static_framework_tests.bzl
@@ -64,7 +64,7 @@ def ios_static_framework_test_suite(name):
         build_type = "simulator",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
         cpus = {
-            "platforms": ["@build_bazel_apple_support//platforms:ios_sim_arm64"],
+            "platforms": ["@apple_support//platforms:ios_sim_arm64"],
             "ios_multi_cpus": [],
         },
         binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",
@@ -79,7 +79,7 @@ def ios_static_framework_test_suite(name):
         binary_test_file = "$BUNDLE_ROOT/SwiftFmwk",
         target_under_test = "//test/starlark_tests/targets_under_test/ios:swift_ios_static_framework",
         cpus = {
-            "platforms": ["@build_bazel_apple_support//platforms:ios_x86_64"],
+            "platforms": ["@apple_support//platforms:ios_x86_64"],
             "ios_multi_cpus": [],
         },
         binary_test_architecture = "x86_64",

--- a/test/starlark_tests/resources/BUILD
+++ b/test/starlark_tests/resources/BUILD
@@ -1,11 +1,11 @@
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_library",
-)
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "swift_library",
+)
 load(
     "//apple:resources.bzl",
     "apple_bundle_import",

--- a/test/starlark_tests/resources/frameworks/BUILD
+++ b/test/starlark_tests/resources/frameworks/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_swift//swift:swift.bzl", "swift_library")
 load("//test/starlark_tests:common.bzl", "common")
 
 package(

--- a/test/starlark_tests/rules/BUILD
+++ b/test/starlark_tests/rules/BUILD
@@ -18,13 +18,13 @@ bzl_library(
         "//apple/internal:intermediates",
         "//apple/internal:providers",
         "//apple/internal:shared_environment",
+        "@apple_support//lib:apple_support",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:new_sets",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:shell",
         "@bazel_skylib//lib:unittest",
-        "@build_bazel_apple_support//lib:apple_support",
-        "@build_bazel_rules_swift//swift",
+        "@rules_swift//swift",
     ],
 )
 

--- a/test/starlark_tests/rules/apple_verification_test.bzl
+++ b/test/starlark_tests/rules/apple_verification_test.bzl
@@ -49,7 +49,7 @@ def _apple_verification_transition_impl(settings, attr):
     """Implementation of the apple_verification_transition transition."""
 
     output_dictionary = {
-        "//command_line_option:platforms": ["@build_bazel_apple_support//platforms:darwin_x86_64"],
+        "//command_line_option:platforms": ["@apple_support//platforms:darwin_x86_64"],
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:compilation_mode": attr.compilation_mode,
         "//command_line_option:objc_enable_binary_stripping": getattr(attr, "objc_enable_binary_stripping") if hasattr(attr, "objc_enable_binary_stripping") else False,

--- a/test/starlark_tests/rules/generate_framework.bzl
+++ b/test/starlark_tests/rules/generate_framework.bzl
@@ -14,9 +14,9 @@
 
 """Rules to generate import-ready frameworks for testing."""
 
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
+load("@rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     "//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",

--- a/test/starlark_tests/rules/generate_framework_dsym.bzl
+++ b/test/starlark_tests/rules/generate_framework_dsym.bzl
@@ -14,12 +14,12 @@
 
 """Rules to generate dSYM bundle from given framework for testing."""
 
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@build_bazel_apple_support//lib:apple_support.bzl",
+    "@apple_support//lib:apple_support.bzl",
     "apple_support",
 )
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//apple:utils.bzl",
     "group_files_by_directory",

--- a/test/starlark_tests/rules/generate_xcframework.bzl
+++ b/test/starlark_tests/rules/generate_xcframework.bzl
@@ -14,12 +14,12 @@
 
 """Rules to generate import-ready XCFrameworks for testing."""
 
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     "//test/starlark_tests/rules:generation_support.bzl",
     "generation_support",

--- a/test/starlark_tests/rules/generation_support.bzl
+++ b/test/starlark_tests/rules/generation_support.bzl
@@ -14,8 +14,8 @@
 
 """Apple frameworks and XCFramework generation support methods for testing."""
 
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "//apple/internal:intermediates.bzl",  # buildifier: disable=bzl-visibility
     "intermediates",

--- a/test/starlark_tests/targets_under_test/apple/BUILD
+++ b/test/starlark_tests/targets_under_test/apple/BUILD
@@ -1,11 +1,11 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_library",
-)
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load(
+    "@rules_swift//swift:swift.bzl",
+    "swift_library",
+)
 load(
     "//apple:apple.bzl",
     "apple_dynamic_xcframework_import",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -1,9 +1,9 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
-load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",

--- a/test/starlark_tests/targets_under_test/macos/BUILD
+++ b/test/starlark_tests/targets_under_test/macos/BUILD
@@ -1,8 +1,8 @@
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
-load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -1,9 +1,9 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
-load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",

--- a/test/starlark_tests/targets_under_test/watchos/BUILD
+++ b/test/starlark_tests/targets_under_test/watchos/BUILD
@@ -1,8 +1,8 @@
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "@rules_swift//swift:swift.bzl",
     "swift_library",
 )
-load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//apple:apple.bzl",
     "apple_dynamic_framework_import",

--- a/tools/codesigningtool/BUILD
+++ b/tools/codesigningtool/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
+load("@apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python:py_library.bzl", "py_library")
 

--- a/tools/hmaptool/BUILD
+++ b/tools/hmaptool/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
+load("@rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
 
 package(default_visibility = ["//apple/internal:__subpackages__"])
 


### PR DESCRIPTION
This is the old pattern that is no longer widely used.