### PR TITLE
Prevent runfiles env leakage into `ipa_post_processor`

### DIFF
--- a/tools/bundletool/bundletool_experimental.py
+++ b/tools/bundletool/bundletool_experimental.py
@@ -382,9 +382,10 @@ class Bundler(object):
     # bundle, but keep the work_dir for compatibility with the bundletool post
     # processing.
     try:
-      env = os.environ.copy()
-      env["TREE_ARTIFACT_OUTPUT"] = bundle_root
-      subprocess.check_call((post_processor, work_dir), env=env)
+      # We do not inherit this process's Bazel runfiles environment. Launcher-based
+      # post-processors need to resolve against their own runfiles manifests.
+      subprocess.check_call(
+          (post_processor, work_dir), env={"TREE_ARTIFACT_OUTPUT": bundle_root})
     except subprocess.CalledProcessError as e:
       raise PostProcessorError(e.returncode) from e
 


### PR DESCRIPTION
Regressed in https://github.com/bazelbuild/rules_apple/pull/2920.

`ipa_post_processor` targets implemented as Bazel `sh_binary` launchers could fail at runtime with:

```
exec: : not found
```

A minimal repro is the `sh_binary(..., use_bash_launcher = True)` post-processor.
With `use_bash_launcher = True`, Bazel runs a generated launcher rather than the underlying shell script directly. That launcher initializes runfiles and resolves the real script path via `rlocation(...)`.
Once BundleTool started inheriting its own environment into the child process, the child launcher also inherited the parent tool’s runfiles variables, especially `RUNFILES_MANIFEST_FILE`. That caused the child launcher to resolve runfiles against the wrong manifest, so `rlocation(...)` returned an empty path and the launcher ended up failing.

Thanks to @john-flanagan for bringing this to my attention in [this thread](https://bazelbuild.slack.com/archives/CD3QY5C2X/p1779986499129409)