### PR TITLE
Remove top level transitions from build_test rules

### DIFF
--- a/apple/internal/testing/build_test_rules.bzl
+++ b/apple/internal/testing/build_test_rules.bzl
@@ -24,6 +24,9 @@ load(
     "transition_support",
 )
 
+# TODO: Remove when we drop 8.x
+_CAN_CHAIN_TRANSITIONS = hasattr(transition_support.apple_rule_transition, "and_then")
+
 _PASSING_TEST_SCRIPT = """\
 #!/bin/bash
 exit 0
@@ -107,7 +110,7 @@ number (for example, `"9.0"`).
             ),
             "targets": attr.label_list(
                 allow_empty = False,
-                cfg = transition_support.apple_platform_split_transition,
+                cfg = transition_support.apple_rule_transition.and_then(transition_support.apple_platform_split_transition) if _CAN_CHAIN_TRANSITIONS else transition_support.apple_platform_split_transition,
                 doc = "The targets to check for successful build.",
             ),
             # This is a public attribute due to an implementation detail of
@@ -118,10 +121,6 @@ number (for example, `"9.0"`).
             "_platform_type": attr.string(default = platform_type),
         },
         doc = doc,
-        exec_groups = {
-            "test": exec_group(),
-        },
         implementation = _apple_build_test_rule_impl,
         test = True,
-        cfg = transition_support.apple_rule_transition,
     )

--- a/test/starlark_tests/ios_build_test_tests.bzl
+++ b/test/starlark_tests/ios_build_test_tests.bzl
@@ -36,6 +36,7 @@ def ios_build_test_test_suite(name):
         targets = [
             "//test/starlark_tests/resources:objc_lib_with_sdk_dylibs",
         ],
+        target_compatible_with = ["@platforms//os:macos"],
         tags = [name],
     )
 


### PR DESCRIPTION
This makes it so you can use target_comaptible_with to scope these to
macOS to avoid building them on Linux

This is a partial revert of 7f75280edbb786b964bf31bfede4de2c5bb0c357 but
works the same for 9.x
