### PR TITLE
Fix Swift module synthesis for imported static XCFrameworks without modulemaps

### DIFF
--- a/apple/internal/framework_import_support.bzl
+++ b/apple/internal/framework_import_support.bzl
@@ -783,10 +783,15 @@ def _primary_module_map(module_maps):
     return module_maps[0] if module_maps else None
 
 def _swift_interop_info_with_dependencies(deps, module_name, module_map_imports):
-    """Return a Swift interop provider for the framework if it has a module map."""
+    """Return a Swift interop provider for the framework.
+
+    When a framework import doesn't ship a module map, rules_swift can still
+    synthesize one from the propagated headers as long as SwiftInteropInfo is
+    present. Prefer the public module map when one exists, but continue
+    returning the provider when it doesn't so imported Objective-C frameworks
+    and XCFrameworks remain visible to Swift.
+    """
     module_map = _primary_module_map(module_map_imports)
-    if not module_map:
-        return None
 
     # Assume that there is only a single module map file (the legacy
     # implementation that read from the Objc provider made the same

--- a/test/starlark_tests/apple_static_xcframework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_xcframework_import_tests.bzl
@@ -15,6 +15,10 @@
 """apple_static_xcframework_import Starlark tests."""
 
 load(
+    "//apple:ios.bzl",
+    "ios_build_test",
+)
+load(
     "//apple/build_settings:build_settings.bzl",
     "build_settings_labels",
 )
@@ -29,6 +33,10 @@ load(
 load(
     "//test/starlark_tests/rules:common_verification_tests.bzl",
     "archive_contents_test",
+)
+load(
+    ":common.bzl",
+    "common",
 )
 
 _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_action_inputs_test_rule({
@@ -109,6 +117,16 @@ def apple_static_xcframework_import_test_suite(name):
         ],
         contains = ["$BUNDLE_ROOT/Frameworks/libswiftCore.dylib"],
         not_contains = ["$BUNDLE_ROOT/Frameworks/generated_static_xcframework_with_headers"],
+        tags = [name],
+    )
+
+    # Verifies that Swift can import an Objective-C static XCFramework even
+    # when the bundle does not ship a module.modulemap and rules_swift must
+    # synthesize the module from the imported headers.
+    ios_build_test(
+        name = "{}_swift_imported_static_xcframework_without_modulemap_build_test".format(name),
+        minimum_os_version = common.min_os_ios.baseline,
+        targets = ["//test/starlark_tests/targets_under_test/ios:static_xcframework_without_modulemap_depending_swift_lib"],
         tags = [name],
     )
 

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4350,6 +4350,27 @@ func static_xcframework_depending_swift_lib_function_function() {
     tags = common.fixture_tags,
 )
 
+swift_library(
+    name = "static_xcframework_without_modulemap_depending_swift_lib",
+    srcs = [":static_xcframework_without_modulemap_depending_swift_lib_src"],
+    tags = common.fixture_tags,
+    deps = [":ios_imported_static_xcframework_without_modulemap"],
+)
+
+write_file(
+    name = "static_xcframework_without_modulemap_depending_swift_lib_src",
+    out = "SwiftWithStaticFrameworkWithoutModulemap.swift",
+    content = ["""
+import generated_static_xcframework_with_headers_and_no_modulemap
+
+func static_xcframework_without_modulemap_depending_swift_lib_function() {
+  let sc = generated_static_xcframework_with_headers_and_no_modulemap.SharedClass()
+  sc.doSomethingShared()
+}
+"""],
+    tags = common.fixture_tags,
+)
+
 apple_static_xcframework_import(
     name = "ios_imported_static_xcframework",
     features = ["-swift.layering_check"],
@@ -4377,6 +4398,14 @@ generate_static_xcframework(
         ],
     },
     tags = common.fixture_tags,
+)
+
+apple_static_xcframework_import(
+    name = "ios_imported_static_xcframework_without_modulemap",
+    features = ["-swift.layering_check"],
+    tags = common.fixture_tags,
+    visibility = ["//visibility:public"],
+    xcframework_imports = [":generated_static_xcframework_with_headers_and_no_modulemap"],
 )
 
 # Swift app with imported Swift XCFramework


### PR DESCRIPTION
Regressed in https://github.com/bazelbuild/rules_apple/pull/2977.

https://github.com/bazelbuild/rules_apple/pull/2977 changed `swift_interop_info_with_dependencies` to return `None` when `_primary_module_map(...)` was missing.
That is correct for code paths that now explicitly handle private module maps and imported swiftmodule / swiftinterface artifacts.
However, for imported Objective-C frameworks/XCFrameworks   we still need to return `SwiftInteropInfo(module_map = None, ...)` so rules_swift can generate the module map from headers. Without that provider, Swift compilation loses the synthesized module and importing fails.

This can be easily reproduced:

MODULE.bazel:

```
bazel_dep(name = "apple_support", version = "2.5.4")
bazel_dep(name = "rules_apple", version = "5.0.0-rc1")
bazel_dep(name = "rules_swift", version = "4.0.0-rc1")

http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "org_webmproject_webp_xcframework",
    url = "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.4.0-ios-framework.tar.gz",
    build_file = "//third_party/org_webmproject_webp_xcframework:BUILD.bazel",
    sha256 = "779fcb78294e59f393319c0f9bf2e1126f9479e862a22fe50bc50d9489c15cd3",
)
```

third_party/org_webmproject_webp_xcframework/BUILD.bazel:

```
load("@rules_apple//apple:apple.bzl", "apple_static_xcframework_import")

apple_static_xcframework_import(
    name = "SharpYuv",
    xcframework_imports = glob(
        ["libwebp-*-ios-framework/SharpYuv.xcframework/**"],
    ),
)

apple_static_xcframework_import(
    name = "WebP",
    visibility = ["//visibility:public"],
    xcframework_imports = glob(
        ["libwebp-*-ios-framework/WebP.xcframework/**"],
        ),
    deps = [
        "SharpYuv",
    ],
)
```

BUILD.bazel:

```
load("@rules_swift//swift:swift.bzl", "swift_library")

swift_library(
    name = "webp_repro",
    srcs = ["Sources/WebPRepro.swift"],
    deps = [
        "@org_webmproject_webp_xcframework//:WebP",
    ],
)
```

Sources/WebPRepro.swift:

```
import WebP

public func webPVersion() -> Int32 {
    WebPGetEncoderVersion()
}
```