### PR TITLE
Separate devicectl app args from options

### DIFF
--- a/apple/internal/templates/apple_device.template.py
+++ b/apple/internal/templates/apple_device.template.py
@@ -496,7 +496,9 @@ def run_app(
     ]
     launch_args = ensure_devicectl_terminate_existing(launch_args)
     # Append optional launch arguments.
-    app_args = [app_bundle_id] + sys.argv[1:]
+    # devicectl keeps parsing dash-prefixed values as command options even
+    # after the bundle identifier. Terminate option parsing before app args.
+    app_args = ["--", app_bundle_id] + sys.argv[1:]
     launch_app(
         launch_args=launch_args,
         app_args=app_args,


### PR DESCRIPTION
devicectl continues parsing dash-prefixed values as command options after the bundle identifier. Add an explicit `--` separator before the bundle ID so user-provided app arguments are forwarded correctly.