### PR TITLE
Only enable swiftinterface compiles for explicit modules

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -239,15 +239,11 @@ def _apple_dynamic_framework_import_impl(ctx):
         framework_files = depset(framework_imports),
     ))
 
-    swiftinterface_files = []
-    if (
-        "apple.import_framework_via_swiftinterface" not in disabled_features and
-        framework.swift_interface_imports
-    ):
-        swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
-            swift_module_files = framework.swift_interface_imports,
-            target_triplet = target_triplet,
-        )
+    swiftinterface_files = framework_import_support.get_swiftinterface_files_with_target_triplet_if_enabled(
+        swift_interface_imports = framework.swift_interface_imports,
+        target_triplet = target_triplet,
+        features = features,
+    )
 
     if swiftinterface_files:
         # Create SwiftInfo provider
@@ -406,15 +402,11 @@ def _apple_static_framework_import_impl(ctx):
     )
     providers.append(cc_info)
 
-    swiftinterface_files = []
-    if (
-        "apple.import_framework_via_swiftinterface" not in disabled_features and
-        framework.swift_interface_imports
-    ):
-        swiftinterface_files = framework_import_support.get_swift_module_files_with_target_triplet(
-            swift_module_files = framework.swift_interface_imports,
-            target_triplet = target_triplet,
-        )
+    swiftinterface_files = framework_import_support.get_swiftinterface_files_with_target_triplet_if_enabled(
+        swift_interface_imports = framework.swift_interface_imports,
+        target_triplet = target_triplet,
+        features = features,
+    )
 
     if swiftinterface_files:
         # Create SwiftInfo provider

--- a/apple/internal/apple_xcframework_import.bzl
+++ b/apple/internal/apple_xcframework_import.bzl
@@ -555,10 +555,13 @@ def _apple_dynamic_xcframework_import_impl(ctx):
     )
     providers.append(apple_dynamic_framework_info)
 
-    if (
-        "apple.import_framework_via_swiftinterface" not in disabled_features and
-        xcframework_library.swift_module_interfaces
-    ):
+    swiftinterface_files = framework_import_support.get_swiftinterface_files_with_target_triplet_if_enabled(
+        swift_interface_imports = xcframework_library.swift_module_interfaces,
+        target_triplet = target_triplet,
+        features = features,
+    )
+
+    if swiftinterface_files:
         # Create SwiftInfo provider
         swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(
@@ -574,7 +577,7 @@ def _apple_dynamic_xcframework_import_impl(ctx):
                 module_name = xcframework.library_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
-                swiftinterface_files = xcframework_library.swift_module_interfaces,
+                swiftinterface_files = swiftinterface_files,
             ),
         )
     elif xcframework_library.swiftmodule:
@@ -740,10 +743,12 @@ def _apple_static_xcframework_import_impl(ctx):
     )
     providers.append(cc_info)
 
-    if (
-        "apple.import_framework_via_swiftinterface" not in disabled_features and
-        xcframework_library.swift_module_interfaces
-    ):
+    swiftinterface_files = framework_import_support.get_swiftinterface_files_with_target_triplet_if_enabled(
+        swift_interface_imports = xcframework_library.swift_module_interfaces,
+        target_triplet = target_triplet,
+        features = features,
+    )
+    if swiftinterface_files:
         # Create SwiftInfo provider
         swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(
@@ -760,7 +765,7 @@ def _apple_static_xcframework_import_impl(ctx):
                 module_name = xcframework.library_name,
                 rule_label = label,
                 swift_toolchains = swift_toolchains,
-                swiftinterface_files = xcframework_library.swift_module_interfaces,
+                swiftinterface_files = swiftinterface_files,
             ),
         )
     elif xcframework_library.swiftmodule:

--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -369,6 +369,25 @@ def _framework_import_info_with_dependencies(
         ),
     )
 
+def _get_swiftinterface_files_with_target_triplet_if_enabled(
+        *,
+        target_triplet,
+        swift_interface_imports,
+        features):
+    swiftinterface_files = []
+    if (
+        (
+            "apple._import_framework_via_swiftinterface" in features or
+            "swift.use_c_modules" in features
+        ) and
+        swift_interface_imports
+    ):
+        swiftinterface_files = _get_swift_module_files_with_target_triplet(
+            swift_module_files = swift_interface_imports,
+            target_triplet = target_triplet,
+        )
+    return swiftinterface_files
+
 def _get_swift_module_files_with_target_triplet(target_triplet, swift_module_files):
     """Filters Swift module files for a target triplet.
 
@@ -795,6 +814,7 @@ framework_import_support = struct(
     get_swift_module_files_with_target_triplet = _get_swift_module_files_with_target_triplet,
     get_dsym_binaries = _get_dsym_binaries,
     get_debug_info_binaries = _get_debug_info_binaries,
+    get_swiftinterface_files_with_target_triplet_if_enabled = _get_swiftinterface_files_with_target_triplet_if_enabled,
     has_private_module_map = _has_private_module_map,
     has_versioned_framework_files = _has_versioned_framework_files,
     swift_info_from_module_interface = _swift_info_from_module_interface,

--- a/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_dynamic_xcframework_import_tests.bzl
@@ -38,6 +38,7 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_contains_xcframework_processor_action_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:apple_verification_test.bzl",
@@ -62,6 +63,17 @@ analysis_output_group_info_files_with_xcframework_processor_test = make_analysis
 })
 
 action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
+
+action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:features": [
+        "apple._import_framework_via_swiftinterface",
+    ],
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
+
+analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
     "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
 })
 
@@ -159,8 +171,15 @@ def apple_dynamic_xcframework_import_test_suite(name):
         tags = [name],
     )
 
-    # Make sure the SwiftCompileModuleInterface action codepath is used
-    action_inputs_with_ios_x86_64_platform_test(
+    analysis_actions_with_ios_x86_64_platform_test(
+        name = "{}_does_not_compile_module_from_swiftinterface_implicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
+        target_mnemonic = "CppModuleMap",
+        not_expected_mnemonic = ["SwiftCompileModuleInterface"],
+        tags = [name],
+    )
+
+    action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test(
         name = "{}_compiles_module_from_swiftinterface".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_swiftinterface",
         mnemonic = "SwiftCompileModuleInterface",
@@ -172,8 +191,9 @@ def apple_dynamic_xcframework_import_test_suite(name):
         ],
         tags = [name],
     )
-    action_inputs_with_ios_x86_64_platform_test(
-        name = "{}_compiles_private_modulemap_from_swiftinterface_implicit_modules".format(name),
+
+    action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test(
+        name = "{}_compiles_private_modulemap_from_swiftinterface".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_dynamic_xcframework_with_private_modulemap",
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [

--- a/test/starlark_tests/apple_static_framework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_framework_import_tests.bzl
@@ -18,8 +18,19 @@ load(
     "//test/starlark_tests/rules:action_inputs_test.bzl",
     "make_action_inputs_test_rule",
 )
+load(
+    "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
+    "make_analysis_target_actions_test",
+)
 
-_action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
+_action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:features": [
+        "apple._import_framework_via_swiftinterface",
+    ],
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
+
+_analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
     "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
 })
 
@@ -30,8 +41,15 @@ def apple_static_framework_import_test_suite(name):
       name: the base name to be used in things created by this macro
     """
 
-    # Make sure the SwiftCompileModuleInterface action codepath is used
-    _action_inputs_with_ios_x86_64_platform_test(
+    _analysis_actions_with_ios_x86_64_platform_test(
+        name = "{}_does_not_compile_module_from_swiftinterface_implicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSImportedSwiftStaticFramework",
+        target_mnemonic = "CppModuleMap",
+        not_expected_mnemonic = ["SwiftCompileModuleInterface"],
+        tags = [name],
+    )
+
+    _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test(
         name = "{}_compiles_module_from_swiftinterface".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:iOSImportedSwiftStaticFramework",
         mnemonic = "SwiftCompileModuleInterface",

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -25,7 +25,6 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_contains_xcframework_processor_action_test",
-    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
@@ -36,10 +35,6 @@ _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_ac
     "//command_line_option:features": [
         "apple._import_framework_via_swiftinterface",
     ],
-    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
-})
-
-_analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
     "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
 })
 

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -59,14 +59,6 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name],
     )
 
-    _analysis_actions_with_ios_x86_64_platform_test(
-        name = "{}_does_not_compile_module_from_swiftinterface_implicit_modules".format(name),
-        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_static_xcframework",
-        target_mnemonic = "CppModuleMap",
-        not_expected_mnemonic = ["SwiftCompileModuleInterface"],
-        tags = [name],
-    )
-
     _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test(
         name = "{}_compiles_module_from_swiftinterface".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_static_xcframework",

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -25,13 +25,21 @@ load(
 load(
     "//test/starlark_tests/rules:analysis_target_actions_test.bzl",
     "analysis_contains_xcframework_processor_action_test",
+    "make_analysis_target_actions_test",
 )
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
 )
 
-_action_inputs_with_ios_x86_64_platform_test = make_action_inputs_test_rule({
+_action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:features": [
+        "apple._import_framework_via_swiftinterface",
+    ],
+    "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
+})
+
+_analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
     "//command_line_option:platforms": str(Label("@build_bazel_apple_support//platforms:ios_x86_64")),
 })
 
@@ -51,8 +59,15 @@ def apple_static_xcframework_import_test_suite(name):
         tags = [name],
     )
 
-    # Make sure the SwiftCompileModuleInterface action codepath is used
-    _action_inputs_with_ios_x86_64_platform_test(
+    _analysis_actions_with_ios_x86_64_platform_test(
+        name = "{}_does_not_compile_module_from_swiftinterface_implicit_modules".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_static_xcframework",
+        target_mnemonic = "CppModuleMap",
+        not_expected_mnemonic = ["SwiftCompileModuleInterface"],
+        tags = [name],
+    )
+
+    _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test(
         name = "{}_compiles_module_from_swiftinterface".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:ios_imported_swift_static_xcframework",
         mnemonic = "SwiftCompileModuleInterface",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4485,7 +4485,10 @@ ios_application(
 
 apple_static_xcframework_import(
     name = "ios_imported_swift_static_xcframework",
-    features = ["-swift.layering_check"],
+    features = [
+        "-swift.layering_check",
+        "apple._import_framework_via_swiftinterface",
+    ],
     tags = common.fixture_tags,
     visibility = ["//visibility:public"],
     xcframework_imports = [":generated_swift_static_xcframework"],


### PR DESCRIPTION
This is a partial revert of 78ae0928dc9e1ab791408d88943c983bb38382b6.
The core problem is that using this feature requires that you have
correctly defined dependencies for your (xc)framework targets. With
rules_swift_package_manager you don't get this for free because SwiftPM
itself doesn't support a dependencies field for binary targets yet. Now
we only enable this by default for explicit modules, since it is
required for that, so you have to deal with those missing deps, but for
implicit modules, we don't want to break builds.
