### PR TITLE
Pass -no_exported_symbols by default

### DIFF
--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -413,6 +413,7 @@ def _contains_exported_symbol_linkopts(linkopts):
     """Returns whether linkopts already control exported symbols."""
     for linkopt in linkopts:
         for exported_symbols_linkopt in [
+            "-alias",
             "-exported_symbol",
             "-exported_symbols_list",
             "-no_exported_symbols",

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -493,7 +493,7 @@ def _register_binary_linking_action(
                 "-Wl,-exported_symbols_list,{}".format(exported_symbols_list.path),
             )
             link_inputs.append(exported_symbols_list)
-    elif not is_shared_library:
+    elif not is_shared_library and not bundle_loader:
         linkopts.append("-Wl,-no_exported_symbols")
 
     if entitlements:

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -486,11 +486,14 @@ def _register_binary_linking_action(
     link_inputs = []
 
     # Add linkopts/linker inputs that are common to all the rules.
-    for exported_symbols_list in exported_symbols_lists:
-        linkopts.append(
-            "-Wl,-exported_symbols_list,{}".format(exported_symbols_list.path),
-        )
-        link_inputs.append(exported_symbols_list)
+    if exported_symbols_lists:
+        for exported_symbols_list in exported_symbols_lists:
+            linkopts.append(
+                "-Wl,-exported_symbols_list,{}".format(exported_symbols_list.path),
+            )
+            link_inputs.append(exported_symbols_list)
+    else:
+        linkopts.append("-Wl,-exported_symbols_list,/dev/null")
 
     if entitlements:
         if platform_prerequisites and platform_prerequisites.platform.is_device and rule_descriptor and rule_descriptor.product_type != apple_product_type.kernel_extension:

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -486,14 +486,15 @@ def _register_binary_linking_action(
     link_inputs = []
 
     # Add linkopts/linker inputs that are common to all the rules.
+    is_shared_library = "-dynamiclib" in extra_linkopts
     if exported_symbols_lists:
         for exported_symbols_list in exported_symbols_lists:
             linkopts.append(
                 "-Wl,-exported_symbols_list,{}".format(exported_symbols_list.path),
             )
             link_inputs.append(exported_symbols_list)
-    else:
-        linkopts.append("-Wl,-exported_symbols_list,/dev/null")
+    elif not is_shared_library:
+        linkopts.append("-Wl,-no_exported_symbols")
 
     if entitlements:
         if platform_prerequisites and platform_prerequisites.platform.is_device and rule_descriptor and rule_descriptor.product_type != apple_product_type.kernel_extension:

--- a/apple/internal/linking_support.bzl
+++ b/apple/internal/linking_support.bzl
@@ -409,6 +409,20 @@ def _sectcreate_cc_info(label, segname, sectname, file):
         ),
     ]
 
+def _contains_exported_symbol_linkopts(linkopts):
+    """Returns whether linkopts already control exported symbols."""
+    for linkopt in linkopts:
+        for exported_symbols_linkopt in [
+            "-exported_symbol",
+            "-exported_symbols_list",
+            "-no_exported_symbols",
+            "-unexported_symbol",
+            "-unexported_symbols_list",
+        ]:
+            if exported_symbols_linkopt in linkopt:
+                return True
+    return False
+
 def _register_binary_linking_action(
         ctx,
         *,
@@ -487,13 +501,16 @@ def _register_binary_linking_action(
 
     # Add linkopts/linker inputs that are common to all the rules.
     is_shared_library = "-dynamiclib" in extra_linkopts
+    has_exported_symbol_linkopts = _contains_exported_symbol_linkopts(
+        extra_linkopts + getattr(ctx.attr, "linkopts", []),
+    )
     if exported_symbols_lists:
         for exported_symbols_list in exported_symbols_lists:
             linkopts.append(
                 "-Wl,-exported_symbols_list,{}".format(exported_symbols_list.path),
             )
             link_inputs.append(exported_symbols_list)
-    elif not is_shared_library and not bundle_loader:
+    elif not is_shared_library and not bundle_loader and not has_exported_symbol_linkopts:
         linkopts.append("-Wl,-no_exported_symbols")
 
     if entitlements:

--- a/examples/multi_platform/Buttons/BUILD
+++ b/examples/multi_platform/Buttons/BUILD
@@ -130,6 +130,7 @@ ios_framework(
 ios_application(
     name = "Buttons",
     bundle_id = "com.google.Buttons",
+    exported_symbols_lists = ["Buttons/ExportedSymbols.exp"],
     extensions = [":ButtonsExtension"],
     families = [
         "iphone",

--- a/examples/multi_platform/Buttons/Buttons/ExportedSymbols.exp
+++ b/examples/multi_platform/Buttons/Buttons/ExportedSymbols.exp
@@ -1,0 +1,1 @@
+_$s7Buttons14ViewControllerCMa

--- a/test/starlark_tests/ios_coverage_tests.bzl
+++ b/test/starlark_tests/ios_coverage_tests.bzl
@@ -15,6 +15,10 @@
 """iOS coverage Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "action_command_line_test",
+)
+load(
     "//test/starlark_tests/rules:apple_coverage_test.bzl",
     "apple_coverage_test",
 )
@@ -88,6 +92,19 @@ def ios_coverage_test_suite(name):
         ],
         target_under_test = "//test/starlark_tests/targets_under_test/ios:coverage_hosted_test",
         tags = [name, "exclusive"],
+    )
+
+    action_command_line_test(
+        name = "{}_hosted_test_host_exported_symbols_list_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:coverage_app",
+        expected_argv = [
+            "-Wl,-exported_symbols_list,test/starlark_tests/targets_under_test/ios/ExportCoverageFoo.exp",
+        ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
+        mnemonic = "ObjcLink",
+        tags = [name],
     )
 
     apple_coverage_test(

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -247,6 +247,9 @@ def ios_unit_test_test_suite(name):
             "app_lipobin",
             "-framework CoreMotion",
         ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
         mnemonic = "ObjcLink",
         tags = [name],
     )

--- a/test/starlark_tests/ios_unit_test_tests.bzl
+++ b/test/starlark_tests/ios_unit_test_tests.bzl
@@ -255,6 +255,19 @@ def ios_unit_test_test_suite(name):
     )
 
     action_command_line_test(
+        name = "{}_bundle_loader_host_exported_symbols_list_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/ios:ext_for_bundle_loader",
+        expected_argv = [
+            "-Wl,-exported_symbols_list,test/starlark_tests/resources/ExportObjectiveCCommonClass.exp",
+        ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
+        mnemonic = "ObjcLink",
+        tags = [name],
+    )
+
+    action_command_line_test(
         name = "{}_no_bundle_loader_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/ios:unit_test_no_bundle_loader.__internal__.__test_bundle",
         not_expected_argv = [

--- a/test/starlark_tests/macos_application_tests.bzl
+++ b/test/starlark_tests/macos_application_tests.bzl
@@ -19,6 +19,10 @@ load(
     "build_settings_labels",
 )
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -106,6 +110,12 @@ _analysis_macos_strip_disabled_dbg_test = make_analysis_target_actions_test(
         "//command_line_option:compilation_mode": "dbg",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_action_macos_x86_64_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:macos_cpus": "x86_64",
     },
 )
 
@@ -370,6 +380,20 @@ def macos_application_test_suite(name):
         compilation_mode = "opt",
         binary_test_architecture = "x86_64",
         binary_contains_symbols = ["_linkopts_test_main"],
+        tags = [name],
+    )
+
+    _action_macos_x86_64_test(
+        name = "{}_custom_exported_symbol_linkopts_skip_no_exported_symbols_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:app_special_linkopts",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-exported_symbol",
+            "_linkopts_test_main",
+        ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_bundle_tests.bzl
+++ b/test/starlark_tests/macos_bundle_tests.bzl
@@ -15,6 +15,10 @@
 """macos_bundle Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -52,6 +56,12 @@ _BUNDLE_PLIST_SUBSTITUTIONS = {
     "PRODUCT_NAME": "bundle",
     "TARGET_NAME": "bundle",
 }
+
+_action_macos_x86_64_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:macos_cpus": "x86_64",
+    },
+)
 
 def macos_bundle_test_suite(name):
     """Test suite for macos_bundle.
@@ -188,6 +198,20 @@ def macos_bundle_test_suite(name):
         compilation_mode = "opt",
         binary_test_architecture = "x86_64",
         binary_contains_symbols = ["_linkopts_test_anotherFunctionShared"],
+        tags = [name],
+    )
+
+    _action_macos_x86_64_test(
+        name = "{}_custom_alias_linkopts_skip_no_exported_symbols_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:bundle_special_linkopts",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-alias",
+            "_linkopts_test_anotherFunctionShared",
+        ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -15,6 +15,10 @@
 """macos_command_line_application Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -68,6 +72,12 @@ _analysis_macos_strip_disabled_dbg_test = make_analysis_target_actions_test(
         "//command_line_option:compilation_mode": "dbg",
         "//command_line_option:macos_cpus": "x86_64",
         "//command_line_option:objc_enable_binary_stripping": True,
+    },
+)
+
+_action_macos_x86_64_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:macos_cpus": "x86_64",
     },
 )
 
@@ -191,6 +201,29 @@ def macos_command_line_application_test_suite(name):
         compilation_mode = "opt",
         binary_test_architecture = "x86_64",
         binary_contains_symbols = ["_linkopts_test_main"],
+        tags = [name],
+    )
+
+    _action_macos_x86_64_test(
+        name = "{}_empty_exported_symbols_lists_uses_dev_null_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-Wl,-exported_symbols_list,/dev/null",
+        ],
+        tags = [name],
+    )
+
+    _action_macos_x86_64_test(
+        name = "{}_exported_symbols_lists_skips_dev_null_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_dead_stripped",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-Wl,-exported_symbols_list,test/starlark_tests/resources/ExportAnotherFunctionMain.exp",
+        ],
+        not_expected_argv = [
+            "-Wl,-exported_symbols_list,/dev/null",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/macos_command_line_application_tests.bzl
+++ b/test/starlark_tests/macos_command_line_application_tests.bzl
@@ -205,24 +205,24 @@ def macos_command_line_application_test_suite(name):
     )
 
     _action_macos_x86_64_test(
-        name = "{}_empty_exported_symbols_lists_uses_dev_null_test".format(name),
+        name = "{}_empty_exported_symbols_lists_uses_no_exported_symbols_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_basic",
         mnemonic = "ObjcLink",
         expected_argv = [
-            "-Wl,-exported_symbols_list,/dev/null",
+            "-Wl,-no_exported_symbols",
         ],
         tags = [name],
     )
 
     _action_macos_x86_64_test(
-        name = "{}_exported_symbols_lists_skips_dev_null_test".format(name),
+        name = "{}_exported_symbols_lists_skips_no_exported_symbols_test".format(name),
         target_under_test = "//test/starlark_tests/targets_under_test/macos:cmd_app_dead_stripped",
         mnemonic = "ObjcLink",
         expected_argv = [
             "-Wl,-exported_symbols_list,test/starlark_tests/resources/ExportAnotherFunctionMain.exp",
         ],
         not_expected_argv = [
-            "-Wl,-exported_symbols_list,/dev/null",
+            "-Wl,-no_exported_symbols",
         ],
         tags = [name],
     )

--- a/test/starlark_tests/macos_dylib_tests.bzl
+++ b/test/starlark_tests/macos_dylib_tests.bzl
@@ -15,6 +15,10 @@
 """macos_dylib Starlark tests."""
 
 load(
+    "//test/starlark_tests/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+load(
     "//test/starlark_tests/rules:analysis_output_group_info_files_test.bzl",
     "analysis_output_group_info_files_test",
 )
@@ -37,6 +41,12 @@ load(
 load(
     "//test/starlark_tests/rules:output_group_test.bzl",
     "output_group_test",
+)
+
+_action_macos_x86_64_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:macos_cpus": "x86_64",
+    },
 )
 
 def macos_dylib_test_suite(name):
@@ -72,6 +82,19 @@ def macos_dylib_test_suite(name):
             "DTXcode": "*",
             "DTXcodeBuild": "*",
         },
+        tags = [name],
+    )
+
+    _action_macos_x86_64_test(
+        name = "{}_empty_exported_symbols_lists_skips_no_exported_symbols_test".format(name),
+        target_under_test = "//test/starlark_tests/targets_under_test/macos:dylib",
+        mnemonic = "ObjcLink",
+        expected_argv = [
+            "-dynamiclib",
+        ],
+        not_expected_argv = [
+            "-Wl,-no_exported_symbols",
+        ],
         tags = [name],
     )
 

--- a/test/starlark_tests/resources/ExportObjectiveCCommonClass.exp
+++ b/test/starlark_tests/resources/ExportObjectiveCCommonClass.exp
@@ -1,0 +1,2 @@
+_OBJC_CLASS_$_ObjectiveCCommonClass
+_OBJC_METACLASS_$_ObjectiveCCommonClass

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -6598,6 +6598,9 @@ ios_extension(
     name = "ext_for_bundle_loader",
     bundle_id = "com.google.example.ext",
     entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    exported_symbols_lists = [
+        "//test/starlark_tests/resources:ExportObjectiveCCommonClass.exp",
+    ],
     families = ["iphone"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",

--- a/test/starlark_tests/targets_under_test/ios/BUILD
+++ b/test/starlark_tests/targets_under_test/ios/BUILD
@@ -4811,6 +4811,9 @@ swift_library(
 ios_application(
     name = "coverage_app",
     bundle_id = "my.bundle.id",
+    exported_symbols_lists = [
+        ":ExportCoverageFoo.exp",
+    ],
     families = ["iphone"],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",

--- a/test/starlark_tests/targets_under_test/ios/ExportCoverageFoo.exp
+++ b/test/starlark_tests/targets_under_test/ios/ExportCoverageFoo.exp
@@ -1,0 +1,1 @@
+_coverageFoo

--- a/test/starlark_tests/targets_under_test/tvos/BUILD
+++ b/test/starlark_tests/targets_under_test/tvos/BUILD
@@ -1581,6 +1581,9 @@ tvos_extension(
     name = "ext_for_bundle_loader",
     bundle_id = "com.google.example.ext",
     entitlements = "//test/starlark_tests/resources:entitlements.plist",
+    exported_symbols_lists = [
+        "//test/starlark_tests/resources:ExportObjectiveCCommonClass.exp",
+    ],
     infoplists = [
         "//test/starlark_tests/resources:Info.plist",
     ],


### PR DESCRIPTION
Passing `-Wl,-no_exported_symbols` has been generally
recommended to reduce app size. Since we have the
`exported_symbols_list` attribute, if those are never set, we can do
this by default. This does require folks export things that they
actually need.
