### PR TITLE
fix macos_test_runner for swift-testing only targets

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -267,8 +267,16 @@ if [[ $parallel_testing_enabled == true ]]; then
 else
   echo "Testing is serialized" >&2
   xctest_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} test.*," "$testlog" | tail -n1 || true)
-  if echo "$xctest_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
-    echo "No tests ran -> count line was 0" >&2
+  swift_testing_target_execution_count=$(grep -e "Test run with [[:digit:]]\{1,\} test.*" "$testlog" | tail -n1 || true)
+  if echo "$xctest_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures" && \
+    [ -z "$swift_testing_target_execution_count" ] ; then
+    echo "No tests ran -> no count lines found" >&2
+    no_tests_ran=true
+  fi
+
+  if echo "$xctest_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures" && \
+    echo "$swift_testing_target_execution_count" | grep -q -e "Test run with 0 tests" ; then
+    echo "No tests ran -> count lines were 0" >&2
     no_tests_ran=true
   fi
 fi


### PR DESCRIPTION
Fixes this error when running a `macos_unit_test` against `rules_apple@HEAD` with no XCTests and some swift-testing tests:

```
Test Suite 'All tests' started at 2026-08-21 15:19:45.960.
Test Suite 'All tests' passed at 2026-08-21 15:19:45.960.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
- Test run started.
- Testing Library Version: 1902
- Target Platform: arm64e-apple-macos14.0
...
- Test run with 1 test in 0 suites passed after 0.012 seconds.
2026-08-21 14:19:46.247 xcodebuild[7284:36528] [MT] IDETestOperationsObserverDebug: 0.942 elapsed -- Testing started completed.
2026-08-21 14:19:46.247 xcodebuild[7284:36528] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2026-08-21 14:19:46.247 xcodebuild[7284:36528] [MT] IDETestOperationsObserverDebug: 0.942 sec, +0.942 sec -- end

...

** TEST EXECUTE SUCCEEDED **

Testing started
Testing is serialized
No tests ran -> count line was 0
error: no tests were executed, is the test bundle empty?
```