### PR TITLE
Document the test-binary-size memory multiplier and the strip mitigation

### DIFF
--- a/apple/internal/rule_attrs.bzl
+++ b/apple/internal/rule_attrs.bzl
@@ -322,6 +322,16 @@ def _test_bundle_attrs():
                 "@apple_support//lib:swizzle_absolute_xcttestsourcelocation",
             ),
         ),
+        "_attachment_payload_shim": attr.label(
+            default = Label(
+                "//apple/testing/default_runner:attachment_payload_shim",
+            ),
+        ),
+        "_test_output_redirect_shim": attr.label(
+            default = Label(
+                "//apple/testing/default_runner:test_output_redirect_shim",
+            ),
+        ),
     }
 
 def _test_host_attrs(

--- a/apple/internal/testing/apple_test_bundle_support.bzl
+++ b/apple/internal/testing/apple_test_bundle_support.bzl
@@ -228,6 +228,26 @@ def _apple_test_bundle_impl(*, ctx, product_type):
 
     extra_link_inputs = []
 
+    # Memory shims for tests driven through `xcodebuild test-without-building`:
+    # linked the same way as the swizzle library below, activated by the
+    # environment variables the test rule sets for the matching feature.
+    shim_targets = []
+    if ("apple.test_drop_attachment_payloads" in features or
+        "apple.test_spill_attachment_payloads" in features):
+        shim_targets.append(ctx.attr._attachment_payload_shim)
+    if "apple.test_redirect_stdout" in features:
+        shim_targets.append(ctx.attr._test_output_redirect_shim)
+    for shim_target in shim_targets:
+        for linker_input in shim_target[CcInfo].linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                static_library = library.static_library
+                extra_link_inputs.append(static_library)
+                extra_linkopts.append(
+                    "-Wl,-force_load,{}".format(static_library.path),
+                )
+            extra_link_inputs.extend(linker_input.additional_inputs)
+            extra_linkopts.extend(linker_input.user_link_flags)
+
     if "apple.swizzle_absolute_xcttestsourcelocation" in features:
         # `linking_support.register_binary_linking_action` uses
         # `apple_common.link_multi_arch_binary`, which doesn't allow specifying

--- a/apple/internal/testing/apple_test_rule_support.bzl
+++ b/apple/internal/testing/apple_test_rule_support.bzl
@@ -199,6 +199,26 @@ def _get_main_thread_checker_test_environment(*, features):
         }
     return {}
 
+def _get_test_memory_shim_environment(*, features):
+    """Returns the environment variables that activate the test memory shims.
+
+    Args:
+        features: List of features enabled by the user. Typically from `ctx.features`.
+    Returns:
+        dict: Environment variables activating the shims linked into the test
+        bundle by `apple_test_bundle_support` for the same features. See
+        `//apple/testing/default_runner:attachment_payload_shim` and
+        `:test_output_redirect_shim` for what each mode does.
+    """
+    test_env = {}
+    if "apple.test_drop_attachment_payloads" in features:
+        test_env["RULES_APPLE_ATTACHMENT_PAYLOADS"] = "drop"
+    elif "apple.test_spill_attachment_payloads" in features:
+        test_env["RULES_APPLE_ATTACHMENT_PAYLOADS"] = "spill"
+    if "apple.test_redirect_stdout" in features:
+        test_env["RULES_APPLE_REDIRECT_TEST_OUTPUT"] = "stdout"
+    return test_env
+
 def _get_simulator_test_environment(
         *,
         command_line_test_env,
@@ -258,6 +278,7 @@ def _get_simulator_test_environment(
         runner_test_env_copy,
         test_env_dyld_insert_pairs,
         _get_main_thread_checker_test_environment(features = features),
+        _get_test_memory_shim_environment(features = features),
     )
 
 def _apple_test_rule_impl(*, ctx, requires_dossiers, test_type):

--- a/apple/testing/default_runner/BUILD
+++ b/apple/testing/default_runner/BUILD
@@ -1,4 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(
@@ -176,4 +177,20 @@ filegroup(
     visibility = [
         "//:__subpackages__",
     ],
+)
+
+objc_library(
+    name = "attachment_payload_shim",
+    testonly = True,
+    srcs = ["attachment_payload_shim.m"],
+    visibility = ["//visibility:public"],
+    alwayslink = True,
+)
+
+objc_library(
+    name = "test_output_redirect_shim",
+    testonly = True,
+    srcs = ["test_output_redirect_shim.m"],
+    visibility = ["//visibility:public"],
+    alwayslink = True,
 )

--- a/apple/testing/default_runner/attachment_payload_shim.m
+++ b/apple/testing/default_runner/attachment_payload_shim.m
@@ -1,0 +1,88 @@
+// Optional memory shim for tests run through `xcodebuild test-without-building`.
+//
+// XCTAttachment payloads transit xcodebuild's memory at ~1.4x their size on
+// their way into the result bundle - even when the configured attachment
+// lifetime discards them at finalization, and even when no result bundle was
+// requested. For attachment-heavy suites this dominates the harness's memory
+// footprint and limits how many simulators a machine can run in parallel.
+//
+// Link this library into a test's `deps` and set the environment variable
+// RULES_APPLE_ATTACHMENT_PAYLOADS (e.g. via the test rule's `env` attribute):
+//   - "drop":  payloads over 4KB are replaced with a short note. Use when the
+//              attachment lifetime is "keepNever" - the payloads were going to
+//              be discarded after transfer anyway.
+//   - "spill": payloads over 4KB are written to
+//              $TEST_UNDECLARED_OUTPUTS_DIR/spilled_attachments/ (delivered in
+//              Bazel's test outputs zip) and replaced in the attachment with a
+//              note naming the file.
+//   - unset or anything else: the shim does nothing.
+//
+// The shim intercepts XCTAttachment's public designated initializer, so it
+// covers every data-based attachment from any library. It fails open: if the
+// class or selector is missing (a future Xcode restructuring), it logs and
+// leaves XCTest untouched.
+#import <Foundation/Foundation.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+static IMP gOriginalInit;
+static BOOL gSpill;
+
+static id RulesAppleAttachmentInit(id self, SEL _cmd, NSString *uti, NSString *name,
+                                   NSData *payload, NSDictionary *userInfo) {
+  NSData *replacement = payload;
+  if (payload.length > 4096) {
+    NSString *note = nil;
+    if (gSpill) {
+      const char *outDir = getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+      if (outDir) {
+        NSString *dir = [[NSString stringWithUTF8String:outDir]
+            stringByAppendingPathComponent:@"spilled_attachments"];
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                                  withIntermediateDirectories:YES
+                                                   attributes:nil
+                                                        error:nil];
+        NSString *file = [dir stringByAppendingPathComponent:
+            [NSString stringWithFormat:@"%@-%@", [NSUUID UUID].UUIDString,
+                                       name ?: @"attachment"]];
+        if ([payload writeToFile:file atomically:NO]) {
+          note = [NSString stringWithFormat:@"attachment payload (%lu bytes) spilled to %@",
+                                            (unsigned long)payload.length, file];
+        }
+      }
+    } else {
+      note = [NSString stringWithFormat:
+          @"attachment payload (%lu bytes) dropped (RULES_APPLE_ATTACHMENT_PAYLOADS=drop)",
+          (unsigned long)payload.length];
+    }
+    if (note) {
+      NSLog(@"RulesAppleAttachmentShim: %@", note);
+      replacement = [note dataUsingEncoding:NSUTF8StringEncoding];
+    }
+  }
+  typedef id (*InitFn)(id, SEL, NSString *, NSString *, NSData *, NSDictionary *);
+  return ((InitFn)gOriginalInit)(self, _cmd, uti, name, replacement, userInfo);
+}
+
+__attribute__((constructor)) static void RulesAppleInstallAttachmentShim(void) {
+  const char *mode = getenv("RULES_APPLE_ATTACHMENT_PAYLOADS");
+  if (!mode) return;
+  if (strcmp(mode, "spill") == 0) {
+    gSpill = YES;
+  } else if (strcmp(mode, "drop") != 0) {
+    return;
+  }
+  Class cls = objc_getClass("XCTAttachment");
+  if (!cls) {
+    NSLog(@"RulesAppleAttachmentShim: XCTAttachment class not found; shim inactive");
+    return;
+  }
+  SEL sel = sel_getUid("initWithUniformTypeIdentifier:name:payload:userInfo:");
+  Method m = class_getInstanceMethod(cls, sel);
+  if (!m) {
+    NSLog(@"RulesAppleAttachmentShim: designated initializer not found; shim inactive");
+    return;
+  }
+  gOriginalInit = method_setImplementation(m, (IMP)RulesAppleAttachmentInit);
+  NSLog(@"RulesAppleAttachmentShim: installed (%s mode)", gSpill ? "spill" : "drop");
+}

--- a/apple/testing/default_runner/test_output_redirect_shim.m
+++ b/apple/testing/default_runner/test_output_redirect_shim.m
@@ -1,0 +1,53 @@
+// Optional memory shim for tests run through `xcodebuild test-without-building`.
+//
+// xcodebuild captures the test process's stdout/stderr into its structured
+// session log with roughly 26x per-byte memory overhead: 300MB of test output
+// drives the xcodebuild client to ~8GB resident. For log-heavy suites this -
+// not attachments - is usually what limits simulator parallelism.
+//
+// Link this library into a test's `deps` and set
+// RULES_APPLE_REDIRECT_TEST_OUTPUT (e.g. via the test rule's `env`
+// attribute) to choose which of the test process's streams are redirected at
+// load time to $TEST_UNDECLARED_OUTPUTS_DIR/test_process_output.log (which
+// Bazel delivers in the test outputs zip):
+//   - "stdout": redirect standard output (Swift `print`, C stdio).
+//   - "stderr": redirect standard error (NSLog and friends).
+//   - "all":    redirect both.
+//
+// IMPORTANT: XCTest emits its own test-result lines ("Test Suite ...",
+// "Executed N tests") on one of these streams, and the test runner greps
+// them to decide whether tests ran. Redirecting the stream that carries them
+// breaks that verdict. Only redirect the stream your suite actually spams;
+// see the target's documentation for which modes are safe with
+// ios_xctestrun_runner.
+#import <Foundation/Foundation.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+__attribute__((constructor)) static void RulesAppleInstallOutputRedirect(void) {
+  const char *mode = getenv("RULES_APPLE_REDIRECT_TEST_OUTPUT");
+  if (!mode) return;
+  int redirect_out = strcmp(mode, "stdout") == 0 || strcmp(mode, "all") == 0;
+  int redirect_err = strcmp(mode, "stderr") == 0 || strcmp(mode, "all") == 0;
+  if (!redirect_out && !redirect_err) return;
+  const char *outDir = getenv("TEST_UNDECLARED_OUTPUTS_DIR");
+  if (!outDir) {
+    NSLog(@"RulesAppleOutputRedirect: TEST_UNDECLARED_OUTPUTS_DIR unset; redirect inactive");
+    return;
+  }
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path), "%s/test_process_output.log", outDir);
+  int fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (fd < 0) {
+    NSLog(@"RulesAppleOutputRedirect: cannot open %s; redirect inactive", path);
+    return;
+  }
+  // Announce before redirecting so the pointer survives in the session log.
+  NSLog(@"RulesAppleOutputRedirect: %s -> %s", mode, path);
+  if (redirect_out) dup2(fd, STDOUT_FILENO);
+  if (redirect_err) dup2(fd, STDERR_FILENO);
+  close(fd);
+}

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -529,6 +529,32 @@ have the paths made absolute via swizzling by enabling the
 set the `BUILD_WORKSPACE_DIRECTORY` environment variable in your scheme to the
 root of your workspace (i.e. `$(SRCROOT)`).
 
+### Reducing test harness memory
+
+`xcodebuild test-without-building` buffers two classes of test payload in its
+own memory, which for attachment- or log-heavy suites dominates the harness's
+footprint and limits how many simulators a machine can run in parallel:
+`XCTAttachment` payloads transit the client at ~1.4x their size (even under an
+attachment lifetime of `keepNever`, which discards them only after the
+transfer), and the test process's console output is captured into the
+structured session log at roughly 26x per byte.
+
+Three opt-in features link a small shim into the test bundle and activate it
+through the test environment:
+
+*   `--features=apple.test_drop_attachment_payloads`: attachment payloads over 4KB
+    are replaced with a short note before reaching XCTest. Intended for suites
+    running with `attachment_lifetime = "keepNever"`, where the payloads would
+    be discarded after transfer anyway.
+*   `--features=apple.test_spill_attachment_payloads`: payloads are written to
+    `$TEST_UNDECLARED_OUTPUTS_DIR/spilled_attachments/` (delivered in Bazel's
+    test outputs zip) and the attachment carries a note naming the file.
+*   `--features=apple.test_redirect_stdout`: the test process's standard
+    output is redirected at load time to
+    `$TEST_UNDECLARED_OUTPUTS_DIR/test_process_output.log`. Only stdout is
+    redirected: XCTest reports test results on stderr, and the test runner
+    relies on those lines to detect that tests ran.
+
 ### Xcode Version Selection and Invalidation
 
 There are a few steps required to properly make Bazel use the right Xcode version. Moreover, a few tricks are needed to make sure that the Bazel server is restarted and certain caches cleared when changing Xcode version using `xcode-select`.

--- a/doc/common_info.md
+++ b/doc/common_info.md
@@ -555,6 +555,44 @@ through the test environment:
     redirected: XCTest reports test results on stderr, and the test runner
     relies on those lines to detect that tests ran.
 
+#### Test binary size is a memory multiplier
+
+At session start - before any test runs, on green runs included - xcodebuild
+eagerly builds an out-of-process symbolication service
+(`XCTOutOfProcessSymbolicationService`) that reads the test bundle and every
+binary in the session into memory, alongside other whole-binary reads while
+constructing the test session. Measured on Xcode 26.2, xcodebuild's peak
+memory grows by roughly **9x the size of the test host binary**, linearly
+(a 100MB host adds ~900MB to the harness; 300MB adds ~2.7GB). Combined with
+the payload classes above, the harness peak is approximately:
+
+    ~230MB fixed + 9x host binary size + 1.4x attachment bytes + 26x console-output bytes
+
+There is no switch that disables the eager symbolication pass:
+`-collect-test-diagnostics never`, attachment lifetimes, and the
+symbolication-related environment variables XCTest consults in-process
+(`XCTDisableAggressiveSymbolication`, `XCT_IMAGE_NAMES_FOR_SYMBOLICATION`)
+were each measured to have no effect on it.
+
+The lever that works is shrinking what gets read. Unstripped Bazel-linked
+binaries carry their full symbol table and debug map in `__LINKEDIT`; on CI
+configurations where lldb-quality symbols in the built products are not
+needed, stripping them at link time is nearly free (relink only, no
+recompile) and directly reduces the multiplier's input:
+
+```
+# CI: the test harness reads test binaries into memory at ~9x their size,
+# so strip local symbols (-x) and the debug map (-S) from linked binaries.
+build:ci --linkopt=-Wl,-x --linkopt=-Wl,-S
+```
+
+Measured on a large modular app (500+ deps), this shrank the test host
+673MB -> 500MB and cut xcodebuild's peak by 26%. The trade-off: symbolicated
+backtraces for crash reports of these binaries degrade to exported symbols
+only (XCTest assertion failures are unaffected - their source locations are
+compiled into the test code, not looked up through the symbol table). Keep
+the flags out of local development configs where lldb needs the symbols.
+
 ### Xcode Version Selection and Invalidation
 
 There are a few steps required to properly make Bazel use the right Xcode version. Moreover, a few tricks are needed to make sure that the Bazel server is restarted and certain caches cleared when changing Xcode version using `xcode-select`.

--- a/test/ios_xctestrun_runner_unit_test.sh
+++ b/test/ios_xctestrun_runner_unit_test.sh
@@ -1204,4 +1204,100 @@ function test_ios_unit_test_parallel_testing_no_tests_fail() {
   expect_log "Executed 1 out of 1 test: 1 fails locally."
 }
 
+function create_shim_canary_tests() {
+  cat > ios/shim_canary_test.m <<EOF
+#import <XCTest/XCTest.h>
+
+@interface AttachmentShimCanaryTest : XCTestCase
+@end
+
+@implementation AttachmentShimCanaryTest
+- (void)testLargePayloadIntercepted {
+  // 256KB payload: over the shim's 4KB threshold, so with
+  // RULES_APPLE_ATTACHMENT_PAYLOADS=drop the payload must be replaced before
+  // it reaches XCTest. This is the canary for a future Xcode rerouting
+  // XCTAttachment's designated initializer: if interception stops working,
+  // the expect_log assertions on the shim's output fail loudly.
+  XCTAttachment *attachment =
+      [XCTAttachment attachmentWithData:[NSMutableData dataWithLength:262144]];
+  attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+  [self addAttachment:attachment];
+  XCTAssertTrue(YES);
+}
+@end
+EOF
+
+  cat > ios/redirect_canary_test.m <<EOF
+#import <XCTest/XCTest.h>
+
+@interface OutputRedirectCanaryTest : XCTestCase
+@end
+
+@implementation OutputRedirectCanaryTest
+- (void)testStdoutRedirected {
+  // With RULES_APPLE_REDIRECT_TEST_OUTPUT=stdout this marker must land in
+  // test_process_output.log instead of the console; XCTest's own result
+  // lines ride stderr and must keep flowing so the runner's verdict works.
+  printf("CANARY_STDOUT_MARKER\n");
+  fflush(stdout);
+  XCTAssertTrue(YES);
+}
+@end
+EOF
+
+  cat >> ios/BUILD <<EOF
+objc_library(
+    name = "shim_canary_test_lib",
+    srcs = ["shim_canary_test.m"],
+)
+
+objc_library(
+    name = "redirect_canary_test_lib",
+    srcs = ["redirect_canary_test.m"],
+)
+
+ios_unit_test(
+    name = "AttachmentShimCanary",
+    infoplists = ["PassUnitTest-Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    runner = ":ios_x86_64_sim_runner",
+    test_host = ":app",
+    deps = [":shim_canary_test_lib"],
+)
+
+ios_unit_test(
+    name = "OutputRedirectShimCanary",
+    infoplists = ["PassUnitTest-Info.plist"],
+    minimum_os_version = "${MIN_OS_IOS}",
+    runner = ":ios_x86_64_sim_runner",
+    test_host = ":app",
+    deps = [":redirect_canary_test_lib"],
+)
+EOF
+}
+
+function test_ios_unit_test_attachment_payload_shim_drops() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  create_shim_canary_tests
+  do_ios_test --features=apple.test_drop_attachment_payloads //ios:AttachmentShimCanary || fail "should pass"
+
+  expect_log "RulesAppleAttachmentShim: installed (drop mode)"
+  expect_log "attachment payload (262144 bytes) dropped"
+  expect_log "Test Suite 'AttachmentShimCanaryTest' passed"
+}
+
+function test_ios_unit_test_output_redirect_shim_stdout() {
+  create_sim_runners
+  create_test_host_app
+  create_ios_unit_tests
+  create_shim_canary_tests
+  do_ios_test --features=apple.test_redirect_stdout //ios:OutputRedirectShimCanary || fail "should pass"
+
+  expect_log "RulesAppleOutputRedirect: stdout ->"
+  expect_not_log "CANARY_STDOUT_MARKER"
+  expect_log "Test Suite 'OutputRedirectCanaryTest' passed"
+}
+
 run_suite "ios_unit_test with iOS xctestrun runner bundling tests"


### PR DESCRIPTION
## Summary

Stacked on #3051 (contains its commit; only the last commit is new). Documents a third — and for large apps, dominant — test-harness memory class, plus the mitigation that works.

At session start, `xcodebuild test-without-building` eagerly builds an out-of-process symbolication service (`XCTOutOfProcessSymbolicationService`) that reads the test bundle and every session binary into memory — before any test runs, green runs included. Profiled on a large modular app (500+ deps), the two top allocation sites were the symbolication service's whole-binary/dSYM reads (~1.39GB) and test-session construction (~705MB).

## Measurements

Size-controlled experiment (Xcode 26.2): a hosted test whose host binary carries an inert `__TEXT` blob, so binary size is the only variable.

| Host binary | xcodebuild peak | delta / size |
|---|---|---|
| ~0MB | 231 MiB | — |
| 100MB | 1,134 MiB | **9.0×** |
| 300MB | 2,908 MiB | **8.9×** |

Linear at ~9× host size. Harness peak model, combining with #3051's measurements:

```
~230MB fixed + 9× host binary + 1.4× attachment bytes + 26× console-output bytes
```

**No off-switch exists.** Each of these was measured against the 300MB fixture with no effect: `-collect-test-diagnostics never`, attachment lifetimes, `XCTDisableAggressiveSymbolication`, `XCT_IMAGE_NAMES_FOR_SYMBOLICATION` (the latter two found by string-mining XCTestCore/XCTHarness; the in-process gates don't govern the harness-side eager pass).

**The working lever** is shrinking what gets read: `--linkopt=-Wl,-x --linkopt=-Wl,-S` on CI configs (relink-only). Field-measured on the 500+ dep app: host 673MB → 500MB (`__LINKEDIT` 318MB → 146MB), xcodebuild peak **−26%**, 8s relink. Trade-offs documented in the section: crash-report backtraces degrade to exported symbols; XCTest assertion locations are unaffected (compiled into test code).

## Steps to reproduce the 9× multiplier

1. Add to any hosted test's app: an assembly file with `.section __TEXT,__const` / `.globl _blob` / `.no_dead_strip _blob` / `.space 314572800`, in an `alwayslink` `objc_library`.
2. Sample: `while :; do ps -axo rss=,comm= | grep xcodebuild; sleep 0.5; done`
3. Run a trivial hosted test with `--nocache_test_results`; compare peak against the same test without the blob; vary `.space` to see the slope.
