### PR TITLE
Fix modules being strings

### DIFF
--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -165,7 +165,7 @@ def _apple_test_info_aspect_impl(target, ctx):
         module_swiftmodules = [
             module.swift.swiftmodule
             for module in all_modules
-            if module.swift
+            if module.swift and type(module.swift.swiftmodule) == "File"
         ]
         swift_modules.append(depset(module_swiftmodules))
 


### PR DESCRIPTION
With explicit system modules these can be strings or files
