### PR TITLE
Make target_compatible_with usable for incompatible-target skipping

### DIFF
--- a/apple/internal/transition_support.bzl
+++ b/apple/internal/transition_support.bzl
@@ -542,15 +542,52 @@ def _command_line_options_for_xcframework_platform(
 
     return output_dictionary
 
+def _options_preserving_declared_constraints(*, options, settings, attr):
+    """Preserves the incoming `--platforms` for constraint-declaring targets.
+
+    Incoming rule transitions run before Bazel evaluates a target's
+    `target_compatible_with`, so forcing `--platforms` to a default Apple
+    platform makes an explicit constraint such as `["@platforms//os:macos"]`
+    match vacuously. The target is then analyzed (instead of skipped as
+    incompatible) on host platforms that cannot build it, and analysis fails
+    during C++ toolchain resolution. Preserving the incoming `--platforms`
+    lets Bazel's incompatible-target skipping evaluate the constraints the
+    target actually declared: incompatible targets are silently skipped by
+    wildcard builds and report `<target> is incompatible and cannot be
+    built, but was explicitly requested` when requested directly.
+
+    See https://github.com/bazelbuild/rules_apple/issues/2442.
+
+    Note: an attribute configured with `select()` is not readable from a
+    transition (it reads as `None`), in which case the transition behaves
+    as it did before this change.
+
+    Args:
+        options: The `"//command_line_option"`s dictionary computed for the
+            current target, which this function may modify.
+        settings: The transition's incoming settings dictionary.
+        attr: The attributes of the current target.
+
+    Returns:
+        The (possibly modified) `options` dictionary.
+    """
+    if getattr(attr, "target_compatible_with", None):
+        options["//command_line_option:platforms"] = settings["//command_line_option:platforms"]
+    return options
+
 def _apple_rule_base_transition_impl(settings, attr):
     """Rule transition for Apple rules using Bazel CPUs and a valid Apple split transition."""
     minimum_os_version = attr.minimum_os_version
     platform_type = attr.platform_type
-    return _command_line_options(
-        environment_arch = _environment_archs(platform_type, minimum_os_version, settings)[0],
-        minimum_os_version = minimum_os_version,
-        platform_type = platform_type,
+    return _options_preserving_declared_constraints(
+        options = _command_line_options(
+            environment_arch = _environment_archs(platform_type, minimum_os_version, settings)[0],
+            minimum_os_version = minimum_os_version,
+            platform_type = platform_type,
+            settings = settings,
+        ),
         settings = settings,
+        attr = attr,
     )
 
 # These flags are a mix of options defined in native Bazel from the following fragments:
@@ -605,12 +642,16 @@ def _apple_platforms_rule_bundle_output_base_transition_impl(settings, attr):
         settings = settings,
         minimum_os_version = minimum_os_version,
     )
-    return _command_line_options(
-        environment_arch = environment_archs[0],
-        force_bundle_outputs = True,
-        minimum_os_version = minimum_os_version,
-        platform_type = platform_type,
+    return _options_preserving_declared_constraints(
+        options = _command_line_options(
+            environment_arch = environment_archs[0],
+            force_bundle_outputs = True,
+            minimum_os_version = minimum_os_version,
+            platform_type = platform_type,
+            settings = settings,
+        ),
         settings = settings,
+        attr = attr,
     )
 
 _apple_platforms_rule_bundle_output_base_transition = transition(


### PR DESCRIPTION
## 🤖 AI Disclaimer

I used Fable 5 to help generate this PR. We have successfully used this diff as a patch in our own fairly large monorepo with success, but please let me know if _anything_ seems not quite right or if there's anything else to consider with this fix (e.g. unintended second order effects, adding unit tests, etc).

Fixes #2442.

## Problem

The Apple rules' incoming rule transitions rewrite `--platforms` to a default Apple platform. This happens before Bazel evaluates the target's `target_compatible_with`, so an explicit constraint such as `["@platforms//os:macos"]` is checked against a platform that is already macOS and matches vacuously. The target is therefore never skipped as incompatible; on a non-Apple host, analysis proceeds into toolchain resolution and hard-fails:

```
While resolving toolchains for target //:app: No matching toolchains found for types:
  @bazel_tools//tools/cpp:toolchain_type
```

This is why `bazel build //...` on Linux breaks outright for workspaces containing a `macos_application`, while a plain `cc_binary` with the same constraint is skipped cleanly (Bazel's direct-incompatibility check runs before toolchain resolution — the transition defeats it).

## Fix

When a target explicitly declares `target_compatible_with`, the rule transition now preserves the incoming `--platforms` instead of forcing the default Apple platform, so incompatible-target skipping evaluates the constraints the target actually declared. Wildcard builds silently skip the target on incompatible platforms; explicit requests report the standard `is incompatible and cannot be built, but was explicitly requested` error.

- Targets that don't set `target_compatible_with` are unaffected (and a `select()`-valued attribute reads as `None` inside a transition, which also preserves existing behavior).
- The universal-binary and arm64-as-arm64e transitions inherit the fix via `_apple_rule_base_transition_impl`; the bundle-output transition applies the same helper directly. The dep split transition and the xcframework transition are deliberately untouched, so per-arch compile/link configurations (`--macos_cpus` etc.) are unchanged.

## Verification

With a minimal workspace containing a `macos_application` with `target_compatible_with = ["@platforms//os:macos"]` (Bazel 9.1.1):

- Linux, unpatched: the toolchain resolution error above.
- Linux, patched: `bazel build //...` succeeds (target skipped); requesting the target explicitly reports the standard incompatibility error.
- macOS, patched: the app builds and signs as before; output artifacts and configuration directories are unchanged.

Also validated against a large production monorepo (both OSes) with no regressions in other Apple targets (`ios_application` etc.).

## Open question

I didn't find an existing harness for transition/incompatibility behavior — `analysistest` can't easily assert skipping since incompatibility propagates into the test rule itself. Happy to add a shell integration test (or whatever you'd prefer) — guidance welcome.