### PR TITLE
Handle smartcard certs with no embedded certificate data in codesigningtool

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -241,12 +241,10 @@ def _find_smartcard_identities(identity=None):
       # as described above
       # Some smartcards report entries with no embedded certificate data, in
       # which case re.search returns None. Skip those rather than crashing.
-      try:
-        cert = re.search(r"(?<=-----BEGIN CERTIFICATE-----)(.*?)(?=-----END CERTIFICATE-----)", data, re.DOTALL).group().strip()
-      except AttributeError:
-        cert = None
-      if cert is None:
+      match = re.search(r"(?<=-----BEGIN CERTIFICATE-----)(.*?)(?=-----END CERTIFICATE-----)", data, re.DOTALL)
+      if not match:
         continue
+      cert = match.group().strip()
       cert = base64.b64decode(cert)
       cert = _certificate_data(cert)
       common_name = _certificate_common_name(cert)

--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -239,7 +239,14 @@ def _find_smartcard_identities(identity=None):
       # This is a valid identity, decode the certificate, extract
       # Common Name and Fingerprint and handle their values accordingly
       # as described above
-      cert = re.search(r"(?<=-----BEGIN CERTIFICATE-----)(.*?)(?=-----END CERTIFICATE-----)", data, re.DOTALL).group().strip()
+      # Some smartcards report entries with no embedded certificate data, in
+      # which case re.search returns None. Skip those rather than crashing.
+      try:
+        cert = re.search(r"(?<=-----BEGIN CERTIFICATE-----)(.*?)(?=-----END CERTIFICATE-----)", data, re.DOTALL).group().strip()
+      except AttributeError:
+        cert = None
+      if cert is None:
+        continue
       cert = base64.b64decode(cert)
       cert = _certificate_data(cert)
       common_name = _certificate_common_name(cert)


### PR DESCRIPTION
## Problem

Follow-up to #3000, which fixed the expiry-date parsing in `_find_smartcard_identities`. The same loop extracts the certificate body immediately after the expiry check:

```python
cert = re.search(r"(?<=-----BEGIN CERTIFICATE-----)(.*?)(?=-----END CERTIFICATE-----)", data, re.DOTALL).group().strip()
```

Some smartcard entries report no embedded certificate data, so `re.search` returns `None` and `.group()` raises `AttributeError`, failing the entire codesign step — and thus device builds — the same way #3000's `N/A` expiry did.

## Fix

Capture the match and skip entries with no certificate data instead of crashing. Unlike the expiry case in #3000 — where a missing date can't prove the cert is expired, so the identity is kept — an entry with no certificate yields no fingerprint or common name, so there's nothing usable to return and it's correctly skipped.