### PR TITLE
Fix swiftmodule embedding from frameworks

### DIFF
--- a/apple/internal/apple_framework_import.bzl
+++ b/apple/internal/apple_framework_import.bzl
@@ -35,6 +35,7 @@ load(
     "find_cc_toolchain",
     "use_cc_toolchain",
 )
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "@rules_swift//swift:swift.bzl",
@@ -143,7 +144,7 @@ def _is_debugging(compilation_mode):
     """
     return compilation_mode in ("dbg", "fastbuild")
 
-def _ensure_swiftmodule_is_embedded(swiftmodule):
+def _ensure_swiftmodule_is_embedded(label, swiftmodule):
     """Ensures that a `.swiftmodule` file is embedded in a library or binary.
 
     rules_apple specific implementation of rules_swift's
@@ -151,9 +152,18 @@ def _ensure_swiftmodule_is_embedded(swiftmodule):
 
     See: https://github.com/bazelbuild/rules_swift/blob/e78ceb37c401a9bf9e551a6accd1df7d864688d5/swift/internal/debugging.bzl#L20-L47
     """
-    return dict(
-        linkopt = depset(["-Wl,-add_ast_path,{}".format(swiftmodule.path)]),
-        link_inputs = depset([swiftmodule]),
+    return CcInfo(
+        linking_context = cc_common.create_linking_context(
+            linker_inputs = depset([
+                cc_common.create_linker_input(
+                    owner = label,
+                    additional_inputs = depset([swiftmodule]),
+                    user_link_flags = [
+                        "-Wl,-add_ast_path,{}".format(swiftmodule.path),
+                    ],
+                ),
+            ]),
+        ),
     )
 
 def _framework_search_paths(header_imports):
@@ -326,10 +336,8 @@ def _apple_static_framework_import_impl(ctx):
         deps = deps,
     ))
 
-    # Collect transitive Objc/CcInfo providers from Swift toolchain
+    # Collect transitive CcInfo providers from Swift toolchain.
     additional_cc_infos = []
-    additional_objc_providers = []
-    additional_objc_provider_fields = {}
     if framework.swift_interface_imports or framework.swift_module_imports or has_swift:
         swift_toolchains = swift_common.find_all_toolchains(ctx)
         providers.append(SwiftUsageInfo())
@@ -347,14 +355,7 @@ def _apple_static_framework_import_impl(ctx):
                 target_triplet.architecture,
             )
             if swiftmodule:
-                additional_objc_provider_fields.update(_ensure_swiftmodule_is_embedded(swiftmodule))
-
-    # Create apple_common.Objc provider
-    additional_objc_providers.extend([
-        dep[apple_common.Objc]
-        for dep in deps
-        if apple_common.Objc in dep
-    ])
+                additional_cc_infos.append(_ensure_swiftmodule_is_embedded(label, swiftmodule))
 
     linkopts = []
     if sdk_dylibs:

--- a/test/starlark_tests/apple_static_framework_import_tests.bzl
+++ b/test/starlark_tests/apple_static_framework_import_tests.bzl
@@ -15,6 +15,10 @@
 """apple_static_framework_import Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+load(
     "//test/starlark_tests/rules:action_inputs_test.bzl",
     "make_action_inputs_test_rule",
 )
@@ -28,6 +32,14 @@ _action_inputs_with_ios_x86_64_import_via_swiftinterface_platform_test = make_ac
         "apple._import_framework_via_swiftinterface",
     ],
     "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_x86_64")),
+})
+
+_action_command_line_with_ios_sim_arm64_platform_test = make_action_command_line_test_rule({
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_sim_arm64")),
+})
+
+_action_inputs_with_ios_sim_arm64_platform_test = make_action_inputs_test_rule({
+    "//command_line_option:platforms": str(Label("@apple_support//platforms:ios_sim_arm64")),
 })
 
 _analysis_actions_with_ios_x86_64_platform_test = make_analysis_target_actions_test({
@@ -56,6 +68,27 @@ def apple_static_framework_import_test_suite(name):
         expected_inputs = [
             "iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
             "iOSSwiftStaticFramework.framework/Modules/iOSSwiftStaticFramework.swiftmodule/x86_64-apple-ios-simulator.private.swiftinterface",
+        ],
+        tags = [name],
+    )
+
+    _action_command_line_with_ios_sim_arm64_platform_test(
+        name = "{}_binary_links_imported_swiftmodule_ast_path".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_framework_binary_swiftmodule",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-Wl,-add_ast_path",
+            "Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftmodule",
+        ],
+        tags = [name],
+    )
+
+    _action_inputs_with_ios_sim_arm64_platform_test(
+        name = "{}_binary_links_imported_swiftmodule_ast_input".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:app_with_imported_static_framework_binary_swiftmodule",
+        mnemonic = "ObjcLink",
+        expected_inputs = [
+            "Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftmodule",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4031,6 +4031,45 @@ genrule(
     tags = common.fixture_tags,
 )
 
+genrule(
+    name = "swiftmodule_static_framework_with_modulemap",
+    srcs = ["//test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_binary_swiftmodule"],
+    outs = [
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Swift3PFmwkBinarySwiftmodule",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Headers/Swift3PFmwkBinarySwiftmodule.h",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Info.plist",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftdoc",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/arm64.swiftmodule",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/x86_64.swiftdoc",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Modules/Swift3PFmwkBinarySwiftmodule.swiftmodule/x86_64.swiftmodule",
+        "binary_swiftmodule_static_framework/Swift3PFmwkBinarySwiftmodule.framework/Modules/module.modulemap",
+    ],
+    cmd = "tmp=$$(mktemp -d) && unzip -qq $(execpath //test/starlark_tests/targets_under_test/apple:ios_swift_3p_xcframework_binary_swiftmodule) -d $$tmp && rm -rf $(RULEDIR)/binary_swiftmodule_static_framework && mkdir -p $(RULEDIR)/binary_swiftmodule_static_framework && cp -R $$tmp/Swift3PFmwkBinarySwiftmodule.xcframework/ios-arm64_x86_64-simulator/Swift3PFmwkBinarySwiftmodule.framework $(RULEDIR)/binary_swiftmodule_static_framework/",
+    tags = common.fixture_tags,
+)
+
+apple_static_framework_import(
+    name = "ios_imported_static_framework_binary_swiftmodule",
+    features = ["-swift.layering_check"],
+    framework_imports = [":swiftmodule_static_framework_with_modulemap"],
+    tags = common.fixture_tags,
+)
+
+ios_application(
+    name = "app_with_imported_static_framework_binary_swiftmodule",
+    bundle_id = "com.google.example",
+    families = ["iphone"],
+    infoplists = [
+        "//test/starlark_tests/resources:Info.plist",
+    ],
+    minimum_os_version = common.min_os_ios.baseline,
+    tags = common.fixture_tags,
+    deps = [
+        ":ios_imported_static_framework_binary_swiftmodule",
+        "//test/starlark_tests/resources:objc_main_lib",
+    ],
+)
+
 apple_dynamic_xcframework_import(
     name = "ios_imported_xcframework_swiftmodule_no_modulemap",
     features = [


### PR DESCRIPTION
Originally implemented in: https://github.com/bazelbuild/rules_apple/pull/567

Silently broken when bazel moved to CcInfo, became unused after 338f9d8ce39f2dfbc7940577a9abeb07d071a7c2
