### PR TITLE
Test no transition for build_test rules

### DIFF
--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -123,5 +123,4 @@ number (for example, `"9.0"`).
         },
         implementation = _apple_build_test_rule_impl,
         test = True,
-        cfg = transition_support.apple_rule_transition,
     )

--- a/test/starlark_tests/macos_build_test_tests.bzl
+++ b/test/starlark_tests/macos_build_test_tests.bzl
@@ -33,6 +33,7 @@ def macos_build_test_test_suite(name):
     macos_build_test(
         name = "{}_builds_simple_library".format(name),
         minimum_os_version = common.min_os_macos.baseline,
+        target_compatible_with = ["@platforms//os:macos"],
         targets = [
             "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
         ],


### PR DESCRIPTION
This makes it so you can use target_comaptible_with to scope these to
macOS to avoid building them on Linux

Reverts 7f75280edbb786b964bf31bfede4de2c5bb0c357
