### PR TITLE
Fix resuse_simulator value always being True

### DIFF
--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -211,7 +211,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--reuse-simulator",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=None,
         help="Toggle simulator reuse; default is True",
     )
     return parser
@@ -231,7 +231,7 @@ def _main() -> None:
     os_version = args.os_version or os.getenv("SIMULATOR_OS_VERSION")
     sdk_version = args.sdk_version or os.getenv("SIMULATOR_SDK_VERSION")
     reuse_simulator: bool = args.reuse_simulator or (
-        os.getenv("SIMULATOR_REUSE_SIMULATOR") is not None
+        os.getenv("SIMULATOR_REUSE_SIMULATOR", default = "1").lower() in ("1", "true")
     )
 
     selected_runtime = _selected_simulator_runtime(os_version, sdk_version)

--- a/apple/testing/default_runner/simulator_creator.py
+++ b/apple/testing/default_runner/simulator_creator.py
@@ -230,7 +230,7 @@ def _main() -> None:
 
     os_version = args.os_version or os.getenv("SIMULATOR_OS_VERSION")
     sdk_version = args.sdk_version or os.getenv("SIMULATOR_SDK_VERSION")
-    reuse_simulator: bool = args.reuse_simulator or (
+    reuse_simulator: bool = args.reuse_simulator if args.reuse_simulator is not None else (
         os.getenv("SIMULATOR_REUSE_SIMULATOR", default = "1").lower() in ("1", "true")
     )
 


### PR DESCRIPTION
`resuse_simulator` was always being set to `True` because of the default value of the `--reuse-simulator` argument.

This PR updates the logic not include a default value for `--reuse-simulator` directly, while still defaulting to `True` when the argument is missing and `SIMULATOR_REUSE_SIMULATOR` is not `0` or `False`.

The previous check for `os.getenv("SIMULATOR_REUSE_SIMULATOR") is not None` wasn't working correctly either because the template always set either `SIMULATOR_REUSE_SIMULATOR=1` or `SIMULATOR_REUSE_SIMULATOR=` which resolve to `"1"` and `""` respectively, both of which returned `True` from `is not None`.

I added a print statement just below the `reuse_simulator` logic to illustrate the problem

### Before
```
$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR= ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=1 ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=True ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=0 ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=False ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=Foo ./simulator_creator.py
Reuse simulator True
```

### After

```
$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR= ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=1 ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=True ./simulator_creator.py
Reuse simulator True

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=0 ./simulator_creator.py
Reuse simulator False

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=False ./simulator_creator.py
Reuse simulator False

$ SIMULATOR_DEVICE_TYPE="iPhone 15" SIMULATOR_REUSE_SIMULATOR=Foo ./simulator_creator.py
Reuse simulator True
```

I think this logic would be better if we explicitly checked `SIMULATOR_REUSE_SIMULATOR` for `True` or `1` and defaulted everything else to `False`, but I wasn't sure if that would mesh with the help text of "Toggle simulator reuse; default is True"

i.e.
```python
    reuse_simulator_env = os.getenv("SIMULATOR_REUSE_SIMULATOR")
    reuse_simulator: bool = args.reuse_simulator or (
        reuse_simulator_env.lower() in ("1", "true") if reuse_simulator_env else False
    )
```