### PR TITLE
Constrain macOS-only tool rules to macOS execution platforms

### DIFF
--- a/apple/BUILD
+++ b/apple/BUILD
@@ -285,6 +285,9 @@ bzl_library(
 
 cc_toolchain_forwarder(
     name = "default_cc_toolchain_forwarder",
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
 )
 
 # Consumed by bazel tests.

--- a/apple/internal/apple_toolchains.bzl
+++ b/apple/internal/apple_toolchains.bzl
@@ -151,7 +151,12 @@ def _apple_mac_tools_toolchain_impl(ctx):
 apple_mac_tools_toolchain = rule(
     attrs = {
         "alticonstool": attr.label(
-            cfg = "exec",
+            # Like the other tools here: the toolchain is already resolved
+            # for a mac execution platform, so "target" keeps the tool in the
+            # same configuration; "exec" would re-resolve against the first
+            # execution platform (which can be non-mac in cross-compilation
+            # setups).
+            cfg = "target",
             executable = True,
             doc = """
 A `File` referencing a tool to insert alternate icons entries in the app bundle's `Info.plist`.

--- a/apple/internal/environment_plist.bzl
+++ b/apple/internal/environment_plist.bzl
@@ -103,6 +103,9 @@ This rule generates the plist containing the required variables about the versio
 being built for and with. This is used by Apple when submitting to the App Store. This reduces the
 amount of duplicative work done generating these plists for the same platforms.
 """,
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
     fragments = ["apple"],
     outputs = {"plist": "%{name}.plist"},
     implementation = _environment_plist_impl,

--- a/apple/internal/resource_rules/apple_intent_library.bzl
+++ b/apple/internal/resource_rules/apple_intent_library.bzl
@@ -112,6 +112,10 @@ def _apple_intent_library_impl(ctx):
 
 apple_intent_library = rule(
     implementation = _apple_intent_library_impl,
+    # Runs xcrun intentbuilderc, a macOS-only tool.
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
     exec_groups = apple_toolchain_utils.use_apple_exec_group_toolchain(),
     attrs = dicts.add(
         apple_support.platform_constraint_attrs(),

--- a/apple/internal/resource_rules/apple_metal_library.bzl
+++ b/apple/internal/resource_rules/apple_metal_library.bzl
@@ -110,6 +110,10 @@ def _apple_metal_library_impl(ctx):
     ]
 
 apple_metal_library = rule(
+    # Runs xcrun metal/metallib, macOS-only tools.
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
     exec_groups = apple_toolchain_utils.use_apple_exec_group_toolchain(),
     attrs = dicts.add(
         apple_support.platform_constraint_attrs(),

--- a/apple/versioning.bzl
+++ b/apple/versioning.bzl
@@ -275,4 +275,7 @@ Provides:
   AppleBundleVersionInfo: Contains a reference to the JSON file that holds the
       version information for a bundle.
 """,
+    exec_compatible_with = [
+        "@platforms//os:macos",
+    ],
 )


### PR DESCRIPTION
Constrain macOS-only tool rules to macOS execution platforms

Several standalone tool rules run macOS-only tools but carry no execution-platform constraint which causes failures where there are multiple execution platforms available. E.g. RBE with a linux toolchains (see [rules_applecross](https://github.com/apple-cross-toolchain/rules_applecross/))

Also switch `apple_mac_tools_toolchain`  `alticonstool to cfg = "target"` like the toolchain's other tool attributes: the toolchain target is already resolved for a mac execution platform, so "exec" would re-resolve against the first registered execution platform.