### PR TITLE
Accept both simulator UUIDs and simulator device names in `@rules_apple//apple/build_settings:ios_device`

### DIFF
--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -170,9 +170,11 @@ def _is_uuid(value):
     """
     if not value or len(value) != 36:
         return False
+
     # Check for hyphens at the correct positions (8, 13, 18, 23)
     if value[8] != "-" or value[13] != "-" or value[18] != "-" or value[23] != "-":
         return False
+
     # Check that all other characters are hexadecimal
     for i, char in enumerate(value):
         if i in [8, 13, 18, 23]:
@@ -525,6 +527,7 @@ def _ios_application_impl(ctx):
         )
     else:
         ios_device = apple_xplat_toolchain_info.build_settings.ios_device
+
         # Determine whether ios_device is a UUID or a device name
         # If it's a UUID, pass it as simulator_identifier
         # If it's a device name, pass it as simulator_device (overriding the default)
@@ -883,6 +886,7 @@ def _ios_app_clip_impl(ctx):
         )
     else:
         ios_device = apple_xplat_toolchain_info.build_settings.ios_device
+
         # Determine whether ios_device is a UUID or a device name
         # If it's a UUID, pass it as simulator_identifier
         # If it's a device name, pass it as simulator_device (overriding the default)

--- a/apple/internal/ios_rules.bzl
+++ b/apple/internal/ios_rules.bzl
@@ -156,6 +156,31 @@ load(
     "main_thread_checker_dylibs",
 )
 
+def _is_uuid(value):
+    """Returns True if the value looks like a UUID, False otherwise.
+
+    A UUID has the format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+    (36 characters with hyphens at specific positions)
+
+    Args:
+        value: The string value to check.
+
+    Returns:
+        True if the value appears to be a UUID, False otherwise.
+    """
+    if not value or len(value) != 36:
+        return False
+    # Check for hyphens at the correct positions (8, 13, 18, 23)
+    if value[8] != "-" or value[13] != "-" or value[18] != "-" or value[23] != "-":
+        return False
+    # Check that all other characters are hexadecimal
+    for i, char in enumerate(value):
+        if i in [8, 13, 18, 23]:
+            continue
+        if not (char.isdigit() or char.lower() in "abcdef"):
+            return False
+    return True
+
 def _ios_simulator_device(*, apple_xplat_toolchain_info, objc_fragment):
     return (apple_xplat_toolchain_info.build_settings.ios_simulator_device or
             # TODO: Remove when we drop Bazel 9.x support.
@@ -499,6 +524,26 @@ def _ios_application_impl(ctx):
             device = apple_xplat_toolchain_info.build_settings.ios_device,
         )
     else:
+        ios_device = apple_xplat_toolchain_info.build_settings.ios_device
+        # Determine whether ios_device is a UUID or a device name
+        # If it's a UUID, pass it as simulator_identifier
+        # If it's a device name, pass it as simulator_device (overriding the default)
+        if ios_device and _is_uuid(ios_device):
+            sim_device = _ios_simulator_device(
+                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
+                objc_fragment = ctx.fragments.objc,
+            )
+            sim_identifier = ios_device
+        elif ios_device:
+            sim_device = ios_device
+            sim_identifier = None
+        else:
+            sim_device = _ios_simulator_device(
+                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
+                objc_fragment = ctx.fragments.objc,
+            )
+            sim_identifier = None
+
         run_support.register_simulator_executable(
             actions = actions,
             bundle_extension = bundle_extension,
@@ -509,13 +554,8 @@ def _ios_application_impl(ctx):
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
             runner_template = ctx.file._simulator_runner_template,
-            simulator_device = _ios_simulator_device(
-                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
-                objc_fragment = ctx.fragments.objc,
-            ),
-            simulator_identifier = (
-                apple_xplat_toolchain_info.build_settings.ios_device
-            ),
+            simulator_device = sim_device,
+            simulator_identifier = sim_identifier,
             simulator_version = _ios_simulator_version(
                 apple_xplat_toolchain_info = apple_xplat_toolchain_info,
                 objc_fragment = ctx.fragments.objc,
@@ -842,6 +882,26 @@ def _ios_app_clip_impl(ctx):
             device = apple_xplat_toolchain_info.build_settings.ios_device,
         )
     else:
+        ios_device = apple_xplat_toolchain_info.build_settings.ios_device
+        # Determine whether ios_device is a UUID or a device name
+        # If it's a UUID, pass it as simulator_identifier
+        # If it's a device name, pass it as simulator_device (overriding the default)
+        if ios_device and _is_uuid(ios_device):
+            sim_device = _ios_simulator_device(
+                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
+                objc_fragment = ctx.fragments.objc,
+            )
+            sim_identifier = ios_device
+        elif ios_device:
+            sim_device = ios_device
+            sim_identifier = None
+        else:
+            sim_device = _ios_simulator_device(
+                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
+                objc_fragment = ctx.fragments.objc,
+            )
+            sim_identifier = None
+
         run_support.register_simulator_executable(
             actions = actions,
             bundle_extension = bundle_extension,
@@ -852,10 +912,8 @@ def _ios_app_clip_impl(ctx):
             predeclared_outputs = predeclared_outputs,
             rule_descriptor = rule_descriptor,
             runner_template = ctx.file._simulator_runner_template,
-            simulator_device = _ios_simulator_device(
-                apple_xplat_toolchain_info = apple_xplat_toolchain_info,
-                objc_fragment = ctx.fragments.objc,
-            ),
+            simulator_device = sim_device,
+            simulator_identifier = sim_identifier,
             simulator_version = _ios_simulator_version(
                 apple_xplat_toolchain_info = apple_xplat_toolchain_info,
                 objc_fragment = ctx.fragments.objc,


### PR DESCRIPTION
The `@rules_apple//apple/build_settings:ios_device` build setting was supposed to accept both simulator UUIDs and simulator device names (like "iPhone 15 Pro"), but it only worked with UUIDs. The problem was in `apple/internal/ios_rules.bzl` where the `ios_device` value was always passed as `simulator_identifier` (which expects a UUID) instead of being passed to the appropriate parameter based on its format.

This is particularly nice for companies that require proxy certs in simulators and allows you to reuse pre-loaded simulators with all the certs

 
Updated the simulator executable registration to:
  - Check if ios_device is a UUID or a device name
  - Pass it as simulator_identifier if it's a UUID
  - Pass it as simulator_device if it's a device name (like "iPhone 15 Pro")
  - Fall back to the default ios_simulator_device setting if ios_device is not set