### PR TITLE
Fix codesign warning silencing for resource-rules

### DIFF
--- a/tools/codesigningtool/codesigningtool.py
+++ b/tools/codesigningtool/codesigningtool.py
@@ -37,7 +37,7 @@ from tools.wrapper_common import execute
 # * Executable=/{path to signed target}
 # * using the deprecated --resource-rules flag
 _BENIGN_CODESIGN_OUTPUT_REGEX = re.compile(
-    r"(signed.*Mach-O (universal|thin)|: replacing existing signature|signed generic|Executable=/|Warning: --resource-rules has been deprecated)"
+    r"(signed.*Mach-O (universal|thin)|: replacing existing signature|signed generic|Executable=/|[Ww]arning: --resource-rules has been deprecated)"
 )
 
 


### PR DESCRIPTION
`_BENIGN_CODESIGN_OUTPUT_REGEX` was introduced in #1018 to silence the `--resource-rules` deprecation notice printed by `codesign` (a useful ~2x codesigning speedup, per that PR). Its regex matches `Warning: --resource-rules has been deprecated` (capital `W`), but `codesign` on current macOS actually prints it lowercase:

```
warning: --resource-rules has been deprecated in Mac OS X >= 10.10!
```

Verified directly:

```
$ codesign -s - --resource-rules=/tmp/rr.plist -f /tmp/rrtest/foo.txt
warning: --resource-rules has been deprecated in Mac OS X >= 10.10!
```

Because of the casing mismatch, `_filter_codesign_output` never actually catches this line, so the "silenced" warning still leaks into build output on current macOS. This change makes the regex match either case so the intended suppression works again.

No other behavior change.