### PR TITLE
Handle smartcard certs with no expiry date in codesigningtool

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -225,10 +225,16 @@ def _find_smartcard_identities(identity=None):
       # Valid from: 2021-02-12 21:35:04 +0000 to: 2022-02-12 21:35:05 +0000, SSL trust: NO, X509 trust: YES
       #
       expiry_date = re.search(r"(?<=to:)(.*?)(?=,)", data, re.DOTALL).group().strip()
-      expiry_date = datetime.datetime.strptime(expiry_date, "%Y-%m-%d %H:%M:%S %z")
-      now = datetime.datetime.now(expiry_date.tzinfo)
-      if now > expiry_date:
-        continue
+      # Some smartcards report certs with no expiry date as "N/A". Treat an
+      # unparseable expiry as non-expiring rather than crashing.
+      try:
+        expiry_date = datetime.datetime.strptime(expiry_date, "%Y-%m-%d %H:%M:%S %z")
+      except ValueError:
+        expiry_date = None
+      if expiry_date is not None:
+        now = datetime.datetime.now(expiry_date.tzinfo)
+        if now > expiry_date:
+          continue
 
       # This is a valid identity, decode the certificate, extract
       # Common Name and Fingerprint and handle their values accordingly


### PR DESCRIPTION
## Problem

`system_profiler SPSmartCardsDataType` reports smartcard certs that have no expiry date as the literal string `N/A` rather than a parseable timestamp. `_find_smartcard_identities` passed that value straight to `datetime.strptime`, raising:

```
File ".../tools/codesigningtool/codesigningtool.py", line 228, in _find_smartcard_identities
  expiry_date = datetime.datetime.strptime(expiry_date, "%Y-%m-%d %H:%M:%S %z")
ValueError: time data 'N/A' does not match format '%Y-%m-%d %H:%M:%S %z'
```

This fails the entire codesign step, so device builds break for anyone with such a smartcard (e.g. a hardware token like a YubiKey/PIV) paired with macOS. Simulator builds are unaffected since they don't codesign.

## Fix

Treat an unparseable expiry as non-expiring so the identity remains a valid signing candidate instead of bringing down the build. An `N/A` expiry means we can't prove the cert is expired, so dropping it would be wrong — we just shouldn't crash on it.