### PR TITLE
Contain xcodebuild's derived data in the test's temp dir

### DIFF
--- a/apple/testing/default_runner/ios_xctestrun_runner.template.sh
+++ b/apple/testing/default_runner/ios_xctestrun_runner.template.sh
@@ -615,6 +615,16 @@ if [[ "$should_use_xcodebuild" == true ]]; then
     -xctestrun "$xctestrun_file" \
   )
 
+  # Contain everything xcodebuild writes to disk. Without -derivedDataPath,
+  # every invocation creates a ~/Library/Developer/Xcode/DerivedData/
+  # temporary-<hash>/ directory that nothing ever deletes: when no result
+  # bundle path is passed it receives a full .xcresult of the run, and even
+  # with one it still leaks a bookkeeping directory per run. Pointing derived
+  # data into the test's temp dir routes all of it somewhere the runner
+  # already deletes on exit. An explicit -resultBundlePath (below, or via
+  # xcodebuild_args) still wins for the result bundle itself.
+  args+=(-derivedDataPath "$test_tmp_dir/derived_data")
+
   if [[ -n "$destination_timeout" ]]; then
     args+=(-destination-timeout "$destination_timeout")
   fi


### PR DESCRIPTION
Every `xcodebuild test-without-building` invocation creates a `~/Library/Developer/Xcode/DerivedData/temporary-<hash>/` directory that nothing ever deletes. When the runner does not pass `-resultBundlePath` — i.e. any xcodebuild-path run without `create_xcresult_bundle` — that directory receives a **full `.xcresult` of the run**; and passing `-resultBundlePath` alone does not fix it, a bookkeeping directory still leaks per run.

One development machine had accumulated **267 of these directories totaling 26GB**. Every CI agent running simulator tests through the xcodebuild path leaks one per test run, silently.

Fix: pass `-derivedDataPath` pointed into the runner's `test_tmp_dir`, which the existing EXIT trap already deletes. An explicit `-resultBundlePath` (from `create_xcresult_bundle` or `xcodebuild_args`) still wins for the result bundle itself.

## Measurements

New DerivedData `temporary-*` directories created per invocation (Xcode 26.2, iOS 26.2 simulator, hosted unit test):

| xcodebuild flags | new dirs per run | contents |
|---|---|---|
| (none — today's runner without `create_xcresult_bundle`) | **1** | 152K, including a complete orphan `.xcresult` |
| `-resultBundlePath` only | **1** | 24K bookkeeping |
| `-derivedDataPath` (this PR) | **0** | — |
| both | **0** | — |

End-to-end through the runner after this change: default mode, dir count unchanged across runs (was +1 per run); with `create_xcresult_bundle = True`, the bundle still lands in `TEST_UNDECLARED_OUTPUTS_DIR` (verified present in `outputs.zip`) and DerivedData stays untouched.

## Steps to reproduce the leak

```sh
ls -d ~/Library/Developer/Xcode/DerivedData/temporary-* | wc -l
# run any hosted test through ios_xctestrun_runner without create_xcresult_bundle,
# e.g. a unit test with a test_host (forces the xcodebuild path):
bazel test //your:HostedTest --runner=@rules_apple//apple/testing/default_runner:ios_xctestrun_ordered_runner --nocache_test_results
ls -d ~/Library/Developer/Xcode/DerivedData/temporary-* | wc -l   # +1, forever
```

## Test plan

- [x] Manual `xcodebuild test-without-building` flag matrix above (each variant run against the same xctestrun).
- [x] Runner end-to-end: default mode creates no DerivedData directories; `CREATE_XCRESULT_BUNDLE=1` still produces `tests.xcresult` in undeclared outputs with DerivedData untouched.
- [x] Rendered template passes `bash -n`.
