### PR TITLE
Support cc_toolchains with rules_cc rule-based configs in triplet

### DIFF
--- a/apple/internal/cc_toolchain_info_support.bzl
+++ b/apple/internal/cc_toolchain_info_support.bzl
@@ -14,6 +14,59 @@
 
 """Support methods for handling CcToolchainInfo providers."""
 
+# Apple cpu name -> (architecture, normalized os, environment). Used to
+# recover the target platform for cc_toolchains built with rules_cc's
+# rule-based toolchain configuration, whose generated CcToolchainConfigInfo
+# hardcodes an empty target_system_name (see rules_cc
+# cc/toolchains/impl/toolchain_config.bzl).
+_APPLE_CPU_TRIPLETS = {
+    "darwin_arm64": ("arm64", "macos", "device"),
+    "darwin_arm64e": ("arm64e", "macos", "device"),
+    "darwin_x86_64": ("x86_64", "macos", "device"),
+    "ios_arm64": ("arm64", "ios", "device"),
+    "ios_arm64e": ("arm64e", "ios", "device"),
+    "ios_sim_arm64": ("arm64", "ios", "simulator"),
+    "ios_x86_64": ("x86_64", "ios", "simulator"),
+    "tvos_arm64": ("arm64", "tvos", "device"),
+    "tvos_sim_arm64": ("arm64", "tvos", "simulator"),
+    "tvos_x86_64": ("x86_64", "tvos", "simulator"),
+    "visionos_arm64": ("arm64", "visionos", "device"),
+    "visionos_sim_arm64": ("arm64", "visionos", "simulator"),
+    "watchos_arm64": ("arm64", "watchos", "simulator"),
+    "watchos_device_arm64": ("arm64", "watchos", "device"),
+    "watchos_device_arm64e": ("arm64e", "watchos", "device"),
+    "watchos_arm64_32": ("arm64_32", "watchos", "device"),
+    "watchos_armv7k": ("armv7k", "watchos", "device"),
+    "watchos_x86_64": ("x86_64", "watchos", "simulator"),
+}
+
+def _triplet_from_rule_based_config(cc_toolchain):
+    """Recovers the Apple platform from a rule-based cc_toolchain's config label.
+
+    rules_cc's rule-based toolchain configuration reports an empty
+    `target_system_name`. The generated config target is named
+    `_<toolchain name>_config`, so match the toolchain name's suffix against
+    the conventional Apple cpu names to recover the platform.
+
+    Args:
+        cc_toolchain: CcToolchainInfo provider with no target triplet.
+    Returns:
+        A normalized Clang target triplet struct, or None if the config label
+        does not end in a recognized Apple cpu name.
+    """
+    config_name = cc_toolchain.toolchain_id.split(":")[-1]
+    toolchain_name = config_name.removeprefix("_").removesuffix("_config")
+    for cpu in sorted(_APPLE_CPU_TRIPLETS, key = len, reverse = True):
+        if toolchain_name == cpu or toolchain_name.endswith("_" + cpu):
+            architecture, os, environment = _APPLE_CPU_TRIPLETS[cpu]
+            return struct(
+                architecture = architecture,
+                vendor = "apple",
+                os = os,
+                environment = environment,
+            )
+    return None
+
 def _get_apple_clang_triplet(cc_toolchain):
     """Parses and performs normalization on Clang target triplet string reference.
 
@@ -27,6 +80,16 @@ def _get_apple_clang_triplet(cc_toolchain):
     Returns:
         A normalized Clang target triplet struct for Apple targets.
     """
+    if "-" not in cc_toolchain.target_gnu_system_name:
+        rule_based_triplet = _triplet_from_rule_based_config(cc_toolchain)
+        if rule_based_triplet:
+            return rule_based_triplet
+        fail(("Cannot determine the Apple target triplet: cc_toolchain '{}' " +
+              "has no target_system_name and its config label does not end " +
+              "in a recognized Apple cpu name.").format(
+            cc_toolchain.toolchain_id,
+        ))
+
     components = cc_toolchain.target_gnu_system_name.split("-")
     raw_triplet = struct(
         architecture = components[0],


### PR DESCRIPTION

`rules_cc` rule-based toolchain configuration (cc/toolchains/...) generates a `CcToolchainConfigInfo` with an empty target_system_name. Importing a framework/xcframework under such a toolchain crashes` _get_apple_clang_triplet`

When `target_gnu_system_name `carries no triple, recover the Apple platform from the toolchain's generated config label instead (rules_cc names it _<toolchain name>_config), matching the toolchain name against the conventional Apple cpu names, and fail with a descriptive message when that is not possible.