### PR TITLE
Collect normal-mode profiles from XCUITest target apps

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.bzl
+++ b/apple/testing/default_runner/ios_xctestrun_runner.bzl
@@ -325,6 +325,60 @@ If you would like this test runner to generate xcresult bundles for your tests,
 pass `--test_env=CREATE_XCRESULT_BUNDLE=1`. It is preferable to use the
 `create_xcresult_bundle` on the test runner itself instead of this parameter.
 
+For an instrumented UI test host app, pass
+`--test_env=LLVM_PROFILE_FILE_FOR_TARGET_APP=%t/<name>-%p.profraw` to collect
+normal-mode profiles from the target app. `%t` resolves to the target app's
+temporary directory and `%p` gives each process a unique file. The app must
+exit normally or explicitly flush its profile. The profile runtime registers
+an automatic writer for normal process exit, so an explicit call is not
+mandatory when that writer runs and produces a fresh profile. To guarantee that
+the profile is committed at the end of a journey, before XCTest terminates the
+app or before a later crash or forced termination, call
+`__llvm_profile_write_file()` from the instrumented target app.
+
+Objective-C can use Apple Clang's instrumentation define:
+
+```objective-c
+#if __LLVM_INSTR_PROFILE_GENERATE
+extern int __llvm_profile_write_file(void);
+#endif
+
+BOOL WriteLLVMProfile(void) {
+#if __LLVM_INSTR_PROFILE_GENERATE
+  return __llvm_profile_write_file() == 0;
+#else
+  return NO;
+#endif
+}
+```
+
+Swift can import the Objective-C helper above, or declare the runtime entry
+point directly. The latter uses the underscored `@_silgen_name` attribute;
+define `LLVM_PROFILE_GENERATION` with `swiftc -D` only for the instrumented
+collection build:
+
+```swift
+#if LLVM_PROFILE_GENERATION
+@_silgen_name("__llvm_profile_write_file")
+private func llvmProfileWriteFile() -> Int32
+
+func writeLLVMProfile() -> Bool {
+  llvmProfileWriteFile() == 0
+}
+#endif
+```
+
+The call must run in the target app process because that process owns the
+profile counters and value records. A call or swizzle in the XCTest runner
+cannot directly flush another process. The runner enforces the observable
+contract: it fails when neither normal exit nor an explicit flush writes a
+fresh target-app profile, and `llvm-profdata merge` fails for invalid profiles.
+It cannot require a particular app method when the normal-exit writer already
+produced valid output. The runner preserves the raw files under
+`target-app-profraw` in the test's undeclared outputs and merges them into
+`Coverage.profdata`. Target app profile collection is only supported on
+simulators.
+
 This rule automatically handles running x86_64 tests on arm64 hosts. The only
 exception is that if you want to generate xcresult bundles or run tests in
 random order, the test must have a test host. This is because of a limitation

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -296,6 +296,59 @@ else
   xctestrun_test_host_based=false
 fi
 
+target_app_profile_file="${LLVM_PROFILE_FILE_FOR_TARGET_APP:-}"
+target_app_profile_glob=""
+target_app_profile_start=""
+xctestrun_ui_target_app_environment_section=""
+if [[ -n "$target_app_profile_file" ]]; then
+  if [[ "$build_for_device" == true ]]; then
+    echo "error: target app profile collection is only supported on simulators" >&2
+    exit 1
+  fi
+  if [[ "$test_type" != "XCUITEST" || -z "$test_host_path" ]]; then
+    echo "error: target app profile collection requires an XCUITest host app" >&2
+    exit 1
+  fi
+  if [[ "$target_app_profile_file" != "%t/"* ]]; then
+    echo "error: LLVM_PROFILE_FILE_FOR_TARGET_APP must start with %t/" >&2
+    exit 1
+  fi
+
+  target_app_profile_basename="${target_app_profile_file#"%t/"}"
+  if [[
+    -z "$target_app_profile_basename" ||
+      "$target_app_profile_basename" == */*
+  ]]; then
+    echo "error: LLVM_PROFILE_FILE_FOR_TARGET_APP must name a file directly under %t" >&2
+    exit 1
+  fi
+  if [[ "$target_app_profile_basename" != *"%p"* ]]; then
+    echo "error: LLVM_PROFILE_FILE_FOR_TARGET_APP must contain %p" >&2
+    exit 1
+  fi
+  if [[
+    "$target_app_profile_basename" == *"*"* ||
+      "$target_app_profile_basename" == *"?"* ||
+      "$target_app_profile_basename" == *"["*
+  ]]; then
+    echo "error: LLVM_PROFILE_FILE_FOR_TARGET_APP cannot contain glob characters" >&2
+    exit 1
+  fi
+
+  target_app_profile_glob="${target_app_profile_basename//%p/*}"
+  if [[ "$target_app_profile_glob" == *"%"* ]]; then
+    echo "error: LLVM_PROFILE_FILE_FOR_TARGET_APP only supports %t and %p substitutions" >&2
+    exit 1
+  fi
+
+  escaped_target_app_profile_file=$(escape "$target_app_profile_file")
+  xctestrun_ui_target_app_environment_section="    <key>UITargetAppEnvironmentVariables</key>\n"
+  xctestrun_ui_target_app_environment_section+="    <dict>\n"
+  xctestrun_ui_target_app_environment_section+="      <key>LLVM_PROFILE_FILE</key>\n"
+  xctestrun_ui_target_app_environment_section+="      <string>$escaped_target_app_profile_file</string>\n"
+  xctestrun_ui_target_app_environment_section+="    </dict>"
+fi
+
 sanitizer_dyld_env=""
 readonly sanitizer_root="$test_tmp_dir/$test_bundle_name.xctest/Frameworks"
 for sanitizer in "$sanitizer_root"/libclang_rt.*.dylib; do
@@ -561,6 +614,7 @@ if [[ "$should_use_xcodebuild" == true ]]; then
     -e "s${sed_delim}BAZEL_INSERT_LIBRARIES${sed_delim}$xctestrun_libraries${sed_delim}g" \
     -e "s${sed_delim}BAZEL_TEST_BUNDLE_PATH${sed_delim}$xcrun_test_bundle_path${sed_delim}g" \
     -e "s${sed_delim}BAZEL_TEST_ENVIRONMENT${sed_delim}$xctestrun_env${sed_delim}g" \
+    -e "s${sed_delim}BAZEL_UI_TARGET_APP_ENVIRONMENT_SECTION${sed_delim}$xctestrun_ui_target_app_environment_section${sed_delim}g" \
     -e "s${sed_delim}BAZEL_TEST_HOST_BASED${sed_delim}$xctestrun_test_host_based${sed_delim}g" \
     -e "s${sed_delim}BAZEL_TEST_HOST_PATH${sed_delim}$xctestrun_test_host_path${sed_delim}g" \
     -e "s${sed_delim}BAZEL_TEST_HOST_BUNDLE_IDENTIFIER${sed_delim}$xcrun_test_host_bundle_identifier${sed_delim}g" \
@@ -580,6 +634,16 @@ if [[ "$should_use_xcodebuild" == true ]]; then
     -e "s${sed_delim}BAZEL_PRODUCT_PATH${sed_delim}$xcrun_test_bundle_path${sed_delim}g" \
     "%(xctestrun_template)s" \
     > "$xctestrun_file"
+
+  if [[ -n "$target_app_profile_file" ]]; then
+    test_product_module_name="${test_bundle_name//-/_}"
+    # These keys make Xcode select continuous mode, which cannot write LLVM
+    # value profile data. Xcode also requires that they be removed together.
+    /usr/libexec/PlistBuddy \
+      -c "Delete :$test_product_module_name:ClangProfileDataDirectoryPath" \
+      -c "Delete :__xctestrun_metadata__:CodeCoverageBuildableInfos" \
+      "$xctestrun_file"
+  fi
 
   if [[ -n "${DEBUG_XCTESTRUNNER:-}" ]]; then
     echo
@@ -611,6 +675,12 @@ if [[ "$should_use_xcodebuild" == true ]]; then
 
   if (( ${#custom_xcodebuild_args[@]} )); then
     args+=("${custom_xcodebuild_args[@]}")
+  fi
+
+  if [[ -n "$target_app_profile_file" ]]; then
+    # Ignore profile files left behind when a reusable simulator is selected.
+    target_app_profile_start="$test_tmp_dir/target-app-profile-start"
+    touch "$target_app_profile_start"
   fi
 
   xcodebuild test-without-building "${args[@]}" \
@@ -645,7 +715,63 @@ if [[ "$should_use_xcodebuild" == false ]]; then
   profdata="$test_tmp_dir/coverage.profdata"
 fi
 
-if [[ "${COLLECT_PROFDATA:-0}" == "1" && -f "$profdata" ]]; then
+if [[ -n "$target_app_profile_file" ]]; then
+  target_app_info_plist="$test_tmp_dir/$test_host_name.app/Info.plist"
+  target_app_bundle_identifier=$(
+    /usr/libexec/PlistBuddy \
+      -c "Print :CFBundleIdentifier" \
+      "$target_app_info_plist"
+  )
+  target_app_container=$(
+    xcrun simctl get_app_container \
+      "$simulator_id" \
+      "$target_app_bundle_identifier" \
+      data
+  )
+
+  target_app_profraws=()
+  while IFS= read -r target_app_profraw; do
+    target_app_profraws+=("$target_app_profraw")
+  done < <(
+    find \
+      "$target_app_container" \
+      -type f \
+      -name "$target_app_profile_glob" \
+      -newer "$target_app_profile_start" \
+      -print \
+      | sort
+  )
+
+  if (( ${#target_app_profraws[@]} == 0 )); then
+    echo \
+      "error: no fresh target app profiles matched $target_app_profile_glob;" \
+      "let the target app exit normally or call __llvm_profile_write_file()" \
+      "in the target app before XCTest terminates it" \
+      >&2
+    exit 1
+  fi
+
+  target_app_profraw_output_dir="$TEST_UNDECLARED_OUTPUTS_DIR/target-app-profraw"
+  mkdir -p "$target_app_profraw_output_dir"
+  for target_app_profraw in "${target_app_profraws[@]}"; do
+    cp "$target_app_profraw" "$target_app_profraw_output_dir/"
+  done
+
+  mkdir -p "$(dirname "$profdata")"
+  xcrun llvm-profdata \
+    merge \
+    "${target_app_profraws[@]}" \
+    --output "$profdata"
+  echo "Collected ${#target_app_profraws[@]} target app profile(s)"
+fi
+
+if [[
+  (
+    "${COLLECT_PROFDATA:-0}" == "1" ||
+      -n "$target_app_profile_file"
+  ) &&
+    -f "$profdata"
+]]; then
   cp -R "$profdata" "$TEST_UNDECLARED_OUTPUTS_DIR"
 fi
 

--- a/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.xctestrun
@@ -38,6 +38,7 @@
       <string>/DUMMY_SRCROOT/</string>
       BAZEL_TEST_ENVIRONMENT
     </dict>
+BAZEL_UI_TARGET_APP_ENVIRONMENT_SECTION
 BAZEL_ATTACHMENT_LIFETIME_SECTION
     <key>ClangProfileDataDirectoryPath</key>
     <string>BAZEL_COVERAGE_OUTPUT_DIR</string>

--- a/doc/rules-ios.md
+++ b/doc/rules-ios.md
@@ -679,6 +679,60 @@ If you would like this test runner to generate xcresult bundles for your tests,
 pass `--test_env=CREATE_XCRESULT_BUNDLE=1`. It is preferable to use the
 `create_xcresult_bundle` on the test runner itself instead of this parameter.
 
+For an instrumented UI test host app, pass
+`--test_env=LLVM_PROFILE_FILE_FOR_TARGET_APP=%t/<name>-%p.profraw` to collect
+normal-mode profiles from the target app. `%t` resolves to the target app's
+temporary directory and `%p` gives each process a unique file. The app must
+exit normally or explicitly flush its profile. The profile runtime registers
+an automatic writer for normal process exit, so an explicit call is not
+mandatory when that writer runs and produces a fresh profile. To guarantee that
+the profile is committed at the end of a journey, before XCTest terminates the
+app or before a later crash or forced termination, call
+`__llvm_profile_write_file()` from the instrumented target app.
+
+Objective-C can use Apple Clang's instrumentation define:
+
+```objective-c
+#if __LLVM_INSTR_PROFILE_GENERATE
+extern int __llvm_profile_write_file(void);
+#endif
+
+BOOL WriteLLVMProfile(void) {
+#if __LLVM_INSTR_PROFILE_GENERATE
+  return __llvm_profile_write_file() == 0;
+#else
+  return NO;
+#endif
+}
+```
+
+Swift can import the Objective-C helper above, or declare the runtime entry
+point directly. The latter uses the underscored `@_silgen_name` attribute;
+define `LLVM_PROFILE_GENERATION` with `swiftc -D` only for the instrumented
+collection build:
+
+```swift
+#if LLVM_PROFILE_GENERATION
+@_silgen_name("__llvm_profile_write_file")
+private func llvmProfileWriteFile() -> Int32
+
+func writeLLVMProfile() -> Bool {
+  llvmProfileWriteFile() == 0
+}
+#endif
+```
+
+The call must run in the target app process because that process owns the
+profile counters and value records. A call or swizzle in the XCTest runner
+cannot directly flush another process. The runner enforces the observable
+contract: it fails when neither normal exit nor an explicit flush writes a
+fresh target-app profile, and `llvm-profdata merge` fails for invalid profiles.
+It cannot require a particular app method when the normal-exit writer already
+produced valid output. The runner preserves the raw files under
+`target-app-profraw` in the test's undeclared outputs and merges them into
+`Coverage.profdata`. Target app profile collection is only supported on
+simulators.
+
 This rule automatically handles running x86_64 tests on arm64 hosts. The only
 exception is that if you want to generate xcresult bundles or run tests in
 random order, the test must have a test host. This is because of a limitation

--- a/test/ios_xctestrun_runner_ui_test.sh
+++ b/test/ios_xctestrun_runner_ui_test.sh
@@ -38,11 +38,16 @@ load(
     "@rules_apple//apple/testing/default_runner:ios_xctestrun_runner.bzl",
     "ios_xctestrun_runner"
 )
+load("@rules_cc//cc:objc_import.bzl", "objc_import")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 
 ios_xctestrun_runner(
     name = "ios_x86_64_sim_runner",
     device_type = "iPhone Xs",
+)
+
+ios_xctestrun_runner(
+    name = "ios_profile_sim_runner",
 )
 
 EOF
@@ -53,12 +58,66 @@ function create_ios_app() {
     fail "create_sim_runners must be called first."
   fi
 
+  local clang_resource_dir
+  clang_resource_dir="$(xcrun --sdk iphonesimulator clang -print-resource-dir)"
+  cp \
+    "$clang_resource_dir/lib/darwin/libclang_rt.profile_iossim.a" \
+    ios/libclang_rt.profile_iossim.a
+
   cat > ios/main.m <<EOF
 #import <UIKit/UIKit.h>
 
 int main(int argc, char * argv[]) {
   @autoreleasepool {
     return UIApplicationMain(argc, argv, nil, nil);
+  }
+}
+EOF
+
+  cat > ios/profiled_main.m <<EOF
+#import <UIKit/UIKit.h>
+
+#if !__LLVM_INSTR_PROFILE_GENERATE
+#error "profiled_app_lib must be compiled with profile instrumentation"
+#endif
+
+extern int __llvm_profile_write_file(void);
+
+typedef int (*ProfileOperation)(int);
+
+__attribute__((noinline))
+static int ProfileTarget(int value) {
+  return value + 1;
+}
+
+__attribute__((noinline))
+static int InvokeProfileTarget(ProfileOperation operation, int value) {
+  return operation(value);
+}
+
+@interface ProfiledAppDelegate : UIResponder <UIApplicationDelegate>
+
+@property(nonatomic, strong) UIWindow *window;
+
+@end
+
+@implementation ProfiledAppDelegate
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  (void)application;
+  NSCAssert(InvokeProfileTarget(ProfileTarget, 1) == 2, @"unexpected result");
+  NSCAssert(__llvm_profile_write_file() == 0, @"profile write failed");
+}
+
+@end
+
+int main(int argc, char * argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(
+        argc,
+        argv,
+        nil,
+        NSStringFromClass([ProfiledAppDelegate class]));
   }
 }
 EOF
@@ -89,6 +148,34 @@ ios_application(
     minimum_os_version = "${MIN_OS_IOS_NPLUS1}",
     provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
     deps = [":app_lib"],
+)
+
+objc_library(
+    name = "profiled_app_lib",
+    copts = ["-fprofile-generate"],
+    srcs = ["profiled_main.m"],
+)
+
+objc_import(
+    name = "profile_runtime",
+    archives = ["libclang_rt.profile_iossim.a"],
+)
+
+ios_application(
+    name = "profiled_app",
+    bundle_id = "my.profiled.bundle.id",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    linkopts = [
+        "-u",
+        "___llvm_profile_runtime",
+    ],
+    minimum_os_version = "${MIN_OS_IOS}",
+    provisioning_profile = "@rules_apple//test/testdata/provisioning:integration_testing_ios.mobileprovision",
+    deps = [
+        ":profile_runtime",
+        ":profiled_app_lib",
+    ],
 )
 EOF
 }
@@ -234,6 +321,15 @@ ios_ui_test(
     minimum_os_version = "${MIN_OS_IOS}",
     test_host = ":app",
     runner = ":ios_x86_64_sim_runner",
+)
+
+ios_ui_test(
+    name = "ProfiledUITest",
+    infoplists = ["PassUITest-Info.plist"],
+    deps = [":pass_ui_test_lib"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    test_host = ":profiled_app",
+    runner = ":ios_profile_sim_runner",
 )
 
 swift_library(
@@ -447,6 +543,33 @@ function test_ios_ui_test_with_env() {
   do_ios_test --test_env=ENV_KEY1=ENV_VALUE2 //ios:EnvUITest || fail "should pass"
 
   expect_log "Test Suite 'EnvUITest' passed"
+}
+
+function test_ios_ui_test_collects_target_app_profiles() {
+  create_sim_runners
+  create_ios_app
+  create_ios_ui_tests
+  do_ios_test \
+    --test_env=DEBUG_XCTESTRUNNER=1 \
+    '--test_env=LLVM_PROFILE_FILE_FOR_TARGET_APP=%t/rules-apple-%p.profraw' \
+    //ios:ProfiledUITest || fail "should pass"
+
+  expect_log "<key>UITargetAppEnvironmentVariables</key>"
+  expect_log "<key>LLVM_PROFILE_FILE</key>"
+  expect_log "<string>%t/rules-apple-%p.profraw</string>"
+  expect_not_log "<key>ClangProfileDataDirectoryPath</key>"
+  expect_not_log "<key>CodeCoverageBuildableInfos</key>"
+  expect_log "Collected 2 target app profile(s)"
+
+  local profile_report="$TEST_TMPDIR/target-app-profile.txt"
+  xcrun llvm-profdata show \
+    --all-functions \
+    --counts \
+    --ic-targets \
+    test-testlogs/ios/ProfiledUITest/test.outputs/Coverage.profdata \
+    > "$profile_report"
+  grep -q "Indirect Call Site Count: 1" "$profile_report" ||
+    fail "target app profile should contain indirect call target values"
 }
 
 function test_ios_ui_test_default_attachment_lifetime_arg() {


### PR DESCRIPTION
## 🤖 AI Disclaimer

I used Codex to help investigate, implement, and test this change. I reviewed
the resulting behavior against LLVM's profile format and exercised the
integration test locally.

## Problem

The `ios_xctestrun_runner` can collect coverage from the XCTest runner, but it
cannot currently put `LLVM_PROFILE_FILE` in the XCUITest target application's
environment or retrieve that application's raw profiles.

This matters for instrumentation PGO. The existing
`ClangProfileDataDirectoryPath` path selects compiler-rt continuous mode.
Continuous mode preserves counters, but its writer skips LLVM value profile
data, including indirect-call targets. A counter-complete profile can therefore
still be unusable for indirect-call promotion and profile-guided
devirtualization.

## Change

Passing:

```text
--test_env=LLVM_PROFILE_FILE_FOR_TARGET_APP=%t/<name>-%p.profraw
```

now makes the runner:

- set the target app's `LLVM_PROFILE_FILE` through
  `UITargetAppEnvironmentVariables`;
- remove `ClangProfileDataDirectoryPath` and its paired coverage metadata so
  Xcode does not select continuous mode;
- collect only raw files created during the current test run from the target
  app's simulator data container;
- fail when no fresh target-app profile was written;
- preserve those raws under `target-app-profraw` in undeclared outputs; and
- merge them into `Coverage.profdata`, failing if the profile is invalid.

The opt-in is restricted to simulator XCUITests with a host app. The pattern
must be a file directly under `%t`, contain `%p`, and use no other substitutions
or glob characters.

Compiler-rt registers an automatic writer for normal process exit, so calling
`__llvm_profile_write_file()` is not mandatory when that writer produces a
fresh profile. An explicit target-app call remains useful to guarantee that the
profile is committed at an exact journey boundary, before XCTest terminates the
app or before a later crash or forced termination. The rule documentation now
contains Objective-C and Swift examples.

This deliberately does not swizzle `XCUIApplication.terminate()`. A swizzle
runs in the XCTest runner and cannot directly call the profiling runtime in
another process. The runner instead enforces the observable result: normal exit
or an explicit target-app flush must produce a fresh, mergeable profile.

Related to #338.

## Verification

Tested locally with Bazel 9.2.0 and Xcode 26.5:

- `bazel build //apple/testing/default_runner:ios_default_runner`
- focused `test_ios_ui_test_collects_target_app_profiles` integration case
  through `//test:ios_xctestrun_runner_ui_test`
- `bazel test //doc:check_ios`
- `shellcheck test/ios_xctestrun_runner_ui_test.sh`
- buildifier and buildifier-lint 8.5.1 through pre-commit
- a reduced Swift 6.3.2 compile/run/merge check for the documented
  `@_silgen_name` declaration

The committed integration case launches an IR-instrumented target app twice,
explicitly flushes in the target process, collects two fresh raw profiles,
merges them, and verifies with `llvm-profdata show --ic-targets` that the merged
profile contains an indirect-call target record.

A local control app with the same instrumentation but no explicit flush also
produced two fresh profiles when XCUITest replaced and ended its processes on
the Xcode 26.5 simulator. That confirms an explicit call is not universally
required when compiler-rt's normal-exit writer runs; the explicit integration
call remains the deterministic journey-boundary example.
