### PR TITLE
Remove most of AppleTestInfo

### DIFF
--- a/apple/internal/providers.bzl
+++ b/apple/internal/providers.bzl
@@ -449,47 +449,11 @@ requirement.
 AppleTestInfo, new_appletestinfo = provider(
     doc = """
 Provider that test targets propagate to be used for IDE integration.
-
-This includes information regarding test source files, transitive include paths,
-transitive module maps, and transitive Swift modules. Test source files are
-considered to be all of which belong to the first-level dependencies on the test
-target.
 """,
     fields = {
-        "includes": """
-`depset` of `String`s representing transitive include paths which are needed by
-IDEs to be used for indexing the test sources.
-""",
-        "module_maps": """
-`depset` of `File`s representing module maps which are needed by IDEs to be used
-for indexing the test sources.
-""",
-        "module_name": """
-`String` representing the module name used by the test's sources. This is only
-set if the test only contains a single top-level Swift dependency. This may be
-used by an IDE to identify the Swift module (if any) used by the test's sources.
-""",
-        "non_arc_sources": """
-`depset` of `File`s containing non-ARC sources from the test's immediate
-deps.
-""",
-        "sources": """
-`depset` of `File`s containing sources and headers from the test's immediate deps.
-""",
-        "swift_modules": """
-`depset` of `File`s representing transitive swift modules which are needed by
-IDEs to be used for indexing the test sources.
-""",
         "test_bundle": "The artifact representing the XCTest bundle for the test target.",
         "test_host": """
 The artifact representing the test host for the test target, if the test requires a test host.
-""",
-        "deps": """
-`depset` of `String`s representing the labels of all immediate deps of the test.
-Only source files from these deps will be present in `sources`. This may be used
-by IDEs to differentiate a test target's transitive module maps from its direct
-module maps, as including the direct module maps may break indexing for the
-source files of the immediate deps.
 """,
     },
     init = _make_banned_init(provider_name = "AppleTestInfo"),

--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -63,10 +63,6 @@ load(
     "//apple/internal/aspects:swift_usage_aspect.bzl",
     "swift_usage_aspect",
 )
-load(
-    "//apple/internal/testing:apple_test_bundle_support.bzl",
-    "apple_test_info_aspect",
-)
 
 def _common_attrs():
     """Private attributes on all rules; these should be included in all rule attributes."""
@@ -174,7 +170,6 @@ def _binary_linking_attrs(
 
     default_stamp = -1
     if is_test_supporting_rule:
-        deps_aspects.append(apple_test_info_aspect)
         default_stamp = 0
 
     if requires_legacy_cc_toolchain:

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -14,10 +14,6 @@
 
 """Helper methods for implementing the test bundles."""
 
-load(
-    "@bazel_skylib//lib:types.bzl",
-    "types",
-)
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "@rules_swift//swift:swift.bzl",
@@ -26,7 +22,6 @@ load(
 load(
     "//apple:providers.bzl",
     "AppleBundleInfo",
-    "AppleTestInfo",
 )
 load(
     "//apple/internal:apple_product_type.bzl",
@@ -103,19 +98,6 @@ load(
 # a bundle ID.
 _DEFAULT_TEST_BUNDLE_ID = "com.bazelbuild.rulesapple.Tests"
 
-def _collect_files(rule_attr, attr_names):
-    """Collects files from given attr_names (when present) into a depset."""
-    transitive_files = []
-
-    for attr_name in attr_names:
-        attr_val = getattr(rule_attr, attr_name, None)
-        if not attr_val:
-            continue
-        attr_val_as_list = attr_val if types.is_list(attr_val) else [attr_val]
-        transitive_files.extend([f.files for f in attr_val_as_list])
-
-    return depset(transitive = transitive_files)
-
 def _is_swift_target(target):
     """Returns whether a target directly exports a Swift module."""
     if SwiftInfo not in target:
@@ -128,131 +110,6 @@ def _is_swift_target(target):
             return True
 
     return False
-
-def _apple_test_info_aspect_impl(target, ctx):
-    """See `test_info_aspect` for full documentation."""
-    includes = []
-    module_maps = []
-    swift_modules = []
-
-    # Not all deps (i.e. source files) will have an AppleTestInfo provider. If the
-    # dep doesn't, just filter it out.
-    test_infos = [
-        x[AppleTestInfo]
-        for x in getattr(ctx.rule.attr, "deps", [])
-        if AppleTestInfo in x
-    ]
-
-    # Collect transitive information from deps.
-    for test_info in test_infos:
-        includes.append(test_info.includes)
-        module_maps.append(test_info.module_maps)
-        swift_modules.append(test_info.swift_modules)
-
-    if apple_common.Objc in target:
-        objc_provider = target[apple_common.Objc]
-        includes.append(objc_provider.strict_include)
-
-    if CcInfo in target:
-        cc_info = target[CcInfo]
-        includes.append(cc_info.compilation_context.includes)
-        includes.append(cc_info.compilation_context.quote_includes)
-        includes.append(cc_info.compilation_context.system_includes)
-
-    if _is_swift_target(target):
-        all_modules = target[SwiftInfo].transitive_modules.to_list()
-
-        module_swiftmodules = [
-            module.swift.swiftmodule
-            for module in all_modules
-            if module.swift and type(module.swift.swiftmodule) == "File"
-        ]
-        swift_modules.append(depset(module_swiftmodules))
-
-        module_module_maps = [
-            module.clang.module_map
-            for module in all_modules
-            if module.clang and type(module.clang.module_map) == "File"
-        ]
-        module_maps.append(depset(module_module_maps))
-
-    # Collect sources from the current target. Note that we do not propagate
-    # sources transitively as we intentionally only show test sources from the
-    # test's first-level of dependencies instead of all transitive dependencies.
-    #
-    # Group the transitively exported headers into `sources` since we have no
-    # need to differentiate between internal headers and transitively exported
-    # headers.
-    non_arc_sources = _collect_files(ctx.rule.attr, ["non_arc_srcs"])
-    sources = _collect_files(ctx.rule.attr, ["srcs", "hdrs", "textual_hdrs"])
-
-    return [new_appletestinfo(
-        includes = depset(transitive = includes),
-        module_maps = depset(transitive = module_maps),
-        non_arc_sources = non_arc_sources,
-        sources = sources,
-        swift_modules = depset(transitive = swift_modules),
-    )]
-
-apple_test_info_aspect = aspect(
-    attr_aspects = [
-        "deps",
-    ],
-    doc = """
-This aspect walks the dependency graph through the `deps` attribute and collects sources, transitive
-includes, transitive module maps, and transitive Swift modules.
-
-This aspect propagates an `AppleTestInfo` provider.
-""",
-    implementation = _apple_test_info_aspect_impl,
-)
-
-def _apple_test_info_provider(deps, test_bundle, test_host):
-    """Returns an AppleTestInfo provider by collecting the relevant data from dependencies."""
-    dep_labels = []
-    swift_infos = []
-
-    transitive_includes = []
-    transitive_module_maps = []
-    transitive_non_arc_sources = []
-    transitive_sources = []
-    transitive_swift_modules = []
-
-    for dep in deps:
-        dep_labels.append(str(dep.label))
-
-        if SwiftInfo in dep:
-            swift_infos.append(dep[SwiftInfo])
-
-        test_info = dep[AppleTestInfo]
-
-        transitive_includes.append(test_info.includes)
-        transitive_module_maps.append(test_info.module_maps)
-        transitive_non_arc_sources.append(test_info.non_arc_sources)
-        transitive_sources.append(test_info.sources)
-        transitive_swift_modules.append(test_info.swift_modules)
-
-    # Set module_name only for test targets with a single Swift dependency that
-    # contains a single Swift module. This is not used if there are multiple
-    # Swift dependencies/modules, as it will not be possible to reduce them into
-    # a single Swift module and picking an arbitrary one is fragile.
-    module_name = None
-    if len(swift_infos) == 1:
-        module_names = [x.name for x in swift_infos[0].direct_modules if x.swift]
-        if len(module_names) == 1:
-            module_name = module_names[0]
-
-    return new_appletestinfo(
-        deps = depset(dep_labels),
-        includes = depset(transitive = transitive_includes),
-        module_maps = depset(transitive = transitive_module_maps),
-        module_name = module_name,
-        non_arc_sources = depset(transitive = transitive_non_arc_sources),
-        sources = depset(transitive = transitive_sources),
-        swift_modules = depset(transitive = transitive_swift_modules),
-        test_bundle = test_bundle,
-        test_host = test_host,
-    )
 
 def _computed_test_bundle_id(test_host_bundle_id):
     """Compute a test bundle ID from the test host, or a default if not given."""
@@ -604,8 +461,7 @@ def _apple_test_bundle_impl(*, ctx, product_type):
     if test_host:
         test_host_archive = test_host[AppleBundleInfo].archive
     providers.extend([
-        _apple_test_info_provider(
-            deps = ctx.attr.deps,
+        new_appletestinfo(
             test_bundle = test_runner_bundle_output,
             test_host = test_host_archive,
         ),

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -581,11 +581,6 @@ AppleTestInfo(<a href="#AppleTestInfo-_init-kwargs">*kwargs</a>)
 
 Provider that test targets propagate to be used for IDE integration.
 
-This includes information regarding test source files, transitive include paths,
-transitive module maps, and transitive Swift modules. Test source files are
-considered to be all of which belong to the first-level dependencies on the test
-target.
-
 **CONSTRUCTOR PARAMETERS**
 
 | Name  | Description | Default Value |
@@ -596,15 +591,8 @@ target.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="AppleTestInfo-includes"></a>includes |  `depset` of `String`s representing transitive include paths which are needed by IDEs to be used for indexing the test sources.    |
-| <a id="AppleTestInfo-module_maps"></a>module_maps |  `depset` of `File`s representing module maps which are needed by IDEs to be used for indexing the test sources.    |
-| <a id="AppleTestInfo-module_name"></a>module_name |  `String` representing the module name used by the test's sources. This is only set if the test only contains a single top-level Swift dependency. This may be used by an IDE to identify the Swift module (if any) used by the test's sources.    |
-| <a id="AppleTestInfo-non_arc_sources"></a>non_arc_sources |  `depset` of `File`s containing non-ARC sources from the test's immediate deps.    |
-| <a id="AppleTestInfo-sources"></a>sources |  `depset` of `File`s containing sources and headers from the test's immediate deps.    |
-| <a id="AppleTestInfo-swift_modules"></a>swift_modules |  `depset` of `File`s representing transitive swift modules which are needed by IDEs to be used for indexing the test sources.    |
 | <a id="AppleTestInfo-test_bundle"></a>test_bundle |  The artifact representing the XCTest bundle for the test target.    |
 | <a id="AppleTestInfo-test_host"></a>test_host |  The artifact representing the test host for the test target, if the test requires a test host.    |
-| <a id="AppleTestInfo-deps"></a>deps |  `depset` of `String`s representing the labels of all immediate deps of the test. Only source files from these deps will be present in `sources`. This may be used by IDEs to differentiate a test target's transitive module maps from its direct module maps, as including the direct module maps may break indexing for the source files of the immediate deps.    |
 
 
 <a id="AppleTestRunnerInfo"></a>


### PR DESCRIPTION
Most of the fields on this provider, as well as the attached aspect,
were added for tulsi. rules_xcodeproj doesn't use these. We still
expose the test specific stuff, but this allows us to remove a lot.