### PR TITLE
Fix macOS testing with newer OS versions

### DIFF
--- a/.github/workflows/macos-latest-xcode.yml
+++ b/.github/workflows/macos-latest-xcode.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-26
+    timeout-minutes: 120
+    concurrency:
+      group: macos-latest-xcode-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+
+          sw_vers
+          sudo xcode-select -s /Applications/Xcode_26.5.app
+          xcode-select -p
+          xcodebuild -version
+
+      - name: Test
+        run: |
+          set -euo pipefail
+
+          bazel test --test_output=errors --build_tests_only //examples/multi_platform/Buttons:ButtonsMacTests

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -123,7 +123,13 @@ def _macos_test_runner_impl(ctx):
     return [
         apple_provider.make_apple_test_runner_info(
             test_runner_template = ctx.outputs.test_runner_template,
-            execution_requirements = {"requires-darwin": ""},
+            # xcodebuild uses LaunchServices to start macOS test hosts. On
+            # macOS 26, LaunchServices strips XCTest's dynamic environment
+            # when xcodebuild is sandboxed, leaving the test session hung.
+            execution_requirements = {
+                "no-sandbox": "1",
+                "requires-darwin": "",
+            },
             execution_environment = _get_execution_environment(xcode_config),
         ),
         DefaultInfo(runfiles = runfiles),

--- a/apple/testing/default_runner/macos_test_runner.bzl
+++ b/apple/testing/default_runner/macos_test_runner.bzl
@@ -123,13 +123,7 @@ def _macos_test_runner_impl(ctx):
     return [
         apple_provider.make_apple_test_runner_info(
             test_runner_template = ctx.outputs.test_runner_template,
-            # xcodebuild uses LaunchServices to start macOS test hosts. On
-            # macOS 26, LaunchServices strips XCTest's dynamic environment
-            # when xcodebuild is sandboxed, leaving the test session hung.
-            execution_requirements = {
-                "no-sandbox": "1",
-                "requires-darwin": "",
-            },
+            execution_requirements = {"requires-darwin": ""},
             execution_environment = _get_execution_environment(xcode_config),
         ),
         DefaultInfo(runfiles = runfiles),

--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -104,9 +104,24 @@ fi
 # depending on whether the test is running with or without a test host.
 XCTESTRUN_TEST_BUNDLE_PATH="__TESTROOT__/$TEST_BUNDLE_NAME.xctest"
 if [[ -n "$TEST_HOST_PATH" ]]; then
-  XCTESTRUN_TEST_HOST_PATH="__TESTROOT__/$TEST_HOST_NAME.app"
-  XCTESTRUN_TEST_HOST_BASED=true
-  XCTESTRUN_TEST_HOST_BINARY="__TESTHOST__/Contents/MacOS/$TEST_HOST_NAME"
+  XCTESTRUN_TEST_HOST_BINARY="__TESTROOT__/$TEST_HOST_NAME.app/Contents/MacOS/$TEST_HOST_NAME"
+  if [[ "$(sw_vers -productVersion | cut -d. -f1)" -ge 26 ]]; then
+    # For app hosted test bundles xcodebuild launches the test host through
+    # LaunchServices. On macOS 26+, LaunchServices strips the environment
+    # variables XCTest needs (DYLD_INSERT_LIBRARIES, XCTestSessionIdentifier,
+    # etc.) from launch requests made by sandboxed processes, so the test
+    # session never starts and xcodebuild hangs until the test times out.
+    # Instead point xcodebuild at the test host's executable as if it were an
+    # unhosted test runner. xcodebuild then spawns it directly as a child
+    # process with the environment intact, the test bundle is still injected
+    # with libXCTestBundleInject, and the app still finishes launching before
+    # the tests start.
+    XCTESTRUN_TEST_HOST_PATH="$XCTESTRUN_TEST_HOST_BINARY"
+    XCTESTRUN_TEST_HOST_BASED=false
+  else
+    XCTESTRUN_TEST_HOST_PATH="__TESTROOT__/$TEST_HOST_NAME.app"
+    XCTESTRUN_TEST_HOST_BASED=true
+  fi
 else
   XCTESTRUN_TEST_HOST_PATH="__PLATFORMS__/MacOSX.platform/Developer/Library/Xcode/Agents/xctest"
   XCTESTRUN_TEST_HOST_BASED=false


### PR DESCRIPTION
This tests macOS unit tests which broke sometime since 26.0. This adds a GitHub actions CI job that validates this passes with Xcode 26.5 + Tahoe because buildkite CI is behind. We can remove this eventually. Without this fix the test times out trying to communicate with the test runner.

Fixes https://github.com/bazelbuild/rules_apple/issues/3031